### PR TITLE
fix: add Vercel rewrites to route API paths to FastAPI

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,8 @@
     "api/**": {
       "excludeFiles": "{.next,.git,node_modules}/**"
     }
-  }
+  },
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "/api/index" }
+  ]
 }


### PR DESCRIPTION
Without this rewrite rule, Vercel only serves /api/index directly. Sub-paths like /api/customers/import/analyze returned 405 errors because they weren't being routed to the FastAPI app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)