### PR TITLE
fix: add requirements.txt to root for Vercel Python functions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+# Core dependencies
+fastapi>=0.100.0
+uvicorn>=0.23.0
+python-dotenv>=1.0.0
+supabase>=2.0.0
+pydantic>=2.0.0
+
+# AI providers (for CSV import mapping)
+anthropic>=0.18.0
+openai>=1.0.0
+google-genai>=0.3.0
+
+# Database
+psycopg2-binary>=2.9.0


### PR DESCRIPTION
Vercel looks for requirements.txt at the project root for Python serverless functions. Without it, dependencies like FastAPI weren't being installed, causing 500 errors on all API endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)