### PR TITLE
fix: limit and batch bulk import requests to avoid 413 payload errors

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,8 @@
 {
   "functions": {
     "api/**": {
-      "excludeFiles": "{.next,.git,node_modules}/**"
+      "excludeFiles": "{.next,.git,node_modules}/**",
+      "maxDuration": 60
     }
   },
   "rewrites": [


### PR DESCRIPTION
Vercel serverless functions have a 4.5MB body limit. Large CSV imports were exceeding this limit. This change:

- Limits validation requests to first 500 rows (enough to detect conflicts)
- Batches execute requests into chunks of 500 rows
- Aggregates batch results into final import summary

Affects: customers, parts, and operations bulk import

🤖 Generated with [Claude Code](https://claude.com/claude-code)