### PR TITLE
Add name fields to signup and personalized header greeting

### DIFF
--- a/components/auth/SignUp.tsx
+++ b/components/auth/SignUp.tsx
@@ -15,6 +15,8 @@ import MuiLink from '@mui/material/Link';
 import { getSupabase } from '@/lib/supabase';
 
 export default function SignUp() {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -26,6 +28,13 @@ export default function SignUp() {
     e.preventDefault();
     setLoading(true);
     setError(null);
+
+    // Validate names
+    if (!firstName.trim() || !lastName.trim()) {
+      setError('First name and last name are required');
+      setLoading(false);
+      return;
+    }
 
     // Validate passwords match
     if (password !== confirmPassword) {
@@ -46,6 +55,13 @@ export default function SignUp() {
       const { error: signUpError } = await supabase.auth.signUp({
         email,
         password,
+        options: {
+          data: {
+            first_name: firstName.trim(),
+            last_name: lastName.trim(),
+            display_name: `${firstName.trim()} ${lastName.trim()}`,
+          },
+        },
       });
 
       if (signUpError) {
@@ -103,6 +119,29 @@ export default function SignUp() {
         )}
 
         <Box component="form" onSubmit={handleSubmit}>
+          <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+            <TextField
+              label="First Name"
+              fullWidth
+              required
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              disabled={loading}
+              autoComplete="given-name"
+              sx={{ flex: 1 }}
+            />
+            <TextField
+              label="Last Name"
+              fullWidth
+              required
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              disabled={loading}
+              autoComplete="family-name"
+              sx={{ flex: 1 }}
+            />
+          </Box>
+
           <TextField
             label="Email"
             type="email"

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -120,7 +120,8 @@ export default function Header({ isMobile = false, onMenuClick }: HeaderProps) {
   const pathname = usePathname();
   const params = useParams();
   const companyId = params.companyId as string | undefined;
-  const { signOut } = useAuth();
+  const { signOut, user } = useAuth();
+  const firstName = user?.user_metadata?.first_name;
   const { isDemoMode } = useDemoMode();
   const pageTitle = getPageTitle(pathname);
 
@@ -170,6 +171,14 @@ export default function Header({ isMobile = false, onMenuClick }: HeaderProps) {
         )}
       </Box>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        {!isMobile && firstName && (
+          <Typography
+            variant="body2"
+            sx={{ color: 'rgba(255, 255, 255, 0.7)', mr: 1 }}
+          >
+            Welcome, {firstName}
+          </Typography>
+        )}
         {companyId && <AlertBadge companyId={companyId} />}
         {isMobile ? (
           <IconButton


### PR DESCRIPTION
## Summary
- Add First Name and Last Name fields to the signup form, stored in Supabase user metadata (`first_name`, `last_name`, `display_name`)
- Add "Welcome, {firstName}" greeting in the dashboard header (desktop only)
- Client-side validation ensures names are non-empty before submission

## Test plan
- [ ] Visit `/signup` and verify First Name / Last Name fields appear above Email
- [ ] Submit with empty names — should show validation error
- [ ] Complete signup and verify `user_metadata` in Supabase contains `first_name`, `last_name`, `display_name`
- [ ] Log in and verify "Welcome, {firstName}" appears in the header on desktop
- [ ] Verify greeting does not appear on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)