### PR TITLE
Fix: add auth callback route for email link token exchange

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get('code');
+  const next = searchParams.get('next') ?? '/';
+
+  if (code) {
+    const cookieStore = await cookies();
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll();
+          },
+          setAll(cookiesToSet) {
+            for (const { name, value, options } of cookiesToSet) {
+              cookieStore.set(name, value, options);
+            }
+          },
+        },
+      }
+    );
+
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  // If code exchange failed or no code, redirect to login with error
+  return NextResponse.redirect(`${origin}/login`);
+}

--- a/components/auth/SignUp.tsx
+++ b/components/auth/SignUp.tsx
@@ -56,6 +56,7 @@ export default function SignUp() {
         email,
         password,
         options: {
+          emailRedirectTo: `${window.location.origin}/auth/callback`,
           data: {
             first_name: firstName.trim(),
             last_name: lastName.trim(),


### PR DESCRIPTION
## Summary
- Signup confirmation and password reset email links fail silently because there's no server-side route to exchange the PKCE authorization code for a session
- Add `app/auth/callback/route.ts` that calls `exchangeCodeForSession()` and redirects the user
- Update signup `emailRedirectTo` to route through `/auth/callback`

## Root cause
Supabase SSR (`@supabase/ssr`) uses PKCE flow by default. Email links contain a `code` param that must be exchanged server-side. Without this route, the code is never exchanged — confirmation silently fails and reset links show "invalid or expired."

## Test plan
- [ ] Sign up with a new email, click confirmation link — should land on `/` with a valid session
- [ ] Request password reset, click link — should land on `/reset-password` with a valid session
- [ ] Ensure Supabase dashboard Redirect URLs include `/auth/callback` for both prod and localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)