### PR TITLE
Enforce admin-reset password change on dashboard login

### DIFF
--- a/app/change-password/page.tsx
+++ b/app/change-password/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { AuthLayout, ChangePassword } from '@/components/auth';
+
+export default function ChangePasswordPage() {
+  return (
+    <AuthLayout>
+      <ChangePassword />
+    </AuthLayout>
+  );
+}

--- a/components/auth/AuthGuard.tsx
+++ b/components/auth/AuthGuard.tsx
@@ -45,6 +45,13 @@ export default function AuthGuard({
       return;
     }
 
+    // If the admin reset this user's password, force them through the
+    // password-change flow before granting access to any dashboard route.
+    if (user.user_metadata?.needs_password_change) {
+      router.replace('/change-password');
+      return;
+    }
+
     // If no company verification needed, we're done
     if (!requireCompany || !companyId) {
       setLoading(false);

--- a/components/auth/ChangePassword.tsx
+++ b/components/auth/ChangePassword.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import * as Sentry from "@sentry/nextjs";
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import Box from '@mui/material/Box';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import { getSupabase } from '@/lib/supabase';
+import { getPostLoginRoute } from '@/utils/companyAccess';
+
+export default function ChangePassword() {
+  const router = useRouter();
+
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [checkingSession, setCheckingSession] = useState(true);
+
+  useEffect(() => {
+    const checkSession = async () => {
+      const supabase = getSupabase();
+      const { data: { session } } = await supabase.auth.getSession();
+
+      if (!session) {
+        router.replace('/login');
+        return;
+      }
+
+      if (!session.user.user_metadata?.needs_password_change) {
+        const redirectRoute = await getPostLoginRoute(session.user.id);
+        router.replace(redirectRoute);
+        return;
+      }
+
+      setCheckingSession(false);
+    };
+
+    checkSession();
+  }, [router]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!currentPassword.trim()) {
+      setError('Please enter your current password');
+      return;
+    }
+
+    if (!newPassword.trim()) {
+      setError('Please enter a new password');
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setError('New password must be at least 8 characters');
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+
+    if (newPassword === currentPassword) {
+      setError('New password must be different from current password');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const supabase = getSupabase();
+      const { data: { user }, error: updateError } = await supabase.auth.updateUser({
+        password: newPassword,
+        data: { needs_password_change: false },
+      });
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      if (!user) {
+        throw new Error('Session lost during password change. Please sign in again.');
+      }
+
+      const redirectRoute = await getPostLoginRoute(user.id);
+      router.replace(redirectRoute);
+    } catch (err) {
+      console.error('Change password error:', err);
+      Sentry.captureException(err);
+      setError(err instanceof Error ? err.message : 'Failed to change password. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (checkingSession) {
+    return (
+      <Card elevation={3}>
+        <CardContent sx={{ p: 4, textAlign: 'center' }}>
+          <CircularProgress sx={{ mb: 2 }} />
+          <Typography variant="body2" color="text.secondary">
+            Loading...
+          </Typography>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card elevation={3}>
+      <CardContent sx={{ p: 4 }}>
+        <Typography variant="h5" component="h2" gutterBottom align="center">
+          Change Your Password
+        </Typography>
+        <Typography variant="body2" color="text.secondary" align="center" sx={{ mb: 3 }}>
+          Your administrator reset your password. Please set a new one to continue.
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 3 }}>
+            {error}
+          </Alert>
+        )}
+
+        <Box component="form" onSubmit={handleSubmit}>
+          <TextField
+            label="Current (Temporary) Password"
+            type={showCurrentPassword ? 'text' : 'password'}
+            fullWidth
+            required
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+            disabled={loading}
+            autoComplete="current-password"
+            autoFocus
+            sx={{ mb: 2 }}
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton onClick={() => setShowCurrentPassword(!showCurrentPassword)} edge="end" size="small">
+                      {showCurrentPassword ? <VisibilityOff /> : <Visibility />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+
+          <TextField
+            label="New Password"
+            type={showNewPassword ? 'text' : 'password'}
+            fullWidth
+            required
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            disabled={loading}
+            autoComplete="new-password"
+            helperText="Minimum 8 characters"
+            sx={{ mb: 2 }}
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton onClick={() => setShowNewPassword(!showNewPassword)} edge="end" size="small">
+                      {showNewPassword ? <VisibilityOff /> : <Visibility />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+
+          <TextField
+            label="Confirm New Password"
+            type={showConfirmPassword ? 'text' : 'password'}
+            fullWidth
+            required
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            disabled={loading}
+            autoComplete="new-password"
+            sx={{ mb: 3 }}
+            error={confirmPassword !== '' && newPassword !== confirmPassword}
+            helperText={
+              confirmPassword !== '' && newPassword !== confirmPassword
+                ? 'Passwords do not match'
+                : ''
+            }
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton onClick={() => setShowConfirmPassword(!showConfirmPassword)} edge="end" size="small">
+                      {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+
+          <Button
+            type="submit"
+            variant="contained"
+            fullWidth
+            size="large"
+            disabled={loading}
+          >
+            {loading ? (
+              <CircularProgress size={24} color="inherit" />
+            ) : (
+              'Change Password'
+            )}
+          </Button>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/auth/Login.tsx
+++ b/components/auth/Login.tsx
@@ -64,6 +64,14 @@ export default function Login({ expired, returnTo }: LoginProps) {
       }
 
       if (data.user) {
+        // If the admin reset this user's password, force them through the
+        // password-change flow before anything else — even a stale returnTo
+        // from a session-expiry redirect must not bypass this.
+        if (data.user.user_metadata?.needs_password_change) {
+          router.push('/change-password');
+          return;
+        }
+
         // If we have a valid returnTo path (e.g., from session expiry), go there
         if (returnTo && isValidReturnTo(returnTo)) {
           router.push(returnTo);

--- a/components/auth/index.ts
+++ b/components/auth/index.ts
@@ -3,6 +3,7 @@ export { default as Login } from './Login';
 export { default as SignUp } from './SignUp';
 export { default as ForgotPassword } from './ForgotPassword';
 export { default as ResetPassword } from './ResetPassword';
+export { default as ChangePassword } from './ChangePassword';
 export { default as CompanySelector } from './CompanySelector';
 export { default as AuthGuard } from './AuthGuard';
 export { default as SystemAdminGuard } from './SystemAdminGuard';


### PR DESCRIPTION
## Summary
- **Bug:** When an admin reset a team member's password, the operator view correctly forced them through a password-change flow, but the admin/dashboard login flow never read `user_metadata.needs_password_change`. Users could sign in at `/login` with the temp password and use the entire app without being prompted to reset.
- **Fix:** Add the check to `Login.tsx` (before `returnTo` handling, so a stale session-expiry redirect can't bypass it) and `AuthGuard.tsx` (re-checks on every protected route to catch mid-session resets).
- **New page:** Global `/change-password` page (`app/change-password/page.tsx` + `components/auth/ChangePassword.tsx`) styled like the rest of admin auth (`AuthLayout` + `Card`). Clears the flag via `supabase.auth.updateUser({ password, data: { needs_password_change: false } })` and redirects through `getPostLoginRoute`.

No schema or backend changes — the flag and Edge Function already exist and were already in use by the operator side.

## Test plan
- [ ] Admin resets a team member's password → member logs in at `/login` with temp password → redirected to `/change-password`, cannot reach `/dashboard/{companyId}` until new password is set.
- [ ] After successful change, redirected to dashboard via `getPostLoginRoute`. Flag is cleared.
- [ ] Logging back in with the new password goes straight to dashboard (no prompt).
- [ ] `returnTo` bypass is blocked: trigger `/login?expired=true&returnTo=/dashboard/...`, have admin reset password, log in → goes to `/change-password`, not the `returnTo`.
- [ ] Mid-session reset: log in, admin resets password, force a session refresh → AuthGuard redirects to `/change-password`.
- [ ] Operator flow unchanged: operator reset → still forced through `/operator/{companyId}/change-password`.
- [ ] Self-service `/forgot-password` email flow unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)