### PR TITLE
Show account email and sign-out escape on /change-password

### DIFF
--- a/components/auth/ChangePassword.tsx
+++ b/components/auth/ChangePassword.tsx
@@ -17,10 +17,13 @@ import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import { getSupabase } from '@/lib/supabase';
 import { getPostLoginRoute } from '@/utils/companyAccess';
+import { useAuth } from '@/components/providers/AuthProvider';
 
 export default function ChangePassword() {
   const router = useRouter();
+  const { signOut } = useAuth();
 
+  const [email, setEmail] = useState<string | null>(null);
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -47,11 +50,17 @@ export default function ChangePassword() {
         return;
       }
 
+      setEmail(session.user.email ?? null);
       setCheckingSession(false);
     };
 
     checkSession();
   }, [router]);
+
+  const handleSignOut = async () => {
+    await signOut();
+    router.replace('/login');
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -129,9 +138,24 @@ export default function ChangePassword() {
         <Typography variant="h5" component="h2" gutterBottom align="center">
           Change Your Password
         </Typography>
-        <Typography variant="body2" color="text.secondary" align="center" sx={{ mb: 3 }}>
+        <Typography variant="body2" color="text.secondary" align="center" sx={{ mb: 1 }}>
           Your administrator reset your password. Please set a new one to continue.
         </Typography>
+        {email && (
+          <Typography variant="body2" align="center" sx={{ mb: 1, fontWeight: 500 }}>
+            Signed in as {email}
+          </Typography>
+        )}
+        <Box sx={{ textAlign: 'center', mb: 3 }}>
+          <Button
+            variant="text"
+            size="small"
+            onClick={handleSignOut}
+            disabled={loading}
+          >
+            Not you? Sign out
+          </Button>
+        </Box>
 
         {error && (
           <Alert severity="error" sx={{ mb: 3 }}>


### PR DESCRIPTION
## Summary
- Display the signed-in user's email on the global `/change-password` card so users know which account the forced password change is for.
- Add a "Not you? Sign out" button wired to `useAuth().signOut()` so users with a stale/bogus session can escape without being trapped.
- Enforcement from #222 is unchanged: `AuthGuard` and `Login` still redirect users with `needs_password_change: true` to this page. The only new behavior is the escape hatch + identity disclosure on the page itself.

## Test plan
- [ ] Log in as a user whose admin just reset their password → `/change-password` shows their email and the "Not you? Sign out" button.
- [ ] Click "Not you? Sign out" → session cleared, redirected to `/login`.
- [ ] Complete the normal flow (enter current + new password) → still redirects to post-login route.
- [ ] Log in as a user without `needs_password_change` → still redirected away from `/change-password`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)