### PR TITLE
Replace copy-from-part with live markup-rate links

### DIFF
--- a/app/dashboard/[companyId]/parts/page.tsx
+++ b/app/dashboard/[companyId]/parts/page.tsx
@@ -22,6 +22,7 @@ import UploadIcon from '@mui/icons-material/Upload';
 import DeleteIcon from '@mui/icons-material/Delete';
 import CategoryIcon from '@mui/icons-material/Category';
 import CheckIcon from '@mui/icons-material/Check';
+import PercentIcon from '@mui/icons-material/Percent';
 
 import { AgGridReact } from 'ag-grid-react';
 import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
@@ -33,6 +34,7 @@ import type {
   ICellRendererParams,
   RowClickedEvent,
   CellKeyDownEvent,
+  ValueFormatterParams,
 } from 'ag-grid-community';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
@@ -40,6 +42,7 @@ ModuleRegistry.registerModules([AllCommunityModule]);
 import { jiggedAgGridTheme } from '@/lib/agGridTheme';
 import { getAllParts, deletePart, bulkDeleteParts } from '@/utils/partsAccess';
 import ExportCsvButton from '@/components/common/ExportCsvButton';
+import BulkApplyRateDialog from '@/components/parts/BulkApplyRateDialog';
 import type { Part } from '@/types/part';
 
 export default function PartsPage() {
@@ -66,6 +69,8 @@ export default function PartsPage() {
     count?: number;
   }>({ open: false, type: 'part' });
   const [deleting, setDeleting] = useState(false);
+
+  const [bulkRateDialogOpen, setBulkRateDialogOpen] = useState(false);
 
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
@@ -218,6 +223,14 @@ export default function PartsPage() {
         );
       },
     },
+    {
+      field: 'markup_rate_name',
+      headerName: 'Markup',
+      width: 180,
+      sortable: true,
+      valueFormatter: (params: ValueFormatterParams<Part, string | null | undefined>) =>
+        params.value ?? 'Custom',
+    },
   ];
 
   return (
@@ -247,6 +260,13 @@ export default function PartsPage() {
               fileName="parts-export"
               selectedCount={selectedPartIds.length}
             />
+            <Button
+              variant="contained"
+              startIcon={<PercentIcon />}
+              onClick={() => setBulkRateDialogOpen(true)}
+            >
+              Apply rate ({selectedPartIds.length})
+            </Button>
             <Button
               variant="contained"
               color="error"
@@ -392,6 +412,33 @@ export default function PartsPage() {
           </Button>
         </DialogActions>
       </Dialog>
+
+      <BulkApplyRateDialog
+        open={bulkRateDialogOpen}
+        companyId={companyId}
+        partIds={selectedPartIds}
+        onClose={() => setBulkRateDialogOpen(false)}
+        onApplied={(succeeded, failed) => {
+          setSelectedPartIds([]);
+          if (partsGridRef.current?.api) {
+            partsGridRef.current.api.deselectAll();
+          }
+          fetchParts();
+          if (failed > 0) {
+            setSnackbar({
+              open: true,
+              message: `Applied to ${succeeded} part${succeeded === 1 ? '' : 's'}, ${failed} failed.`,
+              severity: 'error',
+            });
+          } else {
+            setSnackbar({
+              open: true,
+              message: `Applied to ${succeeded} part${succeeded === 1 ? '' : 's'}.`,
+              severity: 'success',
+            });
+          }
+        }}
+      />
 
       <Snackbar
         open={snackbar.open}

--- a/components/markup-rates/MarkupRateForm.tsx
+++ b/components/markup-rates/MarkupRateForm.tsx
@@ -173,7 +173,19 @@ export default function MarkupRateForm({
       if (mode === 'create') {
         await createMarkupRate(companyId, formData);
       } else if (rateId) {
-        await updateMarkupRate(rateId, formData);
+        const result = await updateMarkupRate(rateId, formData);
+        // Surface cascade outcomes so users know whether the edit propagated
+        // to linked parts. Partial failures are treated as warnings rather
+        // than save errors — the rate itself was saved successfully.
+        if (result.partsFailed.length > 0) {
+          setError(
+            `Saved, but ${result.partsFailed.length} part${
+              result.partsFailed.length === 1 ? '' : 's'
+            } failed to update. Try editing the rate again.`,
+          );
+          setSaving(false);
+          return;
+        }
       }
       router.push(`/dashboard/${companyId}/markup-rates`);
     } catch (err) {
@@ -397,8 +409,9 @@ export default function MarkupRateForm({
         <DialogTitle sx={{ pb: 2 }}>Delete Rate</DialogTitle>
         <DialogContent sx={{ pt: 0 }}>
           <Typography variant="body1" sx={{ mb: 1 }}>
-            Delete <strong>{initialData?.name ?? 'this rate'}</strong>? Parts that previously
-            had it applied keep their pricing tiers — snapshot semantics mean nothing cascades.
+            Delete <strong>{initialData?.name ?? 'this rate'}</strong>? Parts linked to this
+            rate flip to <em>Custom</em> and keep their last tier values — no pricing data is
+            lost, but they'll no longer follow this rate's edits.
           </Typography>
           <Typography variant="body2" color="text.secondary">
             This action cannot be undone.

--- a/components/parts/BulkApplyRateDialog.tsx
+++ b/components/parts/BulkApplyRateDialog.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import Box from '@mui/material/Box';
+import {
+  getAllMarkupRates,
+  bulkApplyMarkupRate,
+} from '@/utils/markupRatesAccess';
+import {
+  type MarkupRate,
+  summarizeBreakpoints,
+} from '@/types/markupRates';
+
+interface BulkApplyRateDialogProps {
+  open: boolean;
+  companyId: string;
+  partIds: string[];
+  onClose: () => void;
+  onApplied: (succeeded: number, failed: number) => void;
+}
+
+export default function BulkApplyRateDialog({
+  open,
+  companyId,
+  partIds,
+  onClose,
+  onApplied,
+}: BulkApplyRateDialogProps) {
+  const [rates, setRates] = useState<MarkupRate[]>([]);
+  const [selectedRate, setSelectedRate] = useState<MarkupRate | null>(null);
+  const [loadingRates, setLoadingRates] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset selection + error each time the dialog opens, and load the
+  // company's rates fresh so newly-created rates show up without a refresh.
+  useEffect(() => {
+    if (!open) return;
+    setSelectedRate(null);
+    setError(null);
+    setLoadingRates(true);
+    getAllMarkupRates(companyId)
+      .then(setRates)
+      .catch((err) => {
+        console.error('Failed to load markup rates:', err);
+        setError(err instanceof Error ? err.message : 'Failed to load rates');
+      })
+      .finally(() => setLoadingRates(false));
+  }, [open, companyId]);
+
+  const handleApply = async () => {
+    if (!selectedRate) return;
+    setApplying(true);
+    setError(null);
+    try {
+      const result = await bulkApplyMarkupRate(
+        companyId,
+        partIds,
+        selectedRate.id,
+      );
+      onApplied(result.succeeded.length, result.failed.length);
+      onClose();
+    } catch (err) {
+      console.error('Failed to bulk apply markup rate:', err);
+      setError(err instanceof Error ? err.message : 'Failed to apply rate');
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const partCount = partIds.length;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => !applying && onClose()}
+      maxWidth="sm"
+      fullWidth
+    >
+      <DialogTitle>
+        Apply markup rate to {partCount} part{partCount === 1 ? '' : 's'}
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          The selected rate&apos;s breakpoints will replace each part&apos;s pricing tiers.
+          Future edits to the rate will cascade into these parts automatically.
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        <Autocomplete
+          options={rates}
+          value={selectedRate}
+          onChange={(_, v) => setSelectedRate(v)}
+          getOptionLabel={(rate) => rate.name}
+          isOptionEqualToValue={(o, v) => o.id === v.id}
+          loading={loadingRates}
+          disabled={applying}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Markup rate"
+              autoFocus
+              slotProps={{
+                input: {
+                  ...params.InputProps,
+                  endAdornment: (
+                    <>
+                      {loadingRates ? <CircularProgress size={16} /> : null}
+                      {params.InputProps.endAdornment}
+                    </>
+                  ),
+                },
+              }}
+            />
+          )}
+          renderOption={(props, rate) => {
+            const { key, ...rest } = props as React.HTMLAttributes<HTMLLIElement> & {
+              key: string;
+            };
+            return (
+              <li key={key} {...rest}>
+                <Box>
+                  <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                    {rate.name}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {summarizeBreakpoints(rate.breakpoints)}
+                  </Typography>
+                </Box>
+              </li>
+            );
+          }}
+        />
+
+        {selectedRate && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ display: 'block', mt: 1 }}
+          >
+            {summarizeBreakpoints(selectedRate.breakpoints)}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2.5 }}>
+        <Button onClick={onClose} disabled={applying} color="inherit">
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleApply}
+          disabled={!selectedRate || applying || partCount === 0}
+          startIcon={applying ? <CircularProgress size={16} color="inherit" /> : null}
+        >
+          {applying
+            ? 'Applying…'
+            : `Apply to ${partCount} part${partCount === 1 ? '' : 's'}`}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/parts/PartPricing.tsx
+++ b/components/parts/PartPricing.tsx
@@ -27,6 +27,9 @@ import CheckIcon from '@mui/icons-material/Check';
 import CloudSyncOutlinedIcon from '@mui/icons-material/CloudSyncOutlined';
 import PercentIcon from '@mui/icons-material/Percent';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import TuneIcon from '@mui/icons-material/Tune';
 import {
   calculateRoutingCost,
   calculateTierPricing,
@@ -35,6 +38,7 @@ import {
 import {
   getTiersForPart,
   replaceTiersForPart,
+  setPartMarkupRate,
 } from '@/utils/partPricingTiersAccess';
 import { getAllMarkupRates, applyRateToPart } from '@/utils/markupRatesAccess';
 import {
@@ -52,21 +56,14 @@ interface PartPricingProps {
 }
 
 /**
- * Working-copy of a tier inside the editor.
+ * Working-copy of a tier inside the editor (Custom mode only).
  *
  * Markup % is the source of truth — `unit_price` is always derived from
  * `base_cost × (1 + markup/100)`. Typing a unit price back-calculates markup
  * before the next save.
- *
- * `phantom: true` rows are UI-only seeds — they show users what a tier looks
- * like for parts that have no tiers yet, but they don't write to the database
- * until the user demonstrates intent (types markup, types a unit price, or
- * edits the seeded qty). If the user navigates away without touching them,
- * no DB rows are created.
  */
 interface EditRow {
   id?: string;
-  phantom?: boolean;
   sequence: number;
   quantity: string;
   markupPercent: string;
@@ -75,6 +72,7 @@ interface EditRow {
 }
 
 const AUTOSAVE_DEBOUNCE_MS = 600;
+const DEFAULT_CUSTOM_MARKUP = '25';
 
 function formatCurrency(value: number | null | undefined): string {
   if (value === null || value === undefined || Number.isNaN(value)) return '—';
@@ -94,26 +92,11 @@ function recomputeRow(row: EditRow, breakdown: RoutingCostBreakdown | null): Edi
   }
   const markup = parseNumber(row.markupPercent);
   const { baseCostPerUnit, unitPrice } = calculateTierPricing(breakdown, qty, markup);
-  // Phantom rows leave unitPrice empty so the input renders the suggested price
-  // as a placeholder rather than a committed value — typing in either Markup
-  // or Unit price flips the row out of phantom and the value becomes real.
-  if (row.phantom) {
-    return { ...row, baseCostPerUnit };
-  }
   return {
     ...row,
     baseCostPerUnit,
     unitPrice: unitPrice !== null ? String(unitPrice) : '',
   };
-}
-
-function makePhantomRows(breakdown: RoutingCostBreakdown | null): EditRow[] {
-  // Single phantom row — qty 1 with a suggested 25% markup. Multi-quantity
-  // exploration lives behind a separate UX (TBD).
-  const rows: EditRow[] = [
-    { phantom: true, sequence: 10, quantity: '1', markupPercent: '25', unitPrice: '', baseCostPerUnit: 0 },
-  ];
-  return rows.map((r) => recomputeRow(r, breakdown));
 }
 
 export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPricingProps) {
@@ -125,9 +108,16 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
-  // Markup rate picker. Applying a rate sets the part's markup_rate_id so
-  // future rate edits cascade into this part's tiers; manually editing tiers
-  // (via the autosave path) clears the link and the part flips to "Custom".
+  // Local mirror of part.markup_rate_id so the UI flips instantly between
+  // rate-linked (read-only) and Custom (editable) without waiting for the
+  // parent to refetch the part.
+  const [linkedRateId, setLinkedRateId] = useState<string | null>(part.markup_rate_id);
+  useEffect(() => {
+    setLinkedRateId(part.markup_rate_id);
+  }, [part.markup_rate_id]);
+
+  // Mode-picker menu. Anchor is set by clicking the chip in the header OR by
+  // clicking "Pick a markup rate" in the empty state.
   const [rateMenuAnchor, setRateMenuAnchor] = useState<HTMLElement | null>(null);
   const [userRates, setUserRates] = useState<MarkupRate[]>([]);
   const [applyingRateName, setApplyingRateName] = useState<string | null>(null);
@@ -135,6 +125,9 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
 
   const queueRef = useRef<Promise<void>>(Promise.resolve());
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const linkedRate = userRates.find((r) => r.id === linkedRateId) ?? null;
+  const isCustom = linkedRateId === null;
 
   const loadAll = useCallback(async () => {
     setLoading(true);
@@ -146,22 +139,15 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
       ]);
       setBreakdown(routingBreakdown);
 
-      if (tiers.length === 0) {
-        // Pre-seed phantom example rows so the user immediately sees what a tier
-        // looks like. Phantoms are UI-only — they don't hit the database until
-        // the user types something to demonstrate intent.
-        setRows(makePhantomRows(routingBreakdown));
-      } else {
-        const asRows: EditRow[] = tiers.map((t) => ({
-          id: t.id,
-          sequence: t.sequence,
-          quantity: String(t.quantity),
-          markupPercent: t.markup_percent !== null ? String(t.markup_percent) : '',
-          unitPrice: t.unit_price !== null ? String(t.unit_price) : '',
-          baseCostPerUnit: t.base_cost_per_unit ?? 0,
-        }));
-        setRows(asRows.map((r) => recomputeRow(r, routingBreakdown)));
-      }
+      const asRows: EditRow[] = tiers.map((t) => ({
+        id: t.id,
+        sequence: t.sequence,
+        quantity: String(t.quantity),
+        markupPercent: t.markup_percent !== null ? String(t.markup_percent) : '',
+        unitPrice: t.unit_price !== null ? String(t.unit_price) : '',
+        baseCostPerUnit: t.base_cost_per_unit ?? 0,
+      }));
+      setRows(asRows.map((r) => recomputeRow(r, routingBreakdown)));
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load pricing');
     } finally {
@@ -173,9 +159,6 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
     loadAll();
   }, [loadAll, refreshKey]);
 
-  // Load this company's user-created rates once. Built-ins are constants and
-  // don't need a fetch. Failures are silent — the picker still works with
-  // built-ins only, and a missing rates table shouldn't break the part page.
   useEffect(() => {
     let cancelled = false;
     getAllMarkupRates(companyId)
@@ -193,10 +176,8 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
       if (debounceRef.current) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => {
         const job = queueRef.current.then(async () => {
-          // Skip phantoms — they exist only as UI hints until the user touches them.
-          const persisted = next.filter((r) => !r.phantom);
-          // Skip if any persisted row has an invalid qty (markup might still be in flight).
-          const allValid = persisted.every((r) => {
+          // Skip if any row has an invalid qty (markup might still be in flight).
+          const allValid = next.every((r) => {
             const q = parseNumber(r.quantity);
             return q !== null && q > 0;
           });
@@ -205,21 +186,22 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
           setSaving(true);
           setError(null);
           try {
-            const sortedRows = [...persisted].sort((a, b) => a.sequence - b.sequence);
+            const sortedRows = [...next].sort((a, b) => a.sequence - b.sequence);
             const payload = sortedRows.map((r, i) => ({
               id: r.id,
               sequence: (i + 1) * 10,
               quantity: parseNumber(r.quantity) as number,
               markup_percent: parseNumber(r.markupPercent),
             }));
+            // No rateId arg → manual edit path; replaceTiersForPart will set
+            // markup_rate_id to null, flipping the part to Custom.
             await replaceTiersForPart(companyId, partId, payload);
+            setLinkedRateId(null);
 
-            // Reload so newly-inserted rows pick up real ids; preserve user's
-            // typed strings where possible.
             const fresh = await getTiersForPart(partId);
             setRows((prev) => {
               const byId = new Map(prev.filter((r) => r.id).map((r) => [r.id, r]));
-              const mergedReal: EditRow[] = fresh.map((t) => {
+              return fresh.map((t) => {
                 const existing = t.id ? byId.get(t.id) : undefined;
                 return existing
                   ? { ...existing, id: t.id, baseCostPerUnit: t.base_cost_per_unit ?? 0 }
@@ -232,10 +214,6 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
                       baseCostPerUnit: t.base_cost_per_unit ?? 0,
                     };
               });
-              // Re-seed phantoms only if the persisted set is empty after a save
-              // (e.g., the user deleted everything).
-              if (mergedReal.length === 0) return makePhantomRows(breakdown);
-              return mergedReal;
             });
           } catch (err) {
             console.error('Failed to save pricing tiers:', err);
@@ -247,7 +225,7 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
         queueRef.current = job.catch(() => undefined);
       }, AUTOSAVE_DEBOUNCE_MS);
     },
-    [companyId, partId, breakdown],
+    [companyId, partId],
   );
 
   const updateRows = (mapper: (prev: EditRow[]) => EditRow[]) => {
@@ -262,10 +240,7 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
     if (!/^\d*$/.test(value)) return;
     updateRows((prev) => {
       const next = [...prev];
-      next[idx] = recomputeRow(
-        { ...next[idx], quantity: value, phantom: false },
-        breakdown,
-      );
+      next[idx] = recomputeRow({ ...next[idx], quantity: value }, breakdown);
       return next;
     });
   };
@@ -274,10 +249,7 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
     if (value !== '' && !/^\d*\.?\d*$/.test(value)) return;
     updateRows((prev) => {
       const next = [...prev];
-      next[idx] = recomputeRow(
-        { ...next[idx], markupPercent: value, phantom: false },
-        breakdown,
-      );
+      next[idx] = recomputeRow({ ...next[idx], markupPercent: value }, breakdown);
       return next;
     });
   };
@@ -294,7 +266,7 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
         const back = calculateMarkupFromUnitPrice(base, unitPrice);
         if (back !== null) markupStr = String(back);
       }
-      next[idx] = { ...row, unitPrice: value, markupPercent: markupStr, phantom: false };
+      next[idx] = { ...row, unitPrice: value, markupPercent: markupStr };
       return next;
     });
   };
@@ -314,11 +286,7 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
   };
 
   const removeRow = (idx: number): void => {
-    updateRows((prev) => {
-      const next = prev.filter((_, i) => i !== idx);
-      // If user deletes everything, fall back to phantoms so the editor isn't blank.
-      return next.length === 0 ? makePhantomRows(breakdown) : next;
-    });
+    updateRows((prev) => prev.filter((_, i) => i !== idx));
   };
 
   const handleApplyRate = async (rate: MarkupRate): Promise<void> => {
@@ -326,10 +294,8 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
     setApplyingRateName(rate.name);
     setError(null);
     try {
-      // applyRateToPart snapshots the breakpoints into tier rows AND sets
-      // parts.markup_rate_id, so future edits to the rate cascade into this
-      // part automatically.
       await applyRateToPart(companyId, partId, rate.id);
+      setLinkedRateId(rate.id);
       await loadAll();
       setAppliedRateName(rate.name);
     } catch (err) {
@@ -340,9 +306,50 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
     }
   };
 
+  const handleSwitchToCustom = async (): Promise<void> => {
+    setRateMenuAnchor(null);
+    if (linkedRateId === null) return;
+    setError(null);
+    try {
+      // Flip the FK to null without rewriting the tiers — the user wants to
+      // start editing from the rate's current values.
+      await setPartMarkupRate(partId, null);
+      setLinkedRateId(null);
+    } catch (err) {
+      console.error('Failed to switch to custom:', err);
+      setError(err instanceof Error ? err.message : 'Failed to switch to custom');
+    }
+  };
+
+  const handleStartCustomFromEmpty = (): void => {
+    // From the empty state "Set custom tiers" CTA: drop in one editable row
+    // at qty=1 with the suggested 25% markup. Autosave will persist it as
+    // soon as the row is valid.
+    updateRows(() => [
+      recomputeRow(
+        {
+          sequence: 10,
+          quantity: '1',
+          markupPercent: DEFAULT_CUSTOM_MARKUP,
+          unitPrice: '',
+          baseCostPerUnit: 0,
+        },
+        breakdown,
+      ),
+    ]);
+  };
+
   const runPerUnit = breakdown ? Math.round(breakdown.total_labor_cost * 100) / 100 : 0;
   const setupBatch = breakdown ? Math.round(breakdown.total_setup_cost * 100) / 100 : 0;
   const materialPerUnit = breakdown ? Math.round(breakdown.total_material_cost * 100) / 100 : 0;
+
+  // What renders below the cost build-up depends on three states:
+  //   1. linked to a rate                → read-only tier table + switch/edit bar
+  //   2. Custom with at least one tier   → editable table + Add tier
+  //   3. Custom with zero tiers          → empty-state cards prompting a choice
+  const showReadOnly = linkedRateId !== null;
+  const showEmptyState = isCustom && rows.length === 0;
+  const showEditable = isCustom && rows.length > 0;
 
   return (
     <Box>
@@ -367,6 +374,23 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
             </Box>
           )}
         </Box>
+
+        {/* Mode chip — always visible, always clickable. The label tells the
+            user which markup source drives this part's pricing; clicking it
+            opens the picker so the choice is one tap away. */}
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={isCustom ? <TuneIcon /> : <PercentIcon />}
+          endIcon={<KeyboardArrowDownIcon />}
+          onClick={(e) => setRateMenuAnchor(e.currentTarget)}
+          disabled={applyingRateName !== null}
+          sx={{ borderRadius: 4, textTransform: 'none', fontWeight: 500 }}
+        >
+          {applyingRateName
+            ? `Applying ${applyingRateName}…`
+            : `Markup: ${isCustom ? 'Custom' : (linkedRate?.name ?? 'rate')}`}
+        </Button>
       </Box>
 
       {error && (
@@ -415,9 +439,7 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
 
       {!loading && breakdown && (
         <>
-          {/* Compact cost build-up — context for the tier rows below.
-              The full per-op / per-material breakdown lives in the routing
-              side panel, so this card stays focused on the per-unit totals. */}
+          {/* Compact cost build-up — context for the tier rows below. */}
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mb: 2 }}>
             <SummaryRow label="Run labor / unit" value={formatCurrency(runPerUnit)} />
             <SummaryRow
@@ -432,107 +454,254 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
 
           <Divider sx={{ mb: 2 }} />
 
-          {/* Tier table */}
-          <TableContainer>
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell>Qty</TableCell>
-                  <TableCell align="right">Base / unit</TableCell>
-                  <TableCell align="right">Markup %</TableCell>
-                  <TableCell align="right">Unit price</TableCell>
-                  <TableCell align="right"></TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {rows.map((row, idx) => {
-                  // Suggested unit price = base × (1 + markup/100). Used as the
-                  // placeholder in the unit price input — phantom rows show this
-                  // as a hint instead of a committed value.
-                  const markupNum = parseNumber(row.markupPercent);
-                  const suggestedUnitPrice =
-                    row.baseCostPerUnit > 0 && markupNum !== null
-                      ? (Math.round(row.baseCostPerUnit * (1 + markupNum / 100) * 100) / 100).toFixed(2)
-                      : '0.00';
-                  return (
-                    <TableRow
-                      key={row.id ?? `tier-${idx}`}
-                      sx={row.phantom ? { opacity: 0.7 } : undefined}
-                    >
-                      <TableCell sx={{ minWidth: 90 }}>
-                        <TextField
-                          size="small"
-                          value={row.quantity}
-                          onChange={(e) => handleQuantityChange(idx, e.target.value)}
-                          inputMode="numeric"
-                          placeholder="1"
-                        />
-                      </TableCell>
-                      <TableCell align="right">{formatCurrency(row.baseCostPerUnit)}</TableCell>
-                      <TableCell align="right" sx={{ minWidth: 120 }}>
-                        <TextField
-                          size="small"
-                          value={row.markupPercent}
-                          onChange={(e) => handleMarkupChange(idx, e.target.value)}
-                          inputMode="decimal"
-                          placeholder="25"
-                          sx={{ width: 100 }}
-                        />
-                      </TableCell>
-                      <TableCell align="right" sx={{ minWidth: 130 }}>
-                        <TextField
-                          size="small"
-                          value={row.unitPrice}
-                          onChange={(e) => handleUnitPriceChange(idx, e.target.value)}
-                          inputMode="decimal"
-                          placeholder={suggestedUnitPrice}
-                          sx={{ width: 120 }}
-                        />
-                      </TableCell>
-                      <TableCell align="right">
-                        <IconButton
-                          size="small"
-                          color="error"
-                          onClick={() => removeRow(idx)}
-                          aria-label="Remove tier"
-                        >
-                          <DeleteOutlineIcon fontSize="small" />
-                        </IconButton>
-                      </TableCell>
+          {/* (1) RATE-LINKED — read-only tier display. The values are owned
+              by the rate; editing them requires either switching to Custom
+              (this part only) or editing the rate (cascades to every part
+              using it). */}
+          {showReadOnly && (
+            <>
+              <TableContainer
+                sx={{
+                  border: (theme) => `1px solid ${theme.palette.divider}`,
+                  borderLeft: (theme) => `3px solid ${theme.palette.primary.main}`,
+                  borderRadius: 1,
+                }}
+              >
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Qty</TableCell>
+                      <TableCell align="right">Base / unit</TableCell>
+                      <TableCell align="right">Markup %</TableCell>
+                      <TableCell align="right">Unit price</TableCell>
                     </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </TableContainer>
+                  </TableHead>
+                  <TableBody>
+                    {rows.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={4}>
+                          <Typography variant="body2" color="text.secondary" sx={{ py: 1 }}>
+                            This rate has no breakpoints yet. Edit the rate to add some,
+                            or switch to Custom to set tiers just for this part.
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      rows.map((row) => {
+                        const markupNum = parseNumber(row.markupPercent);
+                        const unitPriceNum = parseNumber(row.unitPrice);
+                        return (
+                          <TableRow key={row.id}>
+                            <TableCell>{row.quantity || '—'}</TableCell>
+                            <TableCell align="right">
+                              {formatCurrency(row.baseCostPerUnit)}
+                            </TableCell>
+                            <TableCell align="right">
+                              {markupNum !== null ? `${markupNum}%` : '—'}
+                            </TableCell>
+                            <TableCell align="right">
+                              {formatCurrency(unitPriceNum)}
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })
+                    )}
+                  </TableBody>
+                </Table>
+              </TableContainer>
 
-          <Box sx={{ display: 'flex', gap: 1, mt: 2, justifyContent: 'flex-end', flexWrap: 'wrap' }}>
-            <Button
-              size="small"
-              startIcon={<PercentIcon />}
-              endIcon={<KeyboardArrowDownIcon />}
-              onClick={(e) => setRateMenuAnchor(e.currentTarget)}
-              disabled={applyingRateName !== null}
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  mt: 2,
+                  flexWrap: 'wrap',
+                  gap: 1,
+                }}
+              >
+                <Button
+                  size="small"
+                  variant="outlined"
+                  startIcon={<TuneIcon />}
+                  onClick={handleSwitchToCustom}
+                >
+                  Switch to Custom to edit
+                </Button>
+                {linkedRate && (
+                  <Button
+                    size="small"
+                    component={Link}
+                    href={`/dashboard/${companyId}/markup-rates/${linkedRate.id}/edit`}
+                    endIcon={<OpenInNewIcon fontSize="small" />}
+                  >
+                    Edit the {linkedRate.name} rate
+                  </Button>
+                )}
+              </Box>
+            </>
+          )}
+
+          {/* (2) CUSTOM with tiers — editable table. Manual edits keep the
+              part on Custom (replaceTiersForPart writes markup_rate_id = null
+              by default). */}
+          {showEditable && (
+            <>
+              <TableContainer>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Qty</TableCell>
+                      <TableCell align="right">Base / unit</TableCell>
+                      <TableCell align="right">Markup %</TableCell>
+                      <TableCell align="right">Unit price</TableCell>
+                      <TableCell align="right"></TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {rows.map((row, idx) => {
+                      const markupNum = parseNumber(row.markupPercent);
+                      const suggestedUnitPrice =
+                        row.baseCostPerUnit > 0 && markupNum !== null
+                          ? (Math.round(row.baseCostPerUnit * (1 + markupNum / 100) * 100) / 100).toFixed(2)
+                          : '0.00';
+                      return (
+                        <TableRow key={row.id ?? `tier-${idx}`}>
+                          <TableCell sx={{ minWidth: 90 }}>
+                            <TextField
+                              size="small"
+                              value={row.quantity}
+                              onChange={(e) => handleQuantityChange(idx, e.target.value)}
+                              inputMode="numeric"
+                              placeholder="1"
+                            />
+                          </TableCell>
+                          <TableCell align="right">{formatCurrency(row.baseCostPerUnit)}</TableCell>
+                          <TableCell align="right" sx={{ minWidth: 120 }}>
+                            <TextField
+                              size="small"
+                              value={row.markupPercent}
+                              onChange={(e) => handleMarkupChange(idx, e.target.value)}
+                              inputMode="decimal"
+                              placeholder="25"
+                              sx={{ width: 100 }}
+                            />
+                          </TableCell>
+                          <TableCell align="right" sx={{ minWidth: 130 }}>
+                            <TextField
+                              size="small"
+                              value={row.unitPrice}
+                              onChange={(e) => handleUnitPriceChange(idx, e.target.value)}
+                              inputMode="decimal"
+                              placeholder={suggestedUnitPrice}
+                              sx={{ width: 120 }}
+                            />
+                          </TableCell>
+                          <TableCell align="right">
+                            <IconButton
+                              size="small"
+                              color="error"
+                              onClick={() => removeRow(idx)}
+                              aria-label="Remove tier"
+                            >
+                              <DeleteOutlineIcon fontSize="small" />
+                            </IconButton>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
+                <Button size="small" variant="outlined" onClick={addTier} startIcon={<AddIcon />}>
+                  Add tier
+                </Button>
+              </Box>
+            </>
+          )}
+
+          {/* (3) CUSTOM with no tiers — explicit choice prompt. Most users
+              never see this because createPart auto-applies the company's
+              default rate; it shows up after deleting all tiers, or when no
+              default rate exists. */}
+          {showEmptyState && (
+            <Box
+              sx={{
+                py: 4,
+                px: 2,
+                textAlign: 'center',
+                border: (theme) => `1px dashed ${theme.palette.divider}`,
+                borderRadius: 1,
+              }}
             >
-              {applyingRateName ? `Applying ${applyingRateName}…` : 'Apply markup rate'}
-            </Button>
-            <Button size="small" variant="outlined" onClick={addTier} startIcon={<AddIcon />}>
-              Add tier
-            </Button>
-          </Box>
+              <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
+                How should this part be priced?
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+                Pick a markup rate to follow company-wide pricing rules, or set custom
+                tiers just for this part.
+              </Typography>
+              <Box
+                sx={{
+                  display: 'flex',
+                  gap: 2,
+                  justifyContent: 'center',
+                  flexWrap: 'wrap',
+                }}
+              >
+                <Button
+                  variant="contained"
+                  startIcon={<PercentIcon />}
+                  endIcon={<KeyboardArrowDownIcon />}
+                  onClick={(e) => setRateMenuAnchor(e.currentTarget)}
+                  disabled={applyingRateName !== null}
+                >
+                  {userRates.length > 0 ? 'Pick a markup rate' : 'Create a markup rate'}
+                </Button>
+                <Button
+                  variant="outlined"
+                  startIcon={<TuneIcon />}
+                  onClick={handleStartCustomFromEmpty}
+                >
+                  Set custom tiers
+                </Button>
+              </Box>
+            </Box>
+          )}
         </>
       )}
 
-      {/* Apply rate menu. The currently-linked rate (if any) gets a check
-          icon so users can see which rate this part follows; selecting any
-          rate snapshots its breakpoints into the part's tiers and switches
-          the link to that rate. */}
+      {/* Mode picker menu — top-level options are Custom + every rate, plus
+          a tail link to the rates management page. The currently-selected
+          option gets a check icon. */}
       <Menu
         anchorEl={rateMenuAnchor}
         open={Boolean(rateMenuAnchor)}
         onClose={() => setRateMenuAnchor(null)}
         slotProps={{ paper: { sx: { minWidth: 320, maxWidth: 420 } } }}
       >
+        <MenuItem
+          onClick={handleSwitchToCustom}
+          selected={isCustom}
+          disabled={isCustom}
+        >
+          <ListItemIcon sx={{ minWidth: 32 }}>
+            {isCustom ? <CheckIcon fontSize="small" color="primary" /> : <TuneIcon fontSize="small" />}
+          </ListItemIcon>
+          <ListItemText
+            primary="Custom"
+            secondary="Set tier values just for this part"
+            slotProps={{
+              primary: { sx: { fontWeight: 500 } },
+              secondary: { sx: { fontSize: '0.75rem' } },
+            }}
+          />
+        </MenuItem>
+
+        <Divider sx={{ my: 0.5 }} />
+
         {userRates.length === 0 && (
           <MenuItem disabled>
             <ListItemText
@@ -546,7 +715,7 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
           </MenuItem>
         )}
         {userRates.map((rate) => {
-          const isApplied = part.markup_rate_id === rate.id;
+          const isApplied = linkedRateId === rate.id;
           return (
             <MenuItem key={rate.id} onClick={() => handleApplyRate(rate)} selected={isApplied}>
               <ListItemIcon sx={{ minWidth: 32 }}>
@@ -568,14 +737,18 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
           );
         })}
 
+        <Divider sx={{ my: 0.5 }} />
+
         <MenuItem
           component={Link}
-          href={`/dashboard/${companyId}/markup-rates/new`}
+          href={`/dashboard/${companyId}/markup-rates`}
           onClick={() => setRateMenuAnchor(null)}
-          sx={{ mt: 1, color: 'primary.main' }}
+          sx={{ color: 'primary.main' }}
         >
-          <AddIcon fontSize="small" sx={{ mr: 1 }} />
-          Create new rate…
+          <ListItemIcon sx={{ minWidth: 32 }}>
+            <SettingsOutlinedIcon fontSize="small" color="primary" />
+          </ListItemIcon>
+          <ListItemText primary="Manage rates…" />
         </MenuItem>
       </Menu>
 

--- a/components/parts/PartPricing.tsx
+++ b/components/parts/PartPricing.tsx
@@ -15,20 +15,15 @@ import TableBody from '@mui/material/TableBody';
 import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
-import Dialog from '@mui/material/Dialog';
-import DialogTitle from '@mui/material/DialogTitle';
-import DialogContent from '@mui/material/DialogContent';
-import DialogActions from '@mui/material/DialogActions';
-import Autocomplete from '@mui/material/Autocomplete';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
-import ListSubheader from '@mui/material/ListSubheader';
+import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Snackbar from '@mui/material/Snackbar';
 import Link from 'next/link';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckIcon from '@mui/icons-material/Check';
 import CloudSyncOutlinedIcon from '@mui/icons-material/CloudSyncOutlined';
 import PercentIcon from '@mui/icons-material/Percent';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
@@ -40,10 +35,8 @@ import {
 import {
   getTiersForPart,
   replaceTiersForPart,
-  copyTiersFromPart,
 } from '@/utils/partPricingTiersAccess';
-import { getPartsForSelect } from '@/utils/partsAccess';
-import { getAllMarkupRates } from '@/utils/markupRatesAccess';
+import { getAllMarkupRates, applyRateToPart } from '@/utils/markupRatesAccess';
 import {
   type MarkupRate,
   summarizeBreakpoints,
@@ -132,14 +125,9 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
-  const [copyDialogOpen, setCopyDialogOpen] = useState(false);
-  const [copyOptions, setCopyOptions] = useState<Array<{ id: string; label: string }>>([]);
-  const [copyTarget, setCopyTarget] = useState<{ id: string; label: string } | null>(null);
-  const [copying, setCopying] = useState(false);
-
-  // Markup rate picker — built-in starters + user-created rates from this company.
-  // Applying a rate is snapshot semantics: copy the breakpoints into tier rows
-  // and persist immediately. No link back to the rate after apply.
+  // Markup rate picker. Applying a rate sets the part's markup_rate_id so
+  // future rate edits cascade into this part's tiers; manually editing tiers
+  // (via the autosave path) clears the link and the part flips to "Custom".
   const [rateMenuAnchor, setRateMenuAnchor] = useState<HTMLElement | null>(null);
   const [userRates, setUserRates] = useState<MarkupRate[]>([]);
   const [applyingRateName, setApplyingRateName] = useState<string | null>(null);
@@ -338,18 +326,10 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
     setApplyingRateName(rate.name);
     setError(null);
     try {
-      // Snapshot apply: convert the rate's breakpoints into tier rows and
-      // persist directly. Bypass the debounced scheduleSave path because we
-      // want this commit to be atomic and immediate.
-      const payload = rate.breakpoints
-        .slice()
-        .sort((a, b) => a.qty - b.qty)
-        .map((bp, i) => ({
-          sequence: (i + 1) * 10,
-          quantity: bp.qty,
-          markup_percent: bp.markup_percent,
-        }));
-      await replaceTiersForPart(companyId, partId, payload);
+      // applyRateToPart snapshots the breakpoints into tier rows AND sets
+      // parts.markup_rate_id, so future edits to the rate cascade into this
+      // part automatically.
+      await applyRateToPart(companyId, partId, rate.id);
       await loadAll();
       setAppliedRateName(rate.name);
     } catch (err) {
@@ -357,37 +337,6 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
       setError(err instanceof Error ? err.message : 'Failed to apply markup rate');
     } finally {
       setApplyingRateName(null);
-    }
-  };
-
-  const openCopyDialog = async (): Promise<void> => {
-    setCopyTarget(null);
-    setCopyDialogOpen(true);
-    try {
-      const options = await getPartsForSelect(companyId);
-      setCopyOptions(
-        options
-          .filter((p) => p.id !== partId)
-          .map((p) => ({ id: p.id, label: p.part_name + (p.description ? ` — ${p.description}` : '') })),
-      );
-    } catch (err) {
-      console.error('Failed to load parts for copy:', err);
-      setCopyOptions([]);
-    }
-  };
-
-  const handleCopyConfirm = async (): Promise<void> => {
-    if (!copyTarget) return;
-    setCopying(true);
-    setError(null);
-    try {
-      await copyTiersFromPart(companyId, copyTarget.id, partId);
-      setCopyDialogOpen(false);
-      await loadAll();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to copy markup');
-    } finally {
-      setCopying(false);
     }
   };
 
@@ -567,13 +516,6 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
             >
               {applyingRateName ? `Applying ${applyingRateName}…` : 'Apply markup rate'}
             </Button>
-            <Button
-              size="small"
-              startIcon={<ContentCopyIcon />}
-              onClick={openCopyDialog}
-            >
-              Copy markup from another part
-            </Button>
             <Button size="small" variant="outlined" onClick={addTier} startIcon={<AddIcon />}>
               Add tier
             </Button>
@@ -581,9 +523,10 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
         </>
       )}
 
-      {/* Apply rate menu — every rate (defaults + user-created) lives in the
-          DB now and is treated identically. Snapshot semantics: the rate's
-          breakpoints replace the part's current tier rows. */}
+      {/* Apply rate menu. The currently-linked rate (if any) gets a check
+          icon so users can see which rate this part follows; selecting any
+          rate snapshots its breakpoints into the part's tiers and switches
+          the link to that rate. */}
       <Menu
         anchorEl={rateMenuAnchor}
         open={Boolean(rateMenuAnchor)}
@@ -602,18 +545,28 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
             />
           </MenuItem>
         )}
-        {userRates.map((rate) => (
-          <MenuItem key={rate.id} onClick={() => handleApplyRate(rate)}>
-            <ListItemText
-              primary={rate.name}
-              secondary={summarizeBreakpoints(rate.breakpoints)}
-              slotProps={{
-                primary: { sx: { fontWeight: 500 } },
-                secondary: { sx: { fontSize: '0.75rem' } },
-              }}
-            />
-          </MenuItem>
-        ))}
+        {userRates.map((rate) => {
+          const isApplied = part.markup_rate_id === rate.id;
+          return (
+            <MenuItem key={rate.id} onClick={() => handleApplyRate(rate)} selected={isApplied}>
+              <ListItemIcon sx={{ minWidth: 32 }}>
+                {isApplied ? <CheckIcon fontSize="small" color="primary" /> : null}
+              </ListItemIcon>
+              <ListItemText
+                primary={rate.name}
+                secondary={
+                  isApplied
+                    ? `Currently applied · ${summarizeBreakpoints(rate.breakpoints)}`
+                    : summarizeBreakpoints(rate.breakpoints)
+                }
+                slotProps={{
+                  primary: { sx: { fontWeight: 500 } },
+                  secondary: { sx: { fontSize: '0.75rem' } },
+                }}
+              />
+            </MenuItem>
+          );
+        })}
 
         <MenuItem
           component={Link}
@@ -632,37 +585,6 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
         onClose={() => setAppliedRateName(null)}
         message={appliedRateName ? `Applied "${appliedRateName}"` : ''}
       />
-
-      <Dialog open={copyDialogOpen} onClose={() => !copying && setCopyDialogOpen(false)} maxWidth="sm" fullWidth>
-        <DialogTitle>Copy markup from another part</DialogTitle>
-        <DialogContent>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            Copies the source part&apos;s tier quantities and markup percentages onto this part.
-            Unit prices are recomputed against this part&apos;s own routing.
-          </Typography>
-          <Autocomplete
-            options={copyOptions}
-            value={copyTarget}
-            onChange={(_, v) => setCopyTarget(v)}
-            isOptionEqualToValue={(o, v) => o.id === v.id}
-            renderInput={(params) => <TextField {...params} label="Source part" autoFocus />}
-            disabled={copying}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setCopyDialogOpen(false)} disabled={copying}>
-            Cancel
-          </Button>
-          <Button
-            variant="contained"
-            onClick={handleCopyConfirm}
-            disabled={!copyTarget || copying}
-            startIcon={copying ? <CircularProgress size={14} color="inherit" /> : null}
-          >
-            {copying ? 'Copying…' : 'Copy markup'}
-          </Button>
-        </DialogActions>
-      </Dialog>
     </Box>
   );
 }

--- a/supabase/migrations/20260502_parts_markup_rate_link.sql
+++ b/supabase/migrations/20260502_parts_markup_rate_link.sql
@@ -1,0 +1,16 @@
+-- Link parts to a markup rate so the parts list can show which rate (or "Custom") drives each part's pricing,
+-- and so a single rate edit can cascade to every part using it. Snapshot semantics are replaced by a live link
+-- (with ON DELETE SET NULL preserving the last tier values when a rate is removed).
+
+BEGIN;
+
+ALTER TABLE public.parts
+  ADD COLUMN markup_rate_id uuid REFERENCES public.markup_rates(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_parts_markup_rate_id
+  ON public.parts (markup_rate_id);
+
+-- Existing rows start as NULL ("Custom"). Per the design decision recorded with this change,
+-- we do not auto-match by breakpoints — users re-apply rates as needed.
+
+COMMIT;

--- a/types/part.ts
+++ b/types/part.ts
@@ -6,6 +6,13 @@ export interface Part {
   company_id: string;
   part_name: string;
   description: string | null;
+  // Null when the part's pricing tiers are custom (manually edited or no rate
+  // ever applied). Otherwise points to the markup_rates row driving this
+  // part's tier breakpoints — edits to that rate cascade into the part's tiers.
+  markup_rate_id: string | null;
+  // Populated by getAllParts via the markup_rates join. Undefined when the
+  // caller didn't request the join.
+  markup_rate_name?: string | null;
   created_at: string;
   updated_at: string;
   // Optional relation counts (populated by getPartWithRelations)

--- a/utils/markupRatesAccess.ts
+++ b/utils/markupRatesAccess.ts
@@ -79,10 +79,22 @@ export async function createMarkupRate(
   return data as MarkupRate;
 }
 
+/**
+ * Result of an update that cascaded to linked parts. `partsUpdated` is the
+ * count of parts whose tiers were re-snapshotted from the new breakpoints;
+ * `partsFailed` lists per-part errors so the edit UI can surface them instead
+ * of swallowing them silently.
+ */
+export interface MarkupRateUpdateResult {
+  rate: MarkupRate;
+  partsUpdated: number;
+  partsFailed: Array<{ partId: string; error: string }>;
+}
+
 export async function updateMarkupRate(
   rateId: string,
   formData: MarkupRateFormData,
-): Promise<MarkupRate> {
+): Promise<MarkupRateUpdateResult> {
   const supabase = getSupabase();
 
   // Promoting this rate to default? Demote any existing default in the same
@@ -118,7 +130,14 @@ export async function updateMarkupRate(
     throw error;
   }
 
-  return data as MarkupRate;
+  const rate = data as MarkupRate;
+
+  // Cascade: every part linked to this rate gets its tiers re-snapshotted from
+  // the new breakpoints. Per-part unit_price recomputes against each part's
+  // own routing inside replaceTiersForPart.
+  const cascade = await cascadeRateUpdateToParts(rate.company_id, rate.id);
+
+  return { rate, partsUpdated: cascade.updated, partsFailed: cascade.failed };
 }
 
 /**
@@ -167,6 +186,34 @@ export async function getDefaultMarkupRate(companyId: string): Promise<MarkupRat
   return (data as MarkupRate) ?? null;
 }
 
+function breakpointsToTierInputs(rate: MarkupRate): PartPricingTierInput[] {
+  return [...rate.breakpoints]
+    .sort((a, b) => a.qty - b.qty)
+    .map((bp, i) => ({
+      sequence: (i + 1) * 10,
+      quantity: bp.qty,
+      markup_percent: bp.markup_percent,
+    }));
+}
+
+/**
+ * Apply a specific markup rate to a single part: replaces the part's tiers
+ * with the rate's breakpoints and links the part to that rate. Used by the
+ * per-part PartPricing UI and by the bulk-apply flow.
+ */
+export async function applyRateToPart(
+  companyId: string,
+  partId: string,
+  rateId: string,
+): Promise<void> {
+  const rate = await getMarkupRate(rateId);
+  if (!rate) {
+    throw new Error(`Markup rate ${rateId} not found`);
+  }
+  const tiers = breakpointsToTierInputs(rate);
+  await replaceTiersForPart(companyId, partId, tiers, { rateId: rate.id });
+}
+
 /**
  * Snapshot the company's default markup rate's breakpoints into a part's
  * pricing tiers. Used by createPart to give new parts an initial set of
@@ -183,15 +230,85 @@ export async function applyDefaultRateToPart(
   const defaultRate = await getDefaultMarkupRate(companyId);
   if (!defaultRate || defaultRate.breakpoints.length === 0) return;
 
-  const tiers: PartPricingTierInput[] = [...defaultRate.breakpoints]
-    .sort((a, b) => a.qty - b.qty)
-    .map((bp, i) => ({
-      sequence: (i + 1) * 10,
-      quantity: bp.qty,
-      markup_percent: bp.markup_percent,
-    }));
+  const tiers = breakpointsToTierInputs(defaultRate);
+  await replaceTiersForPart(companyId, partId, tiers, { rateId: defaultRate.id });
+}
 
-  await replaceTiersForPart(companyId, partId, tiers);
+/**
+ * Re-apply a rate's current breakpoints to every part linked to it. Called
+ * after a rate edit so the live-link semantic holds: editing a rate updates
+ * every part whose markup_rate_id points to it. Sequential per-part to keep
+ * recompute logic simple — pilot scale (hundreds of parts per company) is
+ * fine; revisit if a single rate ends up linked to thousands of parts.
+ */
+export async function cascadeRateUpdateToParts(
+  companyId: string,
+  rateId: string,
+): Promise<{ updated: number; failed: Array<{ partId: string; error: string }> }> {
+  const supabase = getSupabase();
+
+  const { data: linkedParts, error } = await supabase
+    .from('parts')
+    .select('id')
+    .eq('company_id', companyId)
+    .eq('markup_rate_id', rateId);
+
+  if (error) {
+    console.error('Error fetching parts linked to rate:', error);
+    throw error;
+  }
+
+  const ids = ((linkedParts || []) as Array<{ id: string }>).map((r) => r.id);
+  if (ids.length === 0) return { updated: 0, failed: [] };
+
+  const failed: Array<{ partId: string; error: string }> = [];
+  let updated = 0;
+  for (const partId of ids) {
+    try {
+      await applyRateToPart(companyId, partId, rateId);
+      updated += 1;
+    } catch (err) {
+      failed.push({
+        partId,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+    }
+  }
+  return { updated, failed };
+}
+
+/**
+ * Apply a rate to many parts in one shot. Each part gets its tiers replaced
+ * with the rate's breakpoints and its markup_rate_id set. Iterates
+ * sequentially so a single failure doesn't abort the whole batch — failures
+ * are collected and returned alongside the successes.
+ */
+export async function bulkApplyMarkupRate(
+  companyId: string,
+  partIds: string[],
+  rateId: string,
+): Promise<{ succeeded: string[]; failed: Array<{ partId: string; error: string }> }> {
+  if (partIds.length === 0) return { succeeded: [], failed: [] };
+
+  const rate = await getMarkupRate(rateId);
+  if (!rate) {
+    throw new Error(`Markup rate ${rateId} not found`);
+  }
+
+  const succeeded: string[] = [];
+  const failed: Array<{ partId: string; error: string }> = [];
+  for (const partId of partIds) {
+    try {
+      await applyRateToPart(companyId, partId, rateId);
+      succeeded.push(partId);
+    } catch (err) {
+      failed.push({
+        partId,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+    }
+  }
+  return { succeeded, failed };
 }
 
 export async function deleteMarkupRate(rateId: string): Promise<void> {

--- a/utils/partPricingTiersAccess.ts
+++ b/utils/partPricingTiersAccess.ts
@@ -44,11 +44,19 @@ export async function getTier(tierId: string): Promise<PartPricingTier | null> {
  * `base_cost × (1 + markup/100)` against the current routing. There is no
  * lock concept — typing a unit price in the UI back-calculates markup before
  * calling this function, so the markup field captured here always governs.
+ *
+ * Also updates `parts.markup_rate_id`. `opts.rateId` should be set when the
+ * caller is applying a markup rate (the rate's id), and omitted/null when the
+ * caller is committing a manual edit — manual edits flip the part to "Custom"
+ * (rate_id = null). Centralising this in one access function guarantees the
+ * invariant that tier writes and rate-link state stay in sync no matter which
+ * UI path triggered the save.
  */
 export async function replaceTiersForPart(
   companyId: string,
   partId: string,
   tiers: PartPricingTierInput[],
+  opts: { rateId?: string | null } = {},
 ): Promise<PartPricingTier[]> {
   const supabase = getSupabase();
 
@@ -112,30 +120,17 @@ export async function replaceTiersForPart(
     }
   }
 
+  // Sync the part's rate link with the caller's intent. A rate-apply path
+  // passes the rate id; a manual-edit path omits it and the part flips to
+  // Custom (null). Done last so the FK update reflects a successful tier write.
+  const nextRateId = opts.rateId ?? null;
+  const { error: rateLinkErr } = await supabase
+    .from('parts')
+    .update({ markup_rate_id: nextRateId })
+    .eq('id', partId);
+  if (rateLinkErr) throw rateLinkErr;
+
   return getTiersForPart(partId);
-}
-
-/**
- * Copy pricing tiers from one part to another. Source qty + markup are copied
- * verbatim; unit_price and base_cost_per_unit are recomputed against the
- * target part's own routing so the prices reflect target-part economics.
- */
-export async function copyTiersFromPart(
-  companyId: string,
-  sourcePartId: string,
-  targetPartId: string,
-): Promise<PartPricingTier[]> {
-  const sourceTiers = await getTiersForPart(sourcePartId);
-  if (sourceTiers.length === 0) return getTiersForPart(targetPartId);
-
-  // Existing target tiers are replaced — copy semantics, not merge.
-  const inputs: PartPricingTierInput[] = sourceTiers.map((t, i) => ({
-    sequence: (i + 1) * 10,
-    quantity: t.quantity,
-    markup_percent: t.markup_percent,
-  }));
-
-  return replaceTiersForPart(companyId, targetPartId, inputs);
 }
 
 /**

--- a/utils/partPricingTiersAccess.ts
+++ b/utils/partPricingTiersAccess.ts
@@ -134,6 +134,25 @@ export async function replaceTiersForPart(
 }
 
 /**
+ * Update only the part's markup_rate_id without touching its tiers. Used by
+ * the "Switch to Custom" affordance — flips the part to Custom while
+ * preserving the current tier values as the editable starting point. Pass
+ * `null` to clear, or a rate id to link without re-snapshotting (the apply-
+ * rate paths already handle re-snapshotting).
+ */
+export async function setPartMarkupRate(
+  partId: string,
+  rateId: string | null,
+): Promise<void> {
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from('parts')
+    .update({ markup_rate_id: rateId })
+    .eq('id', partId);
+  if (error) throw error;
+}
+
+/**
  * Delete a single tier.
  */
 export async function deleteTier(tierId: string): Promise<void> {

--- a/utils/partsAccess.ts
+++ b/utils/partsAccess.ts
@@ -20,7 +20,7 @@ export async function getAllParts(
   while (hasMore) {
     let query = supabase
       .from('parts')
-      .select('*, routings(id)')
+      .select('*, routings(id), markup_rates(id, name)')
       .eq('company_id', companyId)
       .order(sortField, { ascending: sortDirection === 'asc' })
       .range(offset, offset + BATCH_SIZE - 1);
@@ -44,11 +44,14 @@ export async function getAllParts(
   return allData.map((part) => {
     const routings = part.routings as Array<{ id: string }> | { id: string } | null;
     const routingRecord = Array.isArray(routings) ? routings[0] : routings;
+    const rateRel = part.markup_rates as { id: string; name: string } | null;
     return {
       id: part.id as string,
       company_id: part.company_id as string,
       part_name: part.part_name as string,
       description: part.description as string | null,
+      markup_rate_id: (part.markup_rate_id as string | null) ?? null,
+      markup_rate_name: rateRel?.name ?? null,
       created_at: part.created_at as string,
       updated_at: part.updated_at as string,
       routing: routingRecord
@@ -94,6 +97,7 @@ export async function getPartsPaginated(
     company_id: part.company_id as string,
     part_name: part.part_name as string,
     description: part.description as string | null,
+    markup_rate_id: (part.markup_rate_id as string | null) ?? null,
     created_at: part.created_at as string,
     updated_at: part.updated_at as string,
   }));


### PR DESCRIPTION
## Summary
- Replace "Copy markup from another part" with a `parts.markup_rate_id` FK so each part is either linked to a named markup rate or "Custom"
- Live cascade: editing a markup rate now re-snapshots breakpoints into every linked part's pricing tiers (reverses the prior snapshot-only design)
- Parts list shows the rate name (or "Custom") in a new "Markup" column and supports bulk-apply via toolbar

## Behaviour details
- New migration adds `parts.markup_rate_id` (nullable, `ON DELETE SET NULL`). Existing rows backfill to NULL — every part starts as "Custom"; users re-apply rates as needed
- Apply-rate path (per-part menu and bulk dialog) goes through `applyRateToPart` which sets the FK and snapshots tiers in one shot
- Manually editing a tier on a linked part flips it to Custom — enforced centrally in `replaceTiersForPart`'s default `opts.rateId = null`
- Rate deletion flips referencing parts to Custom and **keeps** their last tier values, so no pricing data is lost
- `updateMarkupRate` now returns `{ rate, partsUpdated, partsFailed }`; the rate edit form surfaces partial cascade failures inline

## Test plan
- [ ] Apply migration `20260502_parts_markup_rate_link.sql` against staging; confirm column + index exist and all existing parts are NULL
- [ ] Regenerate `supabase/schema.{prod,staging}.sql` with `python scripts/export_schema.py`
- [ ] New part inherits the company's default rate (FK + tiers) via `applyDefaultRateToPart`
- [ ] Per-part: apply "Volume tiers" → Markup column shows "Volume tiers"; manually edit a tier → flips to "Custom"
- [ ] Parts list bulk: select 3 parts → "Apply rate (3)" → success snackbar shows count; rows update
- [ ] Edit "Volume tiers" breakpoints → linked parts' tier rows update; edit form shows partial-failure warning if any parts fail
- [ ] Delete a rate that's linked to ≥1 part → those parts flip to "Custom" and retain their last tier values
- [ ] `grep copyTiersFromPart` is empty across the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)