### PR TITLE
Fix stale post-unify quote queries on at-risk jobs and revenue

### DIFF
--- a/utils/alertsAccess.ts
+++ b/utils/alertsAccess.ts
@@ -30,14 +30,18 @@ interface JobOperationRow {
   estimated_run_minutes_per_unit: number | null;
 }
 
+interface JobPartRow {
+  quantity: number | null;
+  job_operations: JobOperationRow[] | null;
+}
+
 interface JobRow {
   id: string;
   job_number: string | null;
   status: string;
   created_at: string | null;
   customers: { name: string | null } | null;
-  quotes: { quantity: number | null } | null;
-  job_operations: JobOperationRow[] | null;
+  job_parts: JobPartRow[] | null;
 }
 
 interface InventoryRow {
@@ -57,8 +61,10 @@ export async function getAtRiskJobs(companyId: string): Promise<AtRiskJob[]> {
       `
       id, job_number, status, created_at,
       customers!left(name),
-      quotes!jobs_quote_id_fkey(quantity),
-      job_operations(id, status, estimated_setup_minutes, estimated_run_minutes_per_unit)
+      job_parts(
+        quantity,
+        job_operations(id, status, estimated_setup_minutes, estimated_run_minutes_per_unit)
+      )
       `
     )
     .eq('company_id', companyId)
@@ -71,20 +77,23 @@ export async function getAtRiskJobs(companyId: string): Promise<AtRiskJob[]> {
   const atRisk: AtRiskJob[] = [];
 
   for (const job of jobs) {
-    const operations = job.job_operations ?? [];
-    if (operations.length === 0) continue;
-
-    const quantity = Number(job.quotes?.quantity ?? 1) || 1;
-    const totalOps = operations.length;
-    const completedOps = operations.filter((op) => op.status === 'completed').length;
-    const pctComplete = totalOps > 0 ? (completedOps / totalOps) * 100 : 0;
-
+    let totalOps = 0;
+    let completedOps = 0;
     let totalEstimatedHours = 0;
-    for (const op of operations) {
-      const setupMin = Number(op.estimated_setup_minutes ?? 0) || 0;
-      const runMin = Number(op.estimated_run_minutes_per_unit ?? 0) || 0;
-      totalEstimatedHours += (setupMin + runMin * quantity) / 60;
+
+    for (const part of job.job_parts ?? []) {
+      const partQty = Number(part.quantity ?? 1) || 1;
+      for (const op of part.job_operations ?? []) {
+        totalOps++;
+        if (op.status === 'completed') completedOps++;
+        const setupMin = Number(op.estimated_setup_minutes ?? 0) || 0;
+        const runMin = Number(op.estimated_run_minutes_per_unit ?? 0) || 0;
+        totalEstimatedHours += (setupMin + runMin * partQty) / 60;
+      }
     }
+
+    if (totalOps === 0) continue;
+    const pctComplete = (completedOps / totalOps) * 100;
 
     const createdMs = job.created_at ? Date.parse(job.created_at) : NaN;
     const elapsedHours = Number.isFinite(createdMs)

--- a/utils/dashboardAccess.ts
+++ b/utils/dashboardAccess.ts
@@ -245,7 +245,7 @@ async function getRevenueInRange(
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('jobs')
-    .select('id, quotes!jobs_quote_id_fkey(total_price)')
+    .select('id, quotes!jobs_quote_id_fkey(quote_line_items(total_price))')
     .eq('company_id', companyId)
     .eq('status', 'shipped')
     .gte('shipped_at', startIso)
@@ -253,12 +253,14 @@ async function getRevenueInRange(
 
   if (error) throw error;
 
-  return (data || []).reduce(
-    (sum: number, job: { quotes: { total_price: number | null } | null }) => {
-      return sum + (job.quotes?.total_price || 0);
-    },
-    0
-  );
+  type Row = {
+    quotes: { quote_line_items: { total_price: number | null }[] | null } | null;
+  };
+
+  return ((data || []) as unknown as Row[]).reduce((sum, job) => {
+    const lines = job.quotes?.quote_line_items ?? [];
+    return sum + lines.reduce((s, li) => s + (li.total_price || 0), 0);
+  }, 0);
 }
 
 async function getCompletedJobsInRange(


### PR DESCRIPTION
## Summary

Two access-layer queries were carrying pre-unify shape:

- **`utils/alertsAccess.ts:60`** (at-risk-jobs / `AlertBadge`) selected `quotes.quantity` — now lives on `job_parts` after the multi-part-jobs migration. This is the 400 that was firing on every dashboard mount in prod (`column parts.markup_rate_id does not exist` was the first symptom; this was the next).
- **`utils/dashboardAccess.ts:248`** (`getRevenueInRange`) selected `quotes.total_price` — now lives on `quote_line_items`. Same failure mode, hit when the dashboard's revenue chart loads.

Both 400 from PostgREST regardless of whether any rows match — the column reference itself is invalid against the new schema, so even an empty result set still errors.

### `alertsAccess` change
Traverse `jobs → job_parts → job_operations` and weight each op's runtime by its part's quantity. This is the right answer for multi-part jobs anyway — the prior code used a single quote-level quantity that collapsed multi-part work to one number.

### `dashboardAccess` change
Sum `quote_line_items.total_price` per quote. Preserves the prior semantics (revenue per shipped job = source quote's total) without inventing new aggregation logic; the double-counting risk if two jobs share one quote is the same as before.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Verify the parts page (and any other page mounting `AlertBadge`) loads on prod after merge
- [ ] Verify the dashboard revenue chart renders without 400s
- [ ] Spot-check at-risk-jobs output: quantities should now reflect each `job_part`'s quantity, not a single per-job number

🤖 Generated with [Claude Code](https://claude.com/claude-code)