### PR TITLE
Fix failing E2E suite: sign in as test user instead of using service-role

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,6 +37,14 @@ jobs:
           E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          # Service-role seed for e2e/global-setup.ts (added in bfc4938 but
+          # never wired up here, which is why the suite started failing with
+          # "Cannot seed E2E fixtures — missing env vars"). Must point at the
+          # same Supabase project the Vercel preview targets (staging).
+          SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+          E2E_TEST_COMPANY_ID: ${{ secrets.E2E_TEST_COMPANY_ID }}
+          E2E_TEST_USER_ID: ${{ secrets.E2E_TEST_USER_ID }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,14 +37,14 @@ jobs:
           E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-          # Service-role seed for e2e/global-setup.ts (added in bfc4938 but
-          # never wired up here, which is why the suite started failing with
-          # "Cannot seed E2E fixtures — missing env vars"). Must point at the
-          # same Supabase project the Vercel preview targets (staging).
-          SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+          # Seed env for e2e/global-setup.ts (added in bfc4938 but never
+          # wired up, which is why the suite has been failing with "Cannot
+          # seed E2E fixtures — missing env vars"). global-setup signs in as
+          # E2E_TEST_EMAIL and writes through RLS, so only the public anon
+          # key is needed — no service-role secret in CI.
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           E2E_TEST_COMPANY_ID: ${{ secrets.E2E_TEST_COMPANY_ID }}
-          E2E_TEST_USER_ID: ${{ secrets.E2E_TEST_USER_ID }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -9,16 +9,19 @@ session, seeded once per run via `global-setup.ts`.
 Create `e2e/.env.test.local` (gitignored) with:
 
 ```bash
-# Auth — used by e2e/auth.setup.ts to log in via the real UI
+# Auth — used by e2e/auth.setup.ts to log in via the real UI AND by
+# e2e/global-setup.ts to authenticate before seeding fixtures.
 E2E_TEST_EMAIL=...
 E2E_TEST_PASSWORD=...
 
-# Service-role seed — used by e2e/global-setup.ts to populate the test
-# company before any spec runs. NEVER commit these.
+# Seed config — global-setup.ts signs in as E2E_TEST_EMAIL and writes
+# fixtures through RLS using the public anon key (no service-role
+# secret in CI). The test user must have a user_company_access row for
+# E2E_TEST_COMPANY_ID (any role — operator/user/admin all satisfy the
+# RLS predicate).
 SUPABASE_URL=https://<project>.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=eyJ...
+NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ... (same value the browser uses)
 E2E_TEST_COMPANY_ID=<uuid of the company E2E_TEST_EMAIL has access to>
-E2E_TEST_USER_ID=<uuid of the E2E auth user>
 
 # Optional — bypass Vercel Deployment Protection on preview URLs
 VERCEL_AUTOMATION_BYPASS_SECRET=...
@@ -29,9 +32,9 @@ PLAYWRIGHT_TEST_BASE_URL=https://your-preview.vercel.app
 E2E_TEARDOWN_SEEDED=1
 ```
 
-If any of the four service-role variables are missing,
-`global-setup.ts` prints the missing list and exits 1 — silent skipping
-left specs failing with confusing "Autocomplete is empty" timeouts.
+If any of the seed-config variables are missing, `global-setup.ts`
+prints the missing list and exits 1 — silent skipping left specs
+failing with confusing "Autocomplete is empty" timeouts.
 
 ## What gets seeded
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -11,16 +11,24 @@
  * `legacy_id` column (e.g. legacy_id='E2E_SEED_v1'). On each run we look up by
  * marker and skip the insert if it exists. Re-runs are safe.
  *
- * Why service role: this script bypasses RLS so it can write into the test
- * company without going through the auth flow. The service role key MUST
- * never be loaded into a browser bundle — it's only ever used here, in the
- * Node-side global setup.
+ * Why we sign in as the test user (and not service-role): every table we
+ * write to (vendors, work_centers, customers, parts, routings,
+ * routing_operations, parts_bom) has an RLS policy of the form
+ *   company_id IN (SELECT company_id FROM user_company_access WHERE user_id = auth.uid())
+ * So an authenticated user with access to E2E_TEST_COMPANY_ID can do every
+ * insert legitimately, no RLS bypass required. Avoiding the service-role key
+ * shrinks the CI secret surface — if a future seed step actually needs
+ * admin powers (e.g. seeding auth.users or RLS-immune tables), reintroduce
+ * the service-role client at that boundary only, not for the whole script.
  *
  * Env contract:
- *   SUPABASE_URL                — Supabase project URL (e.g. staging)
- *   SUPABASE_SERVICE_ROLE_KEY   — service role JWT (bypasses RLS)
- *   E2E_TEST_COMPANY_ID         — UUID of the company the E2E user belongs to
- *   E2E_TEST_USER_ID            — UUID of the E2E test user
+ *   SUPABASE_URL                       — Supabase project URL (e.g. staging)
+ *   NEXT_PUBLIC_SUPABASE_ANON_KEY      — public key the browser already uses
+ *   E2E_TEST_COMPANY_ID                — UUID of the company the E2E user belongs to
+ *   E2E_TEST_EMAIL / E2E_TEST_PASSWORD — credentials for sign-in (also used by auth.setup.ts)
+ *
+ * The E2E user must have a `user_company_access` row for E2E_TEST_COMPANY_ID
+ * (any role — operator/user/admin all satisfy the RLS predicate).
  *
  * If any are missing we exit 1 — silent skipping would leave specs failing
  * with confusing "Autocomplete is empty" timeouts.
@@ -52,22 +60,29 @@ const PART_SUB_NAME = 'E2E-SUB-001';
 
 interface SeedEnv {
   url: string;
-  serviceRoleKey: string;
+  anonKey: string;
   companyId: string;
-  userId: string;
+  email: string;
+  password: string;
 }
 
 function readEnvOrExit(): SeedEnv {
   const missing: string[] = [];
   const url = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+  const anonKey =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+    process.env.SUPABASE_ANON_KEY ??
+    process.env.SUPABASE_PUBLISHABLE_KEY ??
+    '';
   const companyId = process.env.E2E_TEST_COMPANY_ID ?? '';
-  const userId = process.env.E2E_TEST_USER_ID ?? '';
+  const email = process.env.E2E_TEST_EMAIL ?? '';
+  const password = process.env.E2E_TEST_PASSWORD ?? '';
 
   if (!url) missing.push('SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL)');
-  if (!serviceRoleKey) missing.push('SUPABASE_SERVICE_ROLE_KEY');
+  if (!anonKey) missing.push('NEXT_PUBLIC_SUPABASE_ANON_KEY (or SUPABASE_ANON_KEY)');
   if (!companyId) missing.push('E2E_TEST_COMPANY_ID');
-  if (!userId) missing.push('E2E_TEST_USER_ID');
+  if (!email) missing.push('E2E_TEST_EMAIL');
+  if (!password) missing.push('E2E_TEST_PASSWORD');
 
   if (missing.length > 0) {
     console.error(
@@ -78,13 +93,25 @@ function readEnvOrExit(): SeedEnv {
     process.exit(1);
   }
 
-  return { url, serviceRoleKey, companyId, userId };
+  return { url, anonKey, companyId, email, password };
 }
 
-function makeAdminClient({ url, serviceRoleKey }: SeedEnv): SupabaseClient {
-  return createClient(url, serviceRoleKey, {
+async function makeAuthenticatedClient(env: SeedEnv): Promise<SupabaseClient> {
+  const supabase = createClient(env.url, env.anonKey, {
     auth: { persistSession: false, autoRefreshToken: false },
   });
+  const { error } = await supabase.auth.signInWithPassword({
+    email: env.email,
+    password: env.password,
+  });
+  if (error) {
+    throw new Error(
+      `[e2e/global-setup] Failed to sign in as ${env.email}: ${error.message}. ` +
+        `The E2E test user must exist on this Supabase project and have a ` +
+        `user_company_access row for E2E_TEST_COMPANY_ID.`,
+    );
+  }
+  return supabase;
 }
 
 /**
@@ -312,7 +339,7 @@ async function ensureBomEdge(
 
 export default async function globalSetup(): Promise<void> {
   const env = readEnvOrExit();
-  const supabase = makeAdminClient(env);
+  const supabase = await makeAuthenticatedClient(env);
 
   // eslint-disable-next-line no-console
   console.log(`[e2e/global-setup] Seeding fixtures into company ${env.companyId}…`);

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -7,9 +7,14 @@
  * of: ≥1 vendor, ≥1 internal + ≥1 external work_center, ≥1 customer, ≥1
  * manufacturable part with a routing op, ≥1 stockable raw, ≥1 BOM child.
  *
- * Idempotency strategy: every seeded row carries a sentinel marker via the
- * `legacy_id` column (e.g. legacy_id='E2E_SEED_v1'). On each run we look up by
- * marker and skip the insert if it exists. Re-runs are safe.
+ * Idempotency strategy: every seeded row carries a per-row sentinel via the
+ * `legacy_id` column shaped as `${E2E_SEED_MARKER}:${stable_name}` (e.g.
+ * `E2E_SEED_v1:E2E-MFG-001`). The per-row suffix is required because
+ * `parts_legacy_id_unique_per_company` (and the equivalent on vendors)
+ * forbids two rows in one company sharing the same legacy_id. Lookups
+ * happen by stable name (which also has UNIQUE-per-company constraints),
+ * so the marker is purely for teardown — `legacy_id LIKE 'E2E_SEED_v1%'`
+ * cleanly scopes deletes to seeded rows. Re-runs are safe.
  *
  * Why we sign in as the test user (and not service-role): every table we
  * write to (vendors, work_centers, customers, parts, routings,
@@ -42,9 +47,14 @@ import path from 'path';
 // E2E credentials once.
 dotenv.config({ path: path.resolve(__dirname, '.env.test.local') });
 
-/** Sentinel that tags every row seeded by this script. Bump version when
- *  the seed shape changes so old rows can be migrated cleanly. */
+/** Sentinel prefix that tags every row seeded by this script. Each row's
+ *  legacy_id is `${E2E_SEED_MARKER}:${stable_name}` so the per-company
+ *  legacy_id UNIQUE constraint is satisfied. Bump version when the seed
+ *  shape changes so old rows fall out of the prefix match cleanly. */
 export const E2E_SEED_MARKER = 'E2E_SEED_v1';
+
+/** Build the per-row legacy_id tag for a given stable name. */
+const seedTag = (name: string) => `${E2E_SEED_MARKER}:${name}`;
 
 /** Customer name we look up to detect prior seeds (customers has no
  *  legacy_id column on its schema, so we scope by name + company). */
@@ -141,7 +151,7 @@ async function ensureVendor(
     .insert({
       company_id: companyId,
       name: VENDOR_NAME,
-      legacy_id: E2E_SEED_MARKER,
+      legacy_id: seedTag(VENDOR_NAME),
     })
     .select('id')
     .single();
@@ -248,7 +258,7 @@ async function ensurePart(
       primary_unit: spec.primary_unit,
       quantity: spec.quantity,
       cost_per_unit: spec.cost_per_unit,
-      legacy_id: E2E_SEED_MARKER,
+      legacy_id: seedTag(spec.part_name),
     })
     .select('id')
     .single();

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -131,12 +131,16 @@ async function ensureVendor(
   if (lookupErr) throw new Error(`vendor lookup failed: ${lookupErr.message}`);
   if (existing) return existing.id;
 
+  // The vendors table dropped contact_name/email/phone/notes in
+  // 20260504_vendor_contacts_and_drop_notes — contacts now live on a
+  // separate vendor_contacts row. None of the current specs touch vendor
+  // contact info, so we don't seed a vendor_contacts row here; if a spec
+  // needs one later, add an ensureVendorContact helper alongside this.
   const { data, error } = await supabase
     .from('vendors')
     .insert({
       company_id: companyId,
       name: VENDOR_NAME,
-      contact_email: 'e2e-vendor@example.com',
       legacy_id: E2E_SEED_MARKER,
     })
     .select('id')

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -60,11 +60,15 @@ export default async function globalTeardown(): Promise<void> {
 
   // Find tagged parts first; we need their IDs to clean up routings + BOM
   // edges before deleting the parts themselves.
+  // Prefix match because every seeded row's legacy_id is shaped
+  // `${E2E_SEED_MARKER}:${stable_name}` (per-row to satisfy the
+  // per-company legacy_id UNIQUE constraint). The trailing `%` also
+  // catches any bare-marker rows from earlier seed-script versions.
   const { data: taggedParts } = await supabase
     .from('parts')
     .select('id')
     .eq('company_id', env.companyId)
-    .eq('legacy_id', E2E_SEED_MARKER);
+    .like('legacy_id', `${E2E_SEED_MARKER}%`);
   const partIds = (taggedParts ?? []).map((p: { id: string }) => p.id);
 
   if (partIds.length > 0) {
@@ -87,12 +91,12 @@ export default async function globalTeardown(): Promise<void> {
     .eq('company_id', env.companyId)
     .like('description', 'E2E seed (%');
 
-  // Tagged vendors
+  // Tagged vendors (same prefix-match rationale as parts above).
   await supabase
     .from('vendors')
     .delete()
     .eq('company_id', env.companyId)
-    .eq('legacy_id', E2E_SEED_MARKER);
+    .like('legacy_id', `${E2E_SEED_MARKER}%`);
 
   // eslint-disable-next-line no-console
   console.log('[e2e/global-teardown] Done.');

--- a/e2e/parts-and-routing.spec.ts
+++ b/e2e/parts-and-routing.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { navigateTo } from './helpers/navigation';
+import { navigateTo, waitForGridLoaded } from './helpers/navigation';
 
 /**
  * E2E: Parts + Routing workflow
@@ -63,21 +63,24 @@ test.describe('Parts and Routing workflow', () => {
     // editor row at the bottom of the Operations list (no dialog).
     await page.getByRole('button', { name: /Add Operation/i }).click();
 
-    // Open the Work center autocomplete and select the first available option.
-    // (Renamed from "Operation" in PR 1 — operations now reference work_centers.)
+    // Open the Work center autocomplete. Pick `E2E Internal WC` explicitly
+    // — the seed (e2e/global-setup.ts) creates both an Internal and an
+    // External WC, alphabetical sort puts the External one first, and
+    // selecting an external WC reshapes the editor to vendor-price fields
+    // (no Cycle minutes per unit), which would break the next assertion.
     await page.getByLabel(/^Work center$/).click();
 
     const listbox = page.getByRole('listbox');
-    const firstOption = listbox.getByRole('option').first();
-    const hasOperations = await firstOption
+    const internalWcOption = listbox.getByRole('option', { name: /E2E Internal WC/ });
+    const hasInternalWc = await internalWcOption
       .isVisible({ timeout: 10_000 })
       .catch(() => false);
 
-    if (!hasOperations) {
-      test.skip(true, 'No work centers exist in test company');
+    if (!hasInternalWc) {
+      test.skip(true, 'E2E Internal WC missing from test company (seed should have created it)');
     }
 
-    await firstOption.click();
+    await internalWcOption.click();
 
     // Editor requires at least one of cycle / setup minutes before save will
     // commit (see RoutingOperationRowEditor validation). Fill cycle minutes.
@@ -102,9 +105,21 @@ test.describe('Parts and Routing workflow', () => {
     // ── Step 4: Navigate back to parts list and verify ──
 
     await navigateTo(page, 'Parts');
-    await expect(page).toHaveURL(/\/parts/);
+    // The /\/parts/ pattern would also match /parts/{id}; require the path
+    // to end at /parts so we know we actually left the detail page.
+    await expect(page).toHaveURL(/\/parts(?:\?|$)/);
 
-    // The part should appear in the list
-    await expect(page.getByText(partName)).toBeVisible({ timeout: 10_000 });
+    // Wait for AG Grid to finish loading before asserting on cell content —
+    // otherwise the assertion races against the loading overlay and trips
+    // strict mode against any DOM Next.js still has cached from the
+    // previous /parts/{id} route.
+    await waitForGridLoaded(page);
+
+    // The part should appear in the grid. Scope the text query to the grid
+    // wrapper to avoid strict-mode collisions with any cached/lingering DOM
+    // from the previous route.
+    await expect(
+      page.locator('.ag-root-wrapper').getByText(partName).first()
+    ).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/e2e/parts-and-routing.spec.ts
+++ b/e2e/parts-and-routing.spec.ts
@@ -21,20 +21,27 @@ test.describe('Parts and Routing workflow', () => {
     await navigateTo(page, 'Parts');
     await expect(page).toHaveURL(/\/parts/);
 
+    // "Add Part" now opens an inline PartFormModal instead of navigating to
+    // /parts/new — scope all field interactions to the dialog so we don't
+    // accidentally match the (off-screen) parts list behind it.
     await page.getByRole('button', { name: /Add Part/i }).click();
-    await expect(page).toHaveURL(/\/parts\/new/);
+    const partFormDialog = page.getByRole('dialog');
+    await expect(partFormDialog).toBeVisible();
 
-    // Fill part name (required)
-    await page.getByLabel(/Part Name/i).fill(partName);
+    // Fill part name (required) — Source defaults to 'made' (the modal's
+    // default), which is what the rest of this spec needs to exercise the
+    // routing panel.
+    await partFormDialog.getByLabel(/Part Name/i).fill(partName);
 
     // Fill description
-    await page.getByLabel(/Description/i).fill(partDescription);
+    await partFormDialog.getByLabel(/Description/i).fill(partDescription);
 
-    // Save the part
-    await page.getByRole('button', { name: /^Save$/i }).click();
+    // Submit — primary action is "Create" (was "Save" in the route-based form).
+    await partFormDialog.getByRole('button', { name: /^Create$/i }).click();
 
-    // Should redirect to the part detail page (not /parts/new)
-    await expect(page).toHaveURL(/\/parts\/(?!new)[^/]+$/, { timeout: 15_000 });
+    // After creation the modal closes and we land on the part detail page
+    // (`/parts/{partId}?from=parts`). Anchor on the partId path segment.
+    await expect(page).toHaveURL(/\/parts\/(?!new)[^/]+/, { timeout: 15_000 });
 
     // Verify the part was created
     await expect(page.getByText(partName)).toBeVisible();

--- a/e2e/parts-and-routing.spec.ts
+++ b/e2e/parts-and-routing.spec.ts
@@ -43,8 +43,11 @@ test.describe('Parts and Routing workflow', () => {
     // (`/parts/{partId}?from=parts`). Anchor on the partId path segment.
     await expect(page).toHaveURL(/\/parts\/(?!new)[^/]+/, { timeout: 15_000 });
 
-    // Verify the part was created
-    await expect(page.getByText(partName)).toBeVisible();
+    // Verify the part was created. The part detail page renders the part
+    // name in the page heading AND inside the BOM panel's descriptive copy
+    // ("Parts consumed when manufacturing this <name>."), so a bare
+    // getByText trips strict mode — scope to the heading.
+    await expect(page.getByRole('heading', { name: partName })).toBeVisible();
 
     // ── Step 2: Add an operation via the inline routing editor ──
     // The routing panel is embedded on the part detail page — no navigation needed.

--- a/e2e/parts-and-routing.spec.ts
+++ b/e2e/parts-and-routing.spec.ts
@@ -21,7 +21,7 @@ test.describe('Parts and Routing workflow', () => {
     await navigateTo(page, 'Parts');
     await expect(page).toHaveURL(/\/parts/);
 
-    await page.getByRole('button', { name: /New Part/i }).click();
+    await page.getByRole('button', { name: /Add Part/i }).click();
     await expect(page).toHaveURL(/\/parts\/new/);
 
     // Fill part name (required)


### PR DESCRIPTION
## Summary

Two-part fix for the E2E suite that's been failing on every preview deploy with `Cannot seed E2E fixtures — missing env vars`.

The unify-parts merge (`bfc4938`) added [e2e/global-setup.ts](e2e/global-setup.ts) — a one-time pre-flight that seeds fixture data (1 vendor, 2 work_centers, 1 customer, 3 parts, 1 routing, 1 BOM edge) into the test company. The CI workflow was never updated to forward the env vars it needs, so the suite has been crashing before any spec runs.

### Why not just plumb service-role through?
The first commit on this branch did exactly that. Reading the seed script more carefully (and per the prompt to keep service-role keys out of CI), the script never actually needed RLS bypass — every table it touches has a policy of the form `company_id IN (SELECT company_id FROM user_company_access WHERE user_id = auth.uid())`. The script's own comment admitted bypassing RLS was a shortcut. So the second commit on this branch refactors `global-setup.ts` to sign in as the existing E2E test user and write through RLS, which lets us drop the service-role secret from CI entirely.

### Env contract changes
- **drop** `SUPABASE_SERVICE_ROLE_KEY` (was: RLS bypass; now unnecessary)
- **drop** `E2E_TEST_USER_ID` (was declared in the env contract but never read by the code)
- **add** `NEXT_PUBLIC_SUPABASE_ANON_KEY` (same value the browser already uses)
- **unchanged**: `SUPABASE_URL`, `E2E_TEST_COMPANY_ID`, `E2E_TEST_EMAIL`, `E2E_TEST_PASSWORD` — the email/password vars now do double duty (auth.setup.ts + global-setup.ts)

Workflow uses unprefixed secret names (`SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`) since these are just staging Supabase config, not E2E-specific.

### Pre-req
The test user (`E2E_TEST_EMAIL`) must have a `user_company_access` row for `E2E_TEST_COMPANY_ID`. Any role satisfies the RLS predicate — operator/user/admin all work; no admin requirement.

### If admin powers ever become necessary
If a future seed step needs `auth.users` writes, RLS-immune tables, or cross-company access, reintroduce a service-role client *at that boundary only* — don't regress the whole script back to admin-mode for one operation.

## Repo secrets — confirmed in place

Per the screenshot you shared:

- `E2E_TEST_COMPANY_ID` ✓
- `E2E_TEST_EMAIL` ✓
- `E2E_TEST_PASSWORD` ✓
- `NEXT_PUBLIC_SUPABASE_ANON_KEY` ✓
- `SUPABASE_URL` ✓
- `VERCEL_AUTOMATION_BYPASS_SECRET` ✓

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Trigger a preview deploy; confirm the workflow gets past `global-setup` and specs actually run
- [ ] If you hit `Failed to sign in as <email>: ...`, the test user is missing the `user_company_access` row for `E2E_TEST_COMPANY_ID` — that's the only configuration the new path adds
- [ ] Spot-check the `e2e/README.md` env contract still matches what's in the local `e2e/.env.test.local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)