### PR TITLE
CSV import polish + inventory Import button + page-title + vendor cleanup

### DIFF
--- a/app/dashboard/[companyId]/inventory/page.tsx
+++ b/app/dashboard/[companyId]/inventory/page.tsx
@@ -24,6 +24,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import Inventory2Icon from '@mui/icons-material/Inventory2';
+import UploadIcon from '@mui/icons-material/Upload';
 
 import { AgGridReact } from 'ag-grid-react';
 import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
@@ -342,6 +343,13 @@ export default function InventoryPage() {
         </Typography>
         <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center' }}>
           <Button
+            variant="outlined"
+            startIcon={<UploadIcon />}
+            onClick={() => router.push(`/dashboard/${companyId}/parts/import`)}
+          >
+            Import CSV
+          </Button>
+          <Button
             variant="contained"
             startIcon={<AddIcon />}
             onClick={() => setAddModalOpen(true)}
@@ -407,6 +415,14 @@ export default function InventoryPage() {
         )}
 
         <Box sx={{ flex: 1 }} />
+
+        <Button
+          variant="outlined"
+          startIcon={<UploadIcon />}
+          onClick={() => router.push(`/dashboard/${companyId}/parts/import`)}
+        >
+          Import
+        </Button>
 
         <Button
           variant="contained"

--- a/app/dashboard/[companyId]/vendors/[vendorId]/page.tsx
+++ b/app/dashboard/[companyId]/vendors/[vendorId]/page.tsx
@@ -37,7 +37,7 @@ import NextLink from 'next/link';
 import MuiLink from '@mui/material/Link';
 
 import {
-  getVendorWithDerivedRoles,
+  getVendor,
   deleteVendor,
   getPartsByPreferredVendor,
   getWorkCentersByVendor,
@@ -49,7 +49,7 @@ import {
 } from '@/utils/vendorContactsAccess';
 import { roleDisplayLabel } from '@/types/vendorContact';
 import type { VendorContact } from '@/types/vendorContact';
-import type { VendorWithDerivedRoles } from '@/types/vendor';
+import type { Vendor } from '@/types/vendor';
 import { VendorContactModal } from '@/components/vendors';
 
 interface LinkedPart {
@@ -70,7 +70,7 @@ export default function VendorDetailPage() {
   const companyId = params.companyId as string;
   const vendorId = params.vendorId as string;
 
-  const [vendor, setVendor] = useState<VendorWithDerivedRoles | null>(null);
+  const [vendor, setVendor] = useState<Vendor | null>(null);
   const [contacts, setContacts] = useState<VendorContact[]>([]);
   const [linkedParts, setLinkedParts] = useState<LinkedPart[]>([]);
   const [linkedWorkCenters, setLinkedWorkCenters] = useState<LinkedWorkCenter[]>([]);
@@ -93,7 +93,7 @@ export default function VendorDetailPage() {
   const fetchAll = useCallback(async () => {
     try {
       setLoading(true);
-      const v = await getVendorWithDerivedRoles(vendorId);
+      const v = await getVendor(vendorId);
       setVendor(v);
       if (v) {
         const [parts, wcs, contactList] = await Promise.all([
@@ -116,12 +116,8 @@ export default function VendorDetailPage() {
   // Lighter refresh after a contact mutation — no need to reload parts/wcs.
   const refreshContacts = useCallback(async () => {
     try {
-      const [contactList, v] = await Promise.all([
-        getContactsForVendor(vendorId),
-        getVendorWithDerivedRoles(vendorId),
-      ]);
+      const contactList = await getContactsForVendor(vendorId);
       setContacts(contactList);
-      setVendor(v);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to refresh contacts');
     }
@@ -213,8 +209,8 @@ export default function VendorDetailPage() {
     );
   }
 
-  const supplies = vendor.supplies_materials_count > 0;
-  const outside = vendor.performs_outside_ops_count > 0;
+  const supplies = linkedParts.length > 0;
+  const outside = linkedWorkCenters.length > 0;
   const hasReferences = supplies || outside;
 
   const contactBeingDeleted = deleteContactId
@@ -281,44 +277,29 @@ export default function VendorDetailPage() {
         </Alert>
       )}
 
-      {/* Header card with name + derived role chips */}
+      {/* Header card with name + created/updated timestamps top-right. */}
       <Card elevation={2} sx={{ mb: 3 }}>
         <CardContent>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
+              gap: 2,
+              flexWrap: 'wrap',
+            }}
+          >
             <Typography variant="h5" sx={{ fontWeight: 600 }}>
               {vendor.name}
             </Typography>
-            {!supplies && !outside ? (
-              <Chip
-                size="small"
-                label="No references yet"
-                sx={{ fontWeight: 500 }}
-                variant="outlined"
-              />
-            ) : (
-              <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
-                {supplies && (
-                  <Chip
-                    label={`Supplies materials · ${vendor.supplies_materials_count} part${vendor.supplies_materials_count === 1 ? '' : 's'}`}
-                    sx={{
-                      fontWeight: 500,
-                      bgcolor: 'success.dark',
-                      color: 'common.white',
-                    }}
-                  />
-                )}
-                {outside && (
-                  <Chip
-                    label={`Performs outside ops · ${vendor.performs_outside_ops_count} routing${vendor.performs_outside_ops_count === 1 ? '' : 's'}`}
-                    sx={{
-                      fontWeight: 500,
-                      bgcolor: 'warning.dark',
-                      color: 'common.white',
-                    }}
-                  />
-                )}
-              </Stack>
-            )}
+            <Box sx={{ textAlign: 'right' }}>
+              <Typography variant="caption" color="text.secondary" display="block">
+                Created {formatDate(vendor.created_at)}
+              </Typography>
+              <Typography variant="caption" color="text.secondary" display="block">
+                Updated {formatDate(vendor.updated_at)}
+              </Typography>
+            </Box>
           </Box>
         </CardContent>
       </Card>
@@ -541,7 +522,7 @@ export default function VendorDetailPage() {
                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                   <Typography variant="subtitle1" fontWeight={500}>
                     Parts using this vendor as preferred supplier (
-                    {vendor.supplies_materials_count})
+                    {linkedParts.length})
                   </Typography>
                 </AccordionSummary>
                 <AccordionDetails sx={{ pt: 0 }}>
@@ -573,7 +554,7 @@ export default function VendorDetailPage() {
                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                   <Typography variant="subtitle1" fontWeight={500}>
                     Work centers performing outside ops at this vendor (
-                    {vendor.performs_outside_ops_count})
+                    {linkedWorkCenters.length})
                   </Typography>
                 </AccordionSummary>
                 <AccordionDetails sx={{ pt: 0 }}>
@@ -604,43 +585,6 @@ export default function VendorDetailPage() {
           </Card>
         </Grid>
 
-        {/* Metadata — non-prominent. legacy_id is the import-only identifier
-            for re-import idempotency; useful for support, not for daily use. */}
-        <Grid size={{ xs: 12 }}>
-          <Card elevation={1} sx={{ bgcolor: 'background.default' }}>
-            <CardContent>
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{ textTransform: 'uppercase', letterSpacing: 0.5, fontWeight: 600 }}
-              >
-                Metadata
-              </Typography>
-              <Box sx={{ mt: 1, display: 'flex', flexWrap: 'wrap', gap: 4 }}>
-                <Box>
-                  <Typography variant="body2" color="text.secondary">
-                    Legacy ID
-                  </Typography>
-                  <Typography variant="body2" fontFamily="monospace">
-                    {vendor.legacy_id || '—'}
-                  </Typography>
-                </Box>
-                <Box>
-                  <Typography variant="body2" color="text.secondary">
-                    Created
-                  </Typography>
-                  <Typography variant="body2">{formatDate(vendor.created_at)}</Typography>
-                </Box>
-                <Box>
-                  <Typography variant="body2" color="text.secondary">
-                    Updated
-                  </Typography>
-                  <Typography variant="body2">{formatDate(vendor.updated_at)}</Typography>
-                </Box>
-              </Box>
-            </CardContent>
-          </Card>
-        </Grid>
       </Grid>
 
       {/* Add / Edit contact modal */}
@@ -703,11 +647,11 @@ export default function VendorDetailPage() {
             <Alert severity="warning" sx={{ mt: 2 }}>
               This vendor is referenced by{' '}
               {supplies
-                ? `${vendor.supplies_materials_count} part${vendor.supplies_materials_count === 1 ? '' : 's'} (preferred supplier)`
+                ? `${linkedParts.length} part${linkedParts.length === 1 ? '' : 's'} (preferred supplier)`
                 : null}
               {supplies && outside ? ' and ' : ''}
               {outside
-                ? `${vendor.performs_outside_ops_count} work center${vendor.performs_outside_ops_count === 1 ? '' : 's'}`
+                ? `${linkedWorkCenters.length} work center${linkedWorkCenters.length === 1 ? '' : 's'}`
                 : null}
               . Remove those references before deleting.
             </Alert>

--- a/app/dashboard/[companyId]/vendors/page.tsx
+++ b/app/dashboard/[companyId]/vendors/page.tsx
@@ -16,12 +16,6 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Alert from '@mui/material/Alert';
 import Snackbar from '@mui/material/Snackbar';
-import Chip from '@mui/material/Chip';
-import Stack from '@mui/material/Stack';
-import FormControl from '@mui/material/FormControl';
-import InputLabel from '@mui/material/InputLabel';
-import Select from '@mui/material/Select';
-import MenuItem from '@mui/material/MenuItem';
 import SearchIcon from '@mui/icons-material/Search';
 import AddIcon from '@mui/icons-material/Add';
 import UploadIcon from '@mui/icons-material/Upload';
@@ -37,47 +31,34 @@ import type {
   SortChangedEvent,
   RowClickedEvent,
   CellKeyDownEvent,
-  ICellRendererParams,
 } from 'ag-grid-community';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
 
 import { jiggedAgGridTheme } from '@/lib/agGridTheme';
 import {
-  getAllVendorsWithDerivedRoles,
+  getAllVendorsWithPrimaryContact,
   bulkDeleteVendors,
 } from '@/utils/vendorsAccess';
 import ExportCsvButton from '@/components/common/ExportCsvButton';
-import type { VendorWithDerivedRoles } from '@/types/vendor';
-
-/**
- * Role-filter values:
- *  - 'all'      → no filter
- *  - 'supplies' → supplies_materials_count > 0
- *  - 'outside'  → performs_outside_ops_count > 0
- *  - 'both'     → both > 0
- *  - 'neither'  → both === 0 (vendor exists but nothing references it yet —
- *                 common right after import before classifications are set)
- */
-type RoleFilter = 'all' | 'supplies' | 'outside' | 'both' | 'neither';
+import type { VendorWithPrimaryContact } from '@/types/vendor';
 
 export default function VendorsPage() {
   const router = useRouter();
   const params = useParams();
   const companyId = params.companyId as string;
 
-  const [allRows, setAllRows] = useState<VendorWithDerivedRoles[]>([]);
+  const [rows, setRows] = useState<VendorWithPrimaryContact[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [searchDebounced, setSearchDebounced] = useState('');
-  const [roleFilter, setRoleFilter] = useState<RoleFilter>('all');
   const [sortModel, setSortModel] = useState<{ field: string; sort: 'asc' | 'desc' }>({
     field: 'name',
     sort: 'asc',
   });
 
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const gridRef = useRef<AgGridReact<VendorWithDerivedRoles>>(null);
+  const gridRef = useRef<AgGridReact<VendorWithPrimaryContact>>(null);
 
   const [deleteDialog, setDeleteDialog] = useState<{ open: boolean }>({ open: false });
   const [deleting, setDeleting] = useState(false);
@@ -96,17 +77,13 @@ export default function VendorsPage() {
   const fetchRows = useCallback(async () => {
     setLoading(true);
     try {
-      // Sort by `name` even when the user sorts by a derived-count column —
-      // the count columns aren't queryable, so we let AG Grid sort them
-      // client-side over the already-fetched set.
-      const sortField = sortModel.field === 'name' ? 'name' : 'name';
-      const data = await getAllVendorsWithDerivedRoles(
+      const data = await getAllVendorsWithPrimaryContact(
         companyId,
         searchDebounced,
-        sortField,
+        sortModel.field,
         sortModel.sort,
       );
-      setAllRows(data);
+      setRows(data);
     } catch (err) {
       console.error('Error fetching vendors:', err);
       setSnackbar({
@@ -123,38 +100,12 @@ export default function VendorsPage() {
     fetchRows();
   }, [fetchRows]);
 
-  // Client-side role filter operates on the derived counts. Both counts come
-  // from the same `getAllVendorsWithDerivedRoles` query — there's no second
-  // round-trip needed when the filter changes.
-  const rows = useMemo(() => {
-    switch (roleFilter) {
-      case 'supplies':
-        return allRows.filter(
-          (v) => v.supplies_materials_count > 0 && v.performs_outside_ops_count === 0,
-        );
-      case 'outside':
-        return allRows.filter(
-          (v) => v.performs_outside_ops_count > 0 && v.supplies_materials_count === 0,
-        );
-      case 'both':
-        return allRows.filter(
-          (v) => v.supplies_materials_count > 0 && v.performs_outside_ops_count > 0,
-        );
-      case 'neither':
-        return allRows.filter(
-          (v) => v.supplies_materials_count === 0 && v.performs_outside_ops_count === 0,
-        );
-      default:
-        return allRows;
-    }
-  }, [allRows, roleFilter]);
-
   useEffect(() => {
     setSelectedIds([]);
     if (gridRef.current?.api) {
       gridRef.current.api.deselectAll();
     }
-  }, [searchDebounced, roleFilter]);
+  }, [searchDebounced]);
 
   const gridHeight = useMemo(() => {
     if (loading || rows.length === 0) return 600;
@@ -165,7 +116,7 @@ export default function VendorsPage() {
     return Math.max(headerHeight + rowHeight * displayedRows + paginationHeight, 400);
   }, [loading, rows.length]);
 
-  const handleGridReady = (event: GridReadyEvent<VendorWithDerivedRoles>) => {
+  const handleGridReady = (event: GridReadyEvent<VendorWithPrimaryContact>) => {
     event.api.applyColumnState({
       state: [{ colId: 'name', sort: 'asc' }],
       defaultState: { sort: null },
@@ -185,7 +136,7 @@ export default function VendorsPage() {
     }
   };
 
-  const handleSelectionChanged = (event: SelectionChangedEvent<VendorWithDerivedRoles>) => {
+  const handleSelectionChanged = (event: SelectionChangedEvent<VendorWithPrimaryContact>) => {
     const selectedNodes = event.api.getSelectedNodes();
     const selectedData = selectedNodes
       .map((node) => node.data?.id)
@@ -193,13 +144,13 @@ export default function VendorsPage() {
     setSelectedIds(selectedData);
   };
 
-  const handleRowClicked = (event: RowClickedEvent<VendorWithDerivedRoles>) => {
+  const handleRowClicked = (event: RowClickedEvent<VendorWithPrimaryContact>) => {
     if (event.data) {
       router.push(`/dashboard/${companyId}/vendors/${event.data.id}`);
     }
   };
 
-  const handleCellKeyDown = (event: CellKeyDownEvent<VendorWithDerivedRoles>) => {
+  const handleCellKeyDown = (event: CellKeyDownEvent<VendorWithPrimaryContact>) => {
     const keyboardEvent = event.event as KeyboardEvent | undefined;
     if (keyboardEvent?.key === 'Enter' && event.data) {
       router.push(`/dashboard/${companyId}/vendors/${event.data.id}`);
@@ -240,60 +191,13 @@ export default function VendorsPage() {
     return new Date(val).toLocaleDateString();
   };
 
-  const columnDefs: ColDef<VendorWithDerivedRoles>[] = [
+  const columnDefs: ColDef<VendorWithPrimaryContact>[] = [
     {
       field: 'name',
       headerName: 'Name',
       flex: 1.5,
       minWidth: 200,
       pinned: 'left' as const,
-    },
-    {
-      colId: 'roles',
-      headerName: 'Roles',
-      flex: 1.5,
-      minWidth: 280,
-      sortable: false,
-      // Cell renders both derived-role chips, with em-dash if neither role is set.
-      cellRenderer: (params: ICellRendererParams<VendorWithDerivedRoles>) => {
-        const v = params.data;
-        if (!v) return null;
-        const supplies = v.supplies_materials_count > 0;
-        const outside = v.performs_outside_ops_count > 0;
-        if (!supplies && !outside) {
-          return (
-            <Typography variant="body2" color="text.secondary">
-              —
-            </Typography>
-          );
-        }
-        return (
-          <Stack direction="row" spacing={0.5} sx={{ flexWrap: 'wrap', alignItems: 'center' }}>
-            {supplies && (
-              <Chip
-                size="small"
-                label={`Supplies materials · ${v.supplies_materials_count} part${v.supplies_materials_count === 1 ? '' : 's'}`}
-                sx={{
-                  fontWeight: 500,
-                  bgcolor: 'success.dark',
-                  color: 'common.white',
-                }}
-              />
-            )}
-            {outside && (
-              <Chip
-                size="small"
-                label={`Performs outside ops · ${v.performs_outside_ops_count} routing${v.performs_outside_ops_count === 1 ? '' : 's'}`}
-                sx={{
-                  fontWeight: 500,
-                  bgcolor: 'warning.dark',
-                  color: 'common.white',
-                }}
-              />
-            )}
-          </Stack>
-        );
-      },
     },
     {
       colId: 'contact',
@@ -362,22 +266,6 @@ export default function VendorsPage() {
           }}
         />
 
-        <FormControl size="small" sx={{ minWidth: 200 }}>
-          <InputLabel id="role-filter-label">Filter by role</InputLabel>
-          <Select
-            labelId="role-filter-label"
-            value={roleFilter}
-            label="Filter by role"
-            onChange={(e) => setRoleFilter(e.target.value as RoleFilter)}
-          >
-            <MenuItem value="all">All</MenuItem>
-            <MenuItem value="supplies">Supplies materials</MenuItem>
-            <MenuItem value="outside">Performs outside ops</MenuItem>
-            <MenuItem value="both">Both</MenuItem>
-            <MenuItem value="neither">Neither (unreferenced)</MenuItem>
-          </Select>
-        </FormControl>
-
         {selectedIds.length > 0 && (
           <>
             <ExportCsvButton
@@ -425,11 +313,11 @@ export default function VendorsPage() {
               No vendors yet
             </Typography>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-              {searchDebounced || roleFilter !== 'all'
-                ? 'No vendors match your filters.'
+              {searchDebounced
+                ? 'No vendors match your search.'
                 : 'Add your first vendor or import from CSV.'}
             </Typography>
-            {!searchDebounced && roleFilter === 'all' && (
+            {!searchDebounced && (
               <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center' }}>
                 <Button
                   variant="outlined"
@@ -464,7 +352,7 @@ export default function VendorsPage() {
               },
             }}
           >
-            <AgGridReact<VendorWithDerivedRoles>
+            <AgGridReact<VendorWithPrimaryContact>
               ref={gridRef}
               rowData={rows}
               columnDefs={columnDefs}

--- a/app/dashboard/[companyId]/work-centers/page.tsx
+++ b/app/dashboard/[companyId]/work-centers/page.tsx
@@ -276,6 +276,7 @@ export default function WorkCentersPage() {
           (nodeA.data?.labor_rate ?? -Infinity) - (nodeB.data?.labor_rate ?? -Infinity)
         );
       },
+      cellStyle: { display: 'flex', alignItems: 'center' },
       cellRenderer: (params: ICellRendererParams<WorkCenterRow>) => {
         const wc = params.data;
         if (!wc) return null;
@@ -285,7 +286,7 @@ export default function WorkCentersPage() {
               variant="body2"
               sx={{ fontStyle: 'italic', color: 'text.secondary' }}
             >
-              Per routing op
+              Per operation
             </Typography>
           );
         }

--- a/components/feedback/FeedbackDialog.tsx
+++ b/components/feedback/FeedbackDialog.tsx
@@ -78,6 +78,24 @@ function getPageTitle(pathname: string): string {
   if (segments.includes('settings')) return 'Settings';
   if (segments.includes('team')) return 'Team';
 
+  if (segments.includes('vendors')) {
+    if (segments.includes('new')) return 'New Vendor';
+    if (segments.includes('edit')) return 'Edit Vendor';
+    if (segments.includes('import')) return 'Import Vendors';
+    const idx = segments.indexOf('vendors');
+    if (idx < segments.length - 1 && !['new', 'edit', 'import'].includes(segments[idx + 1])) return 'Vendor Details';
+    return 'Vendors';
+  }
+
+  if (segments.includes('work-centers')) {
+    if (segments.includes('new')) return 'New Work Center';
+    if (segments.includes('edit')) return 'Edit Work Center';
+    if (segments.includes('import')) return 'Import Work Centers';
+    const idx = segments.indexOf('work-centers');
+    if (idx < segments.length - 1 && !['new', 'edit', 'import'].includes(segments[idx + 1])) return 'Work Center Details';
+    return 'Work Centers';
+  }
+
   return 'Dashboard';
 }
 

--- a/components/import/ConflictDialog.tsx
+++ b/components/import/ConflictDialog.tsx
@@ -14,7 +14,33 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Box from '@mui/material/Box';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import DownloadIcon from '@mui/icons-material/Download';
 import type { ConflictDialogProps } from './types';
+
+function escapeCsvField(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function downloadCsv(filename: string, headers: string[], rows: (string | number)[][]): void {
+  const lines = [headers.map(escapeCsvField).join(',')];
+  for (const row of rows) {
+    lines.push(row.map(escapeCsvField).join(','));
+  }
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
 
 /**
  * Shared dialog for displaying import conflicts and validation errors.
@@ -41,12 +67,27 @@ export default function ConflictDialog<
   const errorRowNumbers = new Set(validationErrors.map((e) => e.row_number));
   const totalSkippedRows = new Set([...conflictRowNumbers, ...errorRowNumbers]).size;
 
-  // Limit displayed items
-  const maxDisplayed = 8;
-  const displayedConflicts = conflicts.slice(0, maxDisplayed);
-  const hasMoreConflicts = conflicts.length > maxDisplayed;
-  const displayedErrors = validationErrors.slice(0, 5);
-  const hasMoreErrors = validationErrors.length > 5;
+  const entitySlug = entityName.toLowerCase().replace(/\s+/g, '-');
+
+  const handleDownloadConflicts = () => {
+    const headers = ['Row', ...conflictColumns.map((c) => c.label), 'Conflict', 'Conflicting With'];
+    const rows = conflicts.map((conflict) => {
+      const record = conflict as Record<string, unknown>;
+      return [
+        conflict.row_number,
+        ...conflictColumns.map((col) => (record[col.key] as string) ?? ''),
+        getConflictLabel(conflict),
+        (record.existing_value as string) ?? '',
+      ];
+    });
+    downloadCsv(`${entitySlug}-import-conflicts.csv`, headers, rows);
+  };
+
+  const handleDownloadErrors = () => {
+    const headers = ['Row', 'Error'];
+    const rows = validationErrors.map((error) => [error.row_number, getErrorMessage(error)]);
+    downloadCsv(`${entitySlug}-import-errors.csv`, headers, rows);
+  };
 
   return (
     <Dialog open={open} onClose={onCancel} maxWidth="md" fullWidth>
@@ -86,10 +127,19 @@ export default function ConflictDialog<
         {/* Conflicts Table */}
         {conflicts.length > 0 && (
           <>
-            <Typography variant="subtitle2" gutterBottom sx={{ fontWeight: 600 }}>
-              Conflicting Rows ({conflicts.length})
-            </Typography>
-            <TableContainer sx={{ maxHeight: 300 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+              <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                Conflicting Rows ({conflicts.length})
+              </Typography>
+              <Button
+                size="small"
+                startIcon={<DownloadIcon />}
+                onClick={handleDownloadConflicts}
+              >
+                Download CSV
+              </Button>
+            </Box>
+            <TableContainer sx={{ maxHeight: 360 }}>
               <Table size="small" stickyHeader>
                 <TableHead>
                   <TableRow>
@@ -104,7 +154,7 @@ export default function ConflictDialog<
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {displayedConflicts.map((conflict, idx) => (
+                  {conflicts.map((conflict, idx) => (
                     <TableRow key={`${conflict.row_number}-${idx}`}>
                       <TableCell>{conflict.row_number}</TableCell>
                       {conflictColumns.map((col) => (
@@ -127,21 +177,25 @@ export default function ConflictDialog<
                 </TableBody>
               </Table>
             </TableContainer>
-            {hasMoreConflicts && (
-              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                ... and {conflicts.length - maxDisplayed} more conflicts
-              </Typography>
-            )}
           </>
         )}
 
         {/* Validation Errors Table */}
         {validationErrors.length > 0 && (
           <>
-            <Typography variant="subtitle2" gutterBottom sx={{ fontWeight: 600, mt: 3 }}>
-              Validation Errors ({validationErrors.length})
-            </Typography>
-            <TableContainer sx={{ maxHeight: 200 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mt: 3, mb: 1 }}>
+              <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                Validation Errors ({validationErrors.length})
+              </Typography>
+              <Button
+                size="small"
+                startIcon={<DownloadIcon />}
+                onClick={handleDownloadErrors}
+              >
+                Download CSV
+              </Button>
+            </Box>
+            <TableContainer sx={{ maxHeight: 300 }}>
               <Table size="small" stickyHeader>
                 <TableHead>
                   <TableRow>
@@ -150,7 +204,7 @@ export default function ConflictDialog<
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {displayedErrors.map((error, idx) => (
+                  {validationErrors.map((error, idx) => (
                     <TableRow key={`${error.row_number}-${idx}`}>
                       <TableCell>{error.row_number}</TableCell>
                       <TableCell>
@@ -163,11 +217,6 @@ export default function ConflictDialog<
                 </TableBody>
               </Table>
             </TableContainer>
-            {hasMoreErrors && (
-              <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-                ... and {validationErrors.length - 5} more errors
-              </Typography>
-            )}
           </>
         )}
       </DialogContent>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -96,6 +96,35 @@ function getPageTitle(pathname: string): string {
     return 'Markup Rates';
   }
 
+  // Check for vendors routes
+  if (segments.includes('vendors')) {
+    if (segments.includes('new')) return 'New Vendor';
+    if (segments.includes('edit')) return 'Edit Vendor';
+    if (segments.includes('import')) return 'Import Vendors';
+    const vendorsIndex = segments.indexOf('vendors');
+    if (vendorsIndex < segments.length - 1 && !['new', 'edit', 'import'].includes(segments[vendorsIndex + 1])) {
+      return 'Vendor Details';
+    }
+    return 'Vendors';
+  }
+
+  // Check for work-centers routes
+  if (segments.includes('work-centers')) {
+    if (segments.includes('new')) return 'New Work Center';
+    if (segments.includes('edit')) return 'Edit Work Center';
+    if (segments.includes('import')) return 'Import Work Centers';
+    const wcIndex = segments.indexOf('work-centers');
+    if (wcIndex < segments.length - 1 && !['new', 'edit', 'import'].includes(segments[wcIndex + 1])) {
+      return 'Work Center Details';
+    }
+    return 'Work Centers';
+  }
+
+  // Check for team routes
+  if (segments.includes('team')) {
+    return 'Team';
+  }
+
   // Map other route segments to display titles
   const titleMap: Record<string, string> = {};
 

--- a/types/vendor.ts
+++ b/types/vendor.ts
@@ -40,16 +40,13 @@ export interface VendorFormData {
 }
 
 /**
- * Vendor + the derived role counts the list page renders, plus the joined
- * primary contact (if any). `primary_contact` is hydrated by
- * `getAllVendorsWithDerivedRoles` and `getVendorWithDerivedRoles` via a
- * LEFT JOIN to vendor_contacts WHERE is_primary=true. May be null when
- * the vendor has no contacts yet (a legitimate state — see the migration's
- * NOTICE log for vendors that arrived in this state from the backfill).
+ * Vendor + its joined primary contact (if any). `primary_contact` is hydrated
+ * by `getAllVendorsWithPrimaryContact` via a lookup against vendor_contacts
+ * WHERE is_primary=true. May be null when the vendor has no contacts yet
+ * (a legitimate state — see the migration's NOTICE log for vendors that
+ * arrived in this state from the backfill).
  */
-export interface VendorWithDerivedRoles extends Vendor {
-  supplies_materials_count: number;
-  performs_outside_ops_count: number;
+export interface VendorWithPrimaryContact extends Vendor {
   primary_contact: VendorContact | null;
 }
 

--- a/utils/vendorsAccess.ts
+++ b/utils/vendorsAccess.ts
@@ -2,7 +2,7 @@ import { getSupabase } from '@/lib/supabase';
 import type {
   Vendor,
   VendorFormData,
-  VendorWithDerivedRoles,
+  VendorWithPrimaryContact,
   VendorImportResult,
 } from '@/types/vendor';
 import type {
@@ -68,72 +68,17 @@ export async function getVendor(vendorId: string): Promise<Vendor | null> {
 }
 
 /**
- * Hydrate a single vendor with its derived role counts:
- * supplies materials = parts where preferred_vendor_id = vendor.id;
- * performs outside ops = work_centers where vendor_id = vendor.id.
- *
- * Also fetches the vendor's primary contact (if any) for display in the
- * detail page header / list contact column. `primary_contact` is null when
- * the vendor has no contact rows or no contact is marked is_primary
- * (legitimate state — see the migration's NOTICE log).
+ * List all vendors with their primary contact (if any) joined in. Primary
+ * contacts come from a single query against vendor_contacts
+ * WHERE is_primary=true; the result is stitched onto each vendor by
+ * vendor_id (null when no primary exists).
  */
-export async function getVendorWithDerivedRoles(
-  vendorId: string,
-): Promise<VendorWithDerivedRoles | null> {
-  const supabase = getSupabase();
-
-  const vendor = await getVendor(vendorId);
-  if (!vendor) return null;
-
-  const [
-    { count: suppliesCount, error: supError },
-    { count: opsCount, error: opError },
-    { data: primaryRows, error: contactError },
-  ] = await Promise.all([
-    supabase
-      .from('parts')
-      .select('*', { count: 'exact', head: true })
-      .eq('preferred_vendor_id', vendorId),
-    supabase
-      .from('work_centers')
-      .select('*', { count: 'exact', head: true })
-      .eq('vendor_id', vendorId),
-    supabase
-      .from('vendor_contacts')
-      .select(VENDOR_CONTACT_COLUMNS)
-      .eq('vendor_id', vendorId)
-      .eq('is_primary', true)
-      .limit(1),
-  ]);
-
-  if (supError) throw supError;
-  if (opError) throw opError;
-  if (contactError) throw contactError;
-
-  const primaryContact =
-    ((primaryRows || []) as VendorContact[])[0] || null;
-
-  return {
-    ...vendor,
-    supplies_materials_count: suppliesCount || 0,
-    performs_outside_ops_count: opsCount || 0,
-    primary_contact: primaryContact,
-  };
-}
-
-/**
- * List all vendors with their derived role counts in a single round trip.
- * The role counts come from two aggregate queries fanned across the company,
- * not row-by-row. Primary contacts come from a single query against
- * vendor_contacts WHERE is_primary=true; the result is stitched onto each
- * vendor by vendor_id (null when no primary exists).
- */
-export async function getAllVendorsWithDerivedRoles(
+export async function getAllVendorsWithPrimaryContact(
   companyId: string,
   search: string = '',
   sortField: string = 'name',
   sortDirection: 'asc' | 'desc' = 'asc',
-): Promise<VendorWithDerivedRoles[]> {
+): Promise<VendorWithPrimaryContact[]> {
   const supabase = getSupabase();
 
   const vendors = await getAllVendors(companyId, search, sortField, sortDirection);
@@ -141,44 +86,13 @@ export async function getAllVendorsWithDerivedRoles(
 
   const vendorIds = vendors.map((v) => v.id);
 
-  const [
-    { data: partRows, error: partError },
-    { data: wcRows, error: wcError },
-    { data: contactRows, error: contactError },
-  ] = await Promise.all([
-    supabase
-      .from('parts')
-      .select('preferred_vendor_id')
-      .eq('company_id', companyId)
-      .not('preferred_vendor_id', 'is', null),
-    supabase
-      .from('work_centers')
-      .select('vendor_id')
-      .eq('company_id', companyId)
-      .not('vendor_id', 'is', null),
-    supabase
-      .from('vendor_contacts')
-      .select(VENDOR_CONTACT_COLUMNS)
-      .in('vendor_id', vendorIds)
-      .eq('is_primary', true),
-  ]);
+  const { data: contactRows, error: contactError } = await supabase
+    .from('vendor_contacts')
+    .select(VENDOR_CONTACT_COLUMNS)
+    .in('vendor_id', vendorIds)
+    .eq('is_primary', true);
 
-  if (partError) throw partError;
-  if (wcError) throw wcError;
   if (contactError) throw contactError;
-
-  const suppliesByVendor = new Map<string, number>();
-  for (const r of (partRows || []) as Array<{ preferred_vendor_id: string }>) {
-    suppliesByVendor.set(
-      r.preferred_vendor_id,
-      (suppliesByVendor.get(r.preferred_vendor_id) || 0) + 1,
-    );
-  }
-
-  const opsByVendor = new Map<string, number>();
-  for (const r of (wcRows || []) as Array<{ vendor_id: string }>) {
-    opsByVendor.set(r.vendor_id, (opsByVendor.get(r.vendor_id) || 0) + 1);
-  }
 
   const primaryByVendor = new Map<string, VendorContact>();
   for (const c of (contactRows || []) as VendorContact[]) {
@@ -187,8 +101,6 @@ export async function getAllVendorsWithDerivedRoles(
 
   return vendors.map((v) => ({
     ...v,
-    supplies_materials_count: suppliesByVendor.get(v.id) || 0,
-    performs_outside_ops_count: opsByVendor.get(v.id) || 0,
     primary_contact: primaryByVendor.get(v.id) || null,
   }));
 }


### PR DESCRIPTION
## Summary

A small UX-polish bundle hitting four areas surfaced during a screen-by-screen review.

### 1. CSV import "Issues Detected" dialog

- Conflicts/errors were truncated at 8 / 5 with a static "... and N more" footer. The TableContainer was already scrollable (maxHeight + stickyHeader), but the data was sliced before render.
- Removes the slice so all conflicts and all errors render inside the existing scrollable containers.
- Adds a **Download CSV** button on each section header — exports the full list to `<entity>-import-conflicts.csv` / `<entity>-import-errors.csv` (entity-aware filename: vendors, customers, parts, BOM, work centers).
- Slight max-height bump (conflicts 300 → 360, errors 200 → 300).

Shared component, so the fix applies to all five import flows.

### 2. Inventory page now has an Import button

- The inventory list page only exposed "Add Item"; there was no way to bulk-import after the page had items.
- Adds an Import button to the toolbar (top right) and to the empty state, routing to `/parts/import`.
- Inventory items are just `parts` rows with `is_stocked=true`, so the existing parts importer already handles them — no new import pipeline needed.

### 3. Header page title no longer says "Dashboard" for Team / Vendors / Work Centers

- `getPageTitle` in `components/layout/Header.tsx` had no case for these three routes, so they fell through to "Dashboard".
- Adds branches for `team`, `vendors`, `work-centers` (plus their `new` / `edit` / `import` / detail variants).
- Mirrored in `components/feedback/FeedbackDialog.tsx` so the `page_title` saved with user feedback matches what users actually see.

### 4. Vendor detail + list cleanup

Vendor detail page:
- Drops the separate Metadata card (Legacy ID removed entirely).
- Created / Updated timestamps now sit top-right of the header card.
- Drops the derived role chips from the header — actual referencing items still appear inside the Linked Items accordion.
- Switches to the simpler `getVendor` query.

Vendor list page:
- Drops the Roles column and the "Filter by role" dropdown — the company already knows each vendor's role, so the column was noise.
- Switches to a slimmer `getAllVendorsWithPrimaryContact` query (no joins to parts / work_centers for derived counts).

The unused `getAllVendorsWithDerivedRoles` / `getVendorWithDerivedRoles` helpers and the `VendorWithDerivedRoles` type are removed; replaced with `VendorWithPrimaryContact`.

## Test plan

- [ ] Run a vendors import with >8 conflicts and >5 validation errors — confirm the full list scrolls in each table.
- [ ] Click "Download CSV" on each section; verify the file contains every row with correct columns.
- [ ] Spot-check one other import flow (customers or parts) — headers and filename adapt to the entity.
- [ ] Visit inventory page with existing items; confirm Import button appears at top right and lands on `/parts/import`.
- [ ] Visit /team, /vendors, /work-centers — header shows the module name, not "Dashboard". Spot-check nested routes (e.g. `/vendors/new`, `/work-centers/{id}`).
- [ ] Visit a vendor detail page — no Metadata card, no role chips in header, timestamps show top-right.
- [ ] Verify delete-vendor blocked state still mentions correct part / work-center counts when the vendor is referenced.
- [ ] Visit /vendors — no Roles column, no role filter, primary contact still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)