### PR TITLE
Lighten quote PDF table header for printer-friendliness

### DIFF
--- a/utils/quotePdf.ts
+++ b/utils/quotePdf.ts
@@ -263,9 +263,11 @@ export async function generateQuotePdf(
       textColor: [40, 40, 40],
     },
     headStyles: {
-      fillColor: [30, 30, 46],
-      textColor: [255, 255, 255],
+      fillColor: [240, 240, 240],
+      textColor: [30, 30, 30],
       fontStyle: 'bold',
+      lineColor: [200, 200, 200],
+      lineWidth: 0.5,
     },
     columnStyles: {
       0: { cellWidth: 90, fontStyle: 'bold' },


### PR DESCRIPTION
The header band was near-black ([30,30,46] fill + white text), which floods toner when customers print quotes on a regular office printer. Switch to a light grey fill with dark text + a soft separator line so the header still reads as a distinct band but uses minimal ink.