### PR TITLE
Add in-app quote PDF preview dialog

### DIFF
--- a/__tests__/utils/quotePdf.test.ts
+++ b/__tests__/utils/quotePdf.test.ts
@@ -56,7 +56,7 @@ vi.mock('@/utils/partPricingTiersAccess', () => ({
   getTiersForPart: vi.fn().mockResolvedValue([]),
 }));
 
-import { generateQuotePdf } from '@/utils/quotePdf';
+import { generateQuotePdf, quotePdfFilename } from '@/utils/quotePdf';
 import type { QuoteWithRelations } from '@/types/quote';
 import type { Company } from '@/utils/companyAccess';
 
@@ -125,24 +125,24 @@ describe('generateQuotePdf', () => {
     vi.clearAllMocks();
   });
 
-  it('renders and saves a PDF with a filename based on the quote number', async () => {
-    await generateQuotePdf(baseQuote, baseCompany);
+  it('returns the jsPDF doc without saving (caller decides what to do)', async () => {
+    const doc = await generateQuotePdf(baseQuote, baseCompany);
 
     expect(jsPDFCtor).toHaveBeenCalledWith({ unit: 'pt', format: 'letter' });
     // One main line items table + zero tier sub-tables (no tiers loaded).
     expect(autoTableFn).toHaveBeenCalled();
 
     const docInstance = jsPDFCtor.mock.results[0].value;
-    expect(docInstance.save).toHaveBeenCalledWith('Quote-Q000123.pdf');
+    expect(doc).toBe(docInstance);
+    // Saving is the caller's responsibility now.
+    expect(docInstance.save).not.toHaveBeenCalled();
   });
 
   it('renders without a customer (null customers) without throwing', async () => {
     const sparseQuote: QuoteWithRelations = { ...baseQuote, customers: null };
 
-    await expect(generateQuotePdf(sparseQuote, baseCompany)).resolves.toBeUndefined();
-
-    const docInstance = jsPDFCtor.mock.results[0].value;
-    expect(docInstance.save).toHaveBeenCalled();
+    const doc = await generateQuotePdf(sparseQuote, baseCompany);
+    expect(doc).toBeDefined();
   });
 
   it('renders the line items table with Part / Description / Order qty / Unit price / Total', async () => {
@@ -416,5 +416,11 @@ describe('generateQuotePdf', () => {
       .filter((t: unknown): t is string => typeof t === 'string');
 
     expect(rendered.some((t: string) => t.includes('PRICING TIERS'))).toBe(false);
+  });
+});
+
+describe('quotePdfFilename', () => {
+  it('formats as Quote-{quote_number}.pdf', () => {
+    expect(quotePdfFilename(baseQuote)).toBe('Quote-Q000123.pdf');
   });
 });

--- a/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
+++ b/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
@@ -17,7 +17,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import PrintIcon from '@mui/icons-material/Print';
+import VisibilityIcon from '@mui/icons-material/Visibility';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import Dialog from '@mui/material/Dialog';
@@ -28,7 +28,8 @@ import Chip from '@mui/material/Chip';
 
 import { getQuoteWithRelations, deleteQuote } from '@/utils/quotesAccess';
 import { getCompany } from '@/utils/companyAccess';
-import { generateQuotePdf } from '@/utils/quotePdf';
+import type { Company } from '@/utils/companyAccess';
+import QuotePdfPreviewDialog from '@/components/quotes/QuotePdfPreviewDialog';
 import { getTiersForPart } from '@/utils/partPricingTiersAccess';
 import {
   quoteToFormData,
@@ -57,7 +58,9 @@ export default function QuoteDetailPage() {
     searchParams.get('convert') === 'true'
   );
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [printing, setPrinting] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [company, setCompany] = useState<Company | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
   /** Tier reference data: part_id → all tiers for that part. */
   const [tiersByPart, setTiersByPart] = useState<Record<string, PartPricingTier[]>>({});
 
@@ -123,20 +126,23 @@ export default function QuoteDetailPage() {
     return new Date(dateStr).toLocaleDateString();
   };
 
-  const handlePrintPdf = async () => {
+  const handleOpenPreview = async () => {
     if (!quote) return;
     setError(null);
-    setPrinting(true);
+    setPreviewLoading(true);
     try {
-      const company = await getCompany(companyId);
-      if (!company) {
+      // Fetch (or reuse) the company so the preview dialog can render the
+      // shop header without doing its own data fetch.
+      const c = company ?? (await getCompany(companyId));
+      if (!c) {
         throw new Error('Company info unavailable — cannot generate PDF.');
       }
-      await generateQuotePdf(quote, company);
+      setCompany(c);
+      setPreviewOpen(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to generate PDF');
+      setError(err instanceof Error ? err.message : 'Failed to open preview');
     } finally {
-      setPrinting(false);
+      setPreviewLoading(false);
     }
   };
 
@@ -207,11 +213,11 @@ export default function QuoteDetailPage() {
         <Button
           variant="contained"
           color="primary"
-          startIcon={printing ? <CircularProgress size={16} color="inherit" /> : <PrintIcon />}
-          onClick={handlePrintPdf}
-          disabled={printing || actionLoading}
+          startIcon={previewLoading ? <CircularProgress size={16} color="inherit" /> : <VisibilityIcon />}
+          onClick={handleOpenPreview}
+          disabled={previewLoading || actionLoading}
         >
-          Print PDF
+          View PDF
         </Button>
       </Box>
 
@@ -463,6 +469,16 @@ export default function QuoteDetailPage() {
           </Card>
         </Grid>
       </Grid>
+
+      {/* Preview PDF Dialog */}
+      {company && (
+        <QuotePdfPreviewDialog
+          open={previewOpen}
+          onClose={() => setPreviewOpen(false)}
+          quote={quote}
+          company={company}
+        />
+      )}
 
       {/* Convert to Job Modal */}
       <ConvertToJobModal

--- a/components/quotes/QuotePdfPreviewDialog.tsx
+++ b/components/quotes/QuotePdfPreviewDialog.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import CloseIcon from '@mui/icons-material/Close';
+import DownloadIcon from '@mui/icons-material/Download';
+
+import type { jsPDF } from 'jspdf';
+import type { QuoteWithRelations } from '@/types/quote';
+import type { Company } from '@/utils/companyAccess';
+import { generateQuotePdf, quotePdfFilename } from '@/utils/quotePdf';
+
+interface QuotePdfPreviewDialogProps {
+  open: boolean;
+  onClose: () => void;
+  quote: QuoteWithRelations;
+  company: Company;
+}
+
+export default function QuotePdfPreviewDialog({
+  open,
+  onClose,
+  quote,
+  company,
+}: QuotePdfPreviewDialogProps) {
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const docRef = useRef<jsPDF | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let revoked: string | null = null;
+    let cancelled = false;
+    (async () => {
+      setError(null);
+      setPdfUrl(null);
+      try {
+        const doc = await generateQuotePdf(quote, company);
+        if (cancelled) return;
+        docRef.current = doc;
+        const url = doc.output('bloburl') as unknown as string;
+        revoked = url;
+        setPdfUrl(url);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to generate PDF');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (revoked) URL.revokeObjectURL(revoked);
+      docRef.current = null;
+    };
+  }, [open, quote, company]);
+
+  const handleDownload = () => {
+    const doc = docRef.current;
+    if (!doc) return;
+    doc.save(quotePdfFilename(quote));
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullScreen>
+      <DialogTitle sx={{ pr: 6 }}>
+        Preview — {quote.quote_number ?? 'Quote'}
+        <IconButton
+          aria-label="Close preview"
+          onClick={onClose}
+          sx={{ position: 'absolute', right: 12, top: 12 }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers sx={{ p: 0, bgcolor: 'background.default' }}>
+        {error && (
+          <Alert severity="error" sx={{ m: 2 }}>
+            {error}
+          </Alert>
+        )}
+        {!error && !pdfUrl && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+            <CircularProgress />
+          </Box>
+        )}
+        {pdfUrl && (
+          <Box
+            component="iframe"
+            src={pdfUrl}
+            title={`Quote ${quote.quote_number ?? ''} preview`}
+            sx={{ width: '100%', height: '100%', border: 0, display: 'block' }}
+          />
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+        <Button
+          variant="contained"
+          startIcon={<DownloadIcon />}
+          onClick={handleDownload}
+          disabled={!pdfUrl}
+        >
+          Download
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/utils/quotePdf.ts
+++ b/utils/quotePdf.ts
@@ -107,12 +107,28 @@ async function loadTiersForQuote(
 }
 
 /**
- * Generate and download a PDF for the given quote.
+ * Filename used both when downloading and when attaching to email.
+ * Single source of truth so the preview dialog, download button, and email
+ * route all label the PDF the same way.
+ */
+export function quotePdfFilename(quote: QuoteWithRelations): string {
+  return `Quote-${quote.quote_number}.pdf`;
+}
+
+/**
+ * Build the jsPDF document for a quote and return it without writing
+ * anything to disk. Callers choose how to consume it:
+ *   - doc.save(filename)              → download
+ *   - doc.output('bloburl') as string → URL for <iframe src> previews
+ *   - doc.output('blob')              → Blob for upload (e.g., email attach)
+ *
+ * Returning the doc instead of saving means one rendering path serves all
+ * three product entry points (download, preview, email-attach).
  */
 export async function generateQuotePdf(
   quote: QuoteWithRelations,
   company: Company,
-): Promise<void> {
+): Promise<jsPDF> {
   const doc = new jsPDF({ unit: 'pt', format: 'letter' });
   const pageWidth = doc.internal.pageSize.getWidth();
   const pageHeight = doc.internal.pageSize.getHeight();
@@ -440,5 +456,5 @@ export async function generateQuotePdf(
     doc.text(`Page ${p} of ${pageCount}`, pageWidth - MARGIN, footerY, { align: 'right' });
   }
 
-  doc.save(`Quote-${quote.quote_number}.pdf`);
+  return doc;
 }


### PR DESCRIPTION
Refactor generateQuotePdf to return the jsPDF doc instead of saving it directly. Same rendering path now serves three consumers: download (caller runs doc.save), in-app preview (doc.output('bloburl') into an iframe), and the future email-attach flow (doc.output('blob')).

Replace the quote detail page's "Print PDF" button with "View PDF". It opens a full-screen MUI Dialog with the PDF rendered in an iframe and a Download action in the footer. Closing the dialog revokes the blob URL.

Export quotePdfFilename so every consumer labels the file the same way.

Update tests: generateQuotePdf no longer calls .save() itself, so two test cases switch to asserting the doc is returned.