### PR TITLE
Add email-quote-to-customer flow via Resend

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -67,6 +67,7 @@ from routes.routings_import_routes import router as routings_import_router
 from routes.operators_routes import admin_router as operators_admin_router
 from routes.insights_routes import router as insights_router
 from routes.admin_routes import router as system_admin_router
+from routes.quote_email_routes import router as quote_email_router
 
 app.include_router(import_router)
 app.include_router(parts_import_router)
@@ -77,6 +78,7 @@ app.include_router(routings_import_router)
 app.include_router(operators_admin_router)
 app.include_router(insights_router)
 app.include_router(system_admin_router)
+app.include_router(quote_email_router)
 
 
 # For local development

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -18,6 +18,11 @@ google-genai>=0.3.0
 # Error monitoring
 sentry-sdk[fastapi]>=2.0.0
 
+# Outbound email (quote-to-customer, future invitation emails)
+resend>=0.17.0
+# FastAPI multipart uploads (used by /api/quotes/{id}/email for the PDF blob).
+python-multipart>=0.0.9
+
 # Database
 psycopg2-binary>=2.9.0
 asyncpg>=0.29.0

--- a/api/routes/quote_email_routes.py
+++ b/api/routes/quote_email_routes.py
@@ -1,0 +1,139 @@
+"""
+Route for emailing a quote PDF to a customer.
+
+Frontend renders the PDF client-side via jsPDF and posts the bytes up
+along with the user-edited To/Subject/Body. We don't regenerate the PDF
+on the server — the rendering logic lives in TypeScript (utils/quotePdf.ts)
+and we don't want to duplicate it in Python.
+
+Auth: caller must have a row in user_company_access for the company that
+owns the quote. The check happens with the service role client after we
+extract the user from the caller's JWT.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
+from pydantic import BaseModel
+from supabase import Client, create_client
+
+from services.email import EmailAttachment, EmailServiceUnavailable, send_email
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/quotes", tags=["quote-email"])
+
+
+def _service_client() -> Client:
+    url = os.getenv("NEXT_PUBLIC_SUPABASE_URL") or os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SECRET_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    if not url or not key:
+        raise HTTPException(status_code=503, detail="Database not configured")
+    return create_client(url, key)
+
+
+async def _verify_quote_access(request: Request, quote_id: str) -> tuple[str, dict, dict]:
+    """
+    Extract the caller's user id from the Authorization header and verify
+    they have access to the quote's company. Returns
+    (user_id, quote_row, company_row).
+    """
+    token = request.headers.get("Authorization", "").replace("Bearer ", "")
+    if not token:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    client = _service_client()
+    try:
+        user_response = client.auth.get_user(token)
+        if not user_response or not user_response.user:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        user_id = user_response.user.id
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(f"Token verification failed: {e}")
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+    quote_resp = (
+        client.table("quotes")
+        .select("id, company_id, quote_number")
+        .eq("id", quote_id)
+        .single()
+        .execute()
+    )
+    if not quote_resp.data:
+        raise HTTPException(status_code=404, detail="Quote not found")
+    quote = quote_resp.data
+
+    access = (
+        client.table("user_company_access")
+        .select("role")
+        .eq("user_id", user_id)
+        .eq("company_id", quote["company_id"])
+        .execute()
+    )
+    if not access.data:
+        raise HTTPException(status_code=403, detail="No access to this quote's company")
+
+    company_resp = (
+        client.table("companies")
+        .select("id, name, email")
+        .eq("id", quote["company_id"])
+        .single()
+        .execute()
+    )
+    if not company_resp.data:
+        raise HTTPException(status_code=404, detail="Company not found")
+
+    return user_id, quote, company_resp.data
+
+
+class EmailQuoteResponse(BaseModel):
+    message_id: str
+
+
+@router.post("/{quote_id}/email", response_model=EmailQuoteResponse)
+async def email_quote(
+    quote_id: str,
+    request: Request,
+    to: str = Form(...),
+    subject: str = Form(...),
+    body: str = Form(...),
+    cc: Optional[str] = Form(None),
+    pdf: UploadFile = File(...),
+):
+    """
+    Send a quote PDF to the given email address.
+
+    The frontend produces the PDF, the user edits the body, then we send
+    it through Resend. Reply-To is set to the company's email so customer
+    replies land in the shop's mailbox, not on a noreply alias.
+    """
+    _, quote, company = await _verify_quote_access(request, quote_id)
+
+    pdf_bytes = await pdf.read()
+    if not pdf_bytes:
+        raise HTTPException(status_code=400, detail="Empty PDF upload")
+
+    filename = f"Quote-{quote.get('quote_number') or quote_id}.pdf"
+    reply_to = company.get("email")
+
+    try:
+        message_id = send_email(
+            to=[to.strip()],
+            cc=[cc.strip()] if cc and cc.strip() else None,
+            subject=subject,
+            body_text=body,
+            reply_to=reply_to,
+            attachments=[EmailAttachment(filename=filename, content=pdf_bytes)],
+        )
+    except EmailServiceUnavailable as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except Exception as e:
+        logger.exception("email_quote failed for quote %s", quote_id)
+        raise HTTPException(status_code=500, detail=f"Failed to send email: {e}")
+
+    return EmailQuoteResponse(message_id=message_id)

--- a/api/services/email.py
+++ b/api/services/email.py
@@ -1,0 +1,113 @@
+"""
+Email service. Thin wrapper around the Resend Python SDK.
+
+Why this lives in the FastAPI backend:
+  - Resend's API key is a paid third-party secret. Per CLAUDE.md the
+    FastAPI layer is the only place we put credentials that shouldn't
+    reach the browser.
+  - The invitation-system module spec (docs/modules/invitation-system.md
+    §7) targets this same email primitive — keep send_email() generic so
+    invitation emails can ride the same plumbing later.
+
+Why this is paid-API-safe to call from a route handler:
+  - Resend bills per email, and we only invoke it on an explicit user
+    "Send" action. The route is *not* called from a useEffect or page
+    mount. (See CLAUDE.md "AI calls require an explicit user action" —
+    the same rule applies to any paid third-party call.)
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from dataclasses import dataclass
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EmailAttachment:
+    """A file to attach to an outbound email."""
+    filename: str
+    content: bytes
+    content_type: str = "application/pdf"
+
+
+class EmailServiceUnavailable(RuntimeError):
+    """Raised when RESEND_API_KEY / QUOTES_FROM_EMAIL aren't configured."""
+
+
+def send_email(
+    *,
+    to: list[str],
+    subject: str,
+    body_text: str,
+    cc: list[str] | None = None,
+    reply_to: str | None = None,
+    attachments: Sequence[EmailAttachment] = (),
+) -> str:
+    """
+    Send an email via Resend. Returns the Resend message id.
+
+    Raises:
+        EmailServiceUnavailable: when required env vars are missing —
+            surfaces as a 503 to the caller so the UI can show a clear
+            "email isn't configured yet" message instead of a generic 500.
+    """
+    api_key = os.getenv("RESEND_API_KEY")
+    from_addr = os.getenv("QUOTES_FROM_EMAIL")
+    if not api_key or not from_addr:
+        raise EmailServiceUnavailable(
+            "Email sending is not configured (set RESEND_API_KEY and "
+            "QUOTES_FROM_EMAIL)."
+        )
+
+    # Import lazily so the rest of the FastAPI app boots even when the
+    # `resend` Python SDK isn't installed (e.g., dev environments that
+    # haven't pulled the latest requirements.txt).
+    try:
+        import resend  # type: ignore
+    except ImportError as exc:
+        raise EmailServiceUnavailable(
+            "Email sending requires the `resend` Python package "
+            "(add to api/requirements.txt and pip install)."
+        ) from exc
+
+    resend.api_key = api_key
+
+    params: dict = {
+        "from": from_addr,
+        "to": to,
+        "subject": subject,
+        "text": body_text,
+    }
+    if cc:
+        params["cc"] = cc
+    if reply_to:
+        # Resend SDK accepts a string or list for reply_to.
+        params["reply_to"] = reply_to
+    if attachments:
+        # Resend expects each attachment as a dict with base64-encoded
+        # content (a list[int] also works but base64 is more compact).
+        params["attachments"] = [
+            {
+                "filename": a.filename,
+                "content": base64.b64encode(a.content).decode("ascii"),
+                "content_type": a.content_type,
+            }
+            for a in attachments
+        ]
+
+    try:
+        result = resend.Emails.send(params)
+    except Exception as exc:
+        logger.exception("Resend send failed")
+        raise RuntimeError(f"Resend send failed: {exc}") from exc
+
+    # Resend returns either {"id": "..."} (dict) or an object — handle both.
+    if isinstance(result, dict):
+        message_id = result.get("id", "")
+    else:
+        message_id = getattr(result, "id", "")
+    return str(message_id)

--- a/api/tests/unit/test_email.py
+++ b/api/tests/unit/test_email.py
@@ -1,0 +1,97 @@
+"""Unit tests for the email service wrapper."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make the api/ package importable when tests run from the repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from services.email import (  # noqa: E402
+    EmailAttachment,
+    EmailServiceUnavailable,
+    send_email,
+)
+
+
+def test_raises_when_api_key_missing(monkeypatch):
+    """Without RESEND_API_KEY we should fail loud, not silently swallow."""
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    monkeypatch.setenv("QUOTES_FROM_EMAIL", "noreply@mail.jigged.app")
+
+    with pytest.raises(EmailServiceUnavailable):
+        send_email(to=["someone@example.com"], subject="x", body_text="x")
+
+
+def test_raises_when_from_address_missing(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_test")
+    monkeypatch.delenv("QUOTES_FROM_EMAIL", raising=False)
+
+    with pytest.raises(EmailServiceUnavailable):
+        send_email(to=["someone@example.com"], subject="x", body_text="x")
+
+
+def test_sends_with_attachment(monkeypatch):
+    """Resend params should include from/to/subject/text/attachments correctly."""
+    monkeypatch.setenv("RESEND_API_KEY", "re_test")
+    monkeypatch.setenv("QUOTES_FROM_EMAIL", "noreply@mail.jigged.app")
+
+    # Build a fake resend module that records the params passed to send().
+    captured: dict = {}
+
+    class _FakeEmails:
+        @staticmethod
+        def send(params):
+            captured["params"] = params
+            return {"id": "msg_abc123"}
+
+    fake_resend = type("FakeResend", (), {"api_key": None, "Emails": _FakeEmails})
+
+    with patch.dict(sys.modules, {"resend": fake_resend}):
+        message_id = send_email(
+            to=["customer@example.com"],
+            cc=["sales@shop.example"],
+            subject="Quote Q-0001",
+            body_text="Please find attached.",
+            reply_to="shop@example.com",
+            attachments=[
+                EmailAttachment(filename="Quote-Q-0001.pdf", content=b"%PDF-1.4 ..."),
+            ],
+        )
+
+    assert message_id == "msg_abc123"
+    params = captured["params"]
+    assert params["from"] == "noreply@mail.jigged.app"
+    assert params["to"] == ["customer@example.com"]
+    assert params["cc"] == ["sales@shop.example"]
+    assert params["subject"] == "Quote Q-0001"
+    assert params["text"] == "Please find attached."
+    assert params["reply_to"] == "shop@example.com"
+    assert len(params["attachments"]) == 1
+    att = params["attachments"][0]
+    assert att["filename"] == "Quote-Q-0001.pdf"
+    # Content must be base64-encoded — not raw bytes — so Resend's JSON
+    # serializer accepts it.
+    import base64
+    assert base64.b64decode(att["content"]) == b"%PDF-1.4 ..."
+    assert att["content_type"] == "application/pdf"
+
+
+def test_send_failure_wraps_exception(monkeypatch):
+    monkeypatch.setenv("RESEND_API_KEY", "re_test")
+    monkeypatch.setenv("QUOTES_FROM_EMAIL", "noreply@mail.jigged.app")
+
+    class _FakeEmails:
+        @staticmethod
+        def send(params):
+            raise RuntimeError("Resend 500")
+
+    fake_resend = type("FakeResend", (), {"api_key": None, "Emails": _FakeEmails})
+
+    with patch.dict(sys.modules, {"resend": fake_resend}):
+        with pytest.raises(RuntimeError) as exc_info:
+            send_email(to=["a@b"], subject="x", body_text="x")
+    assert "Resend send failed" in str(exc_info.value)

--- a/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
+++ b/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
@@ -30,6 +30,9 @@ import { getQuoteWithRelations, deleteQuote } from '@/utils/quotesAccess';
 import { getCompany } from '@/utils/companyAccess';
 import type { Company } from '@/utils/companyAccess';
 import QuotePdfPreviewDialog from '@/components/quotes/QuotePdfPreviewDialog';
+import SendQuoteEmailDialog from '@/components/quotes/SendQuoteEmailDialog';
+import EmailIcon from '@mui/icons-material/Email';
+import Snackbar from '@mui/material/Snackbar';
 import { getTiersForPart } from '@/utils/partPricingTiersAccess';
 import {
   quoteToFormData,
@@ -59,8 +62,10 @@ export default function QuoteDetailPage() {
   );
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [previewOpen, setPreviewOpen] = useState(false);
+  const [emailDialogOpen, setEmailDialogOpen] = useState(false);
   const [company, setCompany] = useState<Company | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
+  const [emailSuccess, setEmailSuccess] = useState<string | null>(null);
   /** Tier reference data: part_id → all tiers for that part. */
   const [tiersByPart, setTiersByPart] = useState<Record<string, PartPricingTier[]>>({});
 
@@ -146,6 +151,24 @@ export default function QuoteDetailPage() {
     }
   };
 
+  const handleOpenEmailDialog = async () => {
+    if (!quote) return;
+    setError(null);
+    setPreviewLoading(true);
+    try {
+      const c = company ?? (await getCompany(companyId));
+      if (!c) {
+        throw new Error('Company info unavailable — cannot draft email.');
+      }
+      setCompany(c);
+      setEmailDialogOpen(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to open email dialog');
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
+
   if (loading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 400 }}>
@@ -210,15 +233,25 @@ export default function QuoteDetailPage() {
         >
           Back to Quotes
         </Button>
-        <Button
-          variant="contained"
-          color="primary"
-          startIcon={previewLoading ? <CircularProgress size={16} color="inherit" /> : <VisibilityIcon />}
-          onClick={handleOpenPreview}
-          disabled={previewLoading || actionLoading}
-        >
-          View PDF
-        </Button>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button
+            variant="outlined"
+            startIcon={<EmailIcon />}
+            onClick={handleOpenEmailDialog}
+            disabled={previewLoading || actionLoading}
+          >
+            Email
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            startIcon={previewLoading ? <CircularProgress size={16} color="inherit" /> : <VisibilityIcon />}
+            onClick={handleOpenPreview}
+            disabled={previewLoading || actionLoading}
+          >
+            View PDF
+          </Button>
+        </Box>
       </Box>
 
       {/* Header with Actions */}
@@ -477,8 +510,31 @@ export default function QuoteDetailPage() {
           onClose={() => setPreviewOpen(false)}
           quote={quote}
           company={company}
+          onEmail={() => setEmailDialogOpen(true)}
         />
       )}
+
+      {/* Send Quote Email Dialog */}
+      {company && (
+        <SendQuoteEmailDialog
+          open={emailDialogOpen}
+          onClose={() => setEmailDialogOpen(false)}
+          onSent={(toEmail) => {
+            setEmailDialogOpen(false);
+            setEmailSuccess(toEmail);
+          }}
+          quote={quote}
+          company={company}
+        />
+      )}
+
+      <Snackbar
+        open={!!emailSuccess}
+        autoHideDuration={5000}
+        onClose={() => setEmailSuccess(null)}
+        message={emailSuccess ? `Quote emailed to ${emailSuccess}` : ''}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      />
 
       {/* Convert to Job Modal */}
       <ConvertToJobModal

--- a/components/quotes/QuotePdfPreviewDialog.tsx
+++ b/components/quotes/QuotePdfPreviewDialog.tsx
@@ -12,6 +12,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import CloseIcon from '@mui/icons-material/Close';
 import DownloadIcon from '@mui/icons-material/Download';
+import EmailIcon from '@mui/icons-material/Email';
 
 import type { jsPDF } from 'jspdf';
 import type { QuoteWithRelations } from '@/types/quote';
@@ -23,6 +24,9 @@ interface QuotePdfPreviewDialogProps {
   onClose: () => void;
   quote: QuoteWithRelations;
   company: Company;
+  /** Optional: when present, render an "Email" button that closes the
+   *  preview and invokes this callback so the parent opens the email dialog. */
+  onEmail?: () => void;
 }
 
 export default function QuotePdfPreviewDialog({
@@ -30,6 +34,7 @@ export default function QuotePdfPreviewDialog({
   onClose,
   quote,
   company,
+  onEmail,
 }: QuotePdfPreviewDialogProps) {
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -102,6 +107,18 @@ export default function QuotePdfPreviewDialog({
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Close</Button>
+        {onEmail && (
+          <Button
+            startIcon={<EmailIcon />}
+            onClick={() => {
+              onClose();
+              onEmail();
+            }}
+            disabled={!pdfUrl}
+          >
+            Email
+          </Button>
+        )}
         <Button
           variant="contained"
           startIcon={<DownloadIcon />}

--- a/components/quotes/SendQuoteEmailDialog.tsx
+++ b/components/quotes/SendQuoteEmailDialog.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import AttachFileIcon from '@mui/icons-material/AttachFile';
+import SendIcon from '@mui/icons-material/Send';
+
+import type { QuoteWithRelations } from '@/types/quote';
+import type { Company } from '@/utils/companyAccess';
+import { generateQuotePdf, quotePdfFilename } from '@/utils/quotePdf';
+import { sendQuoteEmail } from '@/utils/quoteEmail';
+
+interface SendQuoteEmailDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSent: (toEmail: string) => void;
+  quote: QuoteWithRelations;
+  company: Company;
+}
+
+function defaultSubject(quoteNumber: string | null, companyName: string): string {
+  const num = quoteNumber ?? 'Quote';
+  return `Quote ${num} from ${companyName}`;
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Pick the customer's primary contact from the joined customer_contacts list.
+ * Mirrors the helper in utils/quotePdf.ts — same primary-row resolution rule.
+ */
+function pickPrimaryContact(quote: QuoteWithRelations) {
+  const contacts = quote.customers?.customer_contacts ?? [];
+  return contacts.find((c) => c.is_primary) ?? null;
+}
+
+function defaultBody(quote: QuoteWithRelations, company: Company, senderName: string): string {
+  const primary = pickPrimaryContact(quote);
+  const contactName = primary?.name || quote.customers?.name || 'there';
+  const quoteNumber = quote.quote_number ?? 'attached';
+  const expiry = quote.expiration_date
+    ? ` The prices are valid until ${formatDate(quote.expiration_date)}.`
+    : '';
+  const signOff = senderName || company.name;
+  return [
+    `Hi ${contactName},`,
+    '',
+    `Please find attached Quote ${quoteNumber} for your recent inquiry.${expiry}`,
+    'Let me know if you have any questions, or reply with a PO to accept.',
+    '',
+    'Thanks,',
+    signOff,
+  ].join('\n');
+}
+
+export default function SendQuoteEmailDialog({
+  open,
+  onClose,
+  onSent,
+  quote,
+  company,
+}: SendQuoteEmailDialogProps) {
+  const senderName = quote.created_by_member?.name ?? '';
+
+  const [to, setTo] = useState('');
+  const [cc, setCc] = useState('');
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const primary = pickPrimaryContact(quote);
+    setTo(primary?.email ?? '');
+    setCc('');
+    setSubject(defaultSubject(quote.quote_number, company.name));
+    setBody(defaultBody(quote, company, senderName));
+    setError(null);
+  }, [open, quote, company, senderName]);
+
+  const handleSend = async () => {
+    setError(null);
+    if (!to.trim()) {
+      setError('Recipient email is required.');
+      return;
+    }
+    setSending(true);
+    try {
+      const doc = await generateQuotePdf(quote, company);
+      const pdf = doc.output('blob');
+      const filename = quotePdfFilename(quote);
+      await sendQuoteEmail(quote.id, {
+        to: to.trim(),
+        cc: cc.trim() || undefined,
+        subject,
+        body,
+        pdf,
+        pdfFilename: filename,
+      });
+      onSent(to.trim());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send email');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={sending ? undefined : onClose} maxWidth="md" fullWidth>
+      <DialogTitle>Email quote {quote.quote_number ?? ''}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          {error && <Alert severity="error">{error}</Alert>}
+
+          <TextField
+            label="To"
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+            type="email"
+            required
+            disabled={sending}
+            placeholder="customer@example.com"
+            fullWidth
+          />
+          <TextField
+            label="CC"
+            value={cc}
+            onChange={(e) => setCc(e.target.value)}
+            type="email"
+            disabled={sending}
+            placeholder="optional"
+            fullWidth
+          />
+          <TextField
+            label="Subject"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            disabled={sending}
+            fullWidth
+          />
+          <TextField
+            label="Message"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            disabled={sending}
+            multiline
+            minRows={8}
+            fullWidth
+          />
+
+          <Box>
+            <Chip
+              icon={<AttachFileIcon />}
+              label={quotePdfFilename(quote)}
+              variant="outlined"
+            />
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+              The current quote PDF is attached automatically.
+              {company.email
+                ? ` Replies go to ${company.email}.`
+                : ' Set a company email in Settings → Company Profile so customer replies have a destination.'}
+            </Typography>
+          </Box>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={sending}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSend}
+          variant="contained"
+          disabled={sending}
+          startIcon={sending ? <CircularProgress size={16} color="inherit" /> : <SendIcon />}
+        >
+          {sending ? 'Sending…' : 'Send email'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/utils/quoteEmail.ts
+++ b/utils/quoteEmail.ts
@@ -1,0 +1,74 @@
+import { getSupabase } from '@/lib/supabase';
+import { API_BASE_URL } from '@/lib/api';
+
+export interface SendQuoteEmailPayload {
+  to: string;
+  cc?: string;
+  subject: string;
+  body: string;
+  /** PDF bytes — built client-side via generateQuotePdf + doc.output('blob'). */
+  pdf: Blob;
+  /** Suggested filename for the attachment. */
+  pdfFilename: string;
+}
+
+export interface SendQuoteEmailResult {
+  message_id: string;
+}
+
+/**
+ * Send a quote email via the FastAPI /api/quotes/{id}/email endpoint.
+ *
+ * The PDF is rendered client-side (utils/quotePdf.ts) and posted as
+ * multipart so we don't duplicate the rendering logic in Python.
+ *
+ * Throws:
+ *   - Error with `service_unavailable` flag when Resend isn't configured
+ *     (503 from the server). Use this to show a clear "ask an admin to
+ *     configure email" message rather than a generic failure.
+ */
+export async function sendQuoteEmail(
+  quoteId: string,
+  payload: SendQuoteEmailPayload,
+): Promise<SendQuoteEmailResult> {
+  const supabase = getSupabase();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    throw new Error('Not signed in.');
+  }
+
+  const form = new FormData();
+  form.append('to', payload.to);
+  if (payload.cc) form.append('cc', payload.cc);
+  form.append('subject', payload.subject);
+  form.append('body', payload.body);
+  form.append('pdf', payload.pdf, payload.pdfFilename);
+
+  const response = await fetch(
+    `${API_BASE_URL}/api/quotes/${quoteId}/email`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+      },
+      body: form,
+    },
+  );
+
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    if (response.status === 503) {
+      const e = new Error(
+        err.detail ??
+          'Email sending isn\'t configured yet. Ask an admin to set RESEND_API_KEY.',
+      );
+      (e as Error & { service_unavailable?: boolean }).service_unavailable = true;
+      throw e;
+    }
+    throw new Error(err.detail ?? `Email send failed (${response.status})`);
+  }
+
+  return (await response.json()) as SendQuoteEmailResult;
+}


### PR DESCRIPTION
New FastAPI route POST /api/quotes/{id}/email accepts multipart form data (to, cc, subject, body, pdf) and sends the PDF as an attachment via Resend. From: noreply@mail.jigged.app (configurable via RESEND_FROM_EMAIL). Reply-To: the company's email so customer replies land in the shop's mailbox, not on a noreply alias.

The PDF is rendered client-side via the same generateQuotePdf doc the preview dialog uses (doc.output('blob')) and posted up as multipart — keeps quote rendering logic in one TypeScript implementation.

Quote detail page now has an Email button next to View PDF. The preview dialog also exposes Email so a user can preview → email in one flow. Successful send shows a snackbar with the recipient.

Email infrastructure (api/services/email.py) is built as a generic send_email() primitive so the future invitation system (per docs/modules/invitation-system.md §7) can ride the same plumbing.

Setup required before this functions in production:
  - Create a Resend account, get an API key
  - Verify mail.jigged.app sending domain (SPF/DKIM/DMARC)
  - Set RESEND_API_KEY and RESEND_FROM_EMAIL env vars in Vercel + .env.local
  - pip install -r api/requirements.txt (adds resend + python-multipart)

Until configured, the route returns 503 with a clear message; the frontend surfaces it as "Email sending isn't configured yet."