### PR TITLE
Use sender's email for quote-email reply-to + BCC

### DIFF
--- a/api/routes/quote_email_routes.py
+++ b/api/routes/quote_email_routes.py
@@ -35,11 +35,13 @@ def _service_client() -> Client:
     return create_client(url, key)
 
 
-async def _verify_quote_access(request: Request, quote_id: str) -> tuple[str, dict, dict]:
+async def _verify_quote_access(
+    request: Request, quote_id: str
+) -> tuple[str, str | None, dict, dict]:
     """
     Extract the caller's user id from the Authorization header and verify
     they have access to the quote's company. Returns
-    (user_id, quote_row, company_row).
+    (user_id, user_email, quote_row, company_row).
     """
     token = request.headers.get("Authorization", "").replace("Bearer ", "")
     if not token:
@@ -51,6 +53,7 @@ async def _verify_quote_access(request: Request, quote_id: str) -> tuple[str, di
         if not user_response or not user_response.user:
             raise HTTPException(status_code=401, detail="Invalid token")
         user_id = user_response.user.id
+        user_email = user_response.user.email
     except HTTPException:
         raise
     except Exception as e:
@@ -80,7 +83,7 @@ async def _verify_quote_access(request: Request, quote_id: str) -> tuple[str, di
 
     company_resp = (
         client.table("companies")
-        .select("id, name, email")
+        .select("id, name")
         .eq("id", quote["company_id"])
         .single()
         .execute()
@@ -88,7 +91,7 @@ async def _verify_quote_access(request: Request, quote_id: str) -> tuple[str, di
     if not company_resp.data:
         raise HTTPException(status_code=404, detail="Company not found")
 
-    return user_id, quote, company_resp.data
+    return user_id, user_email, quote, company_resp.data
 
 
 class EmailQuoteResponse(BaseModel):
@@ -109,25 +112,26 @@ async def email_quote(
     Send a quote PDF to the given email address.
 
     The frontend produces the PDF, the user edits the body, then we send
-    it through Resend. Reply-To is set to the company's email so customer
-    replies land in the shop's mailbox, not on a noreply alias.
+    it through Resend. Reply-To is set to the sending user's email so
+    customer replies land in their personal inbox, and the sender is
+    BCC'd so they have a copy of every quote they sent.
     """
-    _, quote, company = await _verify_quote_access(request, quote_id)
+    _, user_email, quote, _ = await _verify_quote_access(request, quote_id)
 
     pdf_bytes = await pdf.read()
     if not pdf_bytes:
         raise HTTPException(status_code=400, detail="Empty PDF upload")
 
     filename = f"Quote-{quote.get('quote_number') or quote_id}.pdf"
-    reply_to = company.get("email")
 
     try:
         message_id = send_email(
             to=[to.strip()],
             cc=[cc.strip()] if cc and cc.strip() else None,
+            bcc=[user_email] if user_email else None,
             subject=subject,
             body_text=body,
-            reply_to=reply_to,
+            reply_to=user_email,
             attachments=[EmailAttachment(filename=filename, content=pdf_bytes)],
         )
     except EmailServiceUnavailable as e:

--- a/api/services/email.py
+++ b/api/services/email.py
@@ -44,6 +44,7 @@ def send_email(
     subject: str,
     body_text: str,
     cc: list[str] | None = None,
+    bcc: list[str] | None = None,
     reply_to: str | None = None,
     attachments: Sequence[EmailAttachment] = (),
 ) -> str:
@@ -84,6 +85,8 @@ def send_email(
     }
     if cc:
         params["cc"] = cc
+    if bcc:
+        params["bcc"] = bcc
     if reply_to:
         # Resend SDK accepts a string or list for reply_to.
         params["reply_to"] = reply_to

--- a/api/tests/unit/test_email.py
+++ b/api/tests/unit/test_email.py
@@ -54,9 +54,10 @@ def test_sends_with_attachment(monkeypatch):
         message_id = send_email(
             to=["customer@example.com"],
             cc=["sales@shop.example"],
+            bcc=["sender@shop.example"],
             subject="Quote Q-0001",
             body_text="Please find attached.",
-            reply_to="shop@example.com",
+            reply_to="sender@shop.example",
             attachments=[
                 EmailAttachment(filename="Quote-Q-0001.pdf", content=b"%PDF-1.4 ..."),
             ],
@@ -67,9 +68,10 @@ def test_sends_with_attachment(monkeypatch):
     assert params["from"] == "noreply@mail.jigged.app"
     assert params["to"] == ["customer@example.com"]
     assert params["cc"] == ["sales@shop.example"]
+    assert params["bcc"] == ["sender@shop.example"]
     assert params["subject"] == "Quote Q-0001"
     assert params["text"] == "Please find attached."
-    assert params["reply_to"] == "shop@example.com"
+    assert params["reply_to"] == "sender@shop.example"
     assert len(params["attachments"]) == 1
     att = params["attachments"][0]
     assert att["filename"] == "Quote-Q-0001.pdf"


### PR DESCRIPTION
## Summary
- Quote emails now use the authenticated user's email as reply-to (was: company email, often empty) so customer replies route back to the salesperson who sent the quote.
- The sender is automatically BCC'd on every quote email so they keep a copy of what went out.
- Added `bcc` parameter to `send_email()` service wrapper.

## Test plan
- [x] `pytest tests/unit/test_email.py` — 4 passing, including new `bcc` assertion
- [ ] Manual: send a quote in the app, verify the recipient sees reply-to = sender's email and the sender receives a BCC copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)