### PR TITLE
Fix parts dropdown truncation + extract shared part/vendor pickers

### DIFF
--- a/components/operator/JobCompleteModal.tsx
+++ b/components/operator/JobCompleteModal.tsx
@@ -14,16 +14,14 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import Card from '@mui/material/Card';
 import IconButton from '@mui/material/IconButton';
-import Autocomplete from '@mui/material/Autocomplete';
 import Fade from '@mui/material/Fade';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { completeJob, getJobPartMaterialsForCompletion } from '@/utils/operatorAccess';
-import { getStockedParts } from '@/utils/partsAccess';
+import PartAutocomplete, { type PartSelectOption } from '@/components/parts/PartAutocomplete';
 import { formatDuration } from '@/types/operator';
 import type { MaterialConfirmation } from '@/types/operator';
-import type { Part } from '@/types/part';
 
 interface JobCompleteModalProps {
   open: boolean;
@@ -68,8 +66,6 @@ export default function JobCompleteModal({
 
   // For adding extra materials
   const [showAddMaterial, setShowAddMaterial] = useState(false);
-  const [stockableParts, setStockableParts] = useState<Part[]>([]);
-  const [loadingItems, setLoadingItems] = useState(false);
 
   // Update elapsed time while modal is open
   useEffect(() => {
@@ -115,22 +111,11 @@ export default function JobCompleteModal({
     setMaterials((prev) => prev.filter((_, i) => i !== index));
   };
 
-  const handleAddMaterial = async () => {
-    if (stockableParts.length === 0) {
-      setLoadingItems(true);
-      try {
-        const items = await getStockedParts(companyId);
-        setStockableParts(items);
-      } catch {
-        // Silently fail — user can retry
-      } finally {
-        setLoadingItems(false);
-      }
-    }
+  const handleAddMaterial = () => {
     setShowAddMaterial(true);
   };
 
-  const handleSelectNewMaterial = (part: Part | null) => {
+  const handleSelectNewMaterial = (part: PartSelectOption | null) => {
     if (!part) return;
 
     // Don't add duplicates
@@ -358,22 +343,14 @@ export default function JobCompleteModal({
             {/* Add Material */}
             {showAddMaterial ? (
               <Card elevation={1} sx={{ p: 2 }}>
-                <Autocomplete
-                  options={stockableParts.filter(
-                    (item) => !materials.some((m) => m.inventory_item_id === item.id)
-                  )}
-                  getOptionLabel={(option) => option.part_name}
-                  loading={loadingItems}
-                  onChange={(_, value) => handleSelectNewMaterial(value)}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      label="Search inventory items"
-                      size="small"
-                      autoFocus
-                    />
-                  )}
-                  size="small"
+                <PartAutocomplete
+                  companyId={companyId}
+                  kind="stocked"
+                  value={null}
+                  onChange={handleSelectNewMaterial}
+                  excludeIds={materials.map((m) => m.inventory_item_id)}
+                  label="Search inventory items"
+                  autoFocus
                 />
                 <Button
                   size="small"

--- a/components/parts/MaterialRowEditor.tsx
+++ b/components/parts/MaterialRowEditor.tsx
@@ -4,33 +4,23 @@ import { useEffect, useMemo, useState } from 'react';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
-import Autocomplete from '@mui/material/Autocomplete';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 
-/**
- * Lightweight part option used by the material picker. Mirrors the shape
- * returned by `getPartsForSelect`. Defined here (vs imported from
- * partsAccess) to keep the editor's prop surface explicit.
- */
-export interface PartOption {
-  id: string;
-  part_name: string;
-  description: string | null;
-  is_stocked: boolean;
-  source: 'made' | 'bought';
-  primary_unit: string | null;
-}
+import PartAutocomplete, { type PartSelectOption } from '@/components/parts/PartAutocomplete';
+
+export type { PartSelectOption };
 
 export interface MaterialEditorValue {
-  childPart: PartOption | null;
+  childPart: PartSelectOption | null;
   quantity: string;
   unit: string;
 }
 
 export interface MaterialRowEditorProps {
-  parts: PartOption[];
-  partsLoading: boolean;
+  companyId: string;
+  /** Part IDs to hide from the child-part picker (e.g. the parent itself). */
+  excludeIds?: string[];
   /** When provided, the editor is in edit mode for an existing material row. */
   initial?: MaterialEditorValue;
   /**
@@ -63,8 +53,8 @@ const EMPTY_VALUE: MaterialEditorValue = {
  * updateBomLine calls live in PartBomPanel which holds the state machine.
  */
 export default function MaterialRowEditor({
-  parts,
-  partsLoading,
+  companyId,
+  excludeIds,
   initial,
   lockChildPart = false,
   saving = false,
@@ -80,7 +70,7 @@ export default function MaterialRowEditor({
     setValue(initial ?? EMPTY_VALUE);
   }, [initial]);
 
-  const handlePartChange = (option: PartOption | null) => {
+  const handlePartChange = (option: PartSelectOption | null) => {
     setValue((prev) => ({
       ...prev,
       childPart: option,
@@ -111,59 +101,15 @@ export default function MaterialRowEditor({
     >
       <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5, flexWrap: 'wrap' }}>
         <Box sx={{ flex: '1 1 240px', minWidth: 200 }}>
-          <Autocomplete
-            options={parts}
-            loading={partsLoading}
+          <PartAutocomplete
+            companyId={companyId}
             value={value.childPart}
-            onChange={(_, option) => handlePartChange(option)}
-            getOptionLabel={(option) => option.part_name}
-            isOptionEqualToValue={(option, v) => option.id === v.id}
+            onChange={handlePartChange}
+            excludeIds={excludeIds}
             disabled={lockChildPart || saving}
-            size="small"
-            renderOption={(props, option) => {
-              const { key, ...rest } = props as React.HTMLAttributes<HTMLLIElement> & {
-                key?: React.Key;
-              };
-              return (
-                <Box component="li" {...rest} key={key as React.Key} sx={{ minWidth: 0 }}>
-                  <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                    {option.part_name}
-                  </Typography>
-                  {option.description && (
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{
-                        display: 'block',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {option.description}
-                    </Typography>
-                  )}
-                </Box>
-              );
-            }}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                label="Material part"
-                required
-                autoFocus={!lockChildPart}
-                size="small"
-                InputProps={{
-                  ...params.InputProps,
-                  endAdornment: (
-                    <>
-                      {partsLoading ? <CircularProgress size={16} /> : null}
-                      {params.InputProps.endAdornment}
-                    </>
-                  ),
-                }}
-              />
-            )}
+            label="Material part"
+            required
+            autoFocus={!lockChildPart}
           />
         </Box>
 

--- a/components/parts/PartAutocomplete.tsx
+++ b/components/parts/PartAutocomplete.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+
+import { searchPartsForSelect, type PartSelectOption } from '@/utils/partsAccess';
+
+export type { PartSelectOption };
+
+interface CreateNewOption {
+  id: '__create_new_part__';
+  part_name: string;
+  isCreateNew: true;
+}
+
+type AutocompleteOption = PartSelectOption | CreateNewOption;
+
+function isCreateNewOption(o: AutocompleteOption | null): o is CreateNewOption {
+  return !!o && 'isCreateNew' in o && o.isCreateNew === true;
+}
+
+export interface PartAutocompleteProps {
+  companyId: string;
+  value: PartSelectOption | null;
+  onChange: (option: PartSelectOption | null) => void;
+  /** Server-side filter: which subset of the parts table to search. */
+  kind?: 'all' | 'made' | 'stocked' | 'bought';
+  /** Hide options whose id is in this list (e.g. already-picked siblings). */
+  excludeIds?: string[];
+  label: string;
+  /** When provided, prepends a "Create New Part" sentinel that calls this. */
+  onCreateNew?: () => void;
+  createNewLabel?: string;
+  size?: 'small' | 'medium';
+  disabled?: boolean;
+  required?: boolean;
+  autoFocus?: boolean;
+  helperText?: React.ReactNode;
+}
+
+/**
+ * Shared autocomplete for picking a part. Uses server-side search
+ * (`searchPartsForSelect`) so it scales to companies with 10k+ parts without
+ * the page paying a multi-second bulk-load on mount.
+ *
+ * The dropdown only fetches while open. Typing debounces at 300ms; the
+ * initial focus fires immediately so the user sees the top 50 matches as
+ * soon as they click.
+ *
+ * `value` is the source of truth — callers pass the full PartSelectOption
+ * (not just an id) so display can show the label without an extra round
+ * trip. In edit/initial-load flows the caller should hydrate via
+ * `getPartsForSelectByIds`.
+ */
+export default function PartAutocomplete({
+  companyId,
+  value,
+  onChange,
+  kind = 'all',
+  excludeIds,
+  label,
+  onCreateNew,
+  createNewLabel = 'Create New Part',
+  size = 'small',
+  disabled,
+  required,
+  autoFocus,
+  helperText,
+}: PartAutocompleteProps) {
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState('');
+  const [results, setResults] = useState<PartSelectOption[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let active = true;
+    setLoading(true);
+    const delay = inputValue.trim() ? 300 : 0;
+    const timer = setTimeout(async () => {
+      try {
+        const data = await searchPartsForSelect(companyId, inputValue, kind, 50);
+        if (!active) return;
+        setResults(data);
+      } catch (err) {
+        console.error('Part search failed:', err);
+      } finally {
+        if (active) setLoading(false);
+      }
+    }, delay);
+    return () => {
+      active = false;
+      clearTimeout(timer);
+    };
+  }, [inputValue, companyId, kind, open]);
+
+  const exclude = new Set(excludeIds ?? []);
+  const options: AutocompleteOption[] = [
+    ...(onCreateNew
+      ? [
+          {
+            id: '__create_new_part__' as const,
+            part_name: createNewLabel,
+            isCreateNew: true as const,
+          },
+        ]
+      : []),
+    ...results.filter((r) => !exclude.has(r.id)),
+  ];
+
+  // MUI warns when `value` isn't findable in `options`. Append the current
+  // selection if it isn't already in the search results.
+  if (value && !options.some((o) => o.id === value.id)) {
+    options.push(value);
+  }
+
+  return (
+    <Autocomplete
+      size={size}
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      options={options}
+      filterOptions={(x) => x}
+      loading={loading}
+      value={value}
+      inputValue={inputValue}
+      onInputChange={(_, v) => setInputValue(v)}
+      onChange={(_, v) => {
+        if (isCreateNewOption(v)) {
+          onCreateNew?.();
+          return;
+        }
+        onChange((v as PartSelectOption | null) ?? null);
+      }}
+      getOptionLabel={(o) => o.part_name}
+      isOptionEqualToValue={(o, v) => o.id === v.id}
+      disabled={disabled}
+      renderOption={(props, option) => {
+        const { key, ...rest } = props as React.HTMLAttributes<HTMLLIElement> & {
+          key?: React.Key;
+        };
+        const isCreate = isCreateNewOption(option);
+        return (
+          <Box component="li" {...rest} key={key as React.Key} sx={{ minWidth: 0 }}>
+            <Typography
+              variant="body2"
+              sx={{ fontWeight: 500, color: isCreate ? 'primary.main' : undefined }}
+            >
+              {option.part_name}
+            </Typography>
+            {!isCreate && (option as PartSelectOption).description && (
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{
+                  display: 'block',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {(option as PartSelectOption).description}
+              </Typography>
+            )}
+          </Box>
+        );
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          required={required}
+          autoFocus={autoFocus}
+          size={size}
+          helperText={helperText}
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: (
+              <>
+                {loading ? <CircularProgress size={16} /> : null}
+                {params.InputProps.endAdornment}
+              </>
+            ),
+          }}
+        />
+      )}
+    />
+  );
+}

--- a/components/parts/PartBomPanel.tsx
+++ b/components/parts/PartBomPanel.tsx
@@ -28,7 +28,6 @@ import {
   checkBomCycle,
 } from '@/utils/bomAccess';
 import {
-  getPartsForSelect,
   getComputedPartCost,
   getPartCostExplain,
   type PartCostMissingLeaf,
@@ -38,7 +37,7 @@ import { getSupabase } from '@/lib/supabase';
 import type { BomLineFormData, BomLineWithChildPart } from '@/types/bom';
 import MaterialRowEditor, {
   type MaterialEditorValue,
-  type PartOption,
+  type PartSelectOption,
 } from '@/components/parts/MaterialRowEditor';
 
 interface PartBomPanelProps {
@@ -131,11 +130,6 @@ export default function PartBomPanel({
   >({ mode: 'closed' });
   const [editorError, setEditorError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
-
-  // Parts list for the picker, loaded once at panel mount and reused across
-  // every editor invocation. Excludes the parent part (DB also enforces this).
-  const [parts, setParts] = useState<PartOption[]>([]);
-  const [partsLoading, setPartsLoading] = useState(false);
 
   const [pendingDelete, setPendingDelete] = useState<BomLineWithChildPart | null>(null);
   const [deleting, setDeleting] = useState(false);
@@ -295,40 +289,6 @@ export default function PartBomPanel({
     };
   }, [rows, partId]);
 
-  // Load parts list for the picker once. Re-fetches if partId or companyId
-  // changes (rare — only on detail-page navigation).
-  useEffect(() => {
-    let cancelled = false;
-    setPartsLoading(true);
-    getPartsForSelect(companyId, 'all')
-      .then((list) => {
-        if (cancelled) return;
-        setParts(
-          list
-            .filter((p) => p.id !== partId)
-            .map((p) => ({
-              id: p.id,
-              part_name: p.part_name,
-              description: p.description,
-              is_stocked: p.is_stocked,
-              source: p.source,
-              primary_unit: p.primary_unit,
-            })),
-        );
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        console.error('Failed to load parts for material picker:', err);
-        setError('Failed to load parts list.');
-      })
-      .finally(() => {
-        if (!cancelled) setPartsLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [companyId, partId]);
-
   const closeEditor = () => {
     setEditorState({ mode: 'closed' });
     setEditorError(null);
@@ -416,15 +376,18 @@ export default function PartBomPanel({
       : null;
   const editingInitial: MaterialEditorValue | undefined = editingRow
     ? {
-        childPart:
-          parts.find((p) => p.id === editingRow.child_part_id) ?? {
-            id: editingRow.child_part.id,
-            part_name: editingRow.child_part.part_name,
-            description: editingRow.child_part.description,
-            is_stocked: editingRow.child_part.is_stocked,
-            source: editingRow.child_part.source,
-            primary_unit: editingRow.child_part.primary_unit,
-          },
+        // child-part picker is locked in edit mode, so has_routing/quantity
+        // are display-only fillers — synthesize the option from the BOM row.
+        childPart: {
+          id: editingRow.child_part.id,
+          part_name: editingRow.child_part.part_name,
+          description: editingRow.child_part.description,
+          has_routing: false,
+          is_stocked: editingRow.child_part.is_stocked,
+          source: editingRow.child_part.source,
+          primary_unit: editingRow.child_part.primary_unit,
+          quantity: 0,
+        } satisfies PartSelectOption,
         quantity: String(editingRow.quantity),
         unit: editingRow.unit,
       }
@@ -502,8 +465,8 @@ export default function PartBomPanel({
               return (
                 <MaterialRowEditor
                   key={row.id}
-                  parts={parts}
-                  partsLoading={partsLoading}
+                  companyId={companyId}
+                  excludeIds={[partId]}
                   initial={editingInitial}
                   lockChildPart
                   saving={saving}
@@ -617,8 +580,8 @@ export default function PartBomPanel({
 
           {editorState.mode === 'add' && (
             <MaterialRowEditor
-              parts={parts}
-              partsLoading={partsLoading}
+              companyId={companyId}
+              excludeIds={[partId]}
               saving={saving}
               error={editorError}
               onSave={handleEditorSave}

--- a/components/parts/PartForm.tsx
+++ b/components/parts/PartForm.tsx
@@ -21,7 +21,6 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import Stack from '@mui/material/Stack';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import Autocomplete from '@mui/material/Autocomplete';
 import BuildIcon from '@mui/icons-material/Build';
 import LocalMallIcon from '@mui/icons-material/LocalMall';
 import type { Part, PartFormData } from '@/types/part';
@@ -31,8 +30,7 @@ import {
   deletePart,
   checkPartNameExists,
 } from '@/utils/partsAccess';
-import { getAllVendors } from '@/utils/vendorsAccess';
-import type { Vendor } from '@/types/vendor';
+import VendorAutocomplete from '@/components/vendors/VendorAutocomplete';
 import UnitOfMeasurementSelect from './UnitOfMeasurementSelect';
 import { highContrastToggleSx } from '@/lib/highContrastToggleSx';
 
@@ -97,9 +95,6 @@ export default function PartForm({
     severity: 'error',
   });
 
-  const [vendors, setVendors] = useState<Vendor[]>([]);
-  const [vendorsLoading, setVendorsLoading] = useState(false);
-
   // Sync external initialData changes (e.g. when the search-first modal swaps
   // from create -> editing-existing as the user picks a suggestion).
   useEffect(() => {
@@ -107,27 +102,6 @@ export default function PartForm({
     setFieldErrors({});
     setError(null);
   }, [initialData]);
-
-  useEffect(() => {
-    let cancelled = false;
-    async function loadVendors() {
-      setVendorsLoading(true);
-      try {
-        const data = await getAllVendors(companyId);
-        if (!cancelled) setVendors(data);
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to load vendors');
-        }
-      } finally {
-        if (!cancelled) setVendorsLoading(false);
-      }
-    }
-    loadVendors();
-    return () => {
-      cancelled = true;
-    };
-  }, [companyId]);
 
   // Generic text-change handler for top-level string fields.
   const handleTextChange =
@@ -273,9 +247,6 @@ export default function PartForm({
   };
 
   const canDelete = !part || ((part.quotes_count ?? 0) === 0 && (part.jobs_count ?? 0) === 0);
-
-  const selectedVendor =
-    vendors.find((v) => v.id === formData.preferred_vendor_id) || null;
 
   const showUomField = formData.is_stocked;
   // Preferred vendor is procurement-only — a stocked sub-assembly has no
@@ -433,39 +404,18 @@ export default function PartForm({
               )}
               {showVendorPicker && (
                 <Grid size={{ xs: 12 }}>
-                  <Autocomplete
-                    options={vendors}
-                    getOptionLabel={(opt) => opt.name}
-                    value={selectedVendor}
-                    loading={vendorsLoading}
-                    onChange={(_event, newValue) => {
+                  <VendorAutocomplete
+                    companyId={companyId}
+                    valueId={formData.preferred_vendor_id}
+                    onChange={(vendor) => {
                       setFormData((prev) => ({
                         ...prev,
-                        preferred_vendor_id: newValue ? newValue.id : null,
+                        preferred_vendor_id: vendor ? vendor.id : null,
                       }));
                     }}
                     disabled={loading}
-                    isOptionEqualToValue={(opt, val) => opt.id === val.id}
-                    renderInput={(params) => (
-                      <TextField
-                        {...params}
-                        label="Preferred Vendor"
-                        helperText="Optional. The default supplier for this part."
-                        slotProps={{
-                          input: {
-                            ...params.InputProps,
-                            endAdornment: (
-                              <>
-                                {vendorsLoading ? (
-                                  <CircularProgress color="inherit" size={20} />
-                                ) : null}
-                                {params.InputProps.endAdornment}
-                              </>
-                            ),
-                          },
-                        }}
-                      />
-                    )}
+                    label="Preferred Vendor"
+                    helperText="Optional. The default supplier for this part."
                   />
                 </Grid>
               )}

--- a/components/parts/PartFormModal.tsx
+++ b/components/parts/PartFormModal.tsx
@@ -17,7 +17,6 @@ import Switch from '@mui/material/Switch';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import Autocomplete from '@mui/material/Autocomplete';
 import CloseIcon from '@mui/icons-material/Close';
 import BuildIcon from '@mui/icons-material/Build';
 import LocalMallIcon from '@mui/icons-material/LocalMall';
@@ -25,7 +24,7 @@ import { EMPTY_PART_FORM } from '@/types/part';
 import type { Part, PartFormData } from '@/types/part';
 import type { Vendor } from '@/types/vendor';
 import { createPart, checkPartNameExists } from '@/utils/partsAccess';
-import { getAllVendors } from '@/utils/vendorsAccess';
+import VendorAutocomplete from '@/components/vendors/VendorAutocomplete';
 import { highContrastToggleSx } from '@/lib/highContrastToggleSx';
 import UnitOfMeasurementSelect from './UnitOfMeasurementSelect';
 
@@ -78,6 +77,7 @@ export default function PartFormModal({
   );
 
   const [formData, setFormData] = useState<PartFormData>(baseCreate);
+  const [selectedVendor, setSelectedVendor] = useState<Vendor | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<{
@@ -85,36 +85,12 @@ export default function PartFormModal({
     primary_unit?: string;
   }>({});
 
-  // Vendor list — only fetched/shown when the form is in Bought mode, since
-  // preferred_vendor doesn't apply to made parts. Lazy-loaded the first time
-  // the modal opens so closed-modal cost is zero.
-  const [vendors, setVendors] = useState<Vendor[]>([]);
-  const [vendorsLoading, setVendorsLoading] = useState(false);
-
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    setVendorsLoading(true);
-    getAllVendors(companyId)
-      .then((rows) => {
-        if (!cancelled) setVendors(rows);
-      })
-      .catch((err) => {
-        if (!cancelled) console.warn('Failed to load vendors:', err);
-      })
-      .finally(() => {
-        if (!cancelled) setVendorsLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, companyId]);
-
   // Reset whenever the modal closes/reopens, or when defaults change (e.g.
   // user navigates from Parts to Inventory and reopens).
   useEffect(() => {
     if (open) {
       setFormData(baseCreate);
+      setSelectedVendor(null);
       setError(null);
       setFieldErrors({});
     }
@@ -129,6 +105,7 @@ export default function PartFormModal({
       // Made so the field doesn't carry a stale value into the new shape.
       preferred_vendor_id: next === 'made' ? null : prev.preferred_vendor_id,
     }));
+    if (next === 'made') setSelectedVendor(null);
   };
 
   const handleStockedChange = (_e: unknown, checked: boolean) => {
@@ -329,42 +306,22 @@ export default function PartFormModal({
               detail page. Made parts have no vendor concept, so the field
               hides entirely when source='made'. */}
           {formData.source === 'bought' && (
-            <Autocomplete<Vendor>
-              options={vendors}
-              loading={vendorsLoading}
-              value={
-                vendors.find((v) => v.id === formData.preferred_vendor_id) ?? null
-              }
-              onChange={(_e, next) =>
-                setFormData((prev) => ({
-                  ...prev,
-                  preferred_vendor_id: next ? next.id : null,
-                }))
-              }
-              getOptionLabel={(opt) => opt.name}
-              isOptionEqualToValue={(opt, val) => opt.id === val.id}
-              size="small"
-              disabled={submitting}
-              sx={{ mt: 3 }}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Preferred vendor"
-                  helperText="Optional. The default supplier for this part."
-                  slotProps={{
-                    input: {
-                      ...params.InputProps,
-                      endAdornment: (
-                        <>
-                          {vendorsLoading ? <CircularProgress size={14} /> : null}
-                          {params.InputProps.endAdornment}
-                        </>
-                      ),
-                    },
-                  }}
-                />
-              )}
-            />
+            <Box sx={{ mt: 3 }}>
+              <VendorAutocomplete
+                companyId={companyId}
+                value={selectedVendor}
+                onChange={(vendor) => {
+                  setSelectedVendor(vendor);
+                  setFormData((prev) => ({
+                    ...prev,
+                    preferred_vendor_id: vendor ? vendor.id : null,
+                  }));
+                }}
+                disabled={submitting}
+                label="Preferred vendor"
+                helperText="Optional. The default supplier for this part."
+              />
+            </Box>
           )}
         </DialogContent>
 

--- a/components/parts/index.ts
+++ b/components/parts/index.ts
@@ -6,3 +6,4 @@ export { default as PartTransactionHistoryTable } from './PartTransactionHistory
 export { default as PartBomPanel } from './PartBomPanel';
 export { default as PartWhereUsedPanel } from './PartWhereUsedPanel';
 export { default as MaterialRowEditor } from './MaterialRowEditor';
+export { default as PartAutocomplete } from './PartAutocomplete';

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -23,13 +23,14 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 
 import type { QuoteFormData } from '@/types/quote';
 import { createQuote, updateQuote } from '@/utils/quotesAccess';
-import { searchPartsForSelect, getPartsForSelectByIds } from '@/utils/partsAccess';
+import { getPartsForSelectByIds } from '@/utils/partsAccess';
 import { getAllCustomers } from '@/utils/customerAccess';
 import { getTiersForPart } from '@/utils/partPricingTiersAccess';
 import { resolveTier } from '@/utils/quotePricingResolver';
 import type { PartPricingTier } from '@/types/partPricing';
 import CustomerFormModal from '@/components/customers/CustomerFormModal';
 import PartFormModal from '@/components/parts/PartFormModal';
+import PartAutocomplete, { type PartSelectOption } from '@/components/parts/PartAutocomplete';
 import type { Customer } from '@/types/customer';
 
 interface QuoteFormProps {
@@ -46,16 +47,8 @@ interface CustomerOption {
   isCreateNew?: boolean;
 }
 
-interface PartOption {
-  id: string;
-  part_name: string;
-  description: string | null;
-  has_routing: boolean;
-  isCreateNew?: boolean;
-}
-
 interface PartBlockState {
-  part_id: string;
+  part: PartSelectOption | null;
   /** Working-copy string so the input can be empty mid-edit. */
   order_quantity: string;
   override_open: boolean;
@@ -71,14 +64,6 @@ const CREATE_NEW_CUSTOMER: CustomerOption = {
   isCreateNew: true,
 };
 
-const CREATE_NEW_PART: PartOption = {
-  id: '__create_new__',
-  part_name: 'Create New Part',
-  description: null,
-  has_routing: false,
-  isCreateNew: true,
-};
-
 function formatCurrency(value: number | null | undefined): string {
   if (value === null || value === undefined || Number.isNaN(value)) return '—';
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
@@ -86,7 +71,7 @@ function formatCurrency(value: number | null | undefined): string {
 
 function emptyBlock(): PartBlockState {
   return {
-    part_id: '',
+    part: null,
     order_quantity: '',
     override_open: false,
     override_unit_price: '',
@@ -96,9 +81,12 @@ function emptyBlock(): PartBlockState {
   };
 }
 
-function blockFromInitial(p: QuoteFormData['parts'][number]): PartBlockState {
+function blockFromInitial(
+  p: QuoteFormData['parts'][number],
+  hydrated: PartSelectOption | undefined,
+): PartBlockState {
   return {
-    part_id: p.part_id,
+    part: hydrated ?? null,
     order_quantity: String(p.order_quantity),
     override_open: !!p.override,
     override_unit_price: p.override ? String(p.override.unit_price) : '',
@@ -108,132 +96,6 @@ function blockFromInitial(p: QuoteFormData['parts'][number]): PartBlockState {
   };
 }
 
-interface PartAutocompleteProps {
-  companyId: string;
-  partId: string;
-  initialOption?: PartOption | null;
-  onChange: (partId: string) => void;
-  onCreateNew: () => void;
-  label: string;
-}
-
-/**
- * Server-side search autocomplete for parts. Used for each part block on the
- * quote form. Avoids loading every row in the company (8000+ at the Contour
- * shop) just to drive client-side filtering.
- *
- * Own state:
- *  - `inputValue` is the text in the input. Drives the debounced search.
- *  - `options` is the current search-result page (capped at 50).
- *  - `selectedOption` is what the Autocomplete renders as the current value.
- *    Hydrated by `getPartsForSelectByIds` when `partId` is set without a label
- *    (e.g. edit mode, or just after creating a new part via the modal).
- */
-function PartAutocomplete({
-  companyId,
-  partId,
-  initialOption,
-  onChange,
-  onCreateNew,
-  label,
-}: PartAutocompleteProps) {
-  const [open, setOpen] = useState(false);
-  const [inputValue, setInputValue] = useState('');
-  const [options, setOptions] = useState<PartOption[]>([CREATE_NEW_PART]);
-  const [loading, setLoading] = useState(false);
-  const [selectedOption, setSelectedOption] = useState<PartOption | null>(
-    initialOption ?? null,
-  );
-
-  // Hydrate `selectedOption` when `partId` is set but we don't have a matching
-  // option (initial edit-mode load, or a fresh part_id from the create modal).
-  useEffect(() => {
-    if (!partId) {
-      setSelectedOption(null);
-      return;
-    }
-    if (selectedOption && selectedOption.id === partId) return;
-    let active = true;
-    getPartsForSelectByIds([partId])
-      .then((rows) => {
-        if (!active) return;
-        const row = rows[0];
-        if (!row) return;
-        setSelectedOption({
-          id: row.id,
-          part_name: row.part_name,
-          description: row.description,
-          has_routing: row.has_routing,
-        });
-      })
-      .catch((err) => {
-        console.error('Failed to hydrate part option:', err);
-      });
-    return () => {
-      active = false;
-    };
-    // selectedOption is intentionally excluded — we only resync on partId changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [partId]);
-
-  // Debounced search whenever the dropdown is open and the input changes.
-  useEffect(() => {
-    if (!open) return;
-    let active = true;
-    setLoading(true);
-    const delay = inputValue.trim() ? 300 : 0;
-    const timer = setTimeout(async () => {
-      try {
-        const results = await searchPartsForSelect(companyId, inputValue, 'all', 50);
-        if (!active) return;
-        setOptions([
-          CREATE_NEW_PART,
-          ...results.map((r) => ({
-            id: r.id,
-            part_name: r.part_name,
-            description: r.description,
-            has_routing: r.has_routing,
-          })),
-        ]);
-      } catch (err) {
-        console.error('Part search failed:', err);
-      } finally {
-        if (active) setLoading(false);
-      }
-    }, delay);
-    return () => {
-      active = false;
-      clearTimeout(timer);
-    };
-  }, [inputValue, companyId, open]);
-
-  return (
-    <Autocomplete
-      size="small"
-      open={open}
-      onOpen={() => setOpen(true)}
-      onClose={() => setOpen(false)}
-      options={options}
-      filterOptions={(x) => x}
-      loading={loading}
-      value={selectedOption}
-      inputValue={inputValue}
-      onInputChange={(_, v) => setInputValue(v)}
-      onChange={(_, v) => {
-        if (v?.isCreateNew) {
-          onCreateNew();
-          return;
-        }
-        setSelectedOption(v);
-        onChange(v?.id ?? '');
-      }}
-      getOptionLabel={(o) => o.part_name}
-      isOptionEqualToValue={(o, v) => o.id === v.id}
-      renderInput={(params) => <TextField {...params} label={label} />}
-    />
-  );
-}
-
 export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave }: QuoteFormProps) {
   const router = useRouter();
   const params = useParams();
@@ -241,7 +103,7 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
 
   const [formData, setFormData] = useState<QuoteFormData>(initialData);
   const [partBlocks, setPartBlocks] = useState<PartBlockState[]>(
-    initialData.parts.map(blockFromInitial),
+    initialData.parts.map((p) => blockFromInitial(p, undefined)),
   );
 
   const [customers, setCustomers] = useState<CustomerOption[]>([]);
@@ -256,17 +118,34 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   const loadData = useCallback(async () => {
     try {
       setLoadingData(true);
-      const customersData = await getAllCustomers(companyId);
+      const initialPartIds = initialData.parts.map((p) => p.part_id).filter(Boolean);
+      const [customersData, hydratedParts] = await Promise.all([
+        getAllCustomers(companyId),
+        initialPartIds.length > 0
+          ? getPartsForSelectByIds(initialPartIds)
+          : Promise.resolve([]),
+      ]);
       setCustomers([
         CREATE_NEW_CUSTOMER,
         ...customersData.map((c) => ({ id: c.id, name: c.name })),
       ]);
+      if (hydratedParts.length > 0) {
+        const byId = new Map(hydratedParts.map((p) => [p.id, p]));
+        setPartBlocks((prev) =>
+          prev.map((block, idx) => {
+            if (block.part) return block;
+            const initialId = initialData.parts[idx]?.part_id;
+            const hydrated = initialId ? byId.get(initialId) : undefined;
+            return hydrated ? { ...block, part: hydrated } : block;
+          }),
+        );
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load data');
     } finally {
       setLoadingData(false);
     }
-  }, [companyId]);
+  }, [companyId, initialData.parts]);
 
   useEffect(() => {
     loadData();
@@ -304,12 +183,13 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
       }
     };
     partBlocks.forEach((block, idx) => {
-      if (block.part_id && block.tiers.length === 0 && !block.loading && !block.error) {
-        loadTiers(idx, block.part_id);
+      const partId = block.part?.id;
+      if (partId && block.tiers.length === 0 && !block.loading && !block.error) {
+        loadTiers(idx, partId);
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [partBlocks.length, partBlocks.map((b) => b.part_id).join(',')]);
+  }, [partBlocks.length, partBlocks.map((b) => b.part?.id ?? '').join(',')]);
 
   const handleFieldChange = (field: keyof QuoteFormData, value: string | QuoteFormData['parts']) => {
     setFormData((prev) => ({ ...prev, [field]: value } as QuoteFormData));
@@ -323,10 +203,10 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     setPartBlocks((prev) => prev.filter((_, i) => i !== idx));
   };
 
-  const updatePartIdInBlock = (idx: number, partId: string) => {
+  const updatePartInBlock = (idx: number, option: PartSelectOption | null) => {
     setPartBlocks((prev) => {
       const next = [...prev];
-      next[idx] = { ...emptyBlock(), part_id: partId };
+      next[idx] = { ...emptyBlock(), part: option };
       return next;
     });
   };
@@ -359,16 +239,22 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     setCustomerModalOpen(false);
   };
 
-  const handlePartCreated = (part: { id: string }) => {
-    if (partModalTargetIdx !== null) {
-      setPartBlocks((prev) => {
-        const next = [...prev];
-        next[partModalTargetIdx] = { ...emptyBlock(), part_id: part.id };
-        return next;
-      });
-    }
+  const handlePartCreated = async (part: { id: string }) => {
+    const idx = partModalTargetIdx;
     setPartModalOpen(false);
     setPartModalTargetIdx(null);
+    if (idx === null) return;
+    try {
+      const [hydrated] = await getPartsForSelectByIds([part.id]);
+      if (!hydrated) return;
+      setPartBlocks((prev) => {
+        const next = [...prev];
+        next[idx] = { ...emptyBlock(), part: hydrated };
+        return next;
+      });
+    } catch (err) {
+      console.error('Failed to hydrate created part:', err);
+    }
   };
 
   /** Per-block live preview of the resolved tier + total. */
@@ -402,7 +288,7 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     let allComputable = true;
     for (let i = 0; i < partBlocks.length; i++) {
       const block = partBlocks[i];
-      if (!block.part_id) {
+      if (!block.part) {
         allComputable = false;
         continue;
       }
@@ -435,9 +321,9 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     }
     const seen = new Set<string>();
     for (const block of partBlocks) {
-      if (!block.part_id) return 'Every part block must have a part selected.';
-      if (seen.has(block.part_id)) return 'A part can only appear once on a quote.';
-      seen.add(block.part_id);
+      if (!block.part) return 'Every part block must have a part selected.';
+      if (seen.has(block.part.id)) return 'A part can only appear once on a quote.';
+      seen.add(block.part.id);
       const orderQty = Number(block.order_quantity);
       if (!Number.isFinite(orderQty) || orderQty <= 0) {
         return 'Every part needs an order quantity greater than zero.';
@@ -468,7 +354,7 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
       parts: partBlocks.map((b) => {
         const orderQty = Number(b.order_quantity);
         const block: QuoteFormData['parts'][number] = {
-          part_id: b.part_id,
+          part_id: b.part?.id ?? '',
           order_quantity: orderQty,
         };
         if (b.override_open && b.override_unit_price.trim() !== '') {
@@ -575,8 +461,8 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                   <Box sx={{ flex: 1 }}>
                     <PartAutocomplete
                       companyId={companyId}
-                      partId={block.part_id}
-                      onChange={(partId) => updatePartIdInBlock(idx, partId)}
+                      value={block.part}
+                      onChange={(option) => updatePartInBlock(idx, option)}
                       onCreateNew={() => openCreatePartModalForBlock(idx)}
                       label={`Part ${idx + 1}`}
                     />
@@ -598,12 +484,12 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
 
                 {block.error && <Alert severity="error">{block.error}</Alert>}
 
-                {!block.loading && block.part_id && block.tiers.length === 0 && !block.error && (
+                {!block.loading && block.part && block.tiers.length === 0 && !block.error && (
                   <Alert severity="warning">
                     This part has no pricing tiers yet.{' '}
                     <Link
                       component={NextLink}
-                      href={`/dashboard/${companyId}/parts/${block.part_id}`}
+                      href={`/dashboard/${companyId}/parts/${block.part.id}`}
                       target="_blank"
                       rel="noopener"
                       underline="always"
@@ -614,7 +500,7 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                   </Alert>
                 )}
 
-                {!block.loading && block.part_id && (
+                {!block.loading && block.part && (
                   <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
                     <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start', flexWrap: 'wrap' }}>
                       <TextField

--- a/components/vendors/VendorAutocomplete.tsx
+++ b/components/vendors/VendorAutocomplete.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import CircularProgress from '@mui/material/CircularProgress';
+import type { SxProps, Theme } from '@mui/material/styles';
+
+import { getAllVendors } from '@/utils/vendorsAccess';
+import type { Vendor } from '@/types/vendor';
+
+export interface VendorAutocompleteProps {
+  companyId: string;
+  /**
+   * Current selection. Pass either this (fully-resolved Vendor) or `valueId`
+   * (just the id — convenient when the parent only stores the foreign key
+   * and doesn't want to maintain a duplicate vendor object in state).
+   */
+  value?: Vendor | null;
+  /** Convenience: when `value` is unset, looks up the vendor by id from the loaded list. */
+  valueId?: string | null;
+  onChange: (vendor: Vendor | null) => void;
+  label: string;
+  placeholder?: string;
+  helperText?: React.ReactNode;
+  required?: boolean;
+  disabled?: boolean;
+  error?: boolean;
+  size?: 'small' | 'medium';
+  /** MUI Autocomplete renderOption hook for custom dropdown rendering. */
+  renderOption?: (
+    props: React.HTMLAttributes<HTMLLIElement> & { key?: React.Key },
+    option: Vendor,
+  ) => React.ReactNode;
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * Shared vendor picker. Bulk-loads via `getAllVendors` on mount — vendors
+ * are a bounded collection (~hundreds per company), so client-side filter
+ * is the right pattern. Compare with `PartAutocomplete` which scales to
+ * 10k+ via server-side search.
+ *
+ * When the vendor list comes back empty, the helper text falls through to
+ * a default "No vendors yet" message so admins know what to do next.
+ */
+export default function VendorAutocomplete({
+  companyId,
+  value,
+  valueId,
+  onChange,
+  label,
+  placeholder,
+  helperText,
+  required,
+  disabled,
+  error,
+  size = 'small',
+  renderOption,
+  sx,
+}: VendorAutocompleteProps) {
+  const [vendors, setVendors] = useState<Vendor[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  // Resolve effective value. Prefer the explicit Vendor; fall back to id
+  // lookup once the vendor list has loaded. While loading, return null so
+  // MUI doesn't warn about an out-of-options value.
+  const effectiveValue =
+    value ?? (valueId && loaded ? vendors.find((v) => v.id === valueId) ?? null : null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getAllVendors(companyId)
+      .then((rows) => {
+        if (!cancelled) setVendors(rows);
+      })
+      .catch((err) => {
+        if (!cancelled) console.warn('Failed to load vendors:', err);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+        setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [companyId]);
+
+  const finalHelperText =
+    helperText ??
+    (loaded && vendors.length === 0
+      ? 'No vendors yet — add one in Vendors first.'
+      : undefined);
+
+  return (
+    <Autocomplete<Vendor>
+      options={vendors}
+      value={effectiveValue}
+      onChange={(_, v) => onChange(v)}
+      getOptionLabel={(o) => o.name}
+      isOptionEqualToValue={(o, v) => o.id === v.id}
+      loading={loading}
+      disabled={disabled}
+      size={size}
+      sx={sx}
+      renderOption={renderOption}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          placeholder={placeholder}
+          required={required}
+          error={error}
+          helperText={finalHelperText}
+          slotProps={{
+            input: {
+              ...params.InputProps,
+              endAdornment: (
+                <>
+                  {loading ? <CircularProgress color="inherit" size={16} /> : null}
+                  {params.InputProps.endAdornment}
+                </>
+              ),
+            },
+          }}
+        />
+      )}
+    />
+  );
+}

--- a/components/vendors/index.ts
+++ b/components/vendors/index.ts
@@ -1,2 +1,3 @@
 export { default as VendorForm } from './VendorForm';
 export { default as VendorContactModal } from './VendorContactModal';
+export { default as VendorAutocomplete } from './VendorAutocomplete';

--- a/components/work-centers/WorkCenterForm.tsx
+++ b/components/work-centers/WorkCenterForm.tsx
@@ -13,7 +13,6 @@ import CircularProgress from '@mui/material/CircularProgress';
 import InputAdornment from '@mui/material/InputAdornment';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import Autocomplete from '@mui/material/Autocomplete';
 import Grid from '@mui/material/Grid';
 import FactoryIcon from '@mui/icons-material/Factory';
 import LocalShippingIcon from '@mui/icons-material/LocalShipping';
@@ -28,8 +27,7 @@ import {
   updateWorkCenter,
   checkWorkCenterNameExists,
 } from '@/utils/workCentersAccess';
-import { getAllVendors } from '@/utils/vendorsAccess';
-import type { Vendor } from '@/types/vendor';
+import VendorAutocomplete from '@/components/vendors/VendorAutocomplete';
 import { highContrastToggleSx } from '@/lib/highContrastToggleSx';
 
 interface WorkCenterFormProps {
@@ -60,34 +58,6 @@ export default function WorkCenterForm({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
-
-  const [vendors, setVendors] = useState<Vendor[]>([]);
-  const [vendorsLoading, setVendorsLoading] = useState(false);
-  const [vendorsLoaded, setVendorsLoaded] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    async function loadVendors() {
-      setVendorsLoading(true);
-      try {
-        const data = await getAllVendors(companyId);
-        if (!cancelled) {
-          setVendors(data);
-          setVendorsLoaded(true);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to load vendors');
-        }
-      } finally {
-        if (!cancelled) setVendorsLoading(false);
-      }
-    }
-    loadVendors();
-    return () => {
-      cancelled = true;
-    };
-  }, [companyId]);
 
   const handleTextChange = (field: keyof WorkCenterFormData) => (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -206,8 +176,6 @@ export default function WorkCenterForm({
     }
   };
 
-  const selectedVendor = vendors.find((v) => v.id === formData.vendor_id) || null;
-
   return (
     <Box component="form" onSubmit={handleSubmit}>
       {error && (
@@ -323,49 +291,25 @@ export default function WorkCenterForm({
 
             {formData.kind === 'external' && (
               <Grid size={{ xs: 12, sm: 6 }}>
-                <Autocomplete
-                  options={vendors}
-                  getOptionLabel={(opt) => opt.name}
-                  value={selectedVendor}
-                  loading={vendorsLoading}
-                  onChange={(_event, newValue) => {
+                <VendorAutocomplete
+                  companyId={companyId}
+                  valueId={formData.vendor_id}
+                  onChange={(vendor) => {
                     setFormData((prev) => ({
                       ...prev,
-                      vendor_id: newValue ? newValue.id : null,
+                      vendor_id: vendor ? vendor.id : null,
                     }));
                     if (fieldErrors.vendor_id) {
                       setFieldErrors((prev) => ({ ...prev, vendor_id: '' }));
                     }
                   }}
                   disabled={loading}
-                  isOptionEqualToValue={(opt, val) => opt.id === val.id}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      required
-                      label="Vendor"
-                      error={!!fieldErrors.vendor_id}
-                      helperText={
-                        fieldErrors.vendor_id ||
-                        (vendorsLoaded && vendors.length === 0
-                          ? 'No vendors yet — add one in Vendors first.'
-                          : 'Vendor performing this outside operation')
-                      }
-                      slotProps={{
-                        input: {
-                          ...params.InputProps,
-                          endAdornment: (
-                            <>
-                              {vendorsLoading ? (
-                                <CircularProgress color="inherit" size={20} />
-                              ) : null}
-                              {params.InputProps.endAdornment}
-                            </>
-                          ),
-                        },
-                      }}
-                    />
-                  )}
+                  required
+                  label="Vendor"
+                  error={!!fieldErrors.vendor_id}
+                  helperText={
+                    fieldErrors.vendor_id || 'Vendor performing this outside operation'
+                  }
                 />
               </Grid>
             )}


### PR DESCRIPTION
## Summary

- **Root cause fix:** Quote-form part picker showed "No options" for parts past row 1000 because `getPartsForSelect`, `getStockedParts`, `getMadeParts`, `getBoughtParts`, `getAllVendors`, and `getWorkCentersForRouting` were silently capped by Supabase's default 1000-row response limit. All six now batch in 1000-row chunks using the same pattern as the existing `getAllParts`.
- **Quote-form picker → server-side search.** New `searchPartsForSelect(companyId, query, kind, limit)` and `getPartsForSelectByIds` back a self-contained `PartAutocomplete` component with 300ms-debounced search. The form is interactive immediately instead of blocking on a multi-second bulk-load.
- **Shared components.** Extracted `PartAutocomplete` (used in quotes, BOM editor, job-complete modal) and `VendorAutocomplete` (used in PartFormModal, PartForm, WorkCenterForm). Six near-duplicate Autocomplete implementations collapse to two reusable components — net 518 lines deleted, 470 added.
- `PartProcurementPricingPanel`'s vendor picker stays inline — it needs `vendor.name` for an optimistic tier-add update and a custom `getOptionLabel` showing tier counts. Pulling that into the shared component would require enough escape hatches to dilute the abstraction.

## Test plan

- [ ] Open `/dashboard/{companyId}/quotes/new` at Contour (~8k parts) and confirm `CLA-7982 CT235 STACME THD` is reachable in the dropdown.
- [ ] Open an existing quote in edit mode — confirm each part block displays its name without flicker (hydration via `getPartsForSelectByIds`).
- [ ] On a part detail page, open the BOM editor and add a material — confirm the picker searches across all parts.
- [ ] Operator view: complete a job and click "Add Material" — confirm the stocked-parts picker excludes already-added materials and pulls from the full stocked set.
- [ ] Edit a bought part's preferred vendor on PartForm — confirm the vendor shows correctly on initial load (via `valueId` hydration).
- [ ] Create an external work center and pick a vendor — confirm required-field error styling still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)