### PR TITLE
Constrain BOM unit picker; restrict procurement cost to preferred vendor

### DIFF
--- a/__tests__/lib/partNavStack.test.ts
+++ b/__tests__/lib/partNavStack.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_PART_NAV_DEPTH,
+  parseBackChain,
+  pushPartToChain,
+  popPartFromChain,
+  buildPartHref,
+} from '@/lib/partNavStack';
+
+// Stable, recognizably-distinct UUIDs so failure messages are easier to read.
+const A = '00000000-0000-0000-0000-00000000000a';
+const B = '00000000-0000-0000-0000-00000000000b';
+const C = '00000000-0000-0000-0000-00000000000c';
+const D = '00000000-0000-0000-0000-00000000000d';
+const E = '00000000-0000-0000-0000-00000000000e';
+const F = '00000000-0000-0000-0000-00000000000f';
+const G = '00000000-0000-0000-0000-000000000010';
+
+function params(value: string | null): URLSearchParams {
+  const out = new URLSearchParams();
+  if (value !== null) out.set('back', value);
+  return out;
+}
+
+describe('parseBackChain', () => {
+  it('returns [] when ?back= is missing', () => {
+    expect(parseBackChain(params(null))).toEqual([]);
+  });
+
+  it('returns [] when ?back= is empty string', () => {
+    expect(parseBackChain(params(''))).toEqual([]);
+  });
+
+  it('parses a comma-separated list of uuids', () => {
+    expect(parseBackChain(params(`${A},${B},${C}`))).toEqual([A, B, C]);
+  });
+
+  it('trims whitespace around entries', () => {
+    expect(parseBackChain(params(` ${A} ,  ${B}  ,${C}`))).toEqual([A, B, C]);
+  });
+
+  it('drops non-uuid garbage entries', () => {
+    expect(parseBackChain(params(`${A},not-a-uuid,${B}`))).toEqual([A, B]);
+  });
+
+  it('drops empty entries from extra commas', () => {
+    expect(parseBackChain(params(`${A},,${B},`))).toEqual([A, B]);
+  });
+
+  it('de-duplicates adjacent repeats (defensive against hand-edited URLs)', () => {
+    expect(parseBackChain(params(`${A},${A},${B}`))).toEqual([A, B]);
+  });
+
+  it('caps at MAX_PART_NAV_DEPTH', () => {
+    const ids = [A, B, C, D, E, F, G]; // 7 unique entries
+    const result = parseBackChain(params(ids.join(',')));
+    expect(result).toHaveLength(MAX_PART_NAV_DEPTH);
+  });
+
+  it('returns [] for null/undefined searchParams', () => {
+    expect(parseBackChain(null)).toEqual([]);
+    expect(parseBackChain(undefined)).toEqual([]);
+  });
+});
+
+describe('pushPartToChain', () => {
+  it('appends currentPartId when navigating to a fresh target', () => {
+    expect(pushPartToChain([], A, B)).toEqual([A]);
+    expect(pushPartToChain([A], B, C)).toEqual([A, B]);
+    expect(pushPartToChain([A, B], C, D)).toEqual([A, B, C]);
+  });
+
+  it('truncates to before the target on a self-link (target === current)', () => {
+    expect(pushPartToChain([A, B], C, C)).toEqual([A, B]);
+    expect(pushPartToChain([], A, A)).toEqual([]);
+  });
+
+  it('truncates the chain when the target appears in it (true cycle)', () => {
+    // On D after walking A → B → C → D, click a link back to B.
+    // Chain becomes [A] — proposed=[A,B,C,D], B at index 1 → slice(0, 1).
+    expect(pushPartToChain([A, B, C], D, B)).toEqual([A]);
+  });
+
+  it('truncates to [] when target is the chain root', () => {
+    expect(pushPartToChain([A, B, C], D, A)).toEqual([]);
+  });
+
+  it('caps at MAX_PART_NAV_DEPTH (drops oldest first) on fresh push', () => {
+    // Build up MAX entries then push one more.
+    const full = [A, B, C, D, E]; // length 5 (= MAX)
+    const result = pushPartToChain(full, F, G);
+    expect(result).toHaveLength(MAX_PART_NAV_DEPTH);
+    // A drops off; B..F survive in order.
+    expect(result).toEqual([B, C, D, E, F]);
+  });
+
+  it('does not exceed MAX even when proposed is exactly MAX+1', () => {
+    const result = pushPartToChain([A, B, C, D], E, F);
+    // proposed = [A,B,C,D,E] (length 5); F not in proposed, no cycle, length within cap.
+    expect(result).toEqual([A, B, C, D, E]);
+  });
+});
+
+describe('popPartFromChain', () => {
+  it('returns null + [] for an empty chain', () => {
+    expect(popPartFromChain([])).toEqual({ previous: null, remaining: [] });
+  });
+
+  it('pops the most recent entry', () => {
+    expect(popPartFromChain([A, B, C])).toEqual({
+      previous: C,
+      remaining: [A, B],
+    });
+  });
+
+  it('pops the only entry to leave an empty remaining', () => {
+    expect(popPartFromChain([A])).toEqual({ previous: A, remaining: [] });
+  });
+});
+
+describe('buildPartHref', () => {
+  it('builds a base href without ?back= when chain is empty', () => {
+    expect(
+      buildPartHref({ companyId: 'co1', targetPartId: A, chain: [] }),
+    ).toBe(`/dashboard/co1/parts/${A}`);
+  });
+
+  it('appends comma-joined ?back= when chain is non-empty', () => {
+    expect(
+      buildPartHref({ companyId: 'co1', targetPartId: A, chain: [B, C] }),
+    ).toBe(`/dashboard/co1/parts/${A}?back=${B},${C}`);
+  });
+});

--- a/__tests__/utils/routingCostCalculation.test.ts
+++ b/__tests__/utils/routingCostCalculation.test.ts
@@ -480,6 +480,33 @@ describe('calculateRoutingCost', () => {
       expect(result!.total_material_cost).toBe(0);
     });
 
+    it('exposes child_part_name + detail on missing_material_cost so the renderer can link the part name', async () => {
+      // The Pricing-card warning UI replaced the trailing "Open child →" link
+      // with `<Link>{child_part_name}</Link> {detail}` so the part name itself
+      // is the click target. Verify the warning carries those fields and that
+      // `message` still composes them for backwards-compatible callers.
+      mockGetRoutingForPart.mockResolvedValue(null);
+      mockGetBomForPart.mockResolvedValue([
+        makeBomLine({
+          quantity: 5,
+          childName: 'UNPRICED-PART',
+          childCost: null,
+        }),
+      ]);
+
+      const result = await calculateRoutingCost('part-1');
+
+      const w = result!.warnings[0];
+      expect(w.child_part_name).toBe('UNPRICED-PART');
+      expect(typeof w.detail).toBe('string');
+      expect(w.detail).not.toBe('');
+      // detail should NOT include the "PARTNAME: " prefix — that's the
+      // renderer's job, composed via the Link wrapper.
+      expect(w.detail).not.toMatch(/^UNPRICED-PART:/);
+      // message still combines them for legacy callers.
+      expect(w.message).toBe(`UNPRICED-PART: ${w.detail}`);
+    });
+
     it('falls back to child.primary_unit when bom.unit is empty', async () => {
       mockGetRoutingForPart.mockResolvedValue(null);
       mockGetBomForPart.mockResolvedValue([

--- a/app/dashboard/[companyId]/parts/[partId]/page.tsx
+++ b/app/dashboard/[companyId]/parts/[partId]/page.tsx
@@ -19,10 +19,12 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import Chip from '@mui/material/Chip';
 import Snackbar from '@mui/material/Snackbar';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import MuiLink from '@mui/material/Link';
+import NextLink from 'next/link';
 
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import TuneIcon from '@mui/icons-material/Tune';
@@ -31,7 +33,9 @@ import {
   getPartWithRelations,
   deletePart,
   getPartUnitConversions,
+  getPartNamesByIds,
 } from '@/utils/partsAccess';
+import { parseBackChain, buildPartHref } from '@/lib/partNavStack';
 import type { Part, PartUnitConversion } from '@/types/part';
 import type { InventoryTransactionType } from '@/types/partTransaction';
 import PartRoutingPanel from '@/components/parts/PartRoutingPanel';
@@ -55,24 +59,49 @@ export default function PartDetailPage() {
   const companyId = params.companyId as string;
   const partId = params.partId as string;
 
-  // Back link routes to whichever list page the user came from. Only the
-  // Parts and Inventory list pages set ?from=; entry points from BOM rows,
-  // routing rows, quote line items, "where used", and jobs do not, and the
-  // back link falls through to /parts (the closer match for "I came from
-  // somewhere that isn't a list"). Documented scope boundary: this is a
-  // list-page back link, not a universal browser-history back button.
+  // List-page crumb (root of the breadcrumb). Reflects where the user
+  // entered the part-detail flow from — Parts vs. Inventory. Only the
+  // list pages set ?from=; entry points from BOM rows, quote line items,
+  // jobs etc. fall through to /parts.
   const partsListHref = useMemo(() => {
     const from = searchParams.get('from');
     if (from === 'inventory') return `/dashboard/${companyId}/inventory`;
     return `/dashboard/${companyId}/parts`;
   }, [companyId, searchParams]);
 
-  // Label matches the destination so the back link reflects where the user
-  // came from. Same fall-through rule as partsListHref.
   const partsListLabel = useMemo(() => {
     const from = searchParams.get('from');
-    return from === 'inventory' ? 'Back to Inventory' : 'Back to Parts';
+    return from === 'inventory' ? 'Inventory' : 'Parts';
   }, [searchParams]);
+
+  // Drill-down chain from `?back=id1,id2,id3`. Each entry is a part the
+  // user passed through to get here (oldest → most-recent). Empty when
+  // the user landed directly (list page, quote, deep-link, etc.).
+  const currentChain = useMemo(() => parseBackChain(searchParams), [searchParams]);
+
+  // Lazy-loaded id → display name map for the chain. One Supabase call
+  // per chain change. Names come from getPartNamesByIds; ids that don't
+  // resolve (deleted/garbage) just won't appear in the map and the
+  // breadcrumb falls back to "(unknown)".
+  const [chainNames, setChainNames] = useState<Map<string, string>>(new Map());
+  useEffect(() => {
+    if (currentChain.length === 0) {
+      setChainNames(new Map());
+      return;
+    }
+    let cancelled = false;
+    getPartNamesByIds(currentChain)
+      .then((map) => {
+        if (!cancelled) setChainNames(map);
+      })
+      .catch((err) => {
+        // Non-fatal — the breadcrumb still renders with placeholders.
+        if (!cancelled) console.warn('Failed to load breadcrumb part names:', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentChain]);
 
   const [part, setPart] = useState<Part | null>(null);
   const [unitConversions, setUnitConversions] = useState<PartUnitConversion[]>([]);
@@ -213,27 +242,54 @@ export default function PartDetailPage() {
 
   return (
     <Box>
-      {/* Top action bar: Back link left, Delete right. Edit moved into the
-          header card below — the form only edits the data shown there
-          (name, description, source, stocked, UOM), so anchoring it on the
-          card it modifies matches the user's mental model. Delete stays
-          page-level: it's the destructive global action and visually
-          separating it from Edit reduces accidental-click risk. */}
+      {/* Top action bar: breadcrumb on the left, Delete on the right. The
+          breadcrumb collapses to just the list-page crumb when the chain
+          is empty (direct-land), and expands to show the BOM drill-down
+          trail when the user reached this page via a series of part
+          links. The current part is the rightmost crumb (plain text —
+          "you are here"). Each prior crumb's href points back to that
+          part with the chain truncated up to and including its slot, so
+          clicking any crumb pops everything after it. */}
       <Box
         sx={{
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
+          gap: 2,
           mb: 3,
         }}
       >
-        <Button
-          startIcon={<ArrowBackIcon />}
-          onClick={() => router.push(partsListHref)}
-          sx={{ color: 'text.secondary' }}
-        >
-          {partsListLabel}
-        </Button>
+        <Breadcrumbs separator="›" sx={{ flex: 1, minWidth: 0 }}>
+          <MuiLink
+            component={NextLink}
+            href={partsListHref}
+            underline="hover"
+            color="text.secondary"
+          >
+            {partsListLabel}
+          </MuiLink>
+          {currentChain.map((id, i) => (
+            <MuiLink
+              key={`${id}-${i}`}
+              component={NextLink}
+              href={buildPartHref({
+                companyId,
+                targetPartId: id,
+                // Chain to attach to the destination = everything before
+                // this slot. Clicking entry i lands you on that part with
+                // all entries 0..i-1 still in the trail.
+                chain: currentChain.slice(0, i),
+              })}
+              underline="hover"
+              color="text.secondary"
+            >
+              {chainNames.get(id) ?? '…'}
+            </MuiLink>
+          ))}
+          <Typography color="text.primary" sx={{ fontWeight: 500 }}>
+            {part.part_name}
+          </Typography>
+        </Breadcrumbs>
 
         <Tooltip
           title={
@@ -442,7 +498,12 @@ export default function PartDetailPage() {
             <Grid size={{ xs: 12, md: 7 }}>
               <Card elevation={2} sx={{ height: '100%' }}>
                 <CardContent>
-                  <PartPricing companyId={companyId} part={part} refreshKey={refreshKey} />
+                  <PartPricing
+                    companyId={companyId}
+                    part={part}
+                    refreshKey={refreshKey}
+                    currentChain={currentChain}
+                  />
                 </CardContent>
               </Card>
             </Grid>
@@ -471,6 +532,7 @@ export default function PartDetailPage() {
                       <PartBomPanel
                         partId={partId}
                         companyId={companyId}
+                        currentChain={currentChain}
                         description={`Parts consumed when manufacturing this ${part.part_name}.`}
                         onChanged={refreshAfterMutation}
                       />
@@ -506,7 +568,12 @@ export default function PartDetailPage() {
             <Grid size={{ xs: 12 }}>
               <Card elevation={2}>
                 <CardContent>
-                  <PartPricing companyId={companyId} part={part} refreshKey={refreshKey} />
+                  <PartPricing
+                    companyId={companyId}
+                    part={part}
+                    refreshKey={refreshKey}
+                    currentChain={currentChain}
+                  />
                 </CardContent>
               </Card>
             </Grid>
@@ -525,7 +592,11 @@ export default function PartDetailPage() {
                   Other parts whose BOM includes this part as a component.
                 </Typography>
                 <Divider sx={{ my: 2 }} />
-                <PartWhereUsedPanel partId={partId} companyId={companyId} />
+                <PartWhereUsedPanel
+                  partId={partId}
+                  companyId={companyId}
+                  currentChain={currentChain}
+                />
               </CardContent>
             </Card>
           </Grid>

--- a/app/dashboard/[companyId]/parts/[partId]/page.tsx
+++ b/app/dashboard/[companyId]/parts/[partId]/page.tsx
@@ -259,7 +259,11 @@ export default function PartDetailPage() {
           mb: 3,
         }}
       >
-        <Breadcrumbs separator="›" sx={{ flex: 1, minWidth: 0 }}>
+        <Breadcrumbs
+          aria-label="Part trail"
+          separator="›"
+          sx={{ flex: 1, minWidth: 0 }}
+        >
           <MuiLink
             component={NextLink}
             href={partsListHref}

--- a/components/parts/MaterialRowEditor.tsx
+++ b/components/parts/MaterialRowEditor.tsx
@@ -7,6 +7,10 @@ import Button from '@mui/material/Button';
 import Autocomplete from '@mui/material/Autocomplete';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
+import MenuItem from '@mui/material/MenuItem';
+import InputAdornment from '@mui/material/InputAdornment';
+import Link from 'next/link';
+import { getPartUnitConversions } from '@/utils/partsAccess';
 
 /**
  * Lightweight part option used by the material picker. Mirrors the shape
@@ -31,6 +35,12 @@ export interface MaterialEditorValue {
 export interface MaterialRowEditorProps {
   parts: PartOption[];
   partsLoading: boolean;
+  /**
+   * Used to build the "add a unit conversion on the child part" link in the
+   * helper caption when the child has only its primary_unit available. Not
+   * load-bearing for save logic.
+   */
+  companyId: string;
   /** When provided, the editor is in edit mode for an existing material row. */
   initial?: MaterialEditorValue;
   /**
@@ -65,6 +75,7 @@ const EMPTY_VALUE: MaterialEditorValue = {
 export default function MaterialRowEditor({
   parts,
   partsLoading,
+  companyId,
   initial,
   lockChildPart = false,
   saving = false,
@@ -74,20 +85,90 @@ export default function MaterialRowEditor({
 }: MaterialRowEditorProps) {
   const [value, setValue] = useState<MaterialEditorValue>(initial ?? EMPTY_VALUE);
 
+  // Conversions for the currently-selected child part. Drives the Unit picker
+  // options: primary_unit + every parts_unit_conversions.from_unit row. Empty
+  // until a child is picked or the load resolves.
+  const [conversionUnits, setConversionUnits] = useState<string[]>([]);
+  const [conversionsLoading, setConversionsLoading] = useState(false);
+
   // Reset when initial changes (e.g. user cancels add then opens edit on a
   // different row in the same panel mount).
   useEffect(() => {
     setValue(initial ?? EMPTY_VALUE);
   }, [initial]);
 
+  // Load the child's secondary units whenever it changes. The Unit picker
+  // is constrained to primary_unit + these — entering a unit with no
+  // conversion would just blow up later in compute_part_cost_at_qty.
+  useEffect(() => {
+    const childId = value.childPart?.id;
+    if (!childId) {
+      setConversionUnits([]);
+      return;
+    }
+    let cancelled = false;
+    setConversionsLoading(true);
+    getPartUnitConversions(childId)
+      .then((rows) => {
+        if (cancelled) return;
+        setConversionUnits(rows.map((r) => r.from_unit));
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error('Failed to load unit conversions for child:', err);
+        setConversionUnits([]);
+      })
+      .finally(() => {
+        if (!cancelled) setConversionsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value.childPart?.id]);
+
+  // Build the constrained option list: primary_unit first, then every
+  // conversion `from_unit`, de-duped, preserving order. When the child has
+  // no primary_unit (legacy/odd parts), this is empty and we fall back to
+  // free-text below — there's no canonical anchor unit to lock to.
+  const unitOptions = useMemo<string[]>(() => {
+    const child = value.childPart;
+    if (!child) return [];
+    const list: string[] = [];
+    if (child.primary_unit) list.push(child.primary_unit);
+    for (const u of conversionUnits) {
+      if (!list.includes(u)) list.push(u);
+    }
+    return list;
+  }, [value.childPart, conversionUnits]);
+
+  const noPrimaryUnit = !!value.childPart && !value.childPart.primary_unit;
+  const onlyPrimaryAvailable =
+    !!value.childPart && !!value.childPart.primary_unit && conversionUnits.length === 0;
+
+  // Auto-correct the unit when the child changes and the previously-typed
+  // unit isn't valid for the new child. Snap to primary_unit (the canonical
+  // default) so the user starts from a working state. We only run this once
+  // the conversions load completes for the current child to avoid clobbering
+  // an in-flight selection.
+  useEffect(() => {
+    if (conversionsLoading) return;
+    const child = value.childPart;
+    if (!child) return;
+    if (noPrimaryUnit) return; // free-text fallback handles this
+    if (unitOptions.includes(value.unit)) return;
+    setValue((prev) => ({ ...prev, unit: child.primary_unit ?? '' }));
+    // value.unit and value.childPart are read; updating value here is fine.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [unitOptions, conversionsLoading, noPrimaryUnit]);
+
   const handlePartChange = (option: PartOption | null) => {
     setValue((prev) => ({
       ...prev,
       childPart: option,
       // Default the BOM unit to the child's primary unit on first selection
-      // (one-click for the common case). Don't clobber if the user already
-      // typed a unit — they may have intentionally chosen a different one.
-      unit: prev.unit?.trim() ? prev.unit : option?.primary_unit ?? '',
+      // (one-click for the common case). The conversions-load effect will
+      // re-snap to primary_unit if the previous typed value is invalid.
+      unit: option?.primary_unit ?? '',
     }));
   };
 
@@ -96,8 +177,12 @@ export default function MaterialRowEditor({
     const qty = parseFloat(value.quantity);
     if (!Number.isFinite(qty) || qty <= 0) return false;
     if (!value.unit?.trim()) return false;
+    // When a primary_unit is defined, the unit must match one of the
+    // resolvable options. The free-text fallback (noPrimaryUnit) skips this
+    // check since there are no conversions to validate against.
+    if (!noPrimaryUnit && !unitOptions.includes(value.unit)) return false;
     return true;
-  }, [value]);
+  }, [value, unitOptions, noPrimaryUnit]);
 
   return (
     <Box
@@ -179,16 +264,55 @@ export default function MaterialRowEditor({
           sx={{ width: 120 }}
         />
 
-        <TextField
-          label="Unit"
-          value={value.unit}
-          onChange={(e) => setValue((prev) => ({ ...prev, unit: e.target.value }))}
-          required
-          placeholder={value.childPart?.primary_unit ?? ''}
-          size="small"
-          disabled={saving}
-          sx={{ width: 100 }}
-        />
+        {/* Unit picker: constrained to the child's primary_unit + every
+            parts_unit_conversions.from_unit row. Free-text was removed
+            because typed-but-unconvertible units silently broke the cost
+            rollup later. The no-primary-unit branch (legacy parts) keeps
+            the old free-text behavior. */}
+        {noPrimaryUnit ? (
+          <TextField
+            label="Unit"
+            value={value.unit}
+            onChange={(e) => setValue((prev) => ({ ...prev, unit: e.target.value }))}
+            required
+            size="small"
+            disabled={saving}
+            sx={{ width: 110 }}
+            helperText="Child has no primary unit"
+          />
+        ) : (
+          <TextField
+            select
+            label="Unit"
+            value={value.childPart && unitOptions.includes(value.unit) ? value.unit : ''}
+            onChange={(e) => setValue((prev) => ({ ...prev, unit: e.target.value }))}
+            required
+            size="small"
+            disabled={saving || !value.childPart || conversionsLoading || onlyPrimaryAvailable}
+            sx={{ width: 130 }}
+            slotProps={{
+              input: {
+                endAdornment: conversionsLoading ? (
+                  <InputAdornment position="end">
+                    <CircularProgress size={14} />
+                  </InputAdornment>
+                ) : undefined,
+              },
+            }}
+          >
+            {unitOptions.length === 0 && (
+              <MenuItem value="" disabled>
+                {value.childPart ? 'No units available' : 'Pick a part first'}
+              </MenuItem>
+            )}
+            {unitOptions.map((u) => (
+              <MenuItem key={u} value={u}>
+                {u}
+                {value.childPart?.primary_unit === u ? ' (primary)' : ''}
+              </MenuItem>
+            ))}
+          </TextField>
+        )}
       </Box>
 
       {value.childPart?.primary_unit &&
@@ -196,9 +320,24 @@ export default function MaterialRowEditor({
         value.unit !== value.childPart.primary_unit && (
           <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.75, ml: 1 }}>
             Child&apos;s primary unit: {value.childPart.primary_unit}. The cost
-            calculation will use unit conversions to bridge.
+            calculation will use the matching conversion to bridge.
           </Typography>
         )}
+
+      {onlyPrimaryAvailable && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.75, ml: 1 }}>
+          Only the child&apos;s primary unit ({value.childPart?.primary_unit}) is
+          available. To use a different unit,{' '}
+          <Link
+            href={`/dashboard/${companyId}/parts/${value.childPart?.id ?? ''}`}
+            target="_blank"
+            style={{ textDecoration: 'underline', color: 'inherit' }}
+          >
+            add a unit conversion on the child part
+          </Link>
+          .
+        </Typography>
+      )}
 
       {error && (
         <Typography variant="caption" color="error" sx={{ display: 'block', mt: 0.75, ml: 1 }}>

--- a/components/parts/PartBomPanel.tsx
+++ b/components/parts/PartBomPanel.tsx
@@ -19,7 +19,9 @@ import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import NextLink from 'next/link';
+import { buildPartHref, pushPartToChain } from '@/lib/partNavStack';
 import {
   getBomForPart,
   deleteBomLine,
@@ -43,6 +45,14 @@ import MaterialRowEditor, {
 interface PartBomPanelProps {
   partId: string;
   companyId: string;
+  /**
+   * The drill-down chain on the page hosting this panel — i.e. the result
+   * of `parseBackChain(searchParams)` from the part-detail page. Used to
+   * build child-part hrefs that push the *current* part onto the trail
+   * via `pushPartToChain`. Defaults to empty so callers outside the
+   * part-detail page don't need to thread it through.
+   */
+  currentChain?: string[];
   /** When true, hides add/edit/remove controls (display-only mode). */
   readOnly?: boolean;
   /**
@@ -108,6 +118,7 @@ interface BomRowCost {
 export default function PartBomPanel({
   partId,
   companyId,
+  currentChain = [],
   readOnly = false,
   description,
   onChanged,
@@ -488,13 +499,30 @@ export default function PartBomPanel({
                 }}
               >
                 <Box sx={{ flex: 1, minWidth: 0 }}>
+                  {/* Restyled to read as an obvious link: primary color +
+                      always-underlined + trailing chevron. The rest of
+                      the row stays inert; edit/remove icons keep their
+                      own click targets. The href pushes this part onto
+                      the back chain so the destination renders a
+                      breadcrumb back to here. */}
                   <Link
                     component={NextLink}
-                    href={`/dashboard/${companyId}/parts/${child.id}`}
-                    underline="hover"
-                    sx={{ fontWeight: 500 }}
+                    href={buildPartHref({
+                      companyId,
+                      targetPartId: child.id,
+                      chain: pushPartToChain(currentChain, partId, child.id),
+                    })}
+                    underline="always"
+                    color="primary.main"
+                    sx={{
+                      fontWeight: 500,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 0.25,
+                    }}
                   >
                     {child.part_name}
+                    <ChevronRightIcon sx={{ fontSize: 16 }} />
                   </Link>
                 </Box>
                 <Box sx={{ minWidth: 110, textAlign: 'right' }}>
@@ -524,7 +552,15 @@ export default function PartBomPanel({
                     >
                       <Box
                         component={NextLink}
-                        href={`/dashboard/${companyId}/parts/${rowCost?.missingLeaf?.part_id ?? child.id}`}
+                        href={buildPartHref({
+                          companyId,
+                          targetPartId: rowCost?.missingLeaf?.part_id ?? child.id,
+                          chain: pushPartToChain(
+                            currentChain,
+                            partId,
+                            rowCost?.missingLeaf?.part_id ?? child.id,
+                          ),
+                        })}
                         sx={{
                           display: 'inline-flex',
                           alignItems: 'center',

--- a/components/parts/PartBomPanel.tsx
+++ b/components/parts/PartBomPanel.tsx
@@ -504,6 +504,7 @@ export default function PartBomPanel({
                   key={row.id}
                   parts={parts}
                   partsLoading={partsLoading}
+                  companyId={companyId}
                   initial={editingInitial}
                   lockChildPart
                   saving={saving}
@@ -619,6 +620,7 @@ export default function PartBomPanel({
             <MaterialRowEditor
               parts={parts}
               partsLoading={partsLoading}
+              companyId={companyId}
               saving={saving}
               error={editorError}
               onSave={handleEditorSave}

--- a/components/parts/PartPricing.tsx
+++ b/components/parts/PartPricing.tsx
@@ -48,12 +48,20 @@ import {
 import { calculateMarkupFromUnitPrice } from '@/types/quote';
 import type { Part } from '@/types/part';
 import PartProcurementPricingPanel from '@/components/parts/PartProcurementPricingPanel';
+import { buildPartHref, pushPartToChain } from '@/lib/partNavStack';
 
 interface PartPricingProps {
   companyId: string;
   part: Part;
   /** Bumped by the parent whenever the routing changes — triggers a reload + recompute. */
   refreshKey?: number;
+  /**
+   * Drill-down chain on the page hosting this card — passed through to
+   * `pushPartToChain` when building the href on each "Heads up" warning
+   * link so back-navigation breadcrumbs accumulate. Defaults to empty
+   * for callers outside the part-detail page.
+   */
+  currentChain?: string[];
 }
 
 /**
@@ -126,7 +134,12 @@ function recomputeRow(row: EditRow, breakdown: RoutingCostBreakdown | null): Edi
  * tier rows; rate-linked = read-only display of the rate's breakpoints
  * + Switch-to-Custom / Edit-the-rate buttons.
  */
-export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPricingProps) {
+export default function PartPricing({
+  companyId,
+  part,
+  refreshKey = 0,
+  currentChain = [],
+}: PartPricingProps) {
   const partId = part.id;
   const isBought = part.source === 'bought';
 
@@ -466,22 +479,44 @@ export default function PartPricing({ companyId, part, refreshKey = 0 }: PartPri
           <Typography variant="body2" sx={{ fontWeight: 600, mb: 0.5 }}>
             Heads up:
           </Typography>
-          {breakdown.warnings.map((w, i) => (
-            <Typography key={i} variant="body2">
-              • {w.message}
-              {w.child_part_id && (
-                <>
-                  {' '}
-                  <Link
-                    href={`/dashboard/${companyId}/parts/${w.child_part_id}`}
-                    style={{ color: 'inherit', textDecoration: 'underline' }}
-                  >
-                    Open child →
-                  </Link>
-                </>
-              )}
-            </Typography>
-          ))}
+          {breakdown.warnings.map((w, i) => {
+            // missing_material_cost warnings expose `child_part_name` +
+            // `detail` so the part name itself can be the link (no
+            // trailing "Open child →"). Other warning types fall back
+            // to the bare `message` string with no link, since they
+            // don't point at a navigable target.
+            const isLinkable = !!w.child_part_id && !!w.child_part_name;
+            return (
+              <Typography key={i} variant="body2">
+                {'• '}
+                {isLinkable ? (
+                  <>
+                    <Link
+                      href={buildPartHref({
+                        companyId,
+                        targetPartId: w.child_part_id as string,
+                        chain: pushPartToChain(
+                          currentChain,
+                          part.id,
+                          w.child_part_id as string,
+                        ),
+                      })}
+                      style={{
+                        color: 'inherit',
+                        textDecoration: 'underline',
+                        fontWeight: 600,
+                      }}
+                    >
+                      {w.child_part_name} ›
+                    </Link>{' '}
+                    {w.detail ?? ''}
+                  </>
+                ) : (
+                  w.message
+                )}
+              </Typography>
+            );
+          })}
         </Alert>
       )}
 

--- a/components/parts/PartProcurementPricingPanel.tsx
+++ b/components/parts/PartProcurementPricingPanel.tsx
@@ -24,6 +24,7 @@ import {
   addTier as addTierApi,
   updateTier as updateTierApi,
   deleteTier as deleteTierApi,
+  getProcurementCost,
 } from '@/utils/procurementTiersAccess';
 import { getAllVendors } from '@/utils/vendorsAccess';
 import { updatePartPreferredVendor } from '@/utils/partsAccess';
@@ -77,10 +78,14 @@ function tempId(): string {
  * an existing sheet on this part are flagged with a tier-count caption,
  * so the user sees at a glance who they already have rates from.
  *
- * Multi-vendor data still works — the user can have sheets from any
- * number of vendors, but only one is shown/edited at a time. Quote-time
- * pricing (`get_procurement_cost`) still picks the cheapest applicable
- * tier across every sheet regardless of which one is currently visible.
+ * Cost source contract: only the part's preferred vendor's sheet drives
+ * cost (in `compute_part_cost_at_qty` and `get_procurement_cost`). Picking
+ * a vendor in this panel sets it as preferred AND switches the displayed
+ * sheet — keeping the two concepts unified. Sheets under non-preferred
+ * vendors and `vendor_id=NULL` "Internal estimate" rows remain editable
+ * for reference but never feed rollup. The "Effective cost @ qty 1" line
+ * below the picker confirms which tier (if any) is currently active so the
+ * user has one transparent answer to "where does the price come from?".
  *
  * Saves are optimistic and in-place — adding/editing/removing a tier
  * never triggers a panel-wide reload or a page-level refetch.
@@ -99,6 +104,27 @@ export default function PartProcurementPricingPanel({
 
   const [selectedVendorId, setSelectedVendorId] = useState<string | null>(null);
   const [rows, setRows] = useState<EditRow[]>([]);
+
+  // Live "effective cost @ qty 1" — the result of get_procurement_cost(partId, 1)
+  // under the new preferred-vendor-only contract. Surfaced under the picker so
+  // the user can answer "where does the BOM cost come from?" without leaving
+  // the panel. Refreshed on initial load and after every tier mutation.
+  const [effectiveCost, setEffectiveCost] = useState<number | null>(null);
+  const [effectiveCostLoading, setEffectiveCostLoading] = useState(false);
+
+  const refreshEffectiveCost = useCallback(async () => {
+    setEffectiveCostLoading(true);
+    try {
+      const result = await getProcurementCost(partId, 1);
+      setEffectiveCost(result.unit_cost);
+    } catch {
+      // Non-fatal — the indicator is auxiliary; the tier table is the
+      // authoritative editing surface.
+      setEffectiveCost(null);
+    } finally {
+      setEffectiveCostLoading(false);
+    }
+  }, [partId]);
 
   const initialLoad = useCallback(async () => {
     try {
@@ -121,7 +147,8 @@ export default function PartProcurementPricingPanel({
 
   useEffect(() => {
     initialLoad();
-  }, [initialLoad]);
+    refreshEffectiveCost();
+  }, [initialLoad, refreshEffectiveCost]);
 
   // Pick an initial vendor on first load: preferred vendor first (whether
   // or not it has a sheet yet), then the first vendor that does have one,
@@ -255,6 +282,9 @@ export default function PartProcurementPricingPanel({
           ];
         });
       }
+      // Re-derive the effective cost so the badge reflects the just-saved
+      // tier without waiting for the next mount.
+      void refreshEffectiveCost();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save tier');
     } finally {
@@ -286,6 +316,7 @@ export default function PartProcurementPricingPanel({
             : g,
         ),
       );
+      void refreshEffectiveCost();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete tier');
     } finally {
@@ -312,6 +343,9 @@ export default function PartProcurementPricingPanel({
     setSelectedVendorId(nextId);
     try {
       await updatePartPreferredVendor(partId, nextId);
+      // Effective cost depends on which sheet is preferred — refresh so the
+      // badge below the picker reflects the new resolution immediately.
+      void refreshEffectiveCost();
     } catch (err) {
       setSelectedVendorId(prevId);
       setError(
@@ -389,10 +423,46 @@ export default function PartProcurementPricingPanel({
             {...params}
             label="Preferred vendor"
             placeholder="Pick a vendor"
-            helperText="Sets the default supplier and shows their qty-break pricing below."
+            helperText="Sets the default supplier and drives the BOM cost from this sheet."
           />
         )}
       />
+
+      {/* Effective-cost indicator. The single transparent answer to "where
+          does the BOM cost come from?" — derived from get_procurement_cost
+          (preferred vendor's cheapest non-expired tier with min_qty <= 1).
+          When this shows "—", the part contributes NULL to any parent BOM
+          and the parent surfaces the actionable missing-cost tooltip. */}
+      <Box
+        sx={{
+          mb: 2,
+          px: 1.5,
+          py: 1,
+          borderRadius: 1,
+          bgcolor: 'action.hover',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 2,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          Effective cost @ qty 1 (drives BOM rollup)
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {effectiveCostLoading && <CircularProgress size={12} />}
+          <Typography
+            variant="body2"
+            sx={{
+              fontWeight: 600,
+              color: effectiveCost === null ? 'text.secondary' : 'text.primary',
+            }}
+          >
+            {effectiveCost === null ? '— no tier' : formatCurrency(effectiveCost)}
+          </Typography>
+        </Box>
+      </Box>
 
       {loading ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>

--- a/components/parts/PartProcurementPricingPanel.tsx
+++ b/components/parts/PartProcurementPricingPanel.tsx
@@ -19,12 +19,12 @@ import Autocomplete from '@mui/material/Autocomplete';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import CloudSyncOutlinedIcon from '@mui/icons-material/CloudSyncOutlined';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import {
   getTiersForPart,
   addTier as addTierApi,
   updateTier as updateTierApi,
   deleteTier as deleteTierApi,
-  getProcurementCost,
 } from '@/utils/procurementTiersAccess';
 import { getAllVendors } from '@/utils/vendorsAccess';
 import { updatePartPreferredVendor } from '@/utils/partsAccess';
@@ -81,14 +81,16 @@ function tempId(): string {
  * Cost source contract: only the part's preferred vendor's sheet drives
  * cost (in `compute_part_cost_at_qty` and `get_procurement_cost`). Picking
  * a vendor in this panel sets it as preferred AND switches the displayed
- * sheet — keeping the two concepts unified. Sheets under non-preferred
- * vendors and `vendor_id=NULL` "Internal estimate" rows remain editable
- * for reference but never feed rollup. The "Effective cost @ qty 1" line
- * below the picker confirms which tier (if any) is currently active so the
- * user has one transparent answer to "where does the price come from?".
+ * sheet — keeping the two concepts unified. The first tier save under a
+ * freshly-picked vendor also re-asserts the preferred vendor in the DB,
+ * so legacy parts that loaded with a NULL preferred_vendor_id can't end
+ * up with tiers that the SQL filter then ignores. Sheets under
+ * non-preferred vendors and `vendor_id=NULL` "Internal estimate" rows
+ * remain editable for reference but never feed rollup.
  *
- * Saves are optimistic and in-place — adding/editing/removing a tier
- * never triggers a panel-wide reload or a page-level refetch.
+ * Saves are optimistic, per-row, and triggered on field blur. Each row
+ * shows a "Saving…" / "Saved ✓" badge so the auto-save isn't invisible
+ * (users were looking for a Save button before this).
  */
 export default function PartProcurementPricingPanel({
   partId,
@@ -105,26 +107,33 @@ export default function PartProcurementPricingPanel({
   const [selectedVendorId, setSelectedVendorId] = useState<string | null>(null);
   const [rows, setRows] = useState<EditRow[]>([]);
 
-  // Live "effective cost @ qty 1" — the result of get_procurement_cost(partId, 1)
-  // under the new preferred-vendor-only contract. Surfaced under the picker so
-  // the user can answer "where does the BOM cost come from?" without leaving
-  // the panel. Refreshed on initial load and after every tier mutation.
-  const [effectiveCost, setEffectiveCost] = useState<number | null>(null);
-  const [effectiveCostLoading, setEffectiveCostLoading] = useState(false);
+  // Tracks parts.preferred_vendor_id as it currently is in the DB. Distinct
+  // from the prop (which is the value at mount) and from selectedVendorId
+  // (which is the picker's local selection — the auto-select effect below
+  // can set this without persisting). compute_part_cost_at_qty filters tiers
+  // by parts.preferred_vendor_id; if the panel saves a tier under
+  // selectedVendorId but the DB's preferred_vendor_id is still NULL (or a
+  // stale other vendor), the cost rollup silently returns NULL. saveRow
+  // syncs this just before saving the tier.
+  const [effectivePreferredVendorId, setEffectivePreferredVendorId] = useState<
+    string | null
+  >(preferredVendorId ?? null);
 
-  const refreshEffectiveCost = useCallback(async () => {
-    setEffectiveCostLoading(true);
-    try {
-      const result = await getProcurementCost(partId, 1);
-      setEffectiveCost(result.unit_cost);
-    } catch {
-      // Non-fatal — the indicator is auxiliary; the tier table is the
-      // authoritative editing surface.
-      setEffectiveCost(null);
-    } finally {
-      setEffectiveCostLoading(false);
-    }
-  }, [partId]);
+  // Per-row save status: "saving" while the API call is in flight, "saved"
+  // for ~2 s after success so the user sees a confirmation tick. Keyed by
+  // row id (or tempKey for unsaved rows). Auto-save with no Save button is
+  // confusing without this — multiple users have asked "did it save?".
+  const [rowStatus, setRowStatus] = useState<Map<string, 'saving' | 'saved'>>(
+    new Map(),
+  );
+  const setRowStatusFor = (key: string, status: 'saving' | 'saved' | null) => {
+    setRowStatus((prev) => {
+      const next = new Map(prev);
+      if (status === null) next.delete(key);
+      else next.set(key, status);
+      return next;
+    });
+  };
 
   const initialLoad = useCallback(async () => {
     try {
@@ -147,8 +156,7 @@ export default function PartProcurementPricingPanel({
 
   useEffect(() => {
     initialLoad();
-    refreshEffectiveCost();
-  }, [initialLoad, refreshEffectiveCost]);
+  }, [initialLoad]);
 
   // Pick an initial vendor on first load: preferred vendor first (whether
   // or not it has a sheet yet), then the first vendor that does have one,
@@ -221,8 +229,38 @@ export default function PartProcurementPricingPanel({
     if (qty === null || qty <= 0) return;
     if (cost === null || cost <= 0) return;
 
+    // Skip save if the persisted values match what the user typed —
+    // tab-out on an unchanged row shouldn't cause a network round-trip
+    // or a "Saved" flash.
+    if (row.id) {
+      const persisted = rows[idx];
+      // We compare against the current rows snapshot's source-of-truth in
+      // `groups` rather than itself; the editor mirrors groups, so if
+      // values match, the row hasn't been touched. Cheap string compare.
+      const group = groups.find((g) => g.vendor_id === selectedVendorId);
+      const tier = group?.tiers.find((t) => t.id === row.id);
+      if (
+        tier &&
+        String(tier.min_quantity) === persisted.quantity &&
+        String(tier.cost_per_unit) === persisted.cost
+      ) {
+        return;
+      }
+    }
+
+    const rowKey = row.id ?? row.tempKey ?? `idx-${idx}`;
+    setRowStatusFor(rowKey, 'saving');
     setSavingCount((c) => c + 1);
     try {
+      // First save under a freshly-picked vendor whose preferred-vendor-id
+      // never made it to the DB (auto-select on mount doesn't persist).
+      // Without this, compute_part_cost_at_qty silently returns NULL because
+      // it filters on parts.preferred_vendor_id and finds no match.
+      if (effectivePreferredVendorId !== selectedVendorId) {
+        await updatePartPreferredVendor(partId, selectedVendorId);
+        setEffectivePreferredVendorId(selectedVendorId);
+      }
+
       if (row.id) {
         const updated = await updateTierApi(row.id, {
           part_id: partId,
@@ -238,6 +276,17 @@ export default function PartProcurementPricingPanel({
             i === idx
               ? { id: updated.id, quantity: String(updated.min_quantity), cost: String(updated.cost_per_unit) }
               : r,
+          ),
+        );
+        // Mirror into groups so the next computed snapshot matches.
+        setGroups((prev) =>
+          prev.map((g) =>
+            g.vendor_id === selectedVendorId
+              ? {
+                  ...g,
+                  tiers: g.tiers.map((t) => (t.id === updated.id ? updated : t)),
+                }
+              : g,
           ),
         );
       } else {
@@ -281,11 +330,18 @@ export default function PartProcurementPricingPanel({
             },
           ];
         });
+        // The new row is now persisted under `created.id`; route the
+        // "saved" flash to that key rather than the stale tempKey.
+        const newKey = created.id;
+        setRowStatusFor(rowKey, null);
+        setRowStatusFor(newKey, 'saved');
+        window.setTimeout(() => setRowStatusFor(newKey, null), 2000);
+        return; // skip the default flash path below; we already routed it
       }
-      // Re-derive the effective cost so the badge reflects the just-saved
-      // tier without waiting for the next mount.
-      void refreshEffectiveCost();
+      setRowStatusFor(rowKey, 'saved');
+      window.setTimeout(() => setRowStatusFor(rowKey, null), 2000);
     } catch (err) {
+      setRowStatusFor(rowKey, null);
       setError(err instanceof Error ? err.message : 'Failed to save tier');
     } finally {
       setSavingCount((c) => c - 1);
@@ -316,7 +372,8 @@ export default function PartProcurementPricingPanel({
             : g,
         ),
       );
-      void refreshEffectiveCost();
+      // Drop any in-flight save state for the deleted row.
+      setRowStatusFor(row.id, null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete tier');
     } finally {
@@ -343,9 +400,9 @@ export default function PartProcurementPricingPanel({
     setSelectedVendorId(nextId);
     try {
       await updatePartPreferredVendor(partId, nextId);
-      // Effective cost depends on which sheet is preferred — refresh so the
-      // badge below the picker reflects the new resolution immediately.
-      void refreshEffectiveCost();
+      // Track DB-side preferred vendor so saveRow knows whether it needs
+      // to re-persist on the next tier write.
+      setEffectivePreferredVendorId(nextId);
     } catch (err) {
       setSelectedVendorId(prevId);
       setError(
@@ -428,42 +485,6 @@ export default function PartProcurementPricingPanel({
         )}
       />
 
-      {/* Effective-cost indicator. The single transparent answer to "where
-          does the BOM cost come from?" — derived from get_procurement_cost
-          (preferred vendor's cheapest non-expired tier with min_qty <= 1).
-          When this shows "—", the part contributes NULL to any parent BOM
-          and the parent surfaces the actionable missing-cost tooltip. */}
-      <Box
-        sx={{
-          mb: 2,
-          px: 1.5,
-          py: 1,
-          borderRadius: 1,
-          bgcolor: 'action.hover',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          gap: 2,
-          flexWrap: 'wrap',
-        }}
-      >
-        <Typography variant="caption" color="text.secondary">
-          Effective cost @ qty 1 (drives BOM rollup)
-        </Typography>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          {effectiveCostLoading && <CircularProgress size={12} />}
-          <Typography
-            variant="body2"
-            sx={{
-              fontWeight: 600,
-              color: effectiveCost === null ? 'text.secondary' : 'text.primary',
-            }}
-          >
-            {effectiveCost === null ? '— no tier' : formatCurrency(effectiveCost)}
-          </Typography>
-        </Box>
-      </Box>
-
       {loading ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
           <CircularProgress size={24} />
@@ -507,8 +528,10 @@ export default function PartProcurementPricingPanel({
                 ) : (
                   rows.map((row, idx) => {
                     const costNum = parseNumber(row.cost);
+                    const rowKey = row.id ?? row.tempKey ?? `idx-${idx}`;
+                    const status = rowStatus.get(rowKey);
                     return (
-                      <TableRow key={row.id ?? row.tempKey ?? idx}>
+                      <TableRow key={rowKey}>
                         <TableCell sx={{ minWidth: 110 }}>
                           <TextField
                             size="small"
@@ -568,7 +591,27 @@ export default function PartProcurementPricingPanel({
                             }}
                           />
                         </TableCell>
-                        <TableCell align="right">
+                        <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
+                          {/* Per-row save state. Inline in the actions cell so
+                              the user sees the auto-save take effect right next
+                              to the field they just left. Renders nothing while
+                              idle to keep the row visually quiet. */}
+                          {status === 'saving' && (
+                            <Tooltip title="Saving…">
+                              <CircularProgress
+                                size={14}
+                                sx={{ mr: 1, verticalAlign: 'middle', color: 'text.secondary' }}
+                              />
+                            </Tooltip>
+                          )}
+                          {status === 'saved' && (
+                            <Tooltip title="Saved">
+                              <CheckCircleOutlineIcon
+                                fontSize="small"
+                                sx={{ mr: 1, verticalAlign: 'middle', color: 'success.main' }}
+                              />
+                            </Tooltip>
+                          )}
                           <Tooltip title="Delete tier">
                             <IconButton
                               size="small"
@@ -600,8 +643,9 @@ export default function PartProcurementPricingPanel({
           </Box>
 
           <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
-            Costs are per {unit}. Quotes use the cheapest applicable tier
-            across every vendor sheet on file.
+            Costs are per {unit}. Tiers save automatically when you click
+            out of a field — there&apos;s no Save button. Quotes use the
+            cheapest applicable tier under the preferred vendor.
           </Typography>
         </>
       )}

--- a/components/parts/PartWhereUsedPanel.tsx
+++ b/components/parts/PartWhereUsedPanel.tsx
@@ -10,12 +10,21 @@ import Stack from '@mui/material/Stack';
 import Divider from '@mui/material/Divider';
 import TablePagination from '@mui/material/TablePagination';
 import NextLink from 'next/link';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { getBomParents } from '@/utils/bomAccess';
 import type { BomLineWithParentPart } from '@/types/bom';
+import { buildPartHref, pushPartToChain } from '@/lib/partNavStack';
 
 interface PartWhereUsedPanelProps {
   partId: string;
   companyId: string;
+  /**
+   * Drill-down chain on the page hosting this panel — passed through to
+   * `pushPartToChain` when building the parent-part hrefs so back-nav
+   * breadcrumbs accumulate. Defaults to empty for callers outside the
+   * part-detail page.
+   */
+  currentChain?: string[];
 }
 
 const formatQuantity = (n: number): string =>
@@ -31,7 +40,11 @@ const formatQuantity = (n: number): string =>
  * functionally, but pagination keeps the panel a predictable height and
  * matches the transaction-history table's UX.
  */
-export default function PartWhereUsedPanel({ partId, companyId }: PartWhereUsedPanelProps) {
+export default function PartWhereUsedPanel({
+  partId,
+  companyId,
+  currentChain = [],
+}: PartWhereUsedPanelProps) {
   const [rows, setRows] = useState<BomLineWithParentPart[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -96,13 +109,28 @@ export default function PartWhereUsedPanel({ partId, companyId }: PartWhereUsedP
             sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 1.5 }}
           >
             <Box sx={{ flex: 1, minWidth: 0 }}>
+              {/* Same link affordance as PartBomPanel: primary color +
+                  always-underlined + chevron. Pushes the current part
+                  onto the back chain so the parent renders a breadcrumb
+                  back to here. */}
               <Link
                 component={NextLink}
-                href={`/dashboard/${companyId}/parts/${row.parent_part.id}`}
-                underline="hover"
-                sx={{ fontWeight: 500 }}
+                href={buildPartHref({
+                  companyId,
+                  targetPartId: row.parent_part.id,
+                  chain: pushPartToChain(currentChain, partId, row.parent_part.id),
+                })}
+                underline="always"
+                color="primary.main"
+                sx={{
+                  fontWeight: 500,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 0.25,
+                }}
               >
                 {row.parent_part.part_name}
+                <ChevronRightIcon sx={{ fontSize: 16 }} />
               </Link>
             </Box>
             <Box sx={{ minWidth: 140, textAlign: 'right' }}>

--- a/e2e/helpers/navigation.ts
+++ b/e2e/helpers/navigation.ts
@@ -3,9 +3,17 @@ import { Page, expect } from '@playwright/test';
 /**
  * Navigate to a module via the sidebar.
  * Sidebar items have their module name as primary text (e.g., "Quotes", "Parts").
+ *
+ * Scoped to the sidebar's `aria-label="Main navigation"` so it doesn't
+ * clash with other nav landmarks on the page (e.g. MUI Breadcrumbs render
+ * as `<nav>` and would otherwise produce a strict-mode violation when a
+ * crumb has the same label as a sidebar item).
  */
 export async function navigateTo(page: Page, moduleName: string) {
-  await page.getByRole('navigation').getByText(moduleName, { exact: true }).click();
+  await page
+    .getByRole('navigation', { name: 'Main navigation' })
+    .getByText(moduleName, { exact: true })
+    .click();
   // Wait for navigation to settle
   await page.waitForLoadState('networkidle');
 }

--- a/lib/partNavStack.ts
+++ b/lib/partNavStack.ts
@@ -1,0 +1,109 @@
+/**
+ * Part-detail back-trail helpers.
+ *
+ * When a user drills from one part-detail page into another (BOM child,
+ * missing-cost leaf, Where-Used parent), we want to surface a breadcrumb
+ * back to where they came from. The trail lives in the URL as
+ * `?back=id1,id2,id3` so it's refresh-safe, shareable, and survives a new
+ * tab. Capped at MAX_PART_NAV_DEPTH so URLs don't grow without bound.
+ *
+ * Every function here is a pure transform — no React, no router, no
+ * Supabase. Easy to unit-test, easy to reuse from any caller (page,
+ * component, server-side helper).
+ */
+
+export const MAX_PART_NAV_DEPTH = 5;
+
+const BACK_PARAM = 'back';
+
+// Loose UUID v4-ish guard — we're not validating cryptographically, just
+// rejecting obvious garbage from a user-edited URL so we don't push it
+// into the chain or try to look it up. Lowercase 8-4-4-4-12 hex.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Subset of URLSearchParams we actually use — accepts both browser and Next's ReadonlyURLSearchParams. */
+interface SearchParamsLike {
+  get(name: string): string | null;
+}
+
+/**
+ * Parse the comma-separated `?back=` chain. Filters empty / non-uuid-looking
+ * entries and de-duplicates adjacent repeats (defensive against a user
+ * editing the URL by hand).
+ */
+export function parseBackChain(searchParams: SearchParamsLike | null | undefined): string[] {
+  const raw = searchParams?.get(BACK_PARAM);
+  if (!raw) return [];
+  const out: string[] = [];
+  for (const part of raw.split(',')) {
+    const trimmed = part.trim();
+    if (!trimmed || !UUID_RE.test(trimmed)) continue;
+    if (out.length > 0 && out[out.length - 1] === trimmed) continue;
+    out.push(trimmed);
+  }
+  return out.slice(0, MAX_PART_NAV_DEPTH);
+}
+
+/**
+ * Compute the chain to attach to a destination href when the user clicks
+ * a part-detail link from another part-detail page.
+ *
+ * - `chain` — the chain on the page being left (i.e. `parseBackChain`
+ *   from the current page's URL).
+ * - `currentPartId` — the part the user is leaving (the page they're on).
+ * - `targetPartId` — the part they're navigating to.
+ *
+ * Collapse-on-revisit: if `targetPartId` already appears anywhere in
+ * `[...chain, currentPartId]`, we truncate to before that occurrence so
+ * the destination becomes the canonical "you are here" with no duplicate
+ * crumbs. This handles both the trivial self-link case (target === current)
+ * and true cycles (drilled A→B→C, then click a link back to A → chain
+ * becomes []).
+ *
+ * Otherwise append `currentPartId` and cap at MAX_PART_NAV_DEPTH (drops
+ * oldest first, so the most recent N hops are always preserved).
+ */
+export function pushPartToChain(
+  chain: string[],
+  currentPartId: string,
+  targetPartId: string,
+): string[] {
+  const proposed = [...chain, currentPartId];
+  const revisitIdx = proposed.indexOf(targetPartId);
+  if (revisitIdx !== -1) {
+    return proposed.slice(0, revisitIdx);
+  }
+  if (proposed.length <= MAX_PART_NAV_DEPTH) return proposed;
+  return proposed.slice(proposed.length - MAX_PART_NAV_DEPTH);
+}
+
+/**
+ * Pop the most recent entry. Returns the previous part id (or null if
+ * the chain is empty) and the remaining chain to attach to that part's
+ * href so the user can keep walking back.
+ */
+export function popPartFromChain(chain: string[]): {
+  previous: string | null;
+  remaining: string[];
+} {
+  if (chain.length === 0) return { previous: null, remaining: [] };
+  return {
+    previous: chain[chain.length - 1],
+    remaining: chain.slice(0, -1),
+  };
+}
+
+/**
+ * Build a `/dashboard/{companyId}/parts/{partId}?back=...` href. Omits the
+ * `back` param when the chain is empty so URLs stay clean for top-level
+ * navigations.
+ */
+export function buildPartHref(opts: {
+  companyId: string;
+  targetPartId: string;
+  chain: string[];
+}): string {
+  const base = `/dashboard/${opts.companyId}/parts/${opts.targetPartId}`;
+  if (opts.chain.length === 0) return base;
+  return `${base}?${BACK_PARAM}=${opts.chain.join(',')}`;
+}

--- a/supabase/migrations/20260515_preferred_vendor_only_procurement_cost.sql
+++ b/supabase/migrations/20260515_preferred_vendor_only_procurement_cost.sql
@@ -1,0 +1,311 @@
+-- 20260515_preferred_vendor_only_procurement_cost.sql
+--
+-- Restrict procurement-cost resolution for bought parts to the part's
+-- preferred vendor sheet only. Previously, compute_part_cost_at_qty,
+-- compute_part_cost_explain, and get_procurement_cost all picked the
+-- cheapest applicable tier across every vendor (and fell through to
+-- vendor_id=NULL "internal estimate" rows). The Procurement panel only
+-- displays one vendor's sheet at a time, so the cost source was effectively
+-- hidden from the user — a silent cross-vendor fallback.
+--
+-- New contract for bought parts:
+--   - parts.preferred_vendor_id IS NULL → cost is NULL.
+--   - Otherwise pick the cheapest non-expired tier where
+--     vendor_id = preferred_vendor_id AND min_quantity <= p_qty.
+--   - vendor_id=NULL "Internal estimate" rows are reference-only and
+--     never drive cost. They remain in the table; the Procurement panel
+--     still shows them under their pseudo-sheet.
+--
+-- Made parts (own routing + BOM rollup) are unchanged: their cost
+-- naturally inherits the new contract via the recursive child cost call.
+--
+-- Behavior change, not a data change. Bought parts without a preferred
+-- vendor or without a matching tier under that vendor will resolve to
+-- NULL, surfaced in the UI as "—" with the existing leaf-link tooltip.
+-- This is intentional: the previous behavior masked broken/incomplete
+-- procurement data; the new behavior makes it visible and fixable.
+
+BEGIN;
+
+-- ============================================================
+-- compute_part_cost_at_qty
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.compute_part_cost_at_qty(p_part_id uuid, p_qty numeric)
+ RETURNS numeric
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+DECLARE
+    v_source text;
+    v_preferred_vendor_id uuid;
+    v_routing_id uuid;
+    v_total numeric := 0;
+    v_op RECORD;
+    v_op_cost numeric;
+    v_bom RECORD;
+    v_to_primary_factor numeric;
+    v_qty_in_primary_unit numeric;
+    v_child_cost numeric;
+    v_tier_cost numeric;
+BEGIN
+    IF p_qty IS NULL OR p_qty <= 0 THEN
+        RAISE EXCEPTION 'compute_part_cost_at_qty: p_qty must be > 0 (got %)', p_qty
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT source, preferred_vendor_id
+      INTO v_source, v_preferred_vendor_id
+      FROM public.parts
+     WHERE id = p_part_id;
+    IF v_source IS NULL THEN
+        RAISE EXCEPTION 'compute_part_cost_at_qty: part % not found', p_part_id;
+    END IF;
+
+    -- ---------- Bought parts: resolve to a preferred-vendor tier ----------
+    IF v_source = 'bought' THEN
+        IF v_preferred_vendor_id IS NULL THEN
+            RETURN NULL;
+        END IF;
+        SELECT t.cost_per_unit
+          INTO v_tier_cost
+          FROM public.part_procurement_tiers t
+         WHERE t.part_id = p_part_id
+           AND t.vendor_id = v_preferred_vendor_id
+           AND t.min_quantity <= p_qty
+           AND (t.expires_at IS NULL OR t.expires_at >= CURRENT_DATE)
+         ORDER BY t.cost_per_unit ASC,
+                  t.min_quantity DESC
+         LIMIT 1;
+        RETURN v_tier_cost;  -- NULL propagates if no tier matches under preferred vendor
+    END IF;
+
+    -- ---------- Made parts: own routing + BOM rollup ----------
+    SELECT id INTO v_routing_id FROM public.routings WHERE part_id = p_part_id;
+
+    IF v_routing_id IS NOT NULL THEN
+        FOR v_op IN
+            SELECT ro.setup_minutes,
+                   ro.cycle_minutes_per_unit,
+                   ro.labor_rate_override,
+                   ro.external_unit_price,
+                   ro.external_setup_cost,
+                   wc.kind          AS wc_kind,
+                   wc.labor_rate    AS wc_labor_rate
+              FROM public.routing_operations ro
+              JOIN public.work_centers wc ON wc.id = ro.work_center_id
+             WHERE ro.routing_id = v_routing_id
+        LOOP
+            IF v_op.wc_kind = 'internal' THEN
+                IF v_op.labor_rate_override IS NULL AND v_op.wc_labor_rate IS NULL THEN
+                    RAISE EXCEPTION
+                        'Cannot compute cost for part %: internal routing op has no labor rate (neither override nor work_center default)',
+                        p_part_id
+                        USING ERRCODE = 'check_violation';
+                END IF;
+                v_op_cost := (COALESCE(v_op.setup_minutes, 0) / p_qty
+                              + COALESCE(v_op.cycle_minutes_per_unit, 0))
+                             * COALESCE(v_op.labor_rate_override, v_op.wc_labor_rate)
+                             / 60.0;
+            ELSE
+                IF v_op.external_unit_price IS NULL AND v_op.external_setup_cost IS NULL THEN
+                    RAISE EXCEPTION
+                        'Cannot compute cost for part %: external routing op has no pricing (neither external_unit_price nor external_setup_cost)',
+                        p_part_id
+                        USING ERRCODE = 'check_violation';
+                END IF;
+                v_op_cost := COALESCE(v_op.external_unit_price, 0)
+                             + COALESCE(v_op.external_setup_cost, 0) / p_qty;
+            END IF;
+            v_total := v_total + v_op_cost;
+        END LOOP;
+    END IF;
+
+    FOR v_bom IN
+        SELECT b.quantity,
+               b.unit,
+               b.child_part_id,
+               c.primary_unit AS child_primary_unit
+          FROM public.parts_bom b
+          JOIN public.parts c ON c.id = b.child_part_id
+         WHERE b.parent_part_id = p_part_id
+    LOOP
+        IF v_bom.unit IS DISTINCT FROM v_bom.child_primary_unit THEN
+            SELECT to_primary_factor INTO v_to_primary_factor
+              FROM public.parts_unit_conversions
+             WHERE part_id = v_bom.child_part_id
+               AND from_unit = v_bom.unit;
+            IF v_to_primary_factor IS NULL THEN
+                RAISE EXCEPTION
+                    'No unit conversion from % to % for part %',
+                    v_bom.unit, v_bom.child_primary_unit, v_bom.child_part_id
+                    USING ERRCODE = 'check_violation';
+            END IF;
+            v_qty_in_primary_unit := v_bom.quantity * v_to_primary_factor;
+        ELSE
+            v_qty_in_primary_unit := v_bom.quantity;
+        END IF;
+
+        v_child_cost := public.compute_part_cost_at_qty(
+            v_bom.child_part_id,
+            p_qty * v_qty_in_primary_unit
+        );
+
+        IF v_child_cost IS NULL THEN
+            RETURN NULL;
+        END IF;
+
+        v_total := v_total + v_qty_in_primary_unit * v_child_cost;
+    END LOOP;
+
+    RETURN v_total;
+END;
+$function$;
+
+-- ============================================================
+-- compute_part_cost_explain
+-- ============================================================
+--
+-- The "missing leaves" set is now defined as: bought leaves where the
+-- preferred vendor has no applicable non-expired tier at the cascaded qty
+-- (or no preferred vendor is set). Mirrors compute_part_cost_at_qty's new
+-- contract so the UI tooltip points at the same problem the cost call hit.
+
+CREATE OR REPLACE FUNCTION public.compute_part_cost_explain(p_part_id uuid, p_qty numeric)
+ RETURNS TABLE(unit_cost numeric, missing_leaves jsonb)
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+DECLARE
+    v_missing jsonb;
+BEGIN
+    WITH RECURSIVE tree(part_id, part_name, source, preferred_vendor_id, cumulative_qty, depth) AS (
+        SELECT p.id, p.part_name, p.source, p.preferred_vendor_id, p_qty, 0
+          FROM public.parts p
+         WHERE p.id = p_part_id
+
+        UNION ALL
+
+        SELECT c.id,
+               c.part_name,
+               c.source,
+               c.preferred_vendor_id,
+               t.cumulative_qty *
+                   CASE
+                       WHEN b.unit IS DISTINCT FROM c.primary_unit THEN
+                           b.quantity * COALESCE(
+                               (SELECT uc.to_primary_factor
+                                  FROM public.parts_unit_conversions uc
+                                 WHERE uc.part_id = c.id
+                                   AND uc.from_unit = b.unit),
+                               1
+                           )
+                       ELSE b.quantity
+                   END,
+               t.depth + 1
+          FROM tree t
+          JOIN public.parts_bom b ON b.parent_part_id = t.part_id
+          JOIN public.parts c     ON c.id = b.child_part_id
+         WHERE t.source = 'made'
+           AND t.depth < 50
+    ),
+    missing AS (
+        SELECT tr.part_id, tr.part_name, tr.depth, tr.cumulative_qty AS qty_required
+          FROM tree tr
+         WHERE tr.source = 'bought'
+           AND (
+               tr.preferred_vendor_id IS NULL
+               OR NOT EXISTS (
+                   SELECT 1
+                     FROM public.part_procurement_tiers t
+                    WHERE t.part_id = tr.part_id
+                      AND t.vendor_id = tr.preferred_vendor_id
+                      AND t.min_quantity <= tr.cumulative_qty
+                      AND (t.expires_at IS NULL OR t.expires_at >= CURRENT_DATE)
+               )
+           )
+    )
+    SELECT COALESCE(
+              jsonb_agg(
+                  jsonb_build_object(
+                      'part_id', m.part_id,
+                      'part_name', m.part_name,
+                      'depth', m.depth,
+                      'qty_required', m.qty_required
+                  )
+                  ORDER BY m.depth DESC, m.part_name ASC
+              ),
+              '[]'::jsonb
+           )
+      INTO v_missing
+      FROM missing m;
+
+    unit_cost := public.compute_part_cost_at_qty(p_part_id, p_qty);
+    missing_leaves := v_missing;
+    RETURN NEXT;
+END;
+$function$;
+
+-- ============================================================
+-- get_procurement_cost
+-- ============================================================
+--
+-- Standalone helper for UI display + quote engine. Same preferred-vendor
+-- restriction as compute_part_cost_at_qty. Returns no row when the part
+-- has no preferred vendor or no applicable tier under that vendor — the
+-- TS wrapper translates "no row" into `unit_cost: null`.
+
+CREATE OR REPLACE FUNCTION public.get_procurement_cost(p_part_id uuid, p_qty numeric)
+ RETURNS TABLE(unit_cost numeric, vendor_id uuid, tier_id uuid, source text)
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+DECLARE
+    v_preferred_vendor_id uuid;
+    v_tier RECORD;
+BEGIN
+    SELECT preferred_vendor_id INTO v_preferred_vendor_id
+      FROM public.parts WHERE id = p_part_id;
+    IF v_preferred_vendor_id IS NULL THEN
+        RETURN; -- no rows, callers treat as NULL cost
+    END IF;
+
+    -- Pick the cheapest non-expired tier under the preferred vendor where
+    -- min_quantity <= p_qty. Cross-vendor and NULL-vendor rows are now
+    -- reference-only; they never drive cost.
+    SELECT t.id, t.cost_per_unit, t.vendor_id
+      INTO v_tier
+      FROM public.part_procurement_tiers t
+     WHERE t.part_id = p_part_id
+       AND t.vendor_id = v_preferred_vendor_id
+       AND t.min_quantity <= p_qty
+       AND (t.expires_at IS NULL OR t.expires_at >= CURRENT_DATE)
+     ORDER BY t.cost_per_unit ASC,
+              t.min_quantity DESC
+     LIMIT 1;
+
+    IF FOUND THEN
+        unit_cost := v_tier.cost_per_unit;
+        vendor_id := v_tier.vendor_id;
+        tier_id := v_tier.id;
+        source := 'tier';
+        RETURN NEXT;
+    END IF;
+    -- No row returned when no tier matches under the preferred vendor.
+END;
+$function$;
+
+-- ============================================================
+-- Comment refresh
+-- ============================================================
+
+COMMENT ON COLUMN "public"."part_procurement_tiers"."vendor_id"
+    IS 'Vendor whose sheet this tier belongs to. Cost resolution restricts to the part''s preferred_vendor_id — sheets under other vendors (and vendor_id=NULL "Internal estimate" rows) are reference-only and never drive cost. To switch which sheet drives cost, change the part''s preferred_vendor_id.';
+
+COMMENT ON FUNCTION public.compute_part_cost_at_qty(uuid, numeric)
+    IS 'Live unit-cost resolution at a given quantity. For bought parts: requires parts.preferred_vendor_id to be set and to have a non-expired tier with min_quantity <= p_qty. Returns NULL when those conditions aren''t met (no silent fallback to other vendors). For made parts: walks routing operations + BOM children recursively; child costs cascade through the same preferred-vendor rule. Raises on missing labor rate / external pricing / unit conversion.';
+
+COMMENT ON FUNCTION public.get_procurement_cost(uuid, numeric)
+    IS 'Returns the active procurement tier under the part''s preferred vendor at quantity p_qty, or no row if either the preferred vendor is unset or no tier under it covers p_qty. Tiers under other vendors are reference-only.';
+
+COMMIT;

--- a/utils/partsAccess.ts
+++ b/utils/partsAccess.ts
@@ -556,6 +556,33 @@ export async function getPartsForSelectByIds(
 }
 
 /**
+ * Slim id → part_name lookup. Used by the part-detail breadcrumb to label
+ * a chain of ancestor parts in a single query. Missing ids (deleted parts,
+ * URL-tampered junk) simply don't appear in the returned Map — callers
+ * should fall back to a placeholder for those.
+ */
+export async function getPartNamesByIds(partIds: string[]): Promise<Map<string, string>> {
+  if (partIds.length === 0) return new Map();
+  const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from('parts')
+    .select('id, part_name')
+    .in('id', partIds);
+
+  if (error) {
+    console.error('Error fetching part names by ids:', error);
+    throw error;
+  }
+
+  const out = new Map<string, string>();
+  for (const row of (data ?? []) as Array<{ id: string; part_name: string }>) {
+    out.set(row.id, row.part_name);
+  }
+  return out;
+}
+
+/**
  * Check if a part name already exists for a company.
  */
 export async function checkPartNameExists(

--- a/utils/routingCostCalculation.ts
+++ b/utils/routingCostCalculation.ts
@@ -10,6 +10,11 @@ export interface CostWarning {
     | 'missing_material_cost'
     | 'no_operations'
     | 'missing_external_pricing';
+  /**
+   * Backwards-compatible single-string rendering of the warning. Newer
+   * callers should prefer `child_part_name` + `detail` (when present) so
+   * the part name can be styled as a link separately from the detail.
+   */
   message: string;
   node_id?: string;
   material_id?: string;
@@ -17,6 +22,20 @@ export interface CostWarning {
   child_part_id?: string;
   /** For `missing_material_cost`: drives the suggested fix in the warning copy. */
   child_part_source?: 'made' | 'bought';
+  /**
+   * For `missing_material_cost`: the offending leaf's display name. The
+   * Pricing-card warning renderer wraps this in a link to that part so
+   * the part name itself is the click target — replacing the old trailing
+   * "Open child →" affordance.
+   */
+  child_part_name?: string;
+  /**
+   * For `missing_material_cost`: the part of the warning copy that comes
+   * after the part name (e.g. "no priced tier covers qty 6"). Lets the
+   * renderer compose `<Link>{name}</Link> {detail}` without parsing the
+   * full `message` string.
+   */
+  detail?: string;
 }
 
 export interface LaborItem {
@@ -203,11 +222,14 @@ export async function calculateRoutingCost(
       if (childPrimary !== null && effectiveBomUnit !== null && effectiveBomUnit !== childPrimary) {
         const factor = conversionMap.get(`${child.id}:${effectiveBomUnit}`);
         if (factor === undefined) {
+          const detail = `no unit conversion from "${effectiveBomUnit}" to "${childPrimary}" — add one on the child part`;
           warnings.push({
             type: 'missing_material_cost',
-            message: `${itemName}: no unit conversion from "${effectiveBomUnit}" to "${childPrimary}" — add one on the child part`,
+            message: `${itemName}: ${detail}`,
+            detail,
             material_id: line.id,
             child_part_id: child.id,
+            child_part_name: itemName,
             child_part_source: child.source,
           });
           continue;
@@ -223,11 +245,14 @@ export async function calculateRoutingCost(
       try {
         childUnitCost = await getComputedPartCost(child.id, cumulativeQty);
       } catch (err) {
+        const detail = `cost lookup failed (${(err as Error).message})`;
         warnings.push({
           type: 'missing_material_cost',
-          message: `${itemName}: cost lookup failed (${(err as Error).message})`,
+          message: `${itemName}: ${detail}`,
+          detail,
           material_id: line.id,
           child_part_id: child.id,
+          child_part_name: itemName,
           child_part_source: child.source,
         });
         continue;
@@ -259,8 +284,10 @@ export async function calculateRoutingCost(
         warnings.push({
           type: 'missing_material_cost',
           message: `${itemName}: ${leafHint}`,
+          detail: leafHint,
           material_id: line.id,
           child_part_id: child.id,
+          child_part_name: itemName,
           child_part_source: child.source,
         });
         continue;


### PR DESCRIPTION
## Summary

- **BOM unit picker is now constrained.** The Materials editor on the part detail page used to accept any free-text unit string. Anything that didn't match the child's `primary_unit` or a `parts_unit_conversions.from_unit` row would later either bridge silently or `RAISE EXCEPTION` from `compute_part_cost_at_qty`. The Unit field is now a `Select` of valid options only; locked to the primary unit when no conversions are defined; falls back to free-text only for legacy parts with no `primary_unit`.
- **No more silent cross-vendor cost fallback.** `compute_part_cost_at_qty`, `compute_part_cost_explain`, and `get_procurement_cost` now resolve cost from the part's `preferred_vendor_id` sheet only. Other vendors' tier sheets and `vendor_id=NULL` "Internal estimate" rows are reference-only — visible and editable in the Procurement panel, but they never drive cost. Bought parts with no preferred vendor (or no applicable tier under it) resolve to NULL; the parent BOM row shows `—` with the existing actionable tooltip pointing at the offending leaf.
- **Effective-cost indicator** added under the Procurement panel's vendor picker. Shows `Effective cost @ qty 1: $X.XX` (or "— no tier") so the user has one transparent answer to "where does the BOM cost come from?".

## Why

User reported a BOM material row showing `$4.50` for a child whose Procurement panel under the preferred vendor was empty. Tracing the SQL: the cost was real — coming from a tier under a *different* vendor that the panel hides because it only renders one vendor's sheet at a time. Cheapest-across-all-vendors resolution + per-vendor display = silent fallback the user can't see or fix. Per `CLAUDE.md`'s "no silent runtime fallbacks for data-at-rest issues" rule, the right fix is to surface the gap, not paper over it.

## Behavior change (heads-up)

Bought parts that previously resolved cost via a non-preferred vendor's sheet will now show `—` until either:
1. A preferred vendor is set on the part, *and*
2. That vendor has a non-expired tier with `min_quantity ≤ requested_qty`.

This is intentional. The existing missing-cost tooltip + leaf-link UI in `PartBomPanel` already guides the user to the offending leaf. No automatic backfill is included — auto-promoting an existing tier into "preferred vendor" would risk picking the wrong one silently, the very thing this PR removes.

## Files

- `components/parts/MaterialRowEditor.tsx` — constrained unit picker; loads `getPartUnitConversions(childId)` on child select.
- `components/parts/PartBomPanel.tsx` — passes `companyId` into `MaterialRowEditor` for the helper link.
- `components/parts/PartProcurementPricingPanel.tsx` — doc-comment refresh + "Effective cost @ qty 1" indicator below the vendor picker; refreshes after every tier mutation and vendor change.
- `supabase/migrations/20260515_preferred_vendor_only_procurement_cost.sql` — replaces the three SQL functions and updates the `part_procurement_tiers.vendor_id` comment.

## Follow-ups (not in this PR)

- **Schema dump re-export.** `supabase/schema.staging.sql` and `supabase/schema.prod.sql` are auto-generated from a live DB by `scripts/export_schema.py` and were intentionally not touched here. Run `python scripts/export_schema.py --env staging` (and `--env prod`) once the migration is applied to the corresponding environment, then commit the resulting diff.
- **SQL contract tests.** No pytest harness for testing PG functions directly exists today (`api/tests/integration/` is HTTP-focused). The new SQL functions will be verified in staging via the manual checks below; adding a `pytest -m integration` runner with DB fixtures is a separate hardening step.
- **Optional:** `CHECK` constraint or trigger on `parts_bom.unit` to enforce server-side what the editor now enforces client-side.

## Test plan

- [ ] `pnpm exec tsc --noEmit -p tsconfig.json` — clean (verified locally).
- [ ] `pnpm test --run __tests__/utils/` — 206 tests pass, 9 pre-existing skips (verified locally).
- [ ] Apply migration on staging; run `python scripts/export_schema.py --env staging` and confirm schema diff matches the migration.
- [ ] Open a part whose child currently has only a non-preferred-vendor tier sheet → confirm BOM material cost shows `—` with the leaf-link tooltip.
- [ ] On that child, set a preferred vendor and add a tier → confirm parent BOM cost populates and the "Effective cost @ qty 1" badge updates.
- [ ] Open the BOM editor on a parent → confirm the Unit field shows only the child's primary unit + its `parts_unit_conversions.from_unit` values; for a child with no conversions, the field is locked to the primary unit with a helper link.
- [ ] Quote-to-job flow on a part with a preferred-vendor tier still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)