### PR TITLE
Tighten password-reset copy on team member detail

### DIFF
--- a/app/dashboard/[companyId]/team/members/[id]/page.tsx
+++ b/app/dashboard/[companyId]/team/members/[id]/page.tsx
@@ -151,7 +151,7 @@ export default function EditTeamMemberPage() {
       }
 
       setResetDialogOpen(false);
-      setSuccess('If that user has an account, a reset link has been sent.');
+      setSuccess(`Reset link sent to ${member.email}.`);
     } catch (err) {
       console.error('Error sending password reset email:', err);
       setError(err instanceof Error ? err.message : 'Failed to send password reset email');
@@ -292,7 +292,7 @@ export default function EditTeamMemberPage() {
             startIcon={<LockResetIcon />}
             onClick={() => setResetDialogOpen(true)}
           >
-            Send Password Reset Email
+            Reset Password
           </Button>
           <Button
             variant="outlined"
@@ -312,7 +312,7 @@ export default function EditTeamMemberPage() {
         maxWidth="xs"
         fullWidth
       >
-        <DialogTitle>Send password reset email?</DialogTitle>
+        <DialogTitle>Reset password?</DialogTitle>
         <DialogContent>
           <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
             We&apos;ll email <strong>{member.email || 'this user'}</strong> a single-use,
@@ -335,7 +335,7 @@ export default function EditTeamMemberPage() {
             disabled={resetting}
             startIcon={resetting ? <CircularProgress size={16} color="inherit" /> : null}
           >
-            {resetting ? 'Sending...' : 'Send Reset Email'}
+            {resetting ? 'Sending...' : 'Reset Password'}
           </Button>
         </DialogActions>
       </Dialog>

--- a/app/dashboard/[companyId]/team/members/[id]/page.tsx
+++ b/app/dashboard/[companyId]/team/members/[id]/page.tsx
@@ -151,7 +151,7 @@ export default function EditTeamMemberPage() {
       }
 
       setResetDialogOpen(false);
-      setSuccess(`Reset link sent to ${member.email}.`);
+      setSuccess(`Reset link sent to ${member?.email || 'this user'}.`);
     } catch (err) {
       console.error('Error sending password reset email:', err);
       setError(err instanceof Error ? err.message : 'Failed to send password reset email');


### PR DESCRIPTION
## Summary
- Replaces the enumeration-resistant `If that user has an account...` toast with a direct `Reset link sent to {email}.`. The admin is already past auth + an admin-role check and can see the member's name/email on screen — nothing to enumerate.
- Renames the action button from `Send Password Reset Email` to `Reset Password`, and updates the confirmation modal title (`Reset password?`) and confirm button (`Reset Password`). The modal already explains the email mechanism.
- Edge Function generic 200 body is intentionally untouched — it stays as wire-level enumeration protection with audit-only outcome distinction.

## Test plan
- [ ] Open a team member detail page as an admin and click `Reset Password`; modal explains the email step.
- [ ] Confirm; success toast reads `Reset link sent to {email}.`.
- [ ] Verify the recovery email still arrives and lands on `/reset-password`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)