### PR TITLE
Fix: remove jobs.status from quote PostgREST embeds (prod 42703)

### DIFF
--- a/types/quote.ts
+++ b/types/quote.ts
@@ -111,7 +111,6 @@ export interface QuoteWithRelations extends Quote {
   jobs?: Array<{
     id: string;
     job_number: string;
-    status: string;
   }>;
   // Resolved creator profile from user_company_access (populated client-side
   // via a second query — keeps the main PostgREST query simple).

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -66,7 +66,7 @@ const QUOTE_LIST_SELECT = `
   *,
   customers!left(id, name),
   line_items:quote_line_items!left(${QUOTE_LINE_ITEM_FIELDS}),
-  jobs!left(id, job_number, status)
+  jobs!left(id, job_number)
 `;
 
 const QUOTE_DETAIL_SELECT = `
@@ -81,7 +81,7 @@ const QUOTE_DETAIL_SELECT = `
     )
   ),
   line_items:quote_line_items!left(${QUOTE_LINE_ITEM_FIELDS}),
-  jobs!left(id, job_number, status)
+  jobs!left(id, job_number)
 `;
 
 /**


### PR DESCRIPTION
## Summary
- `getQuoteWithRelations` was failing in prod with `column jobs_1.status does not exist` (Postgres 42703), surfacing as "Quote not found" on the quote detail page.
- Migration [`20260523_shipments_pr3_dual_status.sql`](supabase/migrations/20260523_shipments_pr3_dual_status.sql) dropped `jobs.status` and replaced it with `production_status` + `fulfillment_status`. Two PostgREST embed strings in [`utils/quotesAccess.ts`](utils/quotesAccess.ts) were missed during that PR.
- The selected `status` was never actually read — both consumers ([quotes/page.tsx:322](app/dashboard/[companyId]/quotes/page.tsx#L322) and [quotes/[quoteId]/page.tsx:192](app/dashboard/[companyId]/quotes/[quoteId]/page.tsx#L192)) only use `id` and `job_number`. So the fix is just dropping `status` from the embed and from the type.

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm test --run __tests__/utils/quotesAccess.test.ts` — 22 pass
- [ ] Smoke-test in preview: create a quote → land on detail page without error
- [ ] Verify quotes list page still renders the Jobs column

🤖 Generated with [Claude Code](https://claude.com/claude-code)