### PR TITLE
Add Supabase typed client (opt-in) + generated database types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,21 @@ Jigged is a web-based ERP system designed for small-scale precision manufacturin
 
 **Do NOT create new FastAPI endpoints for standard CRUD.** See `docs/architecture.md` Section 8 for the full standard and decision checklist.
 
+### Typed Supabase client (incremental adoption)
+
+`lib/supabase.ts` exposes two getters that share one singleton:
+
+- `getSupabase()` — untyped. Existing `utils/*Access.ts` files use this. Schema mistakes compile silently (this is how the May 2026 `jobs.status` regression shipped).
+- `getTypedSupabase()` — `<Database>`-generic. Every `.from('table').select('...')` chain is checked against [`types/database.ts`](types/database.ts), generated from the linked Supabase project.
+
+**Use `getTypedSupabase()` for any new access function.** When converting an existing file, expect `tsc` to surface real bugs (column drift, narrow-enum mismatches, missing NOT-NULL columns on inserts) — fix them rather than papering over with `as any`. The [`schemaEmbedCheck`](scripts/schemaEmbedCheck.ts) test catches the embed-string class of drift today; typed mode catches everything else.
+
+Regenerate types after every migration that changes columns:
+
+```bash
+pnpm gen:db-types  # wraps: supabase gen types typescript --linked
+```
+
 ---
 
 ## Engineering principles

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,5 +1,6 @@
 import { createBrowserClient } from '@supabase/ssr';
 import { redirectToSessionExpiry } from '@/lib/supabaseErrors';
+import type { Database } from '@/types/database';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
@@ -37,7 +38,7 @@ async function deduplicatedRefresh(): Promise<string | null> {
 }
 
 export function createClient() {
-  return createBrowserClient(supabaseUrl, supabaseAnonKey, {
+  return createBrowserClient<Database>(supabaseUrl, supabaseAnonKey, {
     global: {
       fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
         const response = await fetch(input, init);
@@ -80,17 +81,55 @@ export function createClient() {
   });
 }
 
-// Singleton instance for client-side usage
-let supabaseInstance: ReturnType<typeof createBrowserClient> | null = null;
+// Typed shape of the client when the `Database` generic is honored —
+// `createClient()` builds with this generic, but the runtime instance is
+// the same regardless of which getter returns it.
+export type TypedSupabaseClient = ReturnType<typeof createClient>;
 
-export function getSupabase() {
+// Untyped shape — what every existing access file currently consumes via
+// `getSupabase()`. Cast at the boundary so adoption of typed mode can roll
+// out per-file without forcing a 250-error refactor up front.
+type UntypedSupabaseClient = ReturnType<typeof createBrowserClient>;
+
+let supabaseInstance: TypedSupabaseClient | null = null;
+
+/**
+ * Returns the untyped Supabase client — preserves the legacy behavior
+ * every `utils/*Access.ts` file currently relies on. Calls compile
+ * regardless of whether the embed string matches the schema.
+ *
+ * Prefer `getTypedSupabase()` for new code. Per-file conversion to the
+ * typed getter is the incremental adoption path — see comment above
+ * `getTypedSupabase` for the contract and the May 2026 ADR in
+ * docs/architecture.md for context.
+ */
+export function getSupabase(): UntypedSupabaseClient {
+  if (!supabaseInstance) {
+    supabaseInstance = createClient();
+  }
+  return supabaseInstance as unknown as UntypedSupabaseClient;
+}
+
+/**
+ * Returns the Supabase client with the `Database` generic applied, so
+ * every `.from('quotes').select('...')` chain is validated against
+ * supabase/schema.prod.sql at compile time. This is the path that
+ * would have caught the May 2026 jobs.status incident.
+ *
+ * Use for any new access function or while converting an existing one.
+ * When you switch a file from `getSupabase()` to `getTypedSupabase()`,
+ * expect `tsc` to surface real bugs — fix them in that PR, don't paper
+ * over with `as any`.
+ */
+export function getTypedSupabase(): TypedSupabaseClient {
   if (!supabaseInstance) {
     supabaseInstance = createClient();
   }
   return supabaseInstance;
 }
 
-// Export a convenience alias
+// Export a convenience alias. Stays untyped for back-compat with existing
+// `import { supabase } from '@/lib/supabase'` consumers.
 export const supabase = typeof window !== 'undefined' ? getSupabase() : null;
 
 /**

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "gen:db-types": "supabase gen types typescript --linked > types/database.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/types/database.ts
+++ b/types/database.ts
@@ -1,0 +1,2551 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.1"
+  }
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  public: {
+    Tables: {
+      ai_chat_queries: {
+        Row: {
+          chart_config: Json | null
+          company_id: string
+          created_at: string
+          duration_ms: number | null
+          id: string
+          model: string | null
+          provider: string
+          question: string
+          response: string
+          tokens_used: number | null
+          tool_calls: Json
+          user_id: string | null
+        }
+        Insert: {
+          chart_config?: Json | null
+          company_id: string
+          created_at?: string
+          duration_ms?: number | null
+          id?: string
+          model?: string | null
+          provider: string
+          question: string
+          response: string
+          tokens_used?: number | null
+          tool_calls?: Json
+          user_id?: string | null
+        }
+        Update: {
+          chart_config?: Json | null
+          company_id?: string
+          created_at?: string
+          duration_ms?: number | null
+          id?: string
+          model?: string | null
+          provider?: string
+          question?: string
+          response?: string
+          tokens_used?: number | null
+          tool_calls?: Json
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "ai_chat_queries_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      ai_config: {
+        Row: {
+          company_id: string
+          created_at: string | null
+          feature: string
+          id: string
+          model: string | null
+          provider: string
+          settings: Json | null
+          updated_at: string | null
+        }
+        Insert: {
+          company_id: string
+          created_at?: string | null
+          feature: string
+          id?: string
+          model?: string | null
+          provider?: string
+          settings?: Json | null
+          updated_at?: string | null
+        }
+        Update: {
+          company_id?: string
+          created_at?: string | null
+          feature?: string
+          id?: string
+          model?: string | null
+          provider?: string
+          settings?: Json | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "ai_config_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      auth_audit_log: {
+        Row: {
+          actor_user_id: string | null
+          company_id: string | null
+          created_at: string
+          error_detail: string | null
+          event_type: string
+          id: string
+          outcome: string
+          target_user_id: string | null
+        }
+        Insert: {
+          actor_user_id?: string | null
+          company_id?: string | null
+          created_at?: string
+          error_detail?: string | null
+          event_type: string
+          id?: string
+          outcome: string
+          target_user_id?: string | null
+        }
+        Update: {
+          actor_user_id?: string | null
+          company_id?: string | null
+          created_at?: string
+          error_detail?: string | null
+          event_type?: string
+          id?: string
+          outcome?: string
+          target_user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "auth_audit_log_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      companies: {
+        Row: {
+          address_line1: string | null
+          address_line2: string | null
+          city: string | null
+          country: string | null
+          created_at: string | null
+          default_coc_text: string | null
+          demo_company_id: string | null
+          email: string | null
+          id: string
+          is_demo: boolean | null
+          logo_url: string | null
+          name: string
+          packing_slip_next_seq: number
+          packing_slip_number_format: string
+          packing_slip_seq_year: number | null
+          phone: string | null
+          postal_code: string | null
+          settings: Json | null
+          slug: string | null
+          state: string | null
+          updated_at: string | null
+          website: string | null
+        }
+        Insert: {
+          address_line1?: string | null
+          address_line2?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string | null
+          default_coc_text?: string | null
+          demo_company_id?: string | null
+          email?: string | null
+          id?: string
+          is_demo?: boolean | null
+          logo_url?: string | null
+          name: string
+          packing_slip_next_seq?: number
+          packing_slip_number_format?: string
+          packing_slip_seq_year?: number | null
+          phone?: string | null
+          postal_code?: string | null
+          settings?: Json | null
+          slug?: string | null
+          state?: string | null
+          updated_at?: string | null
+          website?: string | null
+        }
+        Update: {
+          address_line1?: string | null
+          address_line2?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string | null
+          default_coc_text?: string | null
+          demo_company_id?: string | null
+          email?: string | null
+          id?: string
+          is_demo?: boolean | null
+          logo_url?: string | null
+          name?: string
+          packing_slip_next_seq?: number
+          packing_slip_number_format?: string
+          packing_slip_seq_year?: number | null
+          phone?: string | null
+          postal_code?: string | null
+          settings?: Json | null
+          slug?: string | null
+          state?: string | null
+          updated_at?: string | null
+          website?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "companies_demo_company_id_fkey"
+            columns: ["demo_company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      company_custom_units: {
+        Row: {
+          company_id: string
+          created_at: string | null
+          id: string
+          unit_name: string
+        }
+        Insert: {
+          company_id: string
+          created_at?: string | null
+          id?: string
+          unit_name: string
+        }
+        Update: {
+          company_id?: string
+          created_at?: string | null
+          id?: string
+          unit_name?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "company_custom_units_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      customer_addresses: {
+        Row: {
+          address_line1: string | null
+          address_line2: string | null
+          attention_to: string | null
+          city: string | null
+          country: string | null
+          created_at: string
+          customer_id: string
+          default_billing: boolean
+          default_shipping: boolean
+          id: string
+          postal_code: string | null
+          state: string | null
+          updated_at: string
+        }
+        Insert: {
+          address_line1?: string | null
+          address_line2?: string | null
+          attention_to?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string
+          customer_id: string
+          default_billing?: boolean
+          default_shipping?: boolean
+          id?: string
+          postal_code?: string | null
+          state?: string | null
+          updated_at?: string
+        }
+        Update: {
+          address_line1?: string | null
+          address_line2?: string | null
+          attention_to?: string | null
+          city?: string | null
+          country?: string | null
+          created_at?: string
+          customer_id?: string
+          default_billing?: boolean
+          default_shipping?: boolean
+          id?: string
+          postal_code?: string | null
+          state?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "customer_addresses_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      customer_contacts: {
+        Row: {
+          created_at: string
+          customer_id: string
+          email: string | null
+          id: string
+          is_primary: boolean
+          name: string
+          phone: string | null
+          role: string
+          role_label: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          customer_id: string
+          email?: string | null
+          id?: string
+          is_primary?: boolean
+          name: string
+          phone?: string | null
+          role: string
+          role_label?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          customer_id?: string
+          email?: string | null
+          id?: string
+          is_primary?: boolean
+          name?: string
+          phone?: string | null
+          role?: string
+          role_label?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "customer_contacts_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      customers: {
+        Row: {
+          company_id: string
+          created_at: string | null
+          default_carrier: string | null
+          default_coc_text: string | null
+          default_shipping_arrangement: string | null
+          id: string
+          name: string
+          updated_at: string | null
+          website: string | null
+        }
+        Insert: {
+          company_id: string
+          created_at?: string | null
+          default_carrier?: string | null
+          default_coc_text?: string | null
+          default_shipping_arrangement?: string | null
+          id?: string
+          name: string
+          updated_at?: string | null
+          website?: string | null
+        }
+        Update: {
+          company_id?: string
+          created_at?: string | null
+          default_carrier?: string | null
+          default_coc_text?: string | null
+          default_shipping_arrangement?: string | null
+          id?: string
+          name?: string
+          updated_at?: string | null
+          website?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "customers_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      demo_data_templates: {
+        Row: {
+          created_at: string | null
+          created_by: string | null
+          id: string
+          is_active: boolean | null
+          name: string
+          template_data: Json
+          version: number
+        }
+        Insert: {
+          created_at?: string | null
+          created_by?: string | null
+          id?: string
+          is_active?: boolean | null
+          name: string
+          template_data: Json
+          version?: number
+        }
+        Update: {
+          created_at?: string | null
+          created_by?: string | null
+          id?: string
+          is_active?: boolean | null
+          name?: string
+          template_data?: Json
+          version?: number
+        }
+        Relationships: []
+      }
+      feedback: {
+        Row: {
+          company_id: string
+          created_at: string
+          feedback_text: string
+          id: string
+          page_path: string
+          page_title: string
+          user_id: string
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          feedback_text: string
+          id?: string
+          page_path: string
+          page_title: string
+          user_id: string
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          feedback_text?: string
+          id?: string
+          page_path?: string
+          page_title?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "feedback_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      inventory_transactions: {
+        Row: {
+          company_id: string
+          converted_quantity: number
+          created_at: string | null
+          created_by: string | null
+          has_discrepancy: boolean
+          id: string
+          item_name: string
+          job_id: string | null
+          job_operation_id: string | null
+          notes: string | null
+          operator_id: string | null
+          part_id: string | null
+          quantity: number
+          type: string
+          unit: string
+        }
+        Insert: {
+          company_id: string
+          converted_quantity: number
+          created_at?: string | null
+          created_by?: string | null
+          has_discrepancy?: boolean
+          id?: string
+          item_name: string
+          job_id?: string | null
+          job_operation_id?: string | null
+          notes?: string | null
+          operator_id?: string | null
+          part_id?: string | null
+          quantity: number
+          type: string
+          unit: string
+        }
+        Update: {
+          company_id?: string
+          converted_quantity?: number
+          created_at?: string | null
+          created_by?: string | null
+          has_discrepancy?: boolean
+          id?: string
+          item_name?: string
+          job_id?: string | null
+          job_operation_id?: string | null
+          notes?: string | null
+          operator_id?: string | null
+          part_id?: string | null
+          quantity?: number
+          type?: string
+          unit?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "inventory_transactions_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inventory_transactions_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inventory_transactions_job_operation_id_fkey"
+            columns: ["job_operation_id"]
+            isOneToOne: false
+            referencedRelation: "job_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inventory_transactions_part_id_fkey"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      invitations: {
+        Row: {
+          accepted_at: string | null
+          accepted_by: string | null
+          company_id: string
+          created_at: string | null
+          email: string
+          expires_at: string
+          id: string
+          invited_by: string
+          role: string
+          status: string | null
+        }
+        Insert: {
+          accepted_at?: string | null
+          accepted_by?: string | null
+          company_id: string
+          created_at?: string | null
+          email: string
+          expires_at: string
+          id?: string
+          invited_by: string
+          role: string
+          status?: string | null
+        }
+        Update: {
+          accepted_at?: string | null
+          accepted_by?: string | null
+          company_id?: string
+          created_at?: string | null
+          email?: string
+          expires_at?: string
+          id?: string
+          invited_by?: string
+          role?: string
+          status?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "invitations_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      job_fulfillment_audit: {
+        Row: {
+          company_id: string
+          created_at: string
+          from_status: string | null
+          id: string
+          job_id: string
+          to_status: string
+          triggering_shipment_id: string | null
+          triggering_user_id: string | null
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          from_status?: string | null
+          id?: string
+          job_id: string
+          to_status: string
+          triggering_shipment_id?: string | null
+          triggering_user_id?: string | null
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          from_status?: string | null
+          id?: string
+          job_id?: string
+          to_status?: string
+          triggering_shipment_id?: string | null
+          triggering_user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "job_fulfillment_audit_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_fulfillment_audit_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_fulfillment_audit_triggering_shipment_id_fkey"
+            columns: ["triggering_shipment_id"]
+            isOneToOne: false
+            referencedRelation: "shipments"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      job_materials: {
+        Row: {
+          actual_quantity: number | null
+          consumed_at: string | null
+          consumed_by: string | null
+          created_at: string
+          expected_quantity: number
+          id: string
+          job_id: string
+          job_part_id: string
+          material_part_id: string
+          parts_bom_id: string | null
+          status: string
+          unit: string
+          updated_at: string
+        }
+        Insert: {
+          actual_quantity?: number | null
+          consumed_at?: string | null
+          consumed_by?: string | null
+          created_at?: string
+          expected_quantity?: number
+          id?: string
+          job_id: string
+          job_part_id: string
+          material_part_id: string
+          parts_bom_id?: string | null
+          status?: string
+          unit: string
+          updated_at?: string
+        }
+        Update: {
+          actual_quantity?: number | null
+          consumed_at?: string | null
+          consumed_by?: string | null
+          created_at?: string
+          expected_quantity?: number
+          id?: string
+          job_id?: string
+          job_part_id?: string
+          material_part_id?: string
+          parts_bom_id?: string | null
+          status?: string
+          unit?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "job_materials_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_materials_job_part_id_fkey"
+            columns: ["job_part_id"]
+            isOneToOne: false
+            referencedRelation: "job_parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_materials_material_part_id_fkey"
+            columns: ["material_part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_materials_parts_bom_id_fkey"
+            columns: ["parts_bom_id"]
+            isOneToOne: false
+            referencedRelation: "parts_bom"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      job_operations: {
+        Row: {
+          actual_run_minutes: number | null
+          actual_setup_minutes: number | null
+          assigned_to: string | null
+          completed_at: string | null
+          completed_by: string | null
+          created_at: string | null
+          estimated_run_minutes_per_unit: number | null
+          estimated_setup_minutes: number | null
+          id: string
+          instructions: string | null
+          job_id: string
+          job_part_id: string
+          notes: string | null
+          operation_name: string
+          routing_operation_id: string | null
+          sequence: number
+          started_at: string | null
+          status: string
+          updated_at: string | null
+          work_center_id: string | null
+        }
+        Insert: {
+          actual_run_minutes?: number | null
+          actual_setup_minutes?: number | null
+          assigned_to?: string | null
+          completed_at?: string | null
+          completed_by?: string | null
+          created_at?: string | null
+          estimated_run_minutes_per_unit?: number | null
+          estimated_setup_minutes?: number | null
+          id?: string
+          instructions?: string | null
+          job_id: string
+          job_part_id: string
+          notes?: string | null
+          operation_name: string
+          routing_operation_id?: string | null
+          sequence: number
+          started_at?: string | null
+          status?: string
+          updated_at?: string | null
+          work_center_id?: string | null
+        }
+        Update: {
+          actual_run_minutes?: number | null
+          actual_setup_minutes?: number | null
+          assigned_to?: string | null
+          completed_at?: string | null
+          completed_by?: string | null
+          created_at?: string | null
+          estimated_run_minutes_per_unit?: number | null
+          estimated_setup_minutes?: number | null
+          id?: string
+          instructions?: string | null
+          job_id?: string
+          job_part_id?: string
+          notes?: string | null
+          operation_name?: string
+          routing_operation_id?: string | null
+          sequence?: number
+          started_at?: string | null
+          status?: string
+          updated_at?: string | null
+          work_center_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "job_operations_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_operations_job_part_id_fkey"
+            columns: ["job_part_id"]
+            isOneToOne: false
+            referencedRelation: "job_parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_operations_routing_operation_id_fkey"
+            columns: ["routing_operation_id"]
+            isOneToOne: false
+            referencedRelation: "routing_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_operations_work_center_id_fkey"
+            columns: ["work_center_id"]
+            isOneToOne: false
+            referencedRelation: "work_centers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      job_parts: {
+        Row: {
+          company_id: string
+          completed_at: string | null
+          created_at: string
+          current_operation_sequence: number | null
+          fulfillment_status: string
+          id: string
+          job_id: string
+          part_id: string
+          production_status: string
+          quantity: number
+          sequence: number
+          source_quote_line_item_id: string | null
+          started_at: string | null
+          status_changed_at: string | null
+          updated_at: string
+        }
+        Insert: {
+          company_id: string
+          completed_at?: string | null
+          created_at?: string
+          current_operation_sequence?: number | null
+          fulfillment_status: string
+          id?: string
+          job_id: string
+          part_id: string
+          production_status: string
+          quantity: number
+          sequence: number
+          source_quote_line_item_id?: string | null
+          started_at?: string | null
+          status_changed_at?: string | null
+          updated_at?: string
+        }
+        Update: {
+          company_id?: string
+          completed_at?: string | null
+          created_at?: string
+          current_operation_sequence?: number | null
+          fulfillment_status?: string
+          id?: string
+          job_id?: string
+          part_id?: string
+          production_status?: string
+          quantity?: number
+          sequence?: number
+          source_quote_line_item_id?: string | null
+          started_at?: string | null
+          status_changed_at?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "job_parts_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_parts_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_parts_part_id_fkey"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_parts_source_quote_line_item_id_fkey"
+            columns: ["source_quote_line_item_id"]
+            isOneToOne: false
+            referencedRelation: "quote_line_items"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      jobs: {
+        Row: {
+          company_id: string
+          completed_at: string | null
+          created_at: string | null
+          created_by: string | null
+          customer_id: string | null
+          customer_po_number: string | null
+          due_date: string | null
+          fulfillment_status: string
+          id: string
+          job_number: string
+          lead_time_days: number | null
+          production_status: string
+          quote_id: string | null
+          started_at: string | null
+          status_changed_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          company_id: string
+          completed_at?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          customer_id?: string | null
+          customer_po_number?: string | null
+          due_date?: string | null
+          fulfillment_status: string
+          id?: string
+          job_number: string
+          lead_time_days?: number | null
+          production_status: string
+          quote_id?: string | null
+          started_at?: string | null
+          status_changed_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          company_id?: string
+          completed_at?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          customer_id?: string | null
+          customer_po_number?: string | null
+          due_date?: string | null
+          fulfillment_status?: string
+          id?: string
+          job_number?: string
+          lead_time_days?: number | null
+          production_status?: string
+          quote_id?: string | null
+          started_at?: string | null
+          status_changed_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "jobs_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jobs_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jobs_quote_id_fkey"
+            columns: ["quote_id"]
+            isOneToOne: false
+            referencedRelation: "quotes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      markup_rates: {
+        Row: {
+          breakpoints: Json
+          company_id: string
+          created_at: string
+          id: string
+          is_default: boolean
+          name: string
+          updated_at: string
+        }
+        Insert: {
+          breakpoints?: Json
+          company_id: string
+          created_at?: string
+          id?: string
+          is_default?: boolean
+          name: string
+          updated_at?: string
+        }
+        Update: {
+          breakpoints?: Json
+          company_id?: string
+          created_at?: string
+          id?: string
+          is_default?: boolean
+          name?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "markup_rates_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      operator_sessions: {
+        Row: {
+          company_id: string
+          created_at: string | null
+          ended_at: string | null
+          id: string
+          job_id: string
+          job_operation_id: string | null
+          notes: string | null
+          operator_id: string
+          started_at: string | null
+          updated_at: string | null
+          work_center_id: string
+        }
+        Insert: {
+          company_id: string
+          created_at?: string | null
+          ended_at?: string | null
+          id?: string
+          job_id: string
+          job_operation_id?: string | null
+          notes?: string | null
+          operator_id: string
+          started_at?: string | null
+          updated_at?: string | null
+          work_center_id: string
+        }
+        Update: {
+          company_id?: string
+          created_at?: string | null
+          ended_at?: string | null
+          id?: string
+          job_id?: string
+          job_operation_id?: string | null
+          notes?: string | null
+          operator_id?: string
+          started_at?: string | null
+          updated_at?: string | null
+          work_center_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "operator_sessions_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "operator_sessions_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "operator_sessions_job_operation_id_fkey"
+            columns: ["job_operation_id"]
+            isOneToOne: false
+            referencedRelation: "job_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "operator_sessions_work_center_id_fkey"
+            columns: ["work_center_id"]
+            isOneToOne: false
+            referencedRelation: "work_centers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      part_pricing_tiers: {
+        Row: {
+          company_id: string
+          created_at: string
+          id: string
+          markup_percent: number | null
+          part_id: string
+          quantity: number
+          sequence: number
+          unit_price: number | null
+          updated_at: string
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          id?: string
+          markup_percent?: number | null
+          part_id: string
+          quantity: number
+          sequence: number
+          unit_price?: number | null
+          updated_at?: string
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          id?: string
+          markup_percent?: number | null
+          part_id?: string
+          quantity?: number
+          sequence?: number
+          unit_price?: number | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "part_pricing_tiers_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "part_pricing_tiers_part_id_fkey"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      part_procurement_tiers: {
+        Row: {
+          cost_per_unit: number
+          created_at: string
+          expires_at: string | null
+          id: string
+          min_quantity: number
+          notes: string | null
+          part_id: string
+          quoted_at: string | null
+          updated_at: string
+          vendor_id: string | null
+        }
+        Insert: {
+          cost_per_unit: number
+          created_at?: string
+          expires_at?: string | null
+          id?: string
+          min_quantity: number
+          notes?: string | null
+          part_id: string
+          quoted_at?: string | null
+          updated_at?: string
+          vendor_id?: string | null
+        }
+        Update: {
+          cost_per_unit?: number
+          created_at?: string
+          expires_at?: string | null
+          id?: string
+          min_quantity?: number
+          notes?: string | null
+          part_id?: string
+          quoted_at?: string | null
+          updated_at?: string
+          vendor_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "part_procurement_tiers_part_id_fkey"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "part_procurement_tiers_vendor_id_fkey"
+            columns: ["vendor_id"]
+            isOneToOne: false
+            referencedRelation: "vendors"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      parts: {
+        Row: {
+          company_id: string
+          created_at: string
+          description: string | null
+          id: string
+          is_stocked: boolean
+          legacy_id: string | null
+          markup_rate_id: string | null
+          part_name: string
+          preferred_vendor_id: string | null
+          primary_unit: string | null
+          quantity: number
+          reorder_point: number | null
+          source: string
+          updated_at: string
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          description?: string | null
+          id?: string
+          is_stocked?: boolean
+          legacy_id?: string | null
+          markup_rate_id?: string | null
+          part_name: string
+          preferred_vendor_id?: string | null
+          primary_unit?: string | null
+          quantity?: number
+          reorder_point?: number | null
+          source?: string
+          updated_at?: string
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          description?: string | null
+          id?: string
+          is_stocked?: boolean
+          legacy_id?: string | null
+          markup_rate_id?: string | null
+          part_name?: string
+          preferred_vendor_id?: string | null
+          primary_unit?: string | null
+          quantity?: number
+          reorder_point?: number | null
+          source?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "parts_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "parts_markup_rate_id_fkey"
+            columns: ["markup_rate_id"]
+            isOneToOne: false
+            referencedRelation: "markup_rates"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "parts_preferred_vendor_id_fkey"
+            columns: ["preferred_vendor_id"]
+            isOneToOne: false
+            referencedRelation: "vendors"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      parts_bom: {
+        Row: {
+          child_part_id: string
+          created_at: string
+          id: string
+          notes: string | null
+          parent_part_id: string
+          quantity: number
+          sequence: number
+          unit: string
+          updated_at: string
+        }
+        Insert: {
+          child_part_id: string
+          created_at?: string
+          id?: string
+          notes?: string | null
+          parent_part_id: string
+          quantity: number
+          sequence?: number
+          unit: string
+          updated_at?: string
+        }
+        Update: {
+          child_part_id?: string
+          created_at?: string
+          id?: string
+          notes?: string | null
+          parent_part_id?: string
+          quantity?: number
+          sequence?: number
+          unit?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "parts_bom_child_part_id_fkey"
+            columns: ["child_part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "parts_bom_parent_part_id_fkey"
+            columns: ["parent_part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      parts_unit_conversions: {
+        Row: {
+          created_at: string
+          from_unit: string
+          id: string
+          part_id: string
+          to_primary_factor: number
+        }
+        Insert: {
+          created_at?: string
+          from_unit: string
+          id?: string
+          part_id: string
+          to_primary_factor: number
+        }
+        Update: {
+          created_at?: string
+          from_unit?: string
+          id?: string
+          part_id?: string
+          to_primary_factor?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "parts_unit_conversions_part_id_fkey"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      quote_line_items: {
+        Row: {
+          base_cost_per_unit: number | null
+          company_id: string
+          created_at: string
+          id: string
+          is_quote_override: boolean
+          markup_percent: number | null
+          part_id: string
+          quantity: number
+          quote_id: string
+          sequence: number
+          source_tier_id: string | null
+          total_price: number | null
+          unit_price: number
+        }
+        Insert: {
+          base_cost_per_unit?: number | null
+          company_id: string
+          created_at?: string
+          id?: string
+          is_quote_override?: boolean
+          markup_percent?: number | null
+          part_id: string
+          quantity: number
+          quote_id: string
+          sequence: number
+          source_tier_id?: string | null
+          total_price?: number | null
+          unit_price: number
+        }
+        Update: {
+          base_cost_per_unit?: number | null
+          company_id?: string
+          created_at?: string
+          id?: string
+          is_quote_override?: boolean
+          markup_percent?: number | null
+          part_id?: string
+          quantity?: number
+          quote_id?: string
+          sequence?: number
+          source_tier_id?: string | null
+          total_price?: number | null
+          unit_price?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "quote_line_items_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quote_line_items_part_id_fkey"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quote_line_items_quote_id_fkey"
+            columns: ["quote_id"]
+            isOneToOne: false
+            referencedRelation: "quotes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quote_line_items_source_tier_id_fkey"
+            columns: ["source_tier_id"]
+            isOneToOne: false
+            referencedRelation: "part_pricing_tiers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      quote_materials: {
+        Row: {
+          company_id: string
+          cost_per_unit: number | null
+          created_at: string
+          id: string
+          item_name: string
+          line_cost: number | null
+          material_part_id: string | null
+          part_id: string
+          quantity: number
+          quote_id: string
+          sequence: number
+          unit: string | null
+        }
+        Insert: {
+          company_id: string
+          cost_per_unit?: number | null
+          created_at?: string
+          id?: string
+          item_name: string
+          line_cost?: number | null
+          material_part_id?: string | null
+          part_id: string
+          quantity: number
+          quote_id: string
+          sequence: number
+          unit?: string | null
+        }
+        Update: {
+          company_id?: string
+          cost_per_unit?: number | null
+          created_at?: string
+          id?: string
+          item_name?: string
+          line_cost?: number | null
+          material_part_id?: string | null
+          part_id?: string
+          quantity?: number
+          quote_id?: string
+          sequence?: number
+          unit?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "quote_materials_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quote_materials_material_part_id_fkey"
+            columns: ["material_part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quote_materials_part_id_fkey"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quote_materials_quote_id_fkey"
+            columns: ["quote_id"]
+            isOneToOne: false
+            referencedRelation: "quotes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      quote_operations: {
+        Row: {
+          company_id: string
+          created_at: string
+          id: string
+          labor_rate: number | null
+          operation_name: string
+          part_id: string
+          quote_id: string
+          run_cost: number | null
+          run_time_minutes: number | null
+          sequence: number
+          setup_cost: number | null
+          setup_time_minutes: number | null
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          id?: string
+          labor_rate?: number | null
+          operation_name: string
+          part_id: string
+          quote_id: string
+          run_cost?: number | null
+          run_time_minutes?: number | null
+          sequence: number
+          setup_cost?: number | null
+          setup_time_minutes?: number | null
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          id?: string
+          labor_rate?: number | null
+          operation_name?: string
+          part_id?: string
+          quote_id?: string
+          run_cost?: number | null
+          run_time_minutes?: number | null
+          sequence?: number
+          setup_cost?: number | null
+          setup_time_minutes?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "quote_operations_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quote_operations_part_id_fkey"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quote_operations_quote_id_fkey"
+            columns: ["quote_id"]
+            isOneToOne: false
+            referencedRelation: "quotes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      quotes: {
+        Row: {
+          billing_address_id: string | null
+          company_id: string
+          contact_id: string | null
+          converted_at: string | null
+          created_at: string | null
+          created_by: string | null
+          customer_id: string | null
+          expiration_date: string | null
+          id: string
+          lead_time_days: number | null
+          quote_number: string
+          shipping_address_id: string | null
+          status: string
+          status_changed_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          billing_address_id?: string | null
+          company_id: string
+          contact_id?: string | null
+          converted_at?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          customer_id?: string | null
+          expiration_date?: string | null
+          id?: string
+          lead_time_days?: number | null
+          quote_number: string
+          shipping_address_id?: string | null
+          status?: string
+          status_changed_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          billing_address_id?: string | null
+          company_id?: string
+          contact_id?: string | null
+          converted_at?: string | null
+          created_at?: string | null
+          created_by?: string | null
+          customer_id?: string | null
+          expiration_date?: string | null
+          id?: string
+          lead_time_days?: number | null
+          quote_number?: string
+          shipping_address_id?: string | null
+          status?: string
+          status_changed_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "quotes_billing_address_id_fkey"
+            columns: ["billing_address_id"]
+            isOneToOne: false
+            referencedRelation: "customer_addresses"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quotes_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quotes_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "customer_contacts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quotes_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "quotes_shipping_address_id_fkey"
+            columns: ["shipping_address_id"]
+            isOneToOne: false
+            referencedRelation: "customer_addresses"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      routing_operations: {
+        Row: {
+          created_at: string | null
+          cycle_minutes_per_unit: number | null
+          external_setup_cost: number | null
+          external_unit_price: number | null
+          id: string
+          instructions: string | null
+          labor_rate_override: number | null
+          metadata: Json | null
+          routing_id: string
+          sequence: number
+          setup_minutes: number | null
+          updated_at: string | null
+          work_center_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          cycle_minutes_per_unit?: number | null
+          external_setup_cost?: number | null
+          external_unit_price?: number | null
+          id?: string
+          instructions?: string | null
+          labor_rate_override?: number | null
+          metadata?: Json | null
+          routing_id: string
+          sequence?: number
+          setup_minutes?: number | null
+          updated_at?: string | null
+          work_center_id: string
+        }
+        Update: {
+          created_at?: string | null
+          cycle_minutes_per_unit?: number | null
+          external_setup_cost?: number | null
+          external_unit_price?: number | null
+          id?: string
+          instructions?: string | null
+          labor_rate_override?: number | null
+          metadata?: Json | null
+          routing_id?: string
+          sequence?: number
+          setup_minutes?: number | null
+          updated_at?: string | null
+          work_center_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "routing_operations_routing_id_fkey"
+            columns: ["routing_id"]
+            isOneToOne: false
+            referencedRelation: "routings"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "routing_operations_work_center_id_fkey"
+            columns: ["work_center_id"]
+            isOneToOne: false
+            referencedRelation: "work_centers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      routings: {
+        Row: {
+          company_id: string
+          created_at: string | null
+          created_by: string | null
+          description: string | null
+          id: string
+          name: string
+          part_id: string
+          updated_at: string | null
+        }
+        Insert: {
+          company_id: string
+          created_at?: string | null
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          name: string
+          part_id: string
+          updated_at?: string | null
+        }
+        Update: {
+          company_id?: string
+          created_at?: string | null
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          name?: string
+          part_id?: string
+          updated_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "routings_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "routings_part_id_fkey"
+            columns: ["part_id"]
+            isOneToOne: true
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      saved_insights: {
+        Row: {
+          answer: string
+          chart_config: Json | null
+          company_id: string
+          created_at: string
+          id: string
+          question: string
+          user_id: string
+        }
+        Insert: {
+          answer: string
+          chart_config?: Json | null
+          company_id: string
+          created_at?: string
+          id?: string
+          question: string
+          user_id: string
+        }
+        Update: {
+          answer?: string
+          chart_config?: Json | null
+          company_id?: string
+          created_at?: string
+          id?: string
+          question?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "saved_insights_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      shipment_line_items: {
+        Row: {
+          created_at: string
+          id: string
+          job_part_id: string
+          quantity: number
+          shipment_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          job_part_id: string
+          quantity: number
+          shipment_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          job_part_id?: string
+          quantity?: number
+          shipment_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "shipment_line_items_job_part_id_fkey"
+            columns: ["job_part_id"]
+            isOneToOne: false
+            referencedRelation: "job_parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "shipment_line_items_shipment_id_fkey"
+            columns: ["shipment_id"]
+            isOneToOne: false
+            referencedRelation: "shipments"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      shipments: {
+        Row: {
+          carrier: string | null
+          coc_text: string | null
+          company_id: string
+          created_at: string
+          created_by: string | null
+          customer_id: string
+          id: string
+          notes: string | null
+          one_time_address: Json | null
+          package_count: number | null
+          package_type: string | null
+          packing_slip_number: string
+          ship_date: string
+          shipping_address_id: string | null
+          shipping_arrangement: string | null
+          shipping_arrangement_other: string | null
+          tracking_number: string | null
+          voided_at: string | null
+          voided_by: string | null
+          weight_lbs: number | null
+        }
+        Insert: {
+          carrier?: string | null
+          coc_text?: string | null
+          company_id: string
+          created_at?: string
+          created_by?: string | null
+          customer_id: string
+          id?: string
+          notes?: string | null
+          one_time_address?: Json | null
+          package_count?: number | null
+          package_type?: string | null
+          packing_slip_number: string
+          ship_date?: string
+          shipping_address_id?: string | null
+          shipping_arrangement?: string | null
+          shipping_arrangement_other?: string | null
+          tracking_number?: string | null
+          voided_at?: string | null
+          voided_by?: string | null
+          weight_lbs?: number | null
+        }
+        Update: {
+          carrier?: string | null
+          coc_text?: string | null
+          company_id?: string
+          created_at?: string
+          created_by?: string | null
+          customer_id?: string
+          id?: string
+          notes?: string | null
+          one_time_address?: Json | null
+          package_count?: number | null
+          package_type?: string | null
+          packing_slip_number?: string
+          ship_date?: string
+          shipping_address_id?: string | null
+          shipping_arrangement?: string | null
+          shipping_arrangement_other?: string | null
+          tracking_number?: string | null
+          voided_at?: string | null
+          voided_by?: string | null
+          weight_lbs?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "shipments_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "shipments_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "shipments_shipping_address_id_fkey"
+            columns: ["shipping_address_id"]
+            isOneToOne: false
+            referencedRelation: "customer_addresses"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      system_admins: {
+        Row: {
+          created_at: string | null
+          created_by: string | null
+          id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          created_by?: string | null
+          id?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          created_by?: string | null
+          id?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      user_company_access: {
+        Row: {
+          company_id: string
+          created_at: string | null
+          email: string | null
+          id: string
+          name: string | null
+          pin_hash: string | null
+          role: string | null
+          user_id: string
+        }
+        Insert: {
+          company_id: string
+          created_at?: string | null
+          email?: string | null
+          id?: string
+          name?: string | null
+          pin_hash?: string | null
+          role?: string | null
+          user_id: string
+        }
+        Update: {
+          company_id?: string
+          created_at?: string | null
+          email?: string | null
+          id?: string
+          name?: string | null
+          pin_hash?: string | null
+          role?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_company_access_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_preferences: {
+        Row: {
+          created_at: string | null
+          id: string
+          last_company_id: string | null
+          preferences: Json | null
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          last_company_id?: string | null
+          preferences?: Json | null
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          last_company_id?: string | null
+          preferences?: Json | null
+          updated_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_preferences_last_company_id_fkey"
+            columns: ["last_company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vendor_contacts: {
+        Row: {
+          created_at: string
+          email: string | null
+          id: string
+          is_primary: boolean
+          name: string
+          phone: string | null
+          role: string
+          role_label: string | null
+          updated_at: string
+          vendor_id: string
+        }
+        Insert: {
+          created_at?: string
+          email?: string | null
+          id?: string
+          is_primary?: boolean
+          name: string
+          phone?: string | null
+          role: string
+          role_label?: string | null
+          updated_at?: string
+          vendor_id: string
+        }
+        Update: {
+          created_at?: string
+          email?: string | null
+          id?: string
+          is_primary?: boolean
+          name?: string
+          phone?: string | null
+          role?: string
+          role_label?: string | null
+          updated_at?: string
+          vendor_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vendor_contacts_vendor_id_fkey"
+            columns: ["vendor_id"]
+            isOneToOne: false
+            referencedRelation: "vendors"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      vendors: {
+        Row: {
+          address_line1: string | null
+          address_line2: string | null
+          city: string | null
+          company_id: string
+          country: string | null
+          created_at: string
+          id: string
+          legacy_id: string | null
+          name: string
+          postal_code: string | null
+          state: string | null
+          updated_at: string
+        }
+        Insert: {
+          address_line1?: string | null
+          address_line2?: string | null
+          city?: string | null
+          company_id: string
+          country?: string | null
+          created_at?: string
+          id?: string
+          legacy_id?: string | null
+          name: string
+          postal_code?: string | null
+          state?: string | null
+          updated_at?: string
+        }
+        Update: {
+          address_line1?: string | null
+          address_line2?: string | null
+          city?: string | null
+          company_id?: string
+          country?: string | null
+          created_at?: string
+          id?: string
+          legacy_id?: string | null
+          name?: string
+          postal_code?: string | null
+          state?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vendors_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      waitlist: {
+        Row: {
+          company_name: string | null
+          created_at: string | null
+          email: string
+          id: string
+          name: string | null
+          shop_size: string | null
+          source: string | null
+          status: string
+        }
+        Insert: {
+          company_name?: string | null
+          created_at?: string | null
+          email: string
+          id?: string
+          name?: string | null
+          shop_size?: string | null
+          source?: string | null
+          status?: string
+        }
+        Update: {
+          company_name?: string | null
+          created_at?: string | null
+          email?: string
+          id?: string
+          name?: string | null
+          shop_size?: string | null
+          source?: string | null
+          status?: string
+        }
+        Relationships: []
+      }
+      work_centers: {
+        Row: {
+          company_id: string
+          created_at: string
+          description: string | null
+          id: string
+          kind: string
+          labor_rate: number | null
+          metadata: Json | null
+          name: string
+          updated_at: string
+          vendor_id: string | null
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          description?: string | null
+          id?: string
+          kind?: string
+          labor_rate?: number | null
+          metadata?: Json | null
+          name: string
+          updated_at?: string
+          vendor_id?: string | null
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          description?: string | null
+          id?: string
+          kind?: string
+          labor_rate?: number | null
+          metadata?: Json | null
+          name?: string
+          updated_at?: string
+          vendor_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "work_centers_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_centers_vendor_id_fkey"
+            columns: ["vendor_id"]
+            isOneToOne: false
+            referencedRelation: "vendors"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      _migrate_legacy_shipment_for_job: {
+        Args: { p_job_id: string }
+        Returns: string
+      }
+      accept_invitation: {
+        Args: { p_invitation_id: string; p_user_id: string }
+        Returns: string
+      }
+      bulk_apply_markup_rate: {
+        Args: { p_company_id: string; p_part_ids: string[]; p_rate_id: string }
+        Returns: Json
+      }
+      compute_job_fulfillment_status: {
+        Args: { p_job_id: string }
+        Returns: string
+      }
+      compute_job_part_fulfillment_status: {
+        Args: { p_job_part_id: string }
+        Returns: string
+      }
+      compute_job_production_status: {
+        Args: { p_job_id: string }
+        Returns: string
+      }
+      compute_part_cost_at_qty: {
+        Args: { p_part_id: string; p_qty: number }
+        Returns: number
+      }
+      compute_part_cost_explain: {
+        Args: { p_part_id: string; p_qty: number }
+        Returns: {
+          missing_leaves: Json
+          unit_cost: number
+        }[]
+      }
+      create_demo_company: {
+        Args: {
+          p_source_company_id: string
+          p_template_name?: string
+          p_user_id: string
+        }
+        Returns: string
+      }
+      create_job_part_operations_from_routing: {
+        Args: { p_job_part_id: string; p_routing_id: string }
+        Returns: number
+      }
+      create_shipment_with_line_items: {
+        Args: {
+          p_carrier: string
+          p_coc_text: string
+          p_company_id: string
+          p_customer_id: string
+          p_line_items: Json
+          p_notes: string
+          p_one_time_address: Json
+          p_package_count: number
+          p_package_type: string
+          p_ship_date: string
+          p_shipping_address_id: string
+          p_shipping_arrangement: string
+          p_shipping_arrangement_other: string
+          p_tracking_number: string
+          p_weight_lbs: number
+        }
+        Returns: string
+      }
+      format_packing_slip_number: {
+        Args: { p_format: string; p_seq: number; p_year: number }
+        Returns: string
+      }
+      generate_quote_number: { Args: { company_uuid: string }; Returns: string }
+      get_operator_access_id: {
+        Args: { check_company_id: string }
+        Returns: string
+      }
+      get_procurement_cost: {
+        Args: { p_part_id: string; p_qty: number }
+        Returns: {
+          source: string
+          tier_id: string
+          unit_cost: number
+          vendor_id: string
+        }[]
+      }
+      get_ready_operations_batch: {
+        Args: { p_job_ids: string[] }
+        Returns: {
+          job_id: string
+          operation_name: string
+          ready_count: number
+        }[]
+      }
+      get_ready_operations_for_station: {
+        Args: { p_company_id: string; p_work_center_id: string }
+        Returns: {
+          job_id: string
+          job_number: string
+          job_operation_id: string
+          job_part_id: string
+          op_status: string
+          operation_name: string
+          part_description: string
+          part_id: string
+          part_name: string
+          part_quantity: number
+        }[]
+      }
+      get_user_company_ids: { Args: never; Returns: string[] }
+      is_company_admin: { Args: { check_company_id: string }; Returns: boolean }
+      is_system_admin: { Args: { check_user_id: string }; Returns: boolean }
+      job_last_ship_date: { Args: { p_job_id: string }; Returns: string }
+      job_part_last_ship_date: {
+        Args: { p_job_part_id: string }
+        Returns: string
+      }
+      next_packing_slip_number: {
+        Args: { p_company_id: string }
+        Returns: string
+      }
+      reset_demo_company: {
+        Args: { p_source_company_id: string; p_user_id: string }
+        Returns: undefined
+      }
+      search_jobs_by_identifier: {
+        Args: { p_company_id: string; p_query: string }
+        Returns: {
+          job_id: string
+          match_source: string
+        }[]
+      }
+      seed_demo_data: {
+        Args: {
+          p_company_id: string
+          p_template_name?: string
+          p_user_id: string
+        }
+        Returns: undefined
+      }
+      show_limit: { Args: never; Returns: number }
+      show_trgm: { Args: { "": string }; Returns: string[] }
+      sync_demo_access: {
+        Args: { p_demo_company_id: string; p_source_company_id: string }
+        Returns: undefined
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {},
+  },
+} as const


### PR DESCRIPTION
## Summary
- Generates [`types/database.ts`](types/database.ts) (2,551 lines, 40 tables) from the linked Supabase project via `supabase gen types typescript --linked`.
- Adds `getTypedSupabase()` in [`lib/supabase.ts`](lib/supabase.ts) — same runtime singleton as `getSupabase()`, but typed with the `Database` generic so every `.from('quotes').select('...')` chain (and its return shape) is checked against the prod schema at compile time.
- Adds `pnpm gen:db-types` wrapper script for refreshes after migrations.
- Documents the adoption contract in [CLAUDE.md](CLAUDE.md) under "API Architecture Rule" → "Typed Supabase client (incremental adoption)".

## Why opt-in rather than flipping the existing getter

I tested the "flip `getSupabase()` to typed" path first. It surfaced **65 TS errors across 16 access files**, sorted roughly into:
1. **Latent column drift** — `jobs.related_to_job_id` and a handful of others that the generated types say don't exist on `jobs`. Same flavor of bug as `jobs.status` (#279). Each needs a "is the type stale or is the code stale?" investigation.
2. **Type-narrowing mismatches** — manually-written types like `Customer.default_shipping_arrangement: ShippingArrangement | null` clash with the DB's `text | null`. Real design decisions per case (widen the app type, add a runtime check, or add a CHECK constraint).
3. **Insert/update shape errors** — calls like `insert({ customer_id })` missing NOT NULL columns. Probably crash at runtime today; each needs tracing.

These are real bugs the loose typing has been hiding, but they don't belong in a single PR titled "adopt typed mode." This PR ships the **infrastructure** so per-file conversions can land as their own reviewable bug-fix PRs.

## How to adopt incrementally
1. Pick an access file (e.g. `utils/jobsAccess.ts`).
2. Change its `getSupabase()` import to `getTypedSupabase()`.
3. Run `pnpm exec tsc --noEmit -p tsconfig.json`.
4. Fix the errors — don't suppress with `as any`. Each one is a real signal.
5. Land that file as its own PR.

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean (existing access files still use untyped getter)
- [x] Verified type-flow via synthetic test: typed `data?.status` access on a `from('jobs').select('id, job_number')` chain fails compile as expected when using `getTypedSupabase()`
- [x] Existing test suite unaffected — no access file behavior changed

## Companion PRs
- [#279](https://github.com/debola31/Jigged/pull/279) — `jobs.status` prod fix
- [#280](https://github.com/debola31/Jigged/pull/280) — E2E seed pricing tiers (drops the runtime-skip that masked #279)
- [#281](https://github.com/debola31/Jigged/pull/281) — static schema-embed drift check (catches the embed-string class today, independent of typed adoption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)