### PR TITLE
Adopt typed Supabase client in utils/jobsAccess.ts

### DIFF
--- a/utils/jobsAccess.ts
+++ b/utils/jobsAccess.ts
@@ -1,4 +1,18 @@
-import { getSupabase } from '@/lib/supabase';
+// Adopt the typed Supabase client so every .from('jobs').select(...) chain
+// is validated against types/database.ts at compile time. Aliased to
+// getSupabase so the dozens of call sites below don't need renaming —
+// this also keeps the diff small for review. See CLAUDE.md "Typed
+// Supabase client (incremental adoption)" for the rollout contract.
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import type { Database } from '@/types/database';
+
+// Update payloads for tables this file mutates conditionally. The typed
+// `.update(...)` call rejects bare Record<string, unknown> because it
+// can't verify the keys against the table schema; using the generated
+// Update types preserves the column-name check.
+type JobPartUpdate = Database['public']['Tables']['job_parts']['Update'];
+type JobMaterialUpdate = Database['public']['Tables']['job_materials']['Update'];
+type JobOperationUpdate = Database['public']['Tables']['job_operations']['Update'];
 import type {
   Job,
   JobWithRelations,
@@ -239,7 +253,7 @@ export async function updateJobMaterial(
 ): Promise<JobMaterial> {
   const supabase = getSupabase();
 
-  const patch: Record<string, unknown> = {
+  const patch: JobMaterialUpdate = {
     ...updates,
     updated_at: new Date().toISOString(),
   };
@@ -428,7 +442,7 @@ async function recomputeJobPartStatus(
   }
 
   const nowIso = new Date().toISOString();
-  const updates: Record<string, unknown> = {
+  const updates: JobPartUpdate = {
     production_status: newStatus,
     status_changed_at: nowIso,
     updated_at: nowIso,
@@ -572,7 +586,7 @@ export async function completeJobOperation(
 
   const { data: { user } } = await supabase.auth.getUser();
 
-  const updateData: Record<string, unknown> = {
+  const updateData: JobOperationUpdate = {
     status: 'completed',
     completed_at: new Date().toISOString(),
     completed_by: user?.id || null,


### PR DESCRIPTION
## Summary
First per-file conversion under the typed-client rollout that #282 set up. Switches [`utils/jobsAccess.ts`](utils/jobsAccess.ts) from `getSupabase()` to `getTypedSupabase()` (aliased so the 18 call sites don't need touching), so every `.from('jobs').select(...)` chain in this file is now validated against [`types/database.ts`](types/database.ts) at compile time.

## What the type-check surfaced
Three TS2345 errors, all the same pattern: conditional-shape update payloads typed as `Record<string, unknown>`, which the typed `.update(...)` rejects because it can't verify the keys against the table schema. Fixed by typing each patch with the generated `Update` type for its table:

- `updateJobMaterial` → `Database['public']['Tables']['job_materials']['Update']`
- `updateJobPartProductionStatus` → `Database['public']['Tables']['job_parts']['Update']`
- `completeOperation` → `Database['public']['Tables']['job_operations']['Update']`

Each one preserves the dynamic-payload ergonomics (conditional field assignment after declaration) while getting back the column-name safety the bare `Record<string, unknown>` was throwing away.

## What didn't surface
A handful of errors I expected from the earlier smoke test (#282 PR notes flagged `related_to_job_id` references on jobs) — those got cleaned up in #278 before this branch was cut. So this conversion was lighter than the original survey suggested.

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm test --run __tests__/schema/embedCheck.test.ts` — 9 pass (PR #281's drift check still happy)
- [x] `pnpm exec playwright test e2e/quote-to-job.spec.ts` — 1 pass locally (the full quote-create + convert-to-job path runs through `utils/jobsAccess.ts`)
- No dedicated `jobsAccess` unit test exists; the E2E + type-check are the gates here

## Next in series
Other access files still on the untyped getter. Suggest converting one per PR — keeps each diff narrow and the fallout legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)