### PR TITLE
Adopt typed Supabase client in utils/quotesAccess.ts

### DIFF
--- a/__tests__/utils/quotePdf.test.ts
+++ b/__tests__/utils/quotePdf.test.ts
@@ -74,7 +74,6 @@ const baseQuote: QuoteWithRelations = {
   status: 'active',
   status_changed_at: null,
   converted_at: null,
-  legacy_quote_number: null,
   created_by: null,
   created_at: '2026-04-16T10:00:00Z',
   updated_at: '2026-04-16T10:00:00Z',

--- a/__tests__/utils/quotesAccess.test.ts
+++ b/__tests__/utils/quotesAccess.test.ts
@@ -62,9 +62,12 @@ const { mockQueryBuilder, mockSupabase, mockStorageHelpers } = vi.hoisted(() => 
   return { mockQueryBuilder: builder, mockSupabase: supabase, mockStorageHelpers: storageHelpers };
 });
 
-// Mock the supabase module
+// Mock the supabase module. quotesAccess.ts adopted getTypedSupabase
+// (typed-client rollout); include it here returning the same chainable
+// mock so the existing tests keep working without rewriting fixtures.
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/types/quote.ts
+++ b/types/quote.ts
@@ -23,7 +23,11 @@ export interface Quote {
   id: string;
   company_id: string;
   quote_number: string;
-  customer_id: string;
+  // customer_id has no NOT NULL constraint in the schema, so we mirror the
+  // DB type here. In practice the QuoteForm requires a customer before
+  // submit, but read paths still need to tolerate the null case until a
+  // future migration tightens the constraint.
+  customer_id: string | null;
   billing_address_id: string | null;
   shipping_address_id: string | null;
   contact_id: string | null;
@@ -32,7 +36,6 @@ export interface Quote {
   status: QuoteStatus;
   status_changed_at: string | null;
   converted_at: string | null;
-  legacy_quote_number: string | null;
   created_by: string | null;
   created_at: string;
   updated_at: string;
@@ -221,7 +224,9 @@ export function quoteToFormData(quote: QuoteWithRelations): QuoteFormData {
     }
   }
   return {
-    customer_id: quote.customer_id,
+    // customer_id is nullable in the schema but the form treats '' as
+    // "unset" — match the same convention as contact / address IDs below.
+    customer_id: quote.customer_id ?? '',
     contact_id: quote.contact_id ?? '',
     billing_address_id: quote.billing_address_id ?? '',
     shipping_address_id: quote.shipping_address_id ?? '',

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -1,5 +1,9 @@
 import * as Sentry from '@sentry/nextjs';
-import { getSupabase } from '@/lib/supabase';
+// Typed Supabase client — every .from('quotes').select(...) chain in this
+// file is now validated against types/database.ts at compile time. Aliased
+// to getSupabase so the existing call sites don't need touching. See
+// CLAUDE.md "Typed Supabase client (incremental adoption)".
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type {
   Quote,
   QuoteWithRelations,
@@ -17,6 +21,16 @@ import { calculateRoutingCost } from '@/utils/routingCostCalculation';
 import { getCompanyMembers } from '@/utils/companyAccess';
 import { getTiersForPart } from '@/utils/partPricingTiersAccess';
 import { insertLineItemForPart, getLineItemsForQuote } from '@/utils/quoteLineItemsAccess';
+
+/**
+ * Cast a DB row to Quote. The DB stores `status` as text with a CHECK
+ * constraint pinning it to QuoteStatus values (see schema.prod.sql line
+ * ~221); the generated Database type only sees `string`. Centralized
+ * here so the assertion is documented once instead of scattered.
+ */
+function asQuote(row: Record<string, unknown> & { status: string }): Quote {
+  return row as unknown as Quote;
+}
 
 /**
  * Sanitize search string for use in LIKE/ILIKE queries
@@ -244,7 +258,7 @@ export async function getQuote(quoteId: string, companyId: string): Promise<Quot
     console.error('Error fetching quote:', error);
     throw error;
   }
-  return data;
+  return data ? asQuote(data) : null;
 }
 
 /**
@@ -340,6 +354,12 @@ export async function createQuote(
     .from('quotes')
     .insert({
       company_id: companyId,
+      // quote_number is NOT NULL but the set_quote_number trigger
+      // (supabase/schema.prod.sql ~line 4202) fills it from
+      // generate_quote_number() when the value is '' or NULL. Sending ''
+      // explicitly satisfies the typed Insert signature without lying
+      // about runtime behavior.
+      quote_number: '',
       customer_id: formData.customer_id,
       contact_id: nullIfEmpty(formData.contact_id),
       billing_address_id: nullIfEmpty(formData.billing_address_id),
@@ -387,7 +407,7 @@ export async function createQuote(
     }
   }
 
-  return { quote };
+  return { quote: asQuote(quote) };
 }
 
 /**
@@ -443,7 +463,7 @@ export async function updateQuote(quoteId: string, formData: QuoteFormData): Pro
     throw error;
   }
 
-  return data;
+  return asQuote(data);
 }
 
 /**
@@ -641,7 +661,7 @@ export async function expireQuote(quoteId: string, companyId: string): Promise<Q
     console.error('Error expiring quote:', error);
     throw error;
   }
-  return data;
+  return asQuote(data);
 }
 
 // ============== Convert to Job ==============
@@ -862,7 +882,7 @@ export async function convertQuoteToJob(
   }
 
   return {
-    quote: updatedQuote,
+    quote: asQuote(updatedQuote),
     job: {
       id: job.id,
       job_number: job.job_number,


### PR DESCRIPTION
## Summary
Second per-file conversion under the typed-client rollout (#282, #283). Switches [`utils/quotesAccess.ts`](utils/quotesAccess.ts) from `getSupabase()` to `getTypedSupabase()` (aliased so the 14 call sites stay untouched).

Six TS errors surfaced; broke into three buckets:

### 1. Dead type field
`Quote.legacy_quote_number` was declared in [`types/quote.ts`](types/quote.ts) but no migration ever created the column. Same drift class as the `jobs.status` incident (#279). Removed from the type and from the `quotePdf` test fixture.

### 2. Manual type narrower than schema
- `Quote.customer_id` was `string` but the schema permits NULL (no NOT NULL constraint). Widened to `string | null` and updated `quoteToFormData` to coerce `null → ''` matching the convention already used for contact / address IDs. A future migration could tighten the DB side; the comment in the type points at the gap.
- `Quote.status` is the narrow `QuoteStatus` enum but the DB column is `text` (with a CHECK constraint pinning the values). Added a small `asQuote()` helper that documents the bridge in one place and replaces five scattered casts.

### 3. Insert missing a NOT NULL column with a trigger default
`.insert(...)` into `quotes` omitted `quote_number`, which is NOT NULL. At runtime the [`set_quote_number`](supabase/schema.prod.sql) trigger fills it from `generate_quote_number()` when the value is `''` or `NULL`. Added an explicit `quote_number: ''` with a comment pointing at the trigger so the typed Insert is honest about runtime behavior.

## Mock plumbing
Added `getTypedSupabase` to the [`quotesAccess.test.ts`](__tests__/utils/quotesAccess.test.ts) mock so the existing 22 tests keep working without fixture rewrites. This is a one-line addition that future per-file conversions will need to make in their respective test mocks.

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm test --run __tests__/utils/quotesAccess.test.ts __tests__/utils/quotePdf.test.ts __tests__/schema/embedCheck.test.ts` — 47 pass (9 pre-existing skips)
- [x] `pnpm exec playwright test e2e/quote-to-job.spec.ts` — 1 pass locally (exercises both `getQuote` and the create-quote insert with the trigger default)

## Next in series
Suggest `customerAccess.ts` next — it was on the original fallout list with the `default_shipping_arrangement` narrowing pattern, which will give us a template for handling enum-vs-text mismatches consistently across access files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)