### PR TITLE
Adopt typed Supabase client in utils/customerAccess.ts

### DIFF
--- a/__tests__/utils/customerAccess.test.ts
+++ b/__tests__/utils/customerAccess.test.ts
@@ -41,6 +41,9 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 // Mock the supabase module
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
+  // customerAccess.ts adopted getTypedSupabase under the typed-client
+  // rollout; both getters return the same singleton at runtime.
+  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/types/customer.ts
+++ b/types/customer.ts
@@ -9,8 +9,11 @@ export interface Customer {
   default_shipping_arrangement: ShippingArrangement | null;
   default_carrier: string | null;
   default_coc_text: string | null;
-  created_at: string;
-  updated_at: string;
+  // created_at / updated_at have DEFAULT now() but no NOT NULL constraint —
+  // mirror the DB shape. Consumers (e.g. the customer detail page) already
+  // handle null via formatDate(string | null).
+  created_at: string | null;
+  updated_at: string | null;
 }
 
 /**

--- a/utils/customerAccess.ts
+++ b/utils/customerAccess.ts
@@ -1,4 +1,8 @@
-import { getSupabase } from '@/lib/supabase';
+// Typed Supabase client — every .from('customers').select(...) chain in
+// this file is now validated against types/database.ts at compile time.
+// Aliased to getSupabase so the existing call sites stay untouched. See
+// CLAUDE.md "Typed Supabase client (incremental adoption)".
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type {
   Customer,
   CustomerAddress,
@@ -13,6 +17,7 @@ import type {
   CustomerContactFormData,
   CustomerContactRole,
 } from '@/types/customerContact';
+import type { ShippingArrangement } from '@/types/shipment';
 import { createCustomerContact } from '@/utils/customerContactsAccess';
 
 /**
@@ -27,6 +32,20 @@ import { createCustomerContact } from '@/utils/customerContactsAccess';
  * as the primary after the parent row is created — mirrors VendorForm's
  * "Initial Contact (optional)" accordion behavior.
  */
+
+/**
+ * Cast a DB row to Customer. The DB stores `default_shipping_arrangement`
+ * as text with a CHECK constraint pinning it to ShippingArrangement values
+ * (see schema.prod.sql ~line 109); the generated Database type only sees
+ * `string`. Centralized here so the assertion is documented once instead
+ * of scattered across read sites. Same pattern as asQuote() in
+ * utils/quotesAccess.ts.
+ */
+function asCustomer<T extends { default_shipping_arrangement: string | null }>(
+  row: T,
+): T & { default_shipping_arrangement: ShippingArrangement | null } {
+  return row as T & { default_shipping_arrangement: ShippingArrangement | null };
+}
 
 /** Joined customer + primary contact shape returned by the list queries. */
 type CustomerWithPrimaryContactRow = Customer & {
@@ -180,10 +199,10 @@ export async function getCustomer(
 
   if (!data) return null;
 
-  return {
+  return asCustomer({
     ...data,
     addresses: (data.addresses ?? []) as CustomerAddress[],
-  };
+  });
 }
 
 /**
@@ -314,7 +333,7 @@ export async function createCustomer(
     }
   }
 
-  return customer;
+  return asCustomer(customer);
 }
 
 export async function updateCustomer(
@@ -339,7 +358,7 @@ export async function updateCustomer(
     throw error;
   }
 
-  return data;
+  return asCustomer(data);
 }
 
 /**


### PR DESCRIPTION
## Summary
Third per-file conversion under the typed-client rollout (#282, #283, #284). Switches [`utils/customerAccess.ts`](utils/customerAccess.ts) from `getSupabase()` to `getTypedSupabase()` (aliased so the 11 call sites stay untouched).

## Two patterns we'll keep seeing

### 1. Enum vs DB text (the recurring one)
`Customer.default_shipping_arrangement` is the narrow `ShippingArrangement` enum, but the DB column is `text` (with a CHECK constraint pinning the values). Added an `asCustomer<T>()` generic helper that documents the CHECK-bridge once and replaces three scattered casts.

Same shape as `asQuote()` from #284 — this is going to be the dominant pattern as we work through tables that use CHECK-constrained text columns. If a fourth file needs it I'll generalize into a shared helper.

### 2. Manual type narrower than schema
`Customer.created_at` / `updated_at` were declared `string` but the schema has `DEFAULT now()` without `NOT NULL`, so the DB type is `string | null`. Widened in [`types/customer.ts`](types/customer.ts). The only two consumers (customer detail page) already pass through `formatDate(string | null)`, so nothing downstream changed.

## Test mock
Added `getTypedSupabase` to the [`customerAccess.test.ts`](__tests__/utils/customerAccess.test.ts) mock — same one-line pattern each per-file conversion needs.

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm test --run __tests__/utils/customerAccess.test.ts __tests__/schema/embedCheck.test.ts` — 20 pass

## Next in series
`operatorAccess.ts` was the next candidate I called out earlier. Alternative: `dashboardAccess.ts` (had a couple `from(dynamic-string)` errors in the original smoke test that probably want a different treatment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)