### PR TITLE
Adopt typed Supabase client in utils/operatorAccess.ts

### DIFF
--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -14,8 +14,16 @@
  * ready on THAT part. Start/Stop/Complete operate within a single job_part.
  */
 
-import { getSupabase } from '@/lib/supabase';
+// Typed Supabase client (typed-client rollout). Aliased so the 19 call
+// sites stay untouched. See CLAUDE.md "Typed Supabase client".
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import type { Database } from '@/types/database';
 import { calculateActualRunMinutes } from '@/utils/sessionDuration';
+
+// Update payload type for user_company_access. Used where the patch
+// object is built conditionally and would otherwise be inferred as
+// Record<string, unknown>, which the typed .update(...) rejects.
+type UserCompanyAccessUpdate = Database['public']['Tables']['user_company_access']['Update'];
 import type {
   OperatorJob,
   OperatorJobDetail,
@@ -31,14 +39,18 @@ import type {
 } from '@/types/operator';
 import { removePartStockGraceful } from '@/utils/partsAccess';
 
-// Operator type from user_company_access
+// Operator type from user_company_access. role and created_at are
+// nullable in the DB schema (text DEFAULT 'operator'; timestamptz
+// DEFAULT now()) but never null at read time because of the defaults.
+// Mirroring the DB shape here keeps the typed select returns happy
+// without papering the gap with per-site casts.
 interface OperatorAccess {
   id: string;
   user_id: string;
   company_id: string;
-  role: string;
+  role: string | null;
   name: string | null;
-  created_at: string;
+  created_at: string | null;
 }
 
 // ============================================================================
@@ -77,7 +89,7 @@ export async function updateOperator(
 ): Promise<OperatorAccess> {
   const supabase = getSupabase();
 
-  const updates: Record<string, unknown> = {};
+  const updates: UserCompanyAccessUpdate = {};
   if (request.name !== undefined) updates.name = request.name;
 
   const { data, error } = await supabase
@@ -718,7 +730,11 @@ export async function stopJob(
     })
     .eq('id', session.id);
 
-  const started = new Date(session.started_at);
+  // operator_sessions.started_at has DEFAULT now() in the schema, so
+  // every inserted row is non-null in practice. The generated type still
+  // sees `string | null` (DEFAULT without NOT NULL), so we assert.
+  const startedAt = session.started_at ?? now;
+  const started = new Date(startedAt);
   const ended = new Date(now);
   const durationSeconds = Math.floor((ended.getTime() - started.getTime()) / 1000);
 
@@ -728,7 +744,7 @@ export async function stopJob(
     job_id: part.job_id,
     job_operation_id: session.job_operation_id,
     operation_type_id: session.work_center_id,
-    started_at: session.started_at,
+    started_at: startedAt,
     ended_at: now,
     notes: request?.notes || null,
     duration_seconds: durationSeconds,
@@ -931,7 +947,9 @@ export async function completeJob(
     }
   }
 
-  const started = new Date(session.started_at);
+  // DB DEFAULT now() on started_at; never null at read time. See note
+  // in stopSession() above.
+  const started = new Date(session.started_at ?? now);
   const ended = new Date(now);
   const durationSeconds = Math.floor((ended.getTime() - started.getTime()) / 1000);
 
@@ -980,7 +998,9 @@ export async function getActiveSession(
     job_operation_id: session.job_operation_id,
     operation_name: opJoin?.operation_name ?? null,
     operation_type_id: session.work_center_id,
-    started_at: session.started_at,
+    // DB DEFAULT now() — non-null in practice; fall back to '' for the
+    // theoretical case where a row was inserted with explicit NULL.
+    started_at: session.started_at ?? '',
     notes: session.notes,
   };
 }
@@ -1011,7 +1031,10 @@ export async function getOperatorSessions(
     job_id: string;
     job_operation_id: string | null;
     work_center_id: string;
-    started_at: string;
+    // Schema has DEFAULT now() but no NOT NULL constraint; mirror that
+    // here so the typed select's row shape lines up. Consumers below
+    // fall back to '' for the theoretical NULL case.
+    started_at: string | null;
     ended_at: string | null;
     notes: string | null;
     jobs: { job_number: string } | { job_number: string }[] | null;
@@ -1020,7 +1043,7 @@ export async function getOperatorSessions(
 
   return (data || []).map((s: SessionRow) => {
     let durationSeconds: number | undefined;
-    if (s.ended_at) {
+    if (s.ended_at && s.started_at) {
       const started = new Date(s.started_at);
       const ended = new Date(s.ended_at);
       durationSeconds = Math.floor((ended.getTime() - started.getTime()) / 1000);
@@ -1034,7 +1057,7 @@ export async function getOperatorSessions(
       job_id: s.job_id,
       job_operation_id: s.job_operation_id,
       operation_type_id: s.work_center_id,
-      started_at: s.started_at,
+      started_at: s.started_at ?? '',
       ended_at: s.ended_at,
       notes: s.notes,
       duration_seconds: durationSeconds,


### PR DESCRIPTION
## Summary
Fourth per-file conversion under the typed-client rollout (#282–#286). Switches [`utils/operatorAccess.ts`](utils/operatorAccess.ts) from `getSupabase()` to `getTypedSupabase()` (aliased so the 19 call sites stay untouched).

Nine TS errors → three buckets, all patterns we've seen before:

### 1. Local-type narrower than schema
`OperatorAccess.role` and `.created_at` were `string` but `user_company_access` has DEFAULTs without NOT NULL. In practice the DEFAULTs always fire, but the typed select correctly forces us to acknowledge nullability. Widened the local interface (not exported — no downstream blast radius).

### 2. `Record<string, unknown>` patch object
`updateOperator` built a conditional update payload typed as `Record<string, unknown>`, rejected by the typed `.update(...)`. Typed it as `Database['public']['Tables']['user_company_access']['Update']`. Same fix as the three sites in `jobsAccess` (PR #283).

### 3. `operator_sessions.started_at` nullability
Schema has `DEFAULT now()` but no `NOT NULL`. Five consumers treated it as non-null:
- `stopSession()` / `completeJob()`: `new Date(session.started_at)` got `?? now` fallbacks
- `getActiveSession()`: `?? ''` fallback to match the existing convention
- `getOperatorSessions()`'s local `SessionRow` interface: widened to `string | null` with `?? ''` at the map consumer; the duration calculation now guards both `s.started_at` and `s.ended_at`.

## Test mock
None needed this round — `operatorAccess.test.ts` doesn't mock `@/lib/supabase` (it exercises pure helpers like `calculateActualRunMinutes`).

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm test --run __tests__/utils/operatorAccess.test.ts` — 6 pass
- [x] `pnpm test --run __tests__/schema/embedCheck.test.ts` — 9 pass

## Pattern is stabilizing
Four files in (jobs, quotes, customer, operator), the recurring issues are now well-characterized:
- Dead type fields → delete
- Manual type narrower than schema → widen, or pretend with comment
- Enum vs `text+CHECK` → `asXxx()` helper
- Conditional-shape updates → `Database[...]['Update']` type
- DEFAULT-without-NOT-NULL columns → fallback or assert

Worth considering a shared `lib/dbTypeHelpers.ts` if the asXxx pattern keeps recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)