### PR TITLE
Adopt typed Supabase client in utils/dashboardAccess.ts

### DIFF
--- a/utils/dashboardAccess.ts
+++ b/utils/dashboardAccess.ts
@@ -1,5 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
-import { getSupabase } from '@/lib/supabase';
+// Typed Supabase client (typed-client rollout). Aliased so the 8 call
+// sites stay untouched. See CLAUDE.md "Typed Supabase client".
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 
 // ============== Types ==============
 
@@ -199,7 +201,16 @@ export async function setMetricTimePeriod(key: MetricKey, period: MetricTimePeri
 
 // ============== Metric Value Queries ==============
 
-async function getCount(table: string, companyId: string, filters?: Record<string, string[]>): Promise<number> {
+// The typed client needs a literal table name to resolve column types,
+// so this helper is constrained to the tables it actually counts over.
+// Add to the union if a new caller needs a different table.
+type CountableTable = 'quotes' | 'jobs';
+
+async function getCount(
+  table: CountableTable,
+  companyId: string,
+  filters?: Record<string, string[]>,
+): Promise<number> {
   const supabase = getSupabase();
   let query = supabase.from(table).select('*', { count: 'exact', head: true }).eq('company_id', companyId);
 


### PR DESCRIPTION
## Summary
Fifth per-file conversion under the typed-client rollout (#282, #283, #284, #286, #287). Switches [`utils/dashboardAccess.ts`](utils/dashboardAccess.ts) to `getTypedSupabase()` (aliased; 8 call sites untouched).

Two TS errors, both downstream of the same root cause: the local `getCount()` helper accepted `table: string` and called `supabase.from(table)`. The typed client requires a literal table-name union to resolve column types — a bare `string` falls back to the overload-2 `never` shape, which breaks the downstream `.eq('company_id', …)` column lookup.

## Fix
Constrained the parameter to `'quotes' | 'jobs'` (the only tables `getCount` is actually called on today). Adding a new caller for a different table now forces an intentional addition to the union rather than silently producing an untyped query — exactly the forcing function we wanted from typed mode.

## New pattern flagged for remaining files
**Polymorphic helpers that call `from(dynamic-string)` need explicit literal-string-union constraints.** Not seen in #283/#284/#286/#287 because those files used hard-coded table names. Worth grepping for `from\(\w+\)` (variable, not literal) in the remaining access files to anticipate.

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm test --run __tests__/schema/embedCheck.test.ts` — 9 pass
- No dedicated dashboardAccess test file exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)