### PR TITLE
Adopt typed Supabase client in utils/partsAccess.ts

### DIFF
--- a/__tests__/utils/partsAccess.test.ts
+++ b/__tests__/utils/partsAccess.test.ts
@@ -44,6 +44,8 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 // Mock the supabase module
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
+  // partsAccess.ts adopted getTypedSupabase under the typed-client rollout.
+  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/utils/partsAccess.ts
+++ b/utils/partsAccess.ts
@@ -1,4 +1,13 @@
-import { getSupabase } from '@/lib/supabase';
+// Typed Supabase client (typed-client rollout). Aliased so the 30 call
+// sites stay untouched. See CLAUDE.md "Typed Supabase client".
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import type { Database } from '@/types/database';
+
+// Insert payload for the parts table. company_id is supplied at the call
+// site (so the helper that builds the rest of the columns doesn't need
+// to know about scope), but every other NOT NULL column has to be
+// present for the typed insert to compile.
+type PartsInsert = Database['public']['Tables']['parts']['Insert'];
 import type {
   Part,
   PartFormData,
@@ -616,7 +625,7 @@ export async function checkPartNameExists(
 // CREATE / UPDATE / DELETE
 // ============================================================
 
-function formDataToInsert(formData: PartFormData): Record<string, unknown> {
+function formDataToInsert(formData: PartFormData): Omit<PartsInsert, 'company_id'> {
   // `quantity` is intentionally NOT written through this path: only
   // inventory_transactions ever changes the on-hand count
   // (PartTransactionModal / recordInventoryTransaction) so there is always


### PR DESCRIPTION
## Summary
Sixth per-file conversion under the typed-client rollout. Switches [`utils/partsAccess.ts`](utils/partsAccess.ts) to `getTypedSupabase()` (aliased; 30 call sites untouched).

Just **one TS error** — partsAccess was already in good shape compared to the prior files.

## The error
Local `formDataToInsert()` returned `Record<string, unknown>`. When spread into the typed `.insert()` payload, TS lost track of which columns were actually being supplied and rejected the call as missing the NOT NULL `part_name` field.

## Fix
Narrowed the helper's return type to `Omit<Database['public']['Tables']['parts']['Insert'], 'company_id'>`. Preserves the call-site shape (company_id added at the boundary, other columns from the form) and gives full column-name validation across both `createPart` and `updatePart`.

## Pattern recap (6 files in)
Bare untyped helpers — `Record<string, unknown>` or `string` — defeat typed mode. Narrowing them to the table-specific `Insert`/`Update` type is the dominant fix:
- jobsAccess (#283) → 3× `JobOperationUpdate`-style narrowings
- quotesAccess (#284) → `asQuote()` helper for enum bridging, `quote_number: ''` for trigger default
- customerAccess (#286) → `asCustomer<T>()` for enum bridging, widened `created_at | null`
- operatorAccess (#287) → 3 buckets we'd already seen + `started_at | null` for DEFAULT-without-NOT-NULL
- dashboardAccess (#288) → `'quotes' | 'jobs'` literal union for polymorphic `from()`
- partsAccess (this PR) → `Omit<PartsInsert, 'company_id'>` for the form-derived helper

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm test --run __tests__/utils/partsAccess.test.ts __tests__/schema/embedCheck.test.ts` — 25 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)