### PR TITLE
Adopt typed Supabase client in utils/companyAccess.ts

### DIFF
--- a/__tests__/utils/companyAccess.test.ts
+++ b/__tests__/utils/companyAccess.test.ts
@@ -33,6 +33,8 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 // Mock the supabase module
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
+  // companyAccess.ts adopted getTypedSupabase under the typed-client rollout.
+  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/utils/companyAccess.ts
+++ b/utils/companyAccess.ts
@@ -1,4 +1,6 @@
-import { getSupabase } from '@/lib/supabase';
+// Typed Supabase client (typed-client rollout). Aliased so the 10 call
+// sites stay untouched. See CLAUDE.md "Typed Supabase client".
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type { CompanyMember } from '@/types/quote';
 
 export interface Company {
@@ -14,7 +16,10 @@ export interface Company {
   state?: string | null;
   postal_code?: string | null;
   country?: string | null;
-  is_demo?: boolean;
+  // boolean | null mirrors the DB (column has no DEFAULT or NOT NULL).
+  // All consumers treat is_demo via truthy checks, so null behaves like
+  // false — no consumer changes needed.
+  is_demo?: boolean | null;
   demo_company_id?: string | null;
   // Free-form per-tenant settings (feature flags, defaults). Schema: jsonb.
   settings?: Record<string, unknown> | null;
@@ -256,7 +261,12 @@ export async function getCompany(companyId: string): Promise<Company | null> {
     return null;
   }
 
-  return data;
+  // companies.settings is jsonb in the DB → generated type is Json
+  // (string | number | boolean | object | array). The app treats it as
+  // a config object (e.g. `settings.features` in app/admin/page.tsx),
+  // so we narrow here. If a primitive ever lands in this column it
+  // would be a write-side bug; reads stay strongly typed.
+  return data as Company | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
Seventh per-file conversion under the typed-client rollout. Switches [`utils/companyAccess.ts`](utils/companyAccess.ts) to `getTypedSupabase()` (aliased; 10 call sites untouched).

Two TS errors, both **manual-type-narrower-than-schema** (same bucket as `Customer.created_at` in #286):

### 1. `Company.is_demo`
Was `boolean | undefined` but the DB column has no DEFAULT/NOT NULL, so the generated type is `boolean | null`. All three consumers treat `is_demo` via truthy checks, so widening to `boolean | null` is safe — null is falsy in JS, same behavior as undefined.

### 2. `Company.settings`
DB column is `jsonb` (generated as `Json`: `string | number | boolean | object | array`), but the app treats it as a config object (`settings.features` in admin page). Cast at the read site with a comment noting that a primitive landing in this column would be a write-side bug; reads stay strongly typed as `Record<string, unknown> | null`.

`jsonb` columns are a recurring soft spot — typed mode correctly surfaces the gap that "we trust this is an object" isn't enforced anywhere. A real fix would be a CHECK constraint or a separate typed `settings` table.

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm test --run __tests__/utils/companyAccess.test.ts __tests__/schema/embedCheck.test.ts` — 34 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)