### PR TITLE
Adopt typed Supabase client in utils/routingsAccess.ts

### DIFF
--- a/types/routings.ts
+++ b/types/routings.ts
@@ -24,8 +24,11 @@ export interface Routing {
   name: string;
   description: string | null;
   created_by: string | null;
-  created_at: string;
-  updated_at: string;
+  // created_at / updated_at have DEFAULT now() but no NOT NULL constraint —
+  // mirror the DB shape so typed-mode reads stay clean. Same convention as
+  // Customer.created_at (PR #286), Company.is_demo (PR #290).
+  created_at: string | null;
+  updated_at: string | null;
 }
 
 /**

--- a/utils/routingsAccess.ts
+++ b/utils/routingsAccess.ts
@@ -7,7 +7,16 @@
  * `utils/bomAccess.ts`.
  */
 
-import { getSupabase } from '@/lib/supabase';
+// Typed Supabase client (typed-client rollout). Aliased so the 12 call
+// sites stay untouched. See CLAUDE.md "Typed Supabase client".
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import type { Database } from '@/types/database';
+
+// Insert payload for routing_operations, minus the columns the callers
+// add at the boundary (routing_id, sequence, metadata). Narrowing the
+// form-derived shape lets the typed .insert() validate column names
+// instead of falling back to Record<string, unknown>.
+type RoutingOperationInsert = Database['public']['Tables']['routing_operations']['Insert'];
 import type {
   Routing,
   RoutingOperation,
@@ -159,8 +168,9 @@ export async function getRoutings(
     name: string;
     description: string | null;
     created_by: string | null;
-    created_at: string;
-    updated_at: string;
+    // Mirror DB nullability (DEFAULT-without-NOT-NULL).
+    created_at: string | null;
+    updated_at: string | null;
     part: { id: string; part_name: string; description: string | null } | null;
     operations?: Array<{ id: string; cycle_minutes_per_unit: number | null }>;
   }
@@ -302,7 +312,9 @@ function parseNumOrNull(s: string): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-function formDataToOpInsert(formData: RoutingOperationFormData): Record<string, unknown> {
+function formDataToOpInsert(
+  formData: RoutingOperationFormData,
+): Omit<RoutingOperationInsert, 'routing_id' | 'sequence' | 'metadata'> {
   return {
     work_center_id: formData.work_center_id,
     setup_minutes: parseNumOrNull(formData.setup_minutes) ?? 0,


### PR DESCRIPTION
## Summary
Eighth per-file conversion under the typed-client rollout. Switches [`utils/routingsAccess.ts`](utils/routingsAccess.ts) to `getTypedSupabase()` (aliased; 12 call sites untouched).

Seven TS errors, all instances of two patterns we've seen before:

### 1. `created_at` / `updated_at` narrower than DB
- `Routing` type in [`types/routings.ts`](types/routings.ts) declared `created_at: string` but the DB has `DEFAULT now()` without `NOT NULL` → generated type is `string | null`. Six error sites collapsed to one type change. Same convention as Customer (#286), Company (#290).
- The local `RoutingRow` interface inside `getRoutingsWithStats` had the same narrowing — widened in lockstep.

### 2. `formDataToOpInsert` returned `Record<string, unknown>`
When spread into the typed `.insert()`, TS lost track of the keys and reported `work_center_id` as missing while rejecting the explicit `metadata: {}` as unknown. Same fix as #289 (partsAccess): narrow the helper's return type to `Omit<RoutingOperationInsert, 'routing_id' | 'sequence' | 'metadata'>`.

**Note:** the `metadata` jsonb column on `routing_operations` is real and not drift — the TS error was downstream of the lost-typing on the spread, not a missing column. The typed Insert sees it correctly once the helper is narrowed.

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm test --run __tests__/schema/embedCheck.test.ts` — 9 pass
- No dedicated routingsAccess test file exists

## Progress
8 files done (6 merged + 2 PR-open). ~19 left if we sweep the trivial ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)