### PR TITLE
Adopt typed Supabase client in utils/shipmentsAccess.ts

### DIFF
--- a/__tests__/utils/shipmentsAccess.test.ts
+++ b/__tests__/utils/shipmentsAccess.test.ts
@@ -64,6 +64,8 @@ const { mockSupabase, queueBuilders } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
+  // shipmentsAccess.ts adopted getTypedSupabase under the typed-client rollout.
+  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/utils/shipmentsAccess.ts
+++ b/utils/shipmentsAccess.ts
@@ -12,7 +12,9 @@
  * Reads use plain PostgREST joins. Voids are scaffolded but throw — Phase 3.
  */
 
-import { getSupabase } from '@/lib/supabase';
+// Typed Supabase client (typed-client rollout). Aliased so the 10 call
+// sites stay untouched. See CLAUDE.md "Typed Supabase client".
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type {
   CreateShipmentPayload,
   JobPartShipmentSummary,
@@ -46,25 +48,35 @@ export async function createShipment(
 
   const supabase = getSupabase();
 
+  // The SQL function (create_shipment_with_line_items, schema.prod.sql
+  // line ~3042) accepts NULL for every optional shipping field — its body
+  // does `COALESCE(p_ship_date, current_date)` and similar fallbacks.
+  // The typed RPC signature reflects only the parameter type (e.g. text)
+  // without DEFAULT NULL, so the generated client type rejects null
+  // arguments. The right long-term fix is a migration that declares
+  // DEFAULT NULL on the optional params; until then we cast at the call
+  // site with this note.
+  const rpcArgs = {
+    p_company_id: companyId,
+    p_customer_id: payload.customer_id,
+    p_shipping_address_id: payload.shipping_address_id,
+    p_one_time_address: payload.one_time_address ?? null,
+    p_ship_date: payload.ship_date,
+    p_carrier: payload.carrier ?? null,
+    p_tracking_number: payload.tracking_number ?? null,
+    p_shipping_arrangement: payload.shipping_arrangement ?? null,
+    p_shipping_arrangement_other: payload.shipping_arrangement_other ?? null,
+    p_weight_lbs: payload.weight_lbs ?? null,
+    p_package_count: payload.package_count ?? null,
+    p_package_type: payload.package_type ?? null,
+    p_notes: payload.notes ?? null,
+    p_coc_text: payload.coc_text ?? null,
+    p_line_items: payload.line_items,
+  };
   const { data: shipmentId, error } = await supabase.rpc(
     'create_shipment_with_line_items',
-    {
-      p_company_id: companyId,
-      p_customer_id: payload.customer_id,
-      p_shipping_address_id: payload.shipping_address_id,
-      p_one_time_address: payload.one_time_address ?? null,
-      p_ship_date: payload.ship_date,
-      p_carrier: payload.carrier ?? null,
-      p_tracking_number: payload.tracking_number ?? null,
-      p_shipping_arrangement: payload.shipping_arrangement ?? null,
-      p_shipping_arrangement_other: payload.shipping_arrangement_other ?? null,
-      p_weight_lbs: payload.weight_lbs ?? null,
-      p_package_count: payload.package_count ?? null,
-      p_package_type: payload.package_type ?? null,
-      p_notes: payload.notes ?? null,
-      p_coc_text: payload.coc_text ?? null,
-      p_line_items: payload.line_items,
-    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rpcArgs as any,
   );
 
   if (error || !shipmentId) {


### PR DESCRIPTION
## Summary
Ninth per-file conversion under the typed-client rollout. Switches [`utils/shipmentsAccess.ts`](utils/shipmentsAccess.ts) to `getTypedSupabase()` (aliased; 10 call sites untouched).

Eleven TS errors, all surfacing one **new pattern** worth flagging.

## New pattern: SQL function signature lies about nullability

[`create_shipment_with_line_items`](supabase/schema.prod.sql) (line ~3042) declares its optional shipping parameters as bare `text` / `numeric` / `jsonb` — no `DEFAULT NULL` clauses. The function body relies on `COALESCE` (`COALESCE(p_ship_date, current_date)`) to handle NULL inputs, so passing NULL is valid at runtime.

But the typed Supabase RPC generator reflects only the declared parameter types. The typed client refuses NULL for `p_carrier`, `p_tracking_number`, `p_one_time_address`, `p_weight_lbs`, `p_package_count`, etc.

**This isn't drift — it's a real inconsistency in the SQL:** the signature claims required, the body treats them as optional. Typed mode is correctly surfacing the gap.

## Fix in this PR
Cast at the call site with a comment pointing at the gap. One `as any` (eslint-disabled with explanation) instead of 11 scattered ones.

## Follow-up
A migration that does
```sql
ALTER FUNCTION create_shipment_with_line_items(...)
  ALTER ARGUMENT p_carrier SET DEFAULT NULL,
  ALTER ARGUMENT p_tracking_number SET DEFAULT NULL,
  ...
```
would make the typed signature correct and let us remove the cast. Worth flagging as a follow-up; not in scope here.

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm test --run __tests__/utils/shipmentsAccess.test.ts __tests__/schema/embedCheck.test.ts` — 15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)