### PR TITLE
Adopt typed Supabase client in utils/vendorsAccess.ts

### DIFF
--- a/utils/vendorsAccess.ts
+++ b/utils/vendorsAccess.ts
@@ -1,4 +1,12 @@
-import { getSupabase } from '@/lib/supabase';
+// Typed Supabase client (typed-client rollout). Aliased so the 11 call
+// sites stay untouched. See CLAUDE.md "Typed Supabase client".
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import type { Database } from '@/types/database';
+
+// Insert payload for the vendors table, minus company_id which is added
+// at the boundary. Narrowing this avoids the Record<string, unknown>
+// spread that defeats typed-mode column-name validation.
+type VendorInsert = Database['public']['Tables']['vendors']['Insert'];
 import type {
   Vendor,
   VendorFormData,
@@ -197,7 +205,7 @@ export async function checkVendorNameExists(
   return (data?.length || 0) > 0;
 }
 
-function formDataToInsert(formData: VendorFormData): Record<string, unknown> {
+function formDataToInsert(formData: VendorFormData): Omit<VendorInsert, 'company_id'> {
   const trimmed = (s: string) => (s.trim() === '' ? null : s.trim());
   return {
     name: formData.name.trim(),


### PR DESCRIPTION
## Summary
Tenth per-file conversion under the typed-client rollout. Switches [`utils/vendorsAccess.ts`](utils/vendorsAccess.ts) to `getTypedSupabase()` (aliased; 11 call sites untouched).

**One TS error, no new patterns.** Same fix as `partsAccess` (#289) and `routingsAccess` (#291): `formDataToInsert` returned `Record<string, unknown>` which defeats typed-mode column-name validation on the `.insert()` spread. Narrowed to `Omit<VendorInsert, 'company_id'>`.

The recurring "untyped helper return type" issue is now the dominant pattern across access files that build insert payloads from form data.

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm test --run __tests__/schema/embedCheck.test.ts` — 9 pass
- No dedicated vendorsAccess test file exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)