### PR TITLE
Adopt typed Supabase client across remaining 17 access files (sweep)

### DIFF
--- a/__tests__/utils/procurementTiersAccess.test.ts
+++ b/__tests__/utils/procurementTiersAccess.test.ts
@@ -32,6 +32,8 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
+  // procurementTiersAccess.ts adopted getTypedSupabase under the typed-client rollout.
+  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/__tests__/utils/routingCostCalculation.test.ts
+++ b/__tests__/utils/routingCostCalculation.test.ts
@@ -57,11 +57,11 @@ vi.mock('@/utils/partsAccess', () => ({
   getComputedPartCost: (...args: [string, number]) => mockGetComputedPartCost(...args),
   getPartCostExplain: (...args: [string, number]) => mockGetPartCostExplain(...args),
 }));
-vi.mock('@/lib/supabase', () => ({
+vi.mock('@/lib/supabase', () => {
   // Only invoked when a BOM line uses a unit different from the child's
   // primary_unit; tests stay on same-unit rows by default and this returns
   // an empty conversion list.
-  getSupabase: () => ({
+  const makeClient = () => ({
     from: () => ({
       select: () => ({
         in: () => ({
@@ -69,8 +69,13 @@ vi.mock('@/lib/supabase', () => ({
         }),
       }),
     }),
-  }),
-}));
+  });
+  return {
+    getSupabase: makeClient,
+    // typed-client rollout: same singleton at runtime.
+    getTypedSupabase: makeClient,
+  };
+});
 
 import { calculateRoutingCost, calculateTierPricing } from '@/utils/routingCostCalculation';
 

--- a/__tests__/utils/storageHelpers.test.ts
+++ b/__tests__/utils/storageHelpers.test.ts
@@ -28,6 +28,8 @@ const { mockStorage, mockSupabase } = vi.hoisted(() => {
 // Mock the supabase module
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
+  // storageHelpers.ts adopted getTypedSupabase under the typed-client rollout.
+  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/utils/alertsAccess.ts
+++ b/utils/alertsAccess.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 
 export type AlertSeverity = 'critical' | 'high' | 'medium' | 'low';
 

--- a/utils/bomAccess.ts
+++ b/utils/bomAccess.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type {
   BomLine,
   BomLineFormData,

--- a/utils/customerAddressesAccess.ts
+++ b/utils/customerAddressesAccess.ts
@@ -13,7 +13,7 @@
  * the DEFAULT, not a type assertion on the address.
  */
 
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type {
   CustomerAddress,
   CustomerAddressFormData,

--- a/utils/customerContactsAccess.ts
+++ b/utils/customerContactsAccess.ts
@@ -17,16 +17,23 @@
  * because the UI is single-user-per-customer at any given moment.
  */
 
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import type { Database } from '@/types/database';
 import type {
   CustomerContact,
   CustomerContactFormData,
 } from '@/types/customerContact';
 
+// Narrow the form-derived insert so the typed .insert() can validate
+// column names. customer_id is added at the call site.
+type CustomerContactInsert = Database['public']['Tables']['customer_contacts']['Insert'];
+
 const CUSTOMER_CONTACT_COLUMNS =
   'id, customer_id, name, role, role_label, email, phone, is_primary, created_at, updated_at';
 
-function formDataToInsert(formData: CustomerContactFormData): Record<string, unknown> {
+function formDataToInsert(
+  formData: CustomerContactFormData,
+): Omit<CustomerContactInsert, 'customer_id'> {
   const trimmed = (s: string) => (s.trim() === '' ? null : s.trim());
   return {
     name: formData.name.trim(),

--- a/utils/demoAccess.ts
+++ b/utils/demoAccess.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 
 export interface DemoStatus {
   isDemoCompany: boolean;

--- a/utils/insightsAccess.ts
+++ b/utils/insightsAccess.ts
@@ -1,5 +1,5 @@
 import { API_BASE_URL } from '@/lib/api';
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 
 // ============================================================
 // Types

--- a/utils/markupRatesAccess.ts
+++ b/utils/markupRatesAccess.ts
@@ -1,4 +1,5 @@
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import type { Database, Json } from '@/types/database';
 import type {
   MarkupRate,
   MarkupRateFormData,
@@ -6,6 +7,16 @@ import type {
 } from '@/types/markupRates';
 import type { PartPricingTierInput } from '@/types/partPricing';
 import { replaceTiersForPart } from '@/utils/partPricingTiersAccess';
+
+// markup_rates.breakpoints is jsonb in the DB → generated as Json. The
+// app models it as MarkupRateBreakpoint[]. On reads we bridge via this
+// helper; on writes we cast inline (see createMarkupRate / updateMarkupRate).
+// A future migration that adds a CHECK constraint on the shape would let
+// us tighten this without scattered casts.
+type MarkupRateRow = Database['public']['Tables']['markup_rates']['Row'];
+function asMarkupRate(row: MarkupRateRow): MarkupRate {
+  return row as unknown as MarkupRate;
+}
 
 /**
  * Fetch all markup rates for a company, sorted by name ascending. The
@@ -26,7 +37,7 @@ export async function getAllMarkupRates(companyId: string): Promise<MarkupRate[]
     throw error;
   }
 
-  return (data || []) as MarkupRate[];
+  return (data || []).map(asMarkupRate);
 }
 
 export async function getMarkupRate(rateId: string): Promise<MarkupRate | null> {
@@ -43,7 +54,7 @@ export async function getMarkupRate(rateId: string): Promise<MarkupRate | null> 
     throw error;
   }
 
-  return (data as MarkupRate) ?? null;
+  return data ? asMarkupRate(data) : null;
 }
 
 export async function createMarkupRate(
@@ -61,7 +72,8 @@ export async function createMarkupRate(
   const payload = {
     company_id: companyId,
     name: formData.name.trim(),
-    breakpoints: normalizeBreakpoints(formData.breakpoints),
+    // breakpoints is jsonb in the DB → cast required (see asMarkupRate note).
+    breakpoints: normalizeBreakpoints(formData.breakpoints) as unknown as Json,
     is_default: formData.is_default,
   };
 
@@ -76,7 +88,7 @@ export async function createMarkupRate(
     throw error;
   }
 
-  return data as MarkupRate;
+  return asMarkupRate(data);
 }
 
 export async function updateMarkupRate(
@@ -102,7 +114,7 @@ export async function updateMarkupRate(
 
   const payload = {
     name: formData.name.trim(),
-    breakpoints: normalizeBreakpoints(formData.breakpoints),
+    breakpoints: normalizeBreakpoints(formData.breakpoints) as unknown as Json,
     is_default: formData.is_default,
   };
 
@@ -118,7 +130,7 @@ export async function updateMarkupRate(
     throw error;
   }
 
-  return data as MarkupRate;
+  return asMarkupRate(data);
 }
 
 /**
@@ -164,7 +176,7 @@ export async function getDefaultMarkupRate(companyId: string): Promise<MarkupRat
     console.error('Error fetching default markup rate:', error);
     throw error;
   }
-  return (data as MarkupRate) ?? null;
+  return data ? asMarkupRate(data) : null;
 }
 
 /**
@@ -333,11 +345,14 @@ export async function bulkApplyMarkupRate(
         failed.push({ partId, error: error.message });
       }
     } else {
+      // RPC returns jsonb; typed as Json so the precise shape lives in the
+      // interface above. Cast through unknown because Json is a union with
+      // primitives and Json[].
       const result = (data ?? {
         updated: 0,
         price_uncomputed: 0,
         failed: [],
-      }) as BulkApplyMarkupRateRpcResult;
+      }) as unknown as BulkApplyMarkupRateRpcResult;
       updated += result.updated;
       priceUncomputed += result.price_uncomputed;
       for (const f of result.failed) {

--- a/utils/partPricingTiersAccess.ts
+++ b/utils/partPricingTiersAccess.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type { PartPricingTier, PartPricingTierInput } from '@/types/partPricing';
 import { getComputedPartCost } from '@/utils/partsAccess';
 

--- a/utils/procurementTiersAccess.ts
+++ b/utils/procurementTiersAccess.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type {
   ProcurementCostResult,
   ProcurementTier,

--- a/utils/quoteEmail.ts
+++ b/utils/quoteEmail.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import { API_BASE_URL } from '@/lib/api';
 
 export interface SendQuoteEmailPayload {

--- a/utils/quoteLineItemsAccess.ts
+++ b/utils/quoteLineItemsAccess.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type { QuoteLineItem } from '@/types/quote';
 import type { PartPricingTier } from '@/types/partPricing';
 import { resolveTier } from '@/utils/quotePricingResolver';

--- a/utils/routingCostCalculation.ts
+++ b/utils/routingCostCalculation.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import { getRoutingForPart } from '@/utils/routingsAccess';
 import { getBomForPart } from '@/utils/bomAccess';
 import { getComputedPartCost, getPartCostExplain } from '@/utils/partsAccess';

--- a/utils/savedInsightsAccess.ts
+++ b/utils/savedInsightsAccess.ts
@@ -1,4 +1,5 @@
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import type { Json } from '@/types/database';
 import type { ChartConfig, SavedInsight } from '@/utils/insightsAccess';
 
 // ============================================================
@@ -69,7 +70,10 @@ export async function saveInsight(
       company_id: companyId,
       question,
       answer,
-      chart_config,
+      // chart_config is jsonb in the DB → cast required. ChartConfig is
+      // a structured app type; the runtime serialization is correct
+      // (JSON.stringify under the hood).
+      chart_config: chart_config as unknown as Json,
     })
     .select('id, question, answer, chart_config, created_at')
     .single();

--- a/utils/storageHelpers.ts
+++ b/utils/storageHelpers.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 
 /**
  * Get the storage bucket name from environment variable

--- a/utils/unitsAccess.ts
+++ b/utils/unitsAccess.ts
@@ -4,7 +4,7 @@
  * specific units. Used by the UOM combobox to populate the "Custom" group.
  */
 
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type { CompanyCustomUnit } from '@/types/units';
 
 /**

--- a/utils/vendorContactsAccess.ts
+++ b/utils/vendorContactsAccess.ts
@@ -16,7 +16,8 @@
  * because the UI is single-user-per-vendor at any given moment.
  */
 
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import type { Database } from '@/types/database';
 import type {
   VendorContact,
   VendorContactFormData,
@@ -25,7 +26,12 @@ import type {
 const VENDOR_CONTACT_COLUMNS =
   'id, vendor_id, name, role, role_label, email, phone, is_primary, created_at, updated_at';
 
-function formDataToInsert(formData: VendorContactFormData): Record<string, unknown> {
+// Narrow the form-derived insert; vendor_id is added at the call site.
+type VendorContactInsert = Database['public']['Tables']['vendor_contacts']['Insert'];
+
+function formDataToInsert(
+  formData: VendorContactFormData,
+): Omit<VendorContactInsert, 'vendor_id'> {
   const trimmed = (s: string) => (s.trim() === '' ? null : s.trim());
   return {
     name: formData.name.trim(),

--- a/utils/workCentersAccess.ts
+++ b/utils/workCentersAccess.ts
@@ -1,4 +1,4 @@
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type {
   WorkCenter,
   WorkCenterFormData,


### PR DESCRIPTION
## Summary
Final mass-conversion under the typed-client rollout. Switches every remaining `utils/*Access.ts` file from `getSupabase()` to `getTypedSupabase()`.

After this lands, the typed client is universally adopted across `utils/`.

## Files converted (17)
- `utils/alertsAccess.ts`
- `utils/bomAccess.ts`
- `utils/customerAddressesAccess.ts`
- `utils/customerContactsAccess.ts`
- `utils/demoAccess.ts`
- `utils/insightsAccess.ts`
- `utils/markupRatesAccess.ts`
- `utils/partPricingTiersAccess.ts`
- `utils/procurementTiersAccess.ts`
- `utils/quoteEmail.ts`
- `utils/quoteLineItemsAccess.ts`
- `utils/routingCostCalculation.ts`
- `utils/savedInsightsAccess.ts`
- `utils/storageHelpers.ts`
- `utils/unitsAccess.ts`
- `utils/vendorContactsAccess.ts`
- `utils/workCentersAccess.ts`

## Findings
**Of 17 files, 13 compiled cleanly on the import swap alone.** Only 4 needed targeted fixes, all instances of known patterns:

- **customerContactsAccess** + **vendorContactsAccess**: `formDataToInsert` returned `Record<string, unknown>`; narrowed to the table's `Insert` type minus the FK column added at the call site. Same fix as parts (#289), vendors (#293), routings (#291).
- **markupRatesAccess** (8 errors): `breakpoints` is `jsonb` in DB but the app uses `MarkupRateBreakpoint[]`. Added `asMarkupRate()` helper for reads + inline `as unknown as Json` casts for writes. Same shape as `asQuote()` (#284), `asCustomer()` (#286).
- **savedInsightsAccess**: `chart_config` jsonb mismatch on insert. Inline cast at the write site.

## Test mocks updated
Three test files needed `getTypedSupabase` added to their `@/lib/supabase` mocks (procurementTiers, routingCostCalculation, storageHelpers). The remaining 14 swept files have no dedicated test files that mock supabase.

## Follow-up
A consolidated GH issue will list all the long-term schema / migration fixes surfaced across this rollout (DEFAULT NULL for optional RPC params, NOT NULL for DEFAULT-only timestamp columns, CHECK constraints for jsonb shape enforcement, native `CREATE TYPE` enums for text+CHECK columns, dead-type-field audit).

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm test --run` — 347 pass (9 pre-existing skips)
- All 25 test files in the project pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)