### PR TITLE
Fix: remove dead /jobs/new route + buttons (prod 22P02)

### DIFF
--- a/app/dashboard/[companyId]/jobs/page.tsx
+++ b/app/dashboard/[companyId]/jobs/page.tsx
@@ -20,7 +20,6 @@ import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import SearchableSelect, { type SelectOption } from '@/components/common/SearchableSelect';
 import SearchIcon from '@mui/icons-material/Search';
-import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import WorkIcon from '@mui/icons-material/Work';
 
@@ -578,17 +577,12 @@ export default function JobsPage() {
         )}
 
         <Box sx={{ flex: 1 }} />
-
-        <Button
-          variant="contained"
-          startIcon={<AddIcon />}
-          onClick={() => router.push(`/dashboard/${companyId}/jobs/new`)}
-        >
-          New Job
-        </Button>
       </Box>
 
-      {/* Data Grid or Empty State */}
+      {/* Data Grid or Empty State. Jobs are created exclusively by
+          converting an accepted quote (utils/quotesAccess#convertQuoteToJob),
+          so there's no standalone "New Job" CTA — the empty state points
+          the user at the quotes flow instead. */}
       {!loading && jobs.length === 0 ? (
         <Card elevation={2}>
           <CardContent sx={{ p: 6, textAlign: 'center' }}>
@@ -599,15 +593,14 @@ export default function JobsPage() {
             <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
               {searchDebounced || customerFilter || productionFilterValue || fulfillmentFilterValue || overdueOnly
                 ? 'No jobs match your filters.'
-                : 'Create your first job to get started.'}
+                : 'Jobs are created by converting an accepted quote. Create a quote first, then convert it from the quote detail page.'}
             </Typography>
             {!searchDebounced && !customerFilter && !productionFilterValue && !fulfillmentFilterValue && !overdueOnly && (
               <Button
                 variant="contained"
-                startIcon={<AddIcon />}
-                onClick={() => router.push(`/dashboard/${companyId}/jobs/new`)}
+                onClick={() => router.push(`/dashboard/${companyId}/quotes`)}
               >
-                Create Job
+                Go to Quotes
               </Button>
             )}
           </CardContent>

--- a/components/dashboard/QuickActions.tsx
+++ b/components/dashboard/QuickActions.tsx
@@ -13,7 +13,9 @@ interface QuickActionsProps {
 }
 
 /**
- * Quick action buttons for creating new quotes and jobs.
+ * Quick action buttons. Jobs are created exclusively by converting an
+ * accepted quote (see utils/quotesAccess#convertQuoteToJob), so there's
+ * no "New Job" CTA here — the quote flow is the entry point.
  */
 export default function QuickActions({ companyId }: QuickActionsProps) {
   return (
@@ -42,19 +44,6 @@ export default function QuickActions({ companyId }: QuickActionsProps) {
             }}
           >
             New Quote
-          </Button>
-          <Button
-            component={Link}
-            href={`/dashboard/${companyId}/jobs/new`}
-            variant="outlined"
-            color="primary"
-            startIcon={<AddIcon />}
-            sx={{
-              flex: { sm: 1 },
-              py: 1.5,
-            }}
-          >
-            New Job
           </Button>
         </Box>
       </CardContent>


### PR DESCRIPTION
## Summary
Clicking **New Job** or **Create Job** in prod surfaced this error:

```
Error fetching job with relations:
  code: 22P02
  message: invalid input syntax for type uuid: "new"
```

The CTAs in [`app/dashboard/[companyId]/jobs/page.tsx`](app/dashboard/[companyId]/jobs/page.tsx) and [`components/dashboard/QuickActions.tsx`](components/dashboard/QuickActions.tsx) navigated to `/dashboard/<companyId>/jobs/new`, but no such route exists. Next.js fell back to the dynamic `/jobs/[jobId]/page.tsx`, which treated the literal string `"new"` as a UUID. PostgREST rejected it; the detail page caught the error and rendered "Job not found."

## Why no `/jobs/new`?
Jobs are created **exclusively by converting an accepted quote** ([`convertQuoteToJob`](utils/quotesAccess.ts)). There is no standalone job-creation form in this codebase. The CTAs were stale from an earlier product flow.

## Changes
- **jobs list page**: drop the `New Job` header button and the `Create Job` empty-state button. Empty state now explains the quote → job flow and offers a `Go to Quotes` CTA.
- **QuickActions dashboard tile**: drop the `New Job` button, leave `New Quote` as the only creation entry point.

## Notes
- Not surfaced by the typed-client rollout or schema-embed check because nothing about this bug is schema drift — it's a routing/UX mismatch. Worth flagging that PostgREST 400s on type errors look just like schema drift in console output but require different investigation.
- The 5 console errors users were seeing are React StrictMode + Sentry double-reporting on the same failing fetch.

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- [x] `pnpm test --run` — 347 pass
- [ ] Smoke-test in preview: jobs page (no `New Job` button visible), empty state shows quote pointer, QuickActions has only `New Quote`

🤖 Generated with [Claude Code](https://claude.com/claude-code)