### PR TITLE
docs: reconcile module specs with implementation (round 1)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,12 +17,15 @@ Welcome to the Jigged documentation. Jigged is a data platform for small precisi
 See [modules/](modules/) for detailed specifications:
 - [Customers](modules/customers.md)
 - [Parts](modules/parts.md)
+- [Markup Rates](modules/markup-rates.md)
 - [Quotes](modules/quotes.md)
 - [Jobs](modules/jobs.md)
-- [Operations](modules/operations.md)
-- [Dashboard](modules/dashboard.md)
 - [Routings](modules/routings.md)
+- [Work Centers](modules/work-centers.md) — supersedes the older [Operations](modules/operations.md) module
+- [Vendors](modules/vendors.md)
 - [Inventory](modules/inventory.md)
+- [Shipments](modules/shipments.md) — feature-flagged per tenant
+- [Dashboard](modules/dashboard.md)
 - [Operator View](modules/operator-view.md)
 - [Invitation System](modules/invitation-system.md)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,10 +31,13 @@ Jigged/
 │   └── dashboard/[companyId]/  # Protected routes
 │       ├── customers/
 │       ├── parts/
-│       │   └── [partId]/routing/  # Routing editor (1:1 with part)
+│       │   └── [partId]/          # Routing edited inline on the part detail page
 │       ├── quotes/
-│       ├── jobs/
-│       └── operations/
+│       ├── jobs/                  # No /jobs/new — jobs come from quote conversion
+│       ├── work-centers/          # Replaces the old "Operations" module
+│       ├── vendors/
+│       ├── markup-rates/
+│       └── shipments/             # Feature-flagged per tenant
 │
 ├── components/
 │   ├── providers/           # AuthProvider, ThemeProvider
@@ -58,8 +61,12 @@ Jigged/
 │   └── services/          # Business logic
 │
 └── supabase/
-    └── schema.sql         # Database schema
+    ├── migrations/         # Source of truth for schema (timestamped)
+    ├── schema.staging.sql  # Auto-generated; do not edit
+    └── schema.prod.sql     # Auto-generated; do not edit
 ```
+
+Routings live **inline on the part detail page** (`PartRoutingPanel`) — there is no `/parts/[partId]/routing/` page. See [Routings](modules/routings.md).
 
 ---
 

--- a/docs/build-sequence.md
+++ b/docs/build-sequence.md
@@ -2357,11 +2357,7 @@ Phase 0 is complete when the pilot shop owner can:
 
   - Click → Navigate to `/dashboard/{companyId}/quotes/new`
 
-### + New Job Button
-
-  - Secondary button style
-
-  - Click → Navigate to `/dashboard/{companyId}/jobs/new`
+  > **Note:** The dashboard previously had a "+ New Job" button pointing at `/dashboard/{companyId}/jobs/new`. That route and button were removed in commit d9b7e98 — jobs are now created exclusively via quote conversion. New quotes remain the entry point.
 
   ---
 
@@ -2542,29 +2538,7 @@ Phase 0 is complete when the pilot shop owner can:
 
 ### 2. Job Create
 
-  **Route:** `/dashboard/{companyId}/jobs/new`
-
-  **Note:** Jobs are usually created via quote conversion, but direct creation is supported.
-
-  **Form Sections:**
-
-  ▸ **Customer** (required)
-
-  - Customer dropdown with search with quick create part UX option similar to quotes
-
-  ▸ **Part**
-
-  - Part dropdown with search with quick create part UX option similar to quotes
-
-  ▸ **Notes**
-
-  - Notes (multiline)
-
-  **Actions:**
-
-  - Create Job → Creates job in Pending status, redirects to detail
-
-  - Cancel → Returns to list
+  Jobs are **only** created via quote conversion. The `/dashboard/{companyId}/jobs/new` route and standalone "New Job" form were removed in commit d9b7e98. See [Quotes](modules/quotes.md) → "Convert to Job" for the current flow; conversion produces one job per `(part, selected tier)` line on the quote.
 
 ### 3. Job Detail View
 

--- a/docs/modules/dashboard.md
+++ b/docs/modules/dashboard.md
@@ -117,11 +117,7 @@ Activity is derived from `created_at`, `started_at`, `completed_at`, `shipped_at
 
 - Click → Navigate to `/dashboard/{companyId}/quotes/new`
 
-### + New Job Button
-
-- Secondary button style
-
-- Click → Navigate to `/dashboard/{companyId}/jobs/new`
+> **Note:** The dashboard previously had a "+ New Job" button pointing at `/dashboard/{companyId}/jobs/new`. That route and button were removed in commit d9b7e98 — jobs are now created exclusively via quote conversion (see [Quotes](quotes.md) → "Convert to Job"). New quotes remain the entry point.
 
 ---
 

--- a/docs/modules/jobs.md
+++ b/docs/modules/jobs.md
@@ -133,31 +133,14 @@ Overdue surfaces as:
 
 ### 2. Job Create
 
-**Route:** `/dashboard/{companyId}/jobs/new`
+Jobs are **only** created via quote conversion. There is no standalone "New Job" form. The `/dashboard/{companyId}/jobs/new` route and "New Job" button were removed in commit d9b7e98; the spec previously here described that flow.
 
-**Note:** Jobs are usually created via quote conversion, but direct creation is supported.
+To create a job today:
+1. Build a quote with the desired customer / part / pricing tier.
+2. Open the quote detail page.
+3. Use the **Convert to Job** action; one job is produced per `(part, selected tier)` line on the quote.
 
-**Form Sections:**
-
-▸ **Customer** (required)
-
-- Customer dropdown with search with quick create option similar to quotes
-
-▸ **Part** (required)
-
-- Part dropdown (all company parts, independent of selected customer). A part must be selected to proceed. If the selected part has no routing, a warning is shown with a link to create one from the part detail page.
-
-**Note:** Routing is auto-resolved from the selected part. There is no routing dropdown. The part must have a routing defined for the job to be created.
-
-▸ **Notes**
-
-- Notes (multiline)
-
-**Actions:**
-
-- Create Job → Creates job in Not Started status, redirects to detail
-
-- Cancel → Returns to list
+The Convert flow lives in [Quotes](quotes.md) — see the "Convert to Job" section there for current behavior.
 
 ### 3. Job Detail View
 

--- a/docs/modules/markup-rates.md
+++ b/docs/modules/markup-rates.md
@@ -1,0 +1,100 @@
+# Markup Rates Module
+
+## Overview
+
+A **markup rate** is a named pattern of quantity break-points + markup percentages that can be applied to a part to materialize its pricing tiers. Markup rates are company-scoped, snapshot-applied (deleting the rate keeps the tiers it produced), and one rate per company can be marked as the default for new parts.
+
+**Priority:** Built; in production.
+
+**Dependencies:** [Parts](parts.md) (parts link to markup rates via `parts.markup_rate_id`).
+
+---
+
+## Data Model
+
+### `markup_rates` table
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid | PK |
+| `company_id` | uuid | FK → `companies` |
+| `name` | text | Required, unique per company |
+| `breakpoints` | jsonb | Array of `{qty: int>0, markup_percent: number}`, sorted by qty ascending |
+| `is_default` | boolean | At most one row per company has `is_default=true` (partial unique index) |
+| `created_at` / `updated_at` | timestamptz | |
+
+Per-company seeded patterns (from migration 20260428): **Default** (1× 25%), **Volume tiers** (1× 25%, 10× 22%, 100× 18%, 1000× 15%), **Premium small batch** (1× 40%, 10× 32%).
+
+### Part linkage
+
+- `parts.markup_rate_id uuid REFERENCES markup_rates(id) ON DELETE SET NULL`
+- Index: `idx_parts_markup_rate_id`
+- When a part is linked to a rate, the rate's breakpoints are **copied** into `part_pricing_tiers` (snapshot semantics). The link itself is for UI ("Markup: <RateName>" chip) and for re-applying the rate when its breakpoints change.
+
+---
+
+## Pages
+
+### List — `/dashboard/{companyId}/markup-rates`
+
+AG Grid with columns:
+
+- **Name** (pinned left, 240px)
+- **Breakpoints** (flex; monospaced mini-list rendering each `qty: markup%` line)
+
+Row height is dynamic (24px base + 16px per breakpoint line). The default rate is pinned to the top and non-selectable — instead of a checkbox it shows a **"Default"** chip.
+
+**Search:** name only, debounced 300ms.
+
+**Actions:**
+- Click / Enter on a row → edit (`/markup-rates/{rateId}/edit`)
+- New → `/markup-rates/new`
+- Bulk delete (with snapshot-semantics confirmation copy)
+- Export CSV from selection
+
+**Empty states:** "No rates yet" when the table is empty; a warning banner reading "No default rate set" when rates exist but none has `is_default=true`.
+
+### Create / Edit — `/markup-rates/new` and `/markup-rates/{rateId}/edit`
+
+The same `MarkupRateForm` component in `mode="create" | "edit"`. Fields:
+
+- **Name** — required, validated unique-per-company via `checkMarkupRateNameExists`
+- **Breakpoints table** — qty (int > 0) and markup_percent (number); add/remove rows; auto-sorted by qty on save
+- **Is default** — toggle; promoting to default demotes the previous default in the same transaction (`clearOtherDefaults` in the access layer)
+
+Save triggers `createMarkupRate` or `updateMarkupRate`.
+
+---
+
+## Behavior
+
+- **Snapshot semantics on delete.** Deleting a rate clears the FK on parts (`ON DELETE SET NULL`) but leaves their pricing tiers intact. The UI confirmation message reflects this: "Parts that previously had a deleted rate applied keep their pricing tiers."
+- **Re-apply on edit.** Updating a rate's breakpoints triggers `cascadeRateUpdateToParts(companyId, rateId)` — sequentially copies the new breakpoints into each linked part's pricing tiers and collects per-part failures.
+- **Auto-apply default on new parts.** Part creation invokes `applyDefaultRateToPart(companyId, partId)`. Non-fatal: if no default rate exists or it has empty breakpoints, the part is created without tiers.
+- **Bulk apply.** From the Parts list, a multi-select bulk action calls `bulkApplyMarkupRate(companyId, partIds, rateId)` via the `bulk_apply_markup_rate` RPC, 200 parts per chunk, with a progress callback. Returns `{updated, failed[], priceUncomputed}`.
+
+---
+
+## Access Layer
+
+`utils/markupRatesAccess.ts`:
+
+| Function | Purpose |
+|---|---|
+| `getAllMarkupRates(companyId)` | List, ordered by name |
+| `getMarkupRate(rateId)` | Single rate |
+| `getDefaultMarkupRate(companyId)` | The default, or null |
+| `createMarkupRate` / `updateMarkupRate` | Mutations; handle default promotion atomically |
+| `applyRateToPart(companyId, partId, rateId)` | Copy breakpoints → `part_pricing_tiers`, set `parts.markup_rate_id` |
+| `applyDefaultRateToPart(companyId, partId)` | Auto-apply default at part creation |
+| `cascadeRateUpdateToParts(companyId, rateId)` | Per-part re-apply after a rate edit |
+| `bulkApplyMarkupRate(companyId, partIds, rateId)` | Chunked RPC, 200/chunk, progress callback |
+| `deleteMarkupRate`, `bulkDeleteMarkupRates` | Deletes (FK is `SET NULL`, no cascade block) |
+| `normalizeBreakpoints` (helper) | Sorts by qty, drops non-positive entries |
+
+---
+
+## See also
+
+- [Parts](parts.md) — markup rates materialize part pricing tiers.
+- [Quotes](quotes.md) — quote line items snapshot pricing tiers; markup-rate identity is not preserved on the quote line.

--- a/docs/modules/operations.md
+++ b/docs/modules/operations.md
@@ -1,14 +1,16 @@
-# Operations Module
+# Operations Module (Historical)
+
+> **Superseded by [Work Centers](work-centers.md).** Migration `20260502_unify_parts_inventory_add_work_centers_vendors.sql` dropped the `operation_types` table and replaced it with the `work_centers` table. The new design unifies internal machine capabilities and external outsourced work into a single entity with a `kind` enum. This document is retained for historical context only — it does not describe the current implementation.
 
 ## Overview
 
-The Operations module manages the catalog of operation types available in the shop. Operation types define what work can be done and at what cost — they're referenced when creating routings and for job costing.
+The Operations module managed the catalog of operation types available in the shop. Operation types defined what work could be done and at what cost — they were referenced when creating routings and for job costing.
 
-**Priority:** Must Have (Build after Parts, before Quotes)
+**Priority:** Historical.
 
-**Dependencies:** None (foundational module)
+**Dependencies:** None (was foundational).
 
-**Database Tables:** `operation_types`
+**Database Tables:** `operation_types` (dropped — see [work-centers.md](work-centers.md))
 
 ---
 

--- a/docs/modules/shipments.md
+++ b/docs/modules/shipments.md
@@ -1,0 +1,160 @@
+# Shipments Module
+
+## Overview
+
+Shipments capture what physically left the shop, when, to whom, against which job(s), and in what quantity. They generate packing slips, drive job auto-close, and decouple **fulfillment status** (what the customer sees) from **production status** (what the shop is working on).
+
+**Priority:** Built; in production behind a per-tenant feature flag (`settings.features.shipments`). See [`lib/featureFlags.ts`](../../lib/featureFlags.ts).
+
+**Dependencies:** [Jobs](jobs.md), [Customers](customers.md). Updates `jobs.fulfillment_status` via DB triggers.
+
+The product reasoning behind this module is preserved in [PRD-shipments-2.md](PRD-shipments-2.md) (Cagan/Fadell-framed discovery doc). This file describes the implementation.
+
+---
+
+## Data Model
+
+### `shipments` table
+
+One row per packing slip.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid | PK |
+| `company_id` | uuid | FK |
+| `customer_id` | uuid | FK |
+| `shipping_address_id` | uuid? | FK → `customer_addresses` (XOR with `one_time_address`) |
+| `one_time_address` | jsonb? | Phase 3 (XOR via `shipments_one_address_source` constraint) |
+| `packing_slip_number` | text | Unique per company; formatted via `format_packing_slip_number` and a row-locked counter on `companies.packing_slip_next_seq` |
+| `ship_date` | date | Defaults to `current_date` |
+| `carrier` | text? | |
+| `tracking_number` | text? | |
+| `shipping_arrangement` | enum-via-CHECK | `prepaid_and_add | prepaid | collect | third_party_account | customer_pickup | customer_arranged_freight | other` |
+| `shipping_arrangement_other` | text? | Required when `shipping_arrangement='other'` (CHECK constraint `shipments_arrangement_other_text`) |
+| `weight_lbs`, `package_count`, `package_type` | various | |
+| `notes`, `coc_text` | text? | |
+| `created_by` | uuid? | FK → `auth.users`, `ON DELETE SET NULL` |
+| `voided_at`, `voided_by` | timestamptz?, uuid? | Phase 3 (always NULL in Phase 1) |
+
+Trigger `enforce_shipment_address_contact_customer` (BEFORE INS/UPD) verifies `shipping_address_id` belongs to `customer_id`.
+
+### `shipment_line_items` table
+
+One row per `(shipment, job_part)`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid | PK |
+| `shipment_id` | uuid | FK CASCADE |
+| `job_part_id` | uuid | FK |
+| `quantity` | numeric | `> 0` |
+
+### `job_fulfillment_audit` table
+
+Append-only causal record of forward transitions to `fully_shipped`. Written by `create_shipment_with_line_items` when a job's fulfillment status transitions forward.
+
+---
+
+## Fulfillment lifecycle (dual-status)
+
+Jobs carry two independent status columns:
+
+- **`production_status`**: `not_started | in_progress | completed | cancelled` — what the shop is doing.
+- **`fulfillment_status`**: `unshipped | partially_shipped | fully_shipped` — what the customer has received. **Derived**, never written directly.
+
+Three trigger chains keep `fulfillment_status` consistent:
+
+1. `recompute_job_part_fulfillment_from_line` — AFTER INS/UPD/DEL on `shipment_line_items`, recomputes `job_parts.fulfillment_status`.
+2. `recompute_job_part_fulfillment_from_void` — AFTER UPD `voided_at` on `shipments`, cascades void to dependent line items.
+3. `sync_job_fulfillment_status_from_parts` — AFTER INS/UPD `fulfillment_status` / DEL on `job_parts`, recomputes `jobs.fulfillment_status`.
+
+The derivation functions are:
+
+- `compute_job_part_fulfillment_status(uuid)` STABLE → `unshipped | partially_shipped | fully_shipped`, comparing `SUM(non-voided line item quantities)` vs `job_parts.quantity`.
+- `compute_job_fulfillment_status(uuid)` STABLE → aggregates child statuses (does **not** exclude cancelled parts per PRD §7.1).
+
+A job auto-closes (fulfillment_status → `fully_shipped`) when `SUM(shipped) ≥ SUM(ordered)` for all non-cancelled job_parts.
+
+---
+
+## RPC: `create_shipment_with_line_items`
+
+`VOLATILE SECURITY DEFINER`. Inserts a shipment and its line items in a single transaction with sorted `pg_advisory_xact_lock` per affected job (deadlock-free), snapshots `fulfillment_status` pre/post, writes the audit row when applicable, and returns `{shipmentId, packingSlipNumber}`.
+
+Parameters mirror `CreateShipmentPayload` in `types/shipment.ts`.
+
+---
+
+## Pages
+
+### List — `/dashboard/{companyId}/shipments`
+
+Feature-gated by `isShipmentsEnabled(company)`. AG Grid with columns:
+
+- **Packing Slip #** (blue, bold)
+- **Ship Date** (formatted "MMM D, YYYY")
+- **Customer**
+- **Jobs** (chip list — a shipment can span multiple jobs)
+- **Carrier**, **Tracking**
+- **Lines** (line-item count)
+- **Created By** (member name, resolved via batched `getMember` calls)
+
+Search runs across `packing_slip_number`, `customer_name`, `tracking_number`, `job_numbers`, `carrier` (debounced 300ms). Row click opens `PackingSlipPreviewDialog` (PDF preview).
+
+The list is hydrated via `listShipmentsForCompanyWithJobs(companyId)` — two round trips: PostgREST with a nested join through `shipment_line_items → job_parts → jobs`, then batch-resolve `created_by` member IDs.
+
+### Create Shipment — `/dashboard/{companyId}/shipments/new`
+
+Two-step wizard:
+
+1. **Customer picker** (`SearchableSelect`). Pre-selectable via `?customer=` query param.
+2. **`ShipmentForm`** in customer mode (`source: {kind: 'customer', customerId}`).
+
+`ShipmentForm` is also reused from the job detail page (`source: {kind: 'job', jobId}`) for single-job creation.
+
+The form:
+
+- Loads customer context (default carrier, default shipping arrangement, default COC text, addresses).
+- Loads open lines via `getOpenJobPartsForCustomer(companyId, customerId, {excludeFullyShipped: true, excludeCancelled: true})`.
+- Renders a checkbox table of open lines with a per-line **qty** input (warns when `qty > qty_remaining`, blocks submit when all qtys are zero).
+- Customer mode shows a "Ready to Ship" filter chip (`production_status != 'cancelled'` AND `fulfillment_status != 'fully_shipped'`) and a search input over part name / job number / customer PO.
+- Shipment-level fields: `ship_date` (today), `shipping_address_id` (customer addresses), `carrier`, `tracking_number`, `shipping_arrangement` (dropdown; `shipping_arrangement_other` shown when `other`), `weight_lbs`, `package_count`, `package_type`, `notes`, `coc_text`.
+- Submit calls `createShipment(companyId, payload)` which routes through `create_shipment_with_line_items`.
+- Post-create the form opens `PackingSlipPreviewDialog` showing the PDF, then navigates back to `/shipments`.
+
+### Job detail — `ShipmentHistoryCard`
+
+Embedded on the job detail page. Lists shipments for the job (`getShipmentsForJob(jobId)`), newest first by `ship_date` then `created_at`. Rolls up the inner-joined line items so each shipment appears once. Columns: Packing Slip #, Ship Date, Carrier, Tracking, Created By, Qty, Actions (View / Print). A `refreshKey` prop triggers refetch after a new shipment is created; `initialPreviewShipmentId` auto-opens the preview dialog on first mount (post-create flow).
+
+---
+
+## Access Layer
+
+`utils/shipmentsAccess.ts`:
+
+| Function | Purpose |
+|---|---|
+| `createShipment(companyId, payload)` | Validates non-empty line items, calls the RPC, returns `{shipmentId, packingSlipNumber}` |
+| `getShipmentById(shipmentId)` | Hydrated `ShipmentWithRelations` (customer, addresses, nested line_items with job + part) |
+| `getShipmentsForJob(jobId)` | Filtered via `line_items.job_part.job_id`; newest-first |
+| `listShipmentsForCompany(companyId, filters?)` | Flat list |
+| `listShipmentsForCompanyWithJobs(companyId, filters?)` | List page hydration: `job_numbers[]`, `line_item_count`, resolved `created_by_member` |
+| `getJobPartShipmentSummaries(jobId)` | `{job_part_id, qty_ordered, qty_shipped, qty_remaining (clamped ≥0), last_ship_date}` |
+| `getJobShipmentSummary(jobId)` | Job-level rollup: ordered/shipped/remaining, last ship date, latest packing slip #, count |
+| `getOpenJobPartsForCustomer(companyId, customerId, filter?)` | Open-lines picker for `ShipmentForm` |
+| `resolveAttentionLine(shipment)` | Phase 1: ATTN: line comes from `shipping_address.attention_to` only |
+| `voidShipment(shipmentId)` | Phase 3 placeholder; currently throws |
+
+---
+
+## Feature flag
+
+The shipments UI is gated by `isShipmentsEnabled(company)` (see [`lib/featureFlags.ts`](../../lib/featureFlags.ts)). The DB columns and triggers ship to every tenant unconditionally — they're harmless when no shipments exist, and isolating the gate to UI + access layer lets the migration land before rollout.
+
+---
+
+## See also
+
+- [Jobs](jobs.md) — for production_status and the job detail integration.
+- [Customers](customers.md) — addresses live on `customer_addresses` and feed the `shipping_address_id` picker.
+- [PRD-shipments-2.md](PRD-shipments-2.md) — original product-discovery PRD.

--- a/docs/modules/vendors.md
+++ b/docs/modules/vendors.md
@@ -1,0 +1,105 @@
+# Vendors Module
+
+## Overview
+
+The Vendors module manages the master list of external suppliers and outsourced-process providers. Vendors are referenced by parts (`parts.preferred_vendor_id`) and by external work centers (`work_centers.vendor_id`).
+
+**Priority:** Built; in production.
+
+**Dependencies:** None for create. Consumed by [Parts](parts.md) and [Work Centers](work-centers.md).
+
+---
+
+## Data Model
+
+### `vendors` table
+
+| Column | Notes |
+|---|---|
+| `id` | uuid PK |
+| `company_id` | FK |
+| `name` | required |
+| `address_line1`, `address_line2`, `city`, `state`, `postal_code`, `country` | `country` defaults to `'USA'` |
+| `legacy_id` | unique per company; used by importers for idempotent upsert |
+| `created_at`, `updated_at` | |
+
+### `vendor_contacts` table
+
+1-to-many with `vendors`.
+
+| Column | Notes |
+|---|---|
+| `id` | uuid PK |
+| `vendor_id` | FK |
+| `name` | required |
+| `role` | enum: `sales | accounts_payable | quality | engineering | shipping_receiving | customer_service | other` |
+| `role_label` | required when `role='other'` |
+| `email`, `phone` | optional |
+| `is_primary` | exactly one primary per vendor (enforced in access layer) |
+| `created_at`, `updated_at` | |
+
+---
+
+## Pages
+
+### List — `/dashboard/{companyId}/vendors`
+
+AG Grid columns:
+
+- **Name**
+- **Primary contact** — name · email
+- **Location** — city, state
+- **Updated**
+
+Search across name + city. Default sort: name asc. Pagination: 25 / 50 / 100. Bulk export CSV, bulk delete. Single-row entry → vendor detail.
+
+### Detail — `/dashboard/{companyId}/vendors/{vendorId}`
+
+Sections:
+
+- **Header card** — vendor name, created/updated timestamps.
+- **Contacts card** — all `vendor_contacts`; primary marked with a star; per-row actions to edit / set primary / delete.
+- **Address card** — `address_line1`, `address_line2`, `city`, `state`, `postal_code`, `country`, formatted multi-line.
+- **Linked Parts** (accordion) — parts where `preferred_vendor_id = this vendor`. Shows `part_name`, `primary_unit`.
+- **Linked Work Centers** (accordion) — work centers where `vendor_id = this vendor`. Shows `name`, `kind` (`internal | external`; external is the case where the FK is set).
+
+The **Delete** button is disabled when any linked part or work center exists (FK constraint `23503` blocks the delete; the UI checks before showing the button).
+
+### Create — `/dashboard/{companyId}/vendors/new`
+
+Renders `VendorForm` in `mode="create"`.
+
+Form fields:
+
+- **Vendor:** name (required), address fields, country (default `USA`).
+- **Initial contact** (create-mode sub-form, optional): name, role, role_label (when `role='other'`), email, phone. If filled, this contact is created with `is_primary=true`.
+
+No "capabilities" checkboxes — what a vendor is used for is derived from inbound references (`parts.preferred_vendor_id`, `work_centers.vendor_id`).
+
+### Import — `/dashboard/{companyId}/vendors/import`
+
+CSV upload, column mapping, validation, then execute via `/api/vendors/import/*` endpoints. De-duplicates by name (case-insensitive).
+
+---
+
+## Access Layer
+
+`utils/vendorsAccess.ts`:
+
+| Function | Purpose |
+|---|---|
+| `getAllVendors(companyId, search, sortField, sortDir)` | Batched 1000-row fetch; search across name and city; contacts hydrated via separate query |
+| `getPartsByPreferredVendor(vendorId)` | `{id, part_name, primary_unit}` — for the detail page Linked Parts accordion |
+| `getWorkCentersByVendor(vendorId)` | `{id, name, kind}` — for the Linked Work Centers accordion |
+| `createVendor(companyId, formData, initialContact?)` | Inserts vendor, optionally inserts one `vendor_contacts` row with `is_primary=true` |
+| `updateVendor(vendorId, formData)` | Vendor-row update only; contact CRUD is separate |
+| `deleteVendor(vendorId)` | Raises `23503` if FK references exist |
+| `bulkDeleteVendors(vendorIds)` | Batched 100/chunk, same FK guard |
+| `bulkImportVendors(companyId, rows)` | De-dupe by name (case-insensitive); returns `{imported, skipped, errors}` |
+
+---
+
+## See also
+
+- [Parts](parts.md) — preferred vendor link.
+- [Work Centers](work-centers.md) — external work centers point at a vendor.

--- a/docs/modules/work-centers.md
+++ b/docs/modules/work-centers.md
@@ -1,0 +1,101 @@
+# Work Centers Module
+
+## Overview
+
+A **work center** is a unit of production capacity. It can be **internal** (a machine, station, or in-house capability with an hourly labor rate) or **external** (an outsourced process performed by a vendor). Work centers are referenced by routing operations (`routing_operations.work_center_id`).
+
+> **Note on terminology.** This module supersedes what older docs called "Operations" (`operation_types` table). Migration `20260502_unify_parts_inventory_add_work_centers_vendors.sql` dropped `operation_types` and introduced `work_centers`. The two-axis design (internal vs external) unified machine capabilities and outsourced capabilities into one table — see `docs/modules/operations.md` for the historical spec, kept for reference.
+
+**Priority:** Built; in production.
+
+**Dependencies:** [Vendors](vendors.md) (external work centers point at a vendor). Consumed by [Routings](routings.md) (via `routing_operations.work_center_id`).
+
+---
+
+## Data Model
+
+### `work_centers` table
+
+| Column | Notes |
+|---|---|
+| `id` | uuid PK |
+| `company_id` | FK |
+| `name` | required |
+| `kind` | enum: `internal | external` |
+| `vendor_id` | FK → `vendors`; required when `kind='external'` (DB CHECK), null when `kind='internal'` |
+| `labor_rate` | numeric; used when `kind='internal'`; cleared to null when `kind='external'` |
+| `description` | optional multiline |
+| `metadata` | jsonb (e.g. `{code: "WC-LATHE-01"}` used for the Station QR code on internal work centers) |
+| `created_at`, `updated_at` | |
+
+External work centers do **not** carry a labor_rate on the work-center row. Their cost is set per routing operation (`routing_operations.external_unit_price`, `routing_operations.external_setup_cost`) — pricing is per-operation, not per-vendor.
+
+---
+
+## Pages
+
+### List — `/dashboard/{companyId}/work-centers`
+
+AG Grid columns:
+
+- **Name**
+- **Kind** — chip: "Internal" (info color) or "External" (warning color)
+- **Cost** — internal rows display `labor_rate` formatted as `$X.XX/hr` (or `—` if null); external rows display "Per operation" (italic, grey). A custom column comparator keeps internal rows sorted by `labor_rate` and pins external rows to the bottom.
+- **Vendor name** — hidden for internal rows
+- **Description**
+- **Updated**
+
+Search across name. **Filter:** kind dropdown (All / Internal / External). Default sort: name asc. Pagination: 25 / 50 / 100. Bulk export CSV, bulk delete, single-row create, import.
+
+### Detail — `/dashboard/{companyId}/work-centers/{workCenterId}`
+
+Sections:
+
+- **Header card** — name, kind badge (icon + text), vendor link (external only).
+- **Details card** — labor rate (internal) **or** vendor link + "Pricing per routing operation" note (external); description; routing-operation-usage count; created/updated timestamps.
+- **Station QR Code card** (internal only) — `StationQRCode` component rendering `metadata.code`.
+
+The **Delete** button is disabled when `routing_operations_count > 0` (FK constraint `23503` would otherwise block).
+
+### Create — `/dashboard/{companyId}/work-centers/new`
+
+Renders `WorkCenterForm` in `mode="create"`. Fields:
+
+- **Name** — required
+- **Kind toggle** — Internal (FactoryIcon) / External (LocalShippingIcon)
+- **Internal-only:** `labor_rate` (number, ≥ 0, optional)
+- **External-only:** `vendor_id` via `VendorAutocomplete` (required)
+- **Description** — optional
+
+Form validation requires `vendor_id` when `kind='external'`; the DB also enforces this via CHECK constraint.
+
+### Import — `/dashboard/{companyId}/work-centers/import`
+
+CSV upload, column mapping, validation, execute. External-row import resolves `vendor_name` → `vendor_id` via a pre-fetched vendor lookup; rows with unresolved vendors are reported in `errors`. De-duplicates by name.
+
+---
+
+## Access Layer
+
+`utils/workCentersAccess.ts`:
+
+| Function | Purpose |
+|---|---|
+| `getAllWorkCenters(companyId, search, sortField, sortDir)` | Flat list |
+| `getWorkCentersByKind(companyId, kind, search)` | Filter by kind |
+| `getWorkCentersFlat(companyId, options)` | Optional kind / search filter (used by dropdowns) |
+| `getWorkCentersForRouting(companyId, kind?)` | `{id, name, kind, labor_rate, vendor_name}` — vendor name pre-joined for the routing picker |
+| `getWorkCenterWithRelations(workCenterId)` | Hydrates with `routing_operations_count` and vendor |
+| `createWorkCenter(companyId, formData)` | `kind='external'` clears `labor_rate` to null; inserts `metadata: {}` |
+| `updateWorkCenter(workCenterId, formData)` | Same kind logic |
+| `deleteWorkCenter(workCenterId)` | Raises `23503` if `routing_operations` reference |
+| `bulkDeleteWorkCenters(workCenterIds)` | Batched 100/chunk, same FK guard |
+| `bulkImportWorkCenters(companyId, rows)` | Vendor-name resolution for external rows; de-dupe by name |
+
+---
+
+## See also
+
+- [Routings](routings.md) — `routing_operations.work_center_id` is the consumer.
+- [Vendors](vendors.md) — external work centers reference a vendor.
+- [operations.md](operations.md) — historical spec (predates the unification).


### PR DESCRIPTION
**Base:** \`chore/docs-reconciliation-pr1\` (stacked on #300). Once #300 merges, GitHub will re-target this against \`main\` automatically.

## Summary

Round 1 of the PRD ↔ implementation reconciliation work. Adds module specs that were missing entirely, and fixes the most concrete drift items between docs and code. **No code changes** — docs only.

### New module specs

These modules exist in production but had no spec until now. Each was written by walking the actual code (pages, components, access utils, migrations):

- **[docs/modules/markup-rates.md](docs/modules/markup-rates.md)** — Named markup-rate patterns (snapshot-applied to parts via \`parts.markup_rate_id\`), the seeded "Default" / "Volume tiers" / "Premium small batch" rates, list/edit/cascade semantics, bulk-apply RPC.
- **[docs/modules/shipments.md](docs/modules/shipments.md)** — Schema (\`shipments\` + \`shipment_line_items\` + \`job_fulfillment_audit\`), the dual-status lifecycle (\`production_status\` vs \`fulfillment_status\`), all three trigger chains, the \`create_shipment_with_line_items\` RPC, customer-first vs job-first creation flows, and the per-tenant feature-flag gate.
- **[docs/modules/vendors.md](docs/modules/vendors.md)** — \`vendors\` + \`vendor_contacts\` tables, detail-page Linked Parts / Linked Work Centers accordions, delete-FK guard.
- **[docs/modules/work-centers.md](docs/modules/work-centers.md)** — Internal vs external \`kind\` enum, \`labor_rate\` for internal, \`vendor_id\` + per-operation pricing for external, station QR codes, import flow.

### Reconciled contradictions

- **modules/operations.md**: marked as historical / superseded. Migration \`20260502_unify_parts_inventory_add_work_centers_vendors.sql\` dropped the \`operation_types\` table; \`work_centers\` is the unified successor.
- **modules/jobs.md, modules/dashboard.md, build-sequence.md**: removed the dead \`/dashboard/{companyId}/jobs/new\` route + "+ New Job" button references. The route and button were removed in commit d9b7e98 — jobs come from quote conversion only now.
- **architecture.md**: corrected the project-structure tree (routings are inline on the part detail page; no \`/parts/[partId]/routing/\` page) and added the modules that weren't listed (work-centers, vendors, markup-rates, shipments). Pointed at the auto-generated \`schema.{staging,prod}.sql\` instead of the obsolete \`schema.sql\`.

### docs/README.md

Updated the module index to list the four new specs.

## Out of scope (follow-up PRs)

- **Deeper rewrites of existing specs** — parts.md / quotes.md / routings.md / inventory.md / operator-view.md still describe things that have shifted since they were last touched. This PR adds *new* specs and resolves *contradictions* but doesn't rewrite established specs end-to-end.
- **prd.md "work order" → "job" terminology** + milestone refresh.
- **design-system.md** verification against \`lib/theme.ts\`.
- **PR 3**: testing infrastructure overhaul.

## Test plan

- [x] \`rg "/jobs/new" docs/\` matches only the historical-note paragraphs
- [x] \`rg "operation_types" docs/modules/\` only matches the operations.md superseded notice
- [x] All four new spec files render in GitHub's markdown view (links resolve to other modules)
- [ ] Spot-check new specs against the actual pages once Vercel preview is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)