### PR TITLE
e2e: pick a primary unit in parts-and-routing create spec

### DIFF
--- a/components/parts/PartFormModal.tsx
+++ b/components/parts/PartFormModal.tsx
@@ -110,10 +110,6 @@ export default function PartFormModal({
 
   const handleStockedChange = (_e: unknown, checked: boolean) => {
     setFormData((prev) => ({ ...prev, is_stocked: checked }));
-    // If they're toggling off, clear any pending UOM validation.
-    if (!checked && fieldErrors.primary_unit) {
-      setFieldErrors((prev) => ({ ...prev, primary_unit: undefined }));
-    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -128,10 +124,10 @@ export default function PartFormModal({
       errors.part_name = 'Part name is required';
     }
 
-    // Mirror the DB CHECK so the user sees an inline field error rather than
-    // a Postgres exception bubbling up after the round-trip.
-    if (formData.is_stocked && !formData.primary_unit?.trim()) {
-      errors.primary_unit = 'Unit of measurement is required for stocked parts';
+    // Mirror parts_requires_unit so the user sees an inline field error rather
+    // than a Postgres exception bubbling up after the round-trip.
+    if (!formData.primary_unit?.trim()) {
+      errors.primary_unit = 'Unit of measurement is required';
     }
 
     if (Object.keys(errors).length > 0) {
@@ -151,7 +147,7 @@ export default function PartFormModal({
       const payload: PartFormData = {
         ...formData,
         part_name: trimmedName,
-        primary_unit: formData.is_stocked ? formData.primary_unit?.trim() ?? null : null,
+        primary_unit: formData.primary_unit?.trim() ?? null,
       };
 
       const newPart = await createPart(companyId, payload);
@@ -278,28 +274,26 @@ export default function PartFormModal({
             sx={{ mb: 3 }}
           />
 
-          {/* Unit of measurement — required for stocked parts (DB CHECK
-              parts_stocked_requires_unit). Only shown when Stocked is on so
-              the modal stays minimal for parts that don't track quantity. */}
-          {formData.is_stocked && (
-            <UnitOfMeasurementSelect
-              value={formData.primary_unit}
-              onChange={(next) => {
-                setFormData((prev) => ({ ...prev, primary_unit: next }));
-                if (fieldErrors.primary_unit) {
-                  setFieldErrors((prev) => ({ ...prev, primary_unit: undefined }));
-                }
-              }}
-              companyId={companyId}
-              required
-              disabled={submitting}
-              error={!!fieldErrors.primary_unit}
-              helperText={
-                fieldErrors.primary_unit ||
-                'How quantities of this part are measured (each, lbs, sq in, …).'
+          {/* Unit of measurement — required for every part (DB CHECK
+              parts_requires_unit). Costs and quantities are denominated in
+              this unit; without it, downstream BOM and cost rollups break. */}
+          <UnitOfMeasurementSelect
+            value={formData.primary_unit}
+            onChange={(next) => {
+              setFormData((prev) => ({ ...prev, primary_unit: next }));
+              if (fieldErrors.primary_unit) {
+                setFieldErrors((prev) => ({ ...prev, primary_unit: undefined }));
               }
-            />
-          )}
+            }}
+            companyId={companyId}
+            required
+            disabled={submitting}
+            error={!!fieldErrors.primary_unit}
+            helperText={
+              fieldErrors.primary_unit ||
+              'How quantities of this part are measured (each, lbs, sq in, …).'
+            }
+          />
 
           {/* Preferred vendor — bought parts only. Optional; the user can
               also leave it blank and pick a vendor later from the part

--- a/e2e/parts-and-routing.spec.ts
+++ b/e2e/parts-and-routing.spec.ts
@@ -38,15 +38,18 @@ test.describe('Parts and Routing workflow', () => {
 
     // Pick a primary unit. The parts_requires_unit DB constraint (added in
     // 20260602000000_fix_cost_error_part_name_and_unit_canonicalization)
-    // makes primary_unit NOT NULL for every part, and PartForm gates submit
-    // on the same rule client-side — without this, validation blocks Create
-    // and the modal never closes. UnitOfMeasurementSelect renders an MUI
-    // Autocomplete, so the input has role="combobox" — getByLabel doesn't
-    // match it reliably.
+    // makes primary_unit NOT NULL for every part, and PartFormModal gates
+    // submit on the same rule client-side — without this, validation blocks
+    // Create and the modal never closes.
+    //
+    // UnitOfMeasurementSelect wraps an MUI Autocomplete. A bare click on the
+    // combobox doesn't reliably open the listbox, so fill the input instead —
+    // that opens the dropdown AND filters to matching options. The rendered
+    // label for the 'each' standard unit is "Each (ea)".
     const unitCombobox = partFormDialog.getByRole('combobox', { name: /Unit of measurement/i });
     await expect(unitCombobox).toBeVisible();
-    await unitCombobox.click();
-    await page.getByRole('option', { name: /^each$/i }).first().click();
+    await unitCombobox.fill('each');
+    await page.getByRole('option', { name: /Each \(ea\)/i }).first().click();
 
     // Submit — primary action is "Create" (was "Save" in the route-based form).
     await partFormDialog.getByRole('button', { name: /^Create$/i }).click();

--- a/e2e/parts-and-routing.spec.ts
+++ b/e2e/parts-and-routing.spec.ts
@@ -40,8 +40,12 @@ test.describe('Parts and Routing workflow', () => {
     // 20260602000000_fix_cost_error_part_name_and_unit_canonicalization)
     // makes primary_unit NOT NULL for every part, and PartForm gates submit
     // on the same rule client-side — without this, validation blocks Create
-    // and the modal never closes.
-    await partFormDialog.getByLabel(/Unit of measurement/i).click();
+    // and the modal never closes. UnitOfMeasurementSelect renders an MUI
+    // Autocomplete, so the input has role="combobox" — getByLabel doesn't
+    // match it reliably.
+    const unitCombobox = partFormDialog.getByRole('combobox', { name: /Unit of measurement/i });
+    await expect(unitCombobox).toBeVisible();
+    await unitCombobox.click();
     await page.getByRole('option', { name: /^each$/i }).first().click();
 
     // Submit — primary action is "Create" (was "Save" in the route-based form).

--- a/e2e/parts-and-routing.spec.ts
+++ b/e2e/parts-and-routing.spec.ts
@@ -36,6 +36,14 @@ test.describe('Parts and Routing workflow', () => {
     // Fill description
     await partFormDialog.getByLabel(/Description/i).fill(partDescription);
 
+    // Pick a primary unit. The parts_requires_unit DB constraint (added in
+    // 20260602000000_fix_cost_error_part_name_and_unit_canonicalization)
+    // makes primary_unit NOT NULL for every part, and PartForm gates submit
+    // on the same rule client-side — without this, validation blocks Create
+    // and the modal never closes.
+    await partFormDialog.getByLabel(/Unit of measurement/i).click();
+    await page.getByRole('option', { name: /^each$/i }).first().click();
+
     // Submit — primary action is "Create" (was "Save" in the route-based form).
     await partFormDialog.getByRole('button', { name: /^Create$/i }).click();
 


### PR DESCRIPTION
## Summary

Two changes to align the part-create flow with the new `parts_requires_unit` constraint (migration `20260602000000_fix_cost_error_part_name_and_unit_canonicalization`):

1. **`components/parts/PartFormModal.tsx`** — always render the UoM picker, always validate, always submit. The previous `formData.is_stocked &&` gate hid the field for the default (Made + non-stocked) part and forced `primary_unit` to `null` on submit, hitting the new DB CHECK with the modal still open. This mirrors the change PR #302 (the WIP branch) is already carrying — extracting it here so both #301 and #302 can rebase onto a green main.
2. **`e2e/parts-and-routing.spec.ts`** — pick "each" via the UoM combobox before clicking Create. Uses `getByRole('combobox', { name: /Unit of measurement/i })` for the MUI Autocomplete + an explicit visibility wait so future failures surface in ≤5s instead of timing out at 120s.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [ ] Playwright E2E goes green on this PR's preview
- [ ] After merge: rebase / merge main into PR #301 and PR #302. #302 will see a no-op conflict on `PartFormModal.tsx` (its WIP diff is identical) — resolve by taking either side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)