### PR TITLE
fix(test): kill conftest.py prod fallback; drop legacy TEST_*_KEY names

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -27,16 +27,23 @@ from index import app
 @pytest.fixture
 def supabase_admin() -> Generator[Client, None, None]:
     """
-    Create an admin Supabase client using service key.
+    Create an admin Supabase client using the local-Supabase service-role key.
 
-    Uses TEST_SUPABASE_URL and TEST_SUPABASE_SERVICE_KEY environment variables.
-    Falls back to regular Supabase vars if test vars not set.
+    Requires TEST_SUPABASE_URL and TEST_SUPABASE_SECRET_KEY. No fallback to
+    SUPABASE_URL / SUPABASE_SECRET_KEY (those are prod); silently running tests
+    against prod is exactly the failure mode this guard prevents.
     """
-    url = os.getenv("TEST_SUPABASE_URL") or os.getenv("SUPABASE_URL")
-    service_key = os.getenv("TEST_SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SECRET_KEY")
-
-    if not url or not service_key:
-        pytest.skip("Supabase credentials not configured")
+    url = os.getenv("TEST_SUPABASE_URL")
+    if not url:
+        pytest.exit(
+            "TEST_SUPABASE_URL not configured. Run `supabase start` and "
+            "`eval \"$(supabase status -o env)\"`, then export "
+            "TEST_SUPABASE_URL / TEST_SUPABASE_PUBLISHABLE_KEY / TEST_SUPABASE_SECRET_KEY. "
+            "See docs/testing/backend-setup.md."
+        )
+    service_key = os.getenv("TEST_SUPABASE_SECRET_KEY")
+    if not service_key:
+        pytest.exit("TEST_SUPABASE_SECRET_KEY not configured.")
 
     client = create_client(url, service_key)
     yield client

--- a/api/tests/integration/test_shipment_customer_consistency.py
+++ b/api/tests/integration/test_shipment_customer_consistency.py
@@ -38,8 +38,8 @@ pytestmark = pytest.mark.integration
 
 @pytest.fixture(scope="module")
 def admin() -> Client:
-    url = os.getenv("TEST_SUPABASE_URL") or os.getenv("SUPABASE_URL")
-    key = os.getenv("TEST_SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SECRET_KEY")
+    url = os.getenv("TEST_SUPABASE_URL")
+    key = os.getenv("TEST_SUPABASE_SECRET_KEY")
     if not url or not key:
         pytest.skip("Supabase admin credentials not configured")
     return create_client(url, key)

--- a/api/tests/integration/test_shipment_void_permutations.py
+++ b/api/tests/integration/test_shipment_void_permutations.py
@@ -37,8 +37,8 @@ def admin() -> Client:
     Admin Supabase client used by this harness. The harness writes
     directly to the schema (bypassing RLS), so service-role is required.
     """
-    url = os.getenv("TEST_SUPABASE_URL") or os.getenv("SUPABASE_URL")
-    key = os.getenv("TEST_SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SECRET_KEY")
+    url = os.getenv("TEST_SUPABASE_URL")
+    key = os.getenv("TEST_SUPABASE_SECRET_KEY")
     if not url or not key:
         pytest.skip("Supabase admin credentials not configured")
     return create_client(url, key)


### PR DESCRIPTION
Sub-PR 3-pre in the PR 3 series (testing infrastructure overhaul). One-line-equivalent hotfix that lands ahead of the rest of the series so the silent-prod-hit risk doesn't sit live across the remaining sub-PRs.

## Summary

Backend integration tests used to silently hit prod when \`TEST_SUPABASE_URL\` was unset, because [api/tests/conftest.py:35-36](api/tests/conftest.py#L35-L36) fell back to \`os.getenv("SUPABASE_URL")\`. For a pilot-stage project where the same machine that runs \`pytest\` is also developing against prod credentials, that's a real failure mode.

Three changes:

1. **conftest.py:supabase_admin** — remove the prod fallback. If \`TEST_SUPABASE_URL\` / \`TEST_SUPABASE_SECRET_KEY\` is unset, \`pytest.exit\` with an actionable message pointing at \`supabase start\` and docs/testing/backend-setup.md.
2. **test_shipment_customer_consistency.py + test_shipment_void_permutations.py** — same prod-fallback pattern in their own \`admin()\` fixtures; replaced with the TEST_*-only path. These keep \`pytest.skip\` (not exit) because they shouldn't block the whole suite when env is unset; they're integration-marker tests that opt-in.
3. **Adopted prod-aligned key names**: \`TEST_SUPABASE_SECRET_KEY\` (was \`TEST_SUPABASE_SERVICE_KEY\`) to mirror prod's \`SUPABASE_SECRET_KEY\`. Forward-compatible with the local-Supabase setup landing in sub-PR 3c.

## Out of scope

The \`docs/testing/*.md\` files still reference the old env-var names; they're being overhauled in sub-PR 3a (docs hygiene) so churning them here would conflict.

## Test plan

- [x] \`unset TEST_SUPABASE_URL TEST_SUPABASE_SECRET_KEY SUPABASE_URL SUPABASE_SECRET_KEY; cd api && pytest tests/test_smoke.py -v\` — 5 passed
- [x] \`cd api && pytest tests/integration/test_shipment_customer_consistency.py -v\` — 4 skipped cleanly (not silently passing against prod)
- [x] \`rg "TEST_SUPABASE_SERVICE_KEY|TEST_SUPABASE_ANON_KEY" --glob '!docs/'\` — empty; no runtime references to the legacy names remain
- [ ] Backend CI will continue to work (mocked tests pass; integration tests that need DB skip cleanly until 3c restores them via local Supabase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)