### PR TITLE
docs(testing): refresh checklist + registry to 2026-05-27 reality; add DB COMMENT cleanup migration

### DIFF
--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -619,7 +619,7 @@ pnpm test:e2e:ui       # Visual runner
   
   # Test Supabase credentials
   TEST_SUPABASE_URL = os.environ.get("TEST_SUPABASE_URL")
-  TEST_SUPABASE_KEY = os.environ.get("TEST_SUPABASE_SERVICE_KEY")
+  TEST_SUPABASE_KEY = os.environ.get("TEST_SUPABASE_SECRET_KEY")
   
   
   @pytest.fixture(scope="session")
@@ -1042,7 +1042,7 @@ pnpm test:e2e:ui       # Visual runner
   pytestmark = pytest.mark.asyncio
   
   TEST_SUPABASE_URL = os.environ.get("TEST_SUPABASE_URL")
-  TEST_SUPABASE_ANON_KEY = os.environ.get("TEST_SUPABASE_ANON_KEY")
+  TEST_SUPABASE_PUBLISHABLE_KEY = os.environ.get("TEST_SUPABASE_PUBLISHABLE_KEY")
   
   
   class TestCustomerRLS:
@@ -1073,7 +1073,7 @@ pnpm test:e2e:ui       # Visual runner
           # Create client as user
           user_client = create_client(
               TEST_SUPABASE_URL, 
-              TEST_SUPABASE_ANON_KEY
+              TEST_SUPABASE_PUBLISHABLE_KEY
           )
           user_client.auth.set_session(
               session.session.access_token,
@@ -1105,7 +1105,7 @@ pnpm test:e2e:ui       # Visual runner
           
           user_client = create_client(
               TEST_SUPABASE_URL,
-              TEST_SUPABASE_ANON_KEY
+              TEST_SUPABASE_PUBLISHABLE_KEY
           )
           user_client.auth.set_session(
               session.session.access_token,
@@ -1139,7 +1139,7 @@ pnpm test:e2e:ui       # Visual runner
           
           user_client = create_client(
               TEST_SUPABASE_URL,
-              TEST_SUPABASE_ANON_KEY
+              TEST_SUPABASE_PUBLISHABLE_KEY
           )
           user_client.auth.set_session(
               session.session.access_token,
@@ -1182,7 +1182,7 @@ pnpm test:e2e:ui       # Visual runner
           
           user_client = create_client(
               TEST_SUPABASE_URL,
-              TEST_SUPABASE_ANON_KEY
+              TEST_SUPABASE_PUBLISHABLE_KEY
           )
           user_client.auth.set_session(
               session.session.access_token,
@@ -1506,8 +1506,8 @@ pnpm test:e2e:ui       # Visual runner
   
   env:
     TEST_SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL }}
-    TEST_SUPABASE_SERVICE_KEY: ${{ secrets.TEST_SUPABASE_SERVICE_KEY }}
-    TEST_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY }}
+    TEST_SUPABASE_SECRET_KEY: ${{ secrets.TEST_SUPABASE_SECRET_KEY }}
+    TEST_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.TEST_SUPABASE_PUBLISHABLE_KEY }}
   
   jobs:
     frontend-tests:
@@ -1619,8 +1619,8 @@ pnpm test:e2e:ui       # Visual runner
   | Secret Name | Description |
   |---|---|
   | TEST_SUPABASE_URL | Test project URL |
-  | TEST_SUPABASE_SERVICE_KEY | Service role key (bypasses RLS) |
-  | TEST_SUPABASE_ANON_KEY | Anon key for user simulation |
+  | TEST_SUPABASE_SECRET_KEY | Service role key (bypasses RLS) |
+  | TEST_SUPABASE_PUBLISHABLE_KEY | Anon key for user simulation |
   | TEST_PREVIEW_URL | Vercel preview URL for E2E |
 
   ---

--- a/docs/testing/backend-setup.md
+++ b/docs/testing/backend-setup.md
@@ -58,7 +58,7 @@ from api.index import app
 
 # Test Supabase credentials
 TEST_SUPABASE_URL = os.environ.get("TEST_SUPABASE_URL")
-TEST_SUPABASE_KEY = os.environ.get("TEST_SUPABASE_SERVICE_KEY")
+TEST_SUPABASE_KEY = os.environ.get("TEST_SUPABASE_SECRET_KEY")
 
 
 @pytest.fixture(scope="session")

--- a/docs/testing/checklist.md
+++ b/docs/testing/checklist.md
@@ -1,194 +1,102 @@
-# Implementation Priority & Checklist
+# Testing Status & Checklist
 
-## Implementation Status
+**Last updated:** 2026-05-27 (sub-PR 3a of the testing infrastructure overhaul).
 
-✅ **Testing Infrastructure Complete** - Merged December 29, 2025
+## Current state
 
----
+| Suite | Files | Tests | Skipped | Notes |
+|---|---|---|---|---|
+| Frontend (Vitest) | 25 | 348 | 9 | `quotesAccess.test.ts` skips 9 cases across `createQuote`, `convertQuoteToJob`, and the `pending_approval` flow. Resolved by sub-PR 3c. |
+| Backend (pytest) | 13 | 151 | varies | Several integration tests skip when `TEST_SUPABASE_URL` is unset (correct behavior post sub-PR #305). Local Supabase wires up in 3c. |
+| E2E (Playwright) | 4 | 5 | 2 | `parts-and-routing.spec.ts:95` always-skips on seed gap; `csv-import.spec.ts:13` skips in CI (FastAPI requirement). Resolved by sub-PR 3g (deterministic local seed + Anthropic mock). |
 
-## Implementation Order
+## Coverage
 
-| Priority | Task | Est. Time | Status |
-|---|---|---|---|
-| 1 | Frontend: Vitest + RTL + MSW setup | 2 hrs | ✅ Complete |
-| 2 | Frontend: CustomerForm tests | 2 hrs | ✅ Complete (5 tests) |
-| 3 | Frontend: customerAccess utility tests | 1 hr | ✅ Complete (11 tests) |
-| 4 | Backend: pytest + fixtures setup | 2 hrs | ✅ Complete |
-| 5 | Backend: Import API tests | 2 hrs | ✅ Complete (14+ tests) |
-| 6 | Backend: RLS policy tests | 2 hrs | ⬜ Deferred to Phase 1 |
-| 7 | GitHub Actions: CI workflow | 1 hr | ✅ Complete |
-| 8 | Playwright: Setup + auth fixture | 1 hr | ⬜ Deferred to Phase 1 |
-| 9 | E2E: Customer CRUD test | 1 hr | ⬜ Deferred to Phase 1 |
-| 10 | E2E: Quote-to-Job flow test | 2 hrs | ⬜ Deferred to Phase 1 |
+Measured 2026-05-27 via `pnpm test --run --coverage`:
 
----
-
-## Current Test Counts
-
-| Suite | Tests | Status |
+| Metric | Threshold (vitest.config.ts) | Actual |
 |---|---|---|
-| Frontend (Vitest) | 20 | ✅ All passing |
-| Backend (pytest) | 19+ | ✅ All passing |
-| E2E (Playwright) | 0 | ⬜ Not started |
+| Statements | 45% | 47.4% ✅ |
+| Branches | 45% | 42.3% ❌ |
+| Functions | 45% | 43.44% ❌ |
+| Lines | 45% | 48.64% ✅ |
 
----
+Two metrics are currently below the configured threshold. Sub-PR 3e (CI hardening) makes `pnpm test --run --coverage` a CI gate — when that lands, every PR has to keep all four metrics green. Sub-PR 3f+ closes specific component gaps that bring branches/functions back above 45%.
 
-## Setup Checklist
+Backend coverage is unmeasured. Sub-PR 3e adds `pytest --cov` to the workflow; the first commit of 3e measures, the second sets the enforced floor (measured-minus-5).
 
-### Frontend ✅
+## Sub-PR sequence (PR 3 series)
 
-- [x] Install Vitest, RTL, MSW dependencies
+| Sub-PR | Status |
+|---|---|
+| [3-pre](https://github.com/debola31/Jigged/pull/305) — Kill `conftest.py` prod fallback | ✅ Merged |
+| **3a** — Docs hygiene + DB COMMENT cleanup migration | **In progress** |
+| 3b — Migration rebaseline | Planned |
+| 3c — Local Supabase via the CLI + RLS-fixture scaffolding + fix `quotesAccess.test.ts` skips | Planned |
+| 3d — RLS policy tests | Planned |
+| 3e — CI hardening (tsc + lint + enforced coverage thresholds) | Planned |
+| 3f+ — Component coverage gaps (one PR per cluster) | Planned |
+| 3g — E2E migrates to local Supabase + Anthropic mock | Planned |
 
-- [x] Create vitest.config.ts
+The full plan lives in [`.claude/plans/i-d-like-to-do-radiant-token.md`](../../.claude/plans/i-d-like-to-do-radiant-token.md) (local-only; not committed).
 
-- [x] Create **tests**/setup.ts
-
-- [x] Create **tests**/test-utils.tsx
-
-- [x] Create **tests**/mocks/handlers.ts
-
-- [x] Create **tests**/mocks/server.ts
-
-- [x] Add test scripts to package.json
-
-- [x] Run first test successfully
-
-- [x] CustomerForm tests passing
-
-- [x] customerAccess utility tests passing
-
-### Backend ✅
-
-- [x] Create api/requirements-test.txt
-
-- [x] Create api/pytest.ini
-
-- [x] Create api/tests/[conftest.py](http://conftest.py/)
-
-- [x] Create test factories
-
-- [x] Run first test successfully
-
-- [x] Import API integration tests passing
-
-- [ ] Set up test Supabase project (using prod for now)
-
-### E2E ⬜ (Deferred)
-
-- [ ] Install Playwright
-
-- [ ] Create playwright.config.ts
-
-- [ ] Create e2e/fixtures/auth.ts
-
-- [ ] Create test CSV fixtures
-
-- [ ] Run first E2E test successfully
-
-### CI/CD ✅
-
-- [x] Create .github/workflows/test.yml
-
-- [x] Frontend tests run on PR
-
-- [x] Backend tests run on PR
-
-- [ ] Add secrets to GitHub repo (if needed)
-
-- [ ] Set up Codecov (optional)
-
----
-
-## Coverage Targets
+## Coverage targets per module
 
 | Module | Target | Current |
 |---|---|---|
-| Customers | 80% | ~70% ✅ |
-| Parts | 80% | 0% |
-| Quotes | 80% | 0% |
-| Jobs | 80% | 0% |
-| Import (AI) | 70% | ~60% ✅ |
-| RLS Policies | 100% | 0% |
+| Customers (`customerAccess`, `CustomerForm`) | 80% | `customerAccess` 31.81%, `CustomerForm` 51.11% |
+| Parts (`partsAccess`, `PartForm`, `UnitOfMeasurementSelect`) | 80% | `partsAccess` 24.11%, `PartForm` 46.42%, `UnitOfMeasurementSelect` 79.59% |
+| Quotes (`quotesAccess`, `quotePdf`, `quotePricingResolver`) | 80% | `quotesAccess` 33.33%, `quotePdf` 91.66%, `quotePricingResolver` not directly measured |
+| Operator (`operatorAccess`) | 70% | not directly measured |
+| Import (AI mapping, `csvParser`) | 70% | `csvParser` not directly measured |
+| RLS Policies | 100% | 0% — sub-PR 3d |
 
----
+These targets are aspirational. The enforced thresholds in [vitest.config.ts](../../vitest.config.ts) are the floor; per-module targets are how we drive 3f+ priorities.
 
-## Test Naming Conventions
-
-**Frontend:**
-
-```javascript
-__tests__/components/{module}/{Component}.test.tsx
-__tests__/hooks/use{Hook}.test.ts
-__tests__/utils/{util}.test.ts
-```
-
-**Backend:**
-
-```javascript
-api/tests/unit/test_{module}.py
-api/tests/integration/test_{module}_[api.py](http://api.py/)
-```
-
-**E2E:**
-
-```javascript
-e2e/{feature}.spec.ts
-```
-
----
-
-## Quick Reference Commands
+## Quick reference
 
 ```bash
 # Frontend
-pnpm test              # Run all tests
-pnpm test:ui           # Visual test runner
-pnpm test:coverage     # With coverage report
-pnpm test CustomerForm # Run specific test
+pnpm test                          # watch mode
+pnpm test --run                    # one-shot
+pnpm test --run --coverage         # coverage report (enforces thresholds in 3e)
+pnpm test --run __tests__/<path>   # file-scoped
 
-# Backend
-cd api
-pytest                 # Run all tests
-pytest -m unit         # Only unit tests
-pytest -m integration  # Only integration
-pytest --cov           # With coverage
-pytest -k customer     # Run matching tests
+# Backend (requires TEST_SUPABASE_URL + TEST_SUPABASE_SECRET_KEY for integration tests)
+cd api && pytest                   # all (unit tests + skipped integration if env unset)
+cd api && pytest tests/unit/       # unit only
+cd api && pytest -m integration    # integration marker
 
-# E2E (when set up)
-pnpm test:e2e          # Run all E2E
-pnpm test:e2e:ui       # Visual runner
+# E2E (Playwright)
+pnpm test:e2e                      # full suite
+pnpm exec playwright test e2e/<spec>.spec.ts --reporter=list
 ```
 
----
+## Naming conventions
 
-## Next Steps
+```
+__tests__/components/{module}/{Component}.test.tsx
+__tests__/utils/{util}.test.ts
+__tests__/lib/{lib}.test.ts
+api/tests/unit/test_{module}.py
+api/tests/integration/test_{module}_api.py
+api/tests/database/test_{topic}.py   # added in sub-PR 3d
+e2e/{feature}.spec.ts
+```
 
-1. **Add tests as modules are built** - Parts, Quotes, Jobs should follow the Customers testing pattern
+## When to write tests
 
-2. **RLS policy tests** - Add before going to production with real multi-tenant data
+Always: new API endpoints; form validation; business logic (status transitions, calculations); RLS policies; critical user flows (quote-to-job, parts-and-routing).
 
-3. **E2E tests** - Add for critical flows (quote-to-job) before MVP launch
+Optional: pure presentation components; third-party-library wrappers; one-off admin scripts.
 
----
+## Known gaps (resolved in subsequent sub-PRs)
 
-## When to Write Tests
-
-**Always write tests for:**
-
-- New API endpoints
-
-- Form validation logic
-
-- Business logic (status transitions, calculations)
-
-- RLS policies
-
-- Critical user flows (quote-to-job)
-
-**Optional (lower priority):**
-
-- Pure presentation components
-
-- Third-party library wrappers
-
-- One-off admin scripts
+- **No RLS policy coverage.** Multi-tenant data isolation has zero automated tests. → 3d.
+- **No backend coverage measurement in CI.** `pytest --cov` not yet wired. → 3e.
+- **No tsc / lint in PR-time CI.** `next build` catches them on Vercel preview, but later than PR review. → 3e.
+- **`quotesAccess.test.ts` skips.** 9 tests skipped across `createQuote`, `convertQuoteToJob`, and pending-approval flow. → 3c.
+- **`parts-and-routing.spec.ts:95` always-skip.** Always-true skip on the cloud-staging seed gap. → 3g (deterministic local seed).
+- **`csv-import.spec.ts:13` CI-skip.** Needs the FastAPI backend running, which CI doesn't provide. → 3g (Anthropic mock + start-server-and-test orchestration).
+- **Untested components.** `QuoteForm`, `OperationForm`, `Login`, `SignUp`, `CompanySelector`, import UI (`MappingReviewTable`, `ConflictDialog`, `ConfidenceChip`), `VendorAutocomplete` — zero coverage today. → 3f+.
+- **Untested access files.** 17 of 24 `utils/*Access.ts` files have zero test coverage. → 3f+.

--- a/docs/testing/cicd.md
+++ b/docs/testing/cicd.md
@@ -15,8 +15,8 @@ on:
 
 env:
   TEST_SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL }}
-  TEST_SUPABASE_SERVICE_KEY: ${{ secrets.TEST_SUPABASE_SERVICE_KEY }}
-  TEST_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY }}
+  TEST_SUPABASE_SECRET_KEY: ${{ secrets.TEST_SUPABASE_SECRET_KEY }}
+  TEST_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.TEST_SUPABASE_PUBLISHABLE_KEY }}
 
 jobs:
   frontend-tests:
@@ -128,8 +128,8 @@ Add these to GitHub repository settings:
 | Secret Name | Description |
 |---|---|
 | TEST_SUPABASE_URL | Test project URL |
-| TEST_SUPABASE_SERVICE_KEY | Service role key (bypasses RLS) |
-| TEST_SUPABASE_ANON_KEY | Anon key for user simulation |
+| TEST_SUPABASE_SECRET_KEY | Service role key (bypasses RLS) |
+| TEST_SUPABASE_PUBLISHABLE_KEY | Anon key for user simulation |
 | TEST_PREVIEW_URL | Vercel preview URL for E2E |
 
 ---

--- a/docs/testing/database-rls.md
+++ b/docs/testing/database-rls.md
@@ -18,7 +18,7 @@ import os
 pytestmark = pytest.mark.asyncio
 
 TEST_SUPABASE_URL = os.environ.get("TEST_SUPABASE_URL")
-TEST_SUPABASE_ANON_KEY = os.environ.get("TEST_SUPABASE_ANON_KEY")
+TEST_SUPABASE_PUBLISHABLE_KEY = os.environ.get("TEST_SUPABASE_PUBLISHABLE_KEY")
 
 
 class TestCustomerRLS:
@@ -49,7 +49,7 @@ class TestCustomerRLS:
         # Create client as user
         user_client = create_client(
             TEST_SUPABASE_URL, 
-            TEST_SUPABASE_ANON_KEY
+            TEST_SUPABASE_PUBLISHABLE_KEY
         )
         user_client.auth.set_session(
             session.session.access_token,
@@ -81,7 +81,7 @@ class TestCustomerRLS:
         
         user_client = create_client(
             TEST_SUPABASE_URL,
-            TEST_SUPABASE_ANON_KEY
+            TEST_SUPABASE_PUBLISHABLE_KEY
         )
         user_client.auth.set_session(
             session.session.access_token,
@@ -115,7 +115,7 @@ class TestCustomerRLS:
         
         user_client = create_client(
             TEST_SUPABASE_URL,
-            TEST_SUPABASE_ANON_KEY
+            TEST_SUPABASE_PUBLISHABLE_KEY
         )
         user_client.auth.set_session(
             session.session.access_token,
@@ -158,7 +158,7 @@ class TestPartsRLS:
         
         user_client = create_client(
             TEST_SUPABASE_URL,
-            TEST_SUPABASE_ANON_KEY
+            TEST_SUPABASE_PUBLISHABLE_KEY
         )
         user_client.auth.set_session(
             session.session.access_token,

--- a/docs/testing/test-registry.md
+++ b/docs/testing/test-registry.md
@@ -1,130 +1,149 @@
 # Test Registry
 
-## Coverage Dashboard
+**Last updated:** 2026-05-27. Counts measured directly from `pnpm exec vitest --run --reporter=json` and `cd api && pytest --collect-only`.
 
-Current test coverage metrics:
+## Coverage dashboard
 
-| Metric | Target | Current |
+| Metric | Threshold | Current |
 |---|---|---|
-| Statements | 45% | ~65% |
-| Branches | 45% | ~59% |
-| Functions | 45% | ~67% |
-| Lines | 45% | ~66% |
+| Statements | 45% | 47.4% |
+| Branches | 45% | 42.3% (under threshold) |
+| Functions | 45% | 43.44% (under threshold) |
+| Lines | 45% | 48.64% |
 
----
+Two metrics are under the configured floor. Sub-PR 3e (CI hardening) makes this a PR-blocking check; sub-PR 3f+ closes the gaps. See [checklist.md](checklist.md) for the sequence.
 
-## Coverage Roadmap
+Coverage roadmap: 45% → 50% → 55% → 60%. Each 3f sub-PR raises the floor in lockstep with the tests it adds (ratchet, not target).
 
-- Phase 1: 45% (achieved)
+## Frontend test files (25 files, 348 tests + 9 skipped)
 
-- Phase 2: 50%
+### Utilities
 
-- Phase 3: 55%
-
-- Phase 4: 60%
-
----
-
-## Test Files Inventory
-
-### Unit Tests - Utilities
-
-| Module | File | Tests | Coverage |
-|---|---|---|---|
-| quotesAccess | __tests__/utils/quotesAccess.test.ts | 58 | ~67% |
-| companyAccess | __tests__/utils/companyAccess.test.ts | 23 | 100% |
-| operationsAccess | __tests__/utils/operationsAccess.test.ts | 35 | ~70% |
-| csvParser | __tests__/utils/csvParser.test.ts | 24 | 100% |
-| storageHelpers | __tests__/utils/storageHelpers.test.ts | 28 | 100% |
-| customerAccess | __tests__/utils/customerAccess.test.ts | 12 | ~34% |
-| partsAccess | __tests__/utils/partsAccess.test.ts | 26 | ~68% |
-
-### Component Tests
-
-| Component | File | Tests | Coverage |
-|---|---|---|---|
-| AuthGuard | __tests__/components/auth/AuthGuard.test.tsx | 11 | 93% |
-| CustomerForm | __tests__/components/customers/CustomerForm.test.tsx | 5 | ~58% |
-| PartForm | __tests__/components/parts/PartForm.test.tsx | 9 | ~52% |
-
-### Backend Tests (pytest)
-
-| Module | File | Description |
+| File | Tests | Coverage notes |
 |---|---|---|
-| Customer Import | api/tests/integration/test_import_api.py | 3-phase import flow |
-| Parts Import | api/tests/integration/test_parts_import_api.py | Parts CSV import |
-| Smoke | api/tests/test_smoke.py | Basic sanity checks |
+| `__tests__/utils/quotesAccess.test.ts` | 29 (+9 skipped) | `quotesAccess.ts` 33.33%. Skips: `createQuote`, `convertQuoteToJob`, pending-approval — fixed in sub-PR 3c. |
+| `__tests__/utils/storageHelpers.test.ts` | 31 | `storageHelpers.ts` 93.18%. |
+| `__tests__/utils/csvParser.test.ts` | 28 | `csvParser.ts` covered indirectly via import flows. |
+| `__tests__/utils/companyAccess.test.ts` | 25 | `companyAccess.ts` 64.04%. |
+| `__tests__/utils/routingCostCalculation.test.ts` | 22 | `routingCostCalculation.ts` 85.45%. |
+| `__tests__/utils/procurementTiersAccess.test.ts` | 20 | `partPricingTiersAccess.ts` 95.83% (related). |
+| `__tests__/utils/quotePdf.test.ts` | 18 | `quotePdf.ts` 91.66%. |
+| `__tests__/utils/partsAccess.test.ts` | 16 | `partsAccess.ts` 24.11%. |
+| `__tests__/utils/customerAccess.test.ts` | 11 | `customerAccess.ts` 31.81%. |
+| `__tests__/utils/quotePricingResolver.test.ts` | 9 | Embedded in `quotesAccess`. |
+| `__tests__/utils/operatorAccess.test.ts` | 6 | `operatorAccess.ts` not separately reported. |
+| `__tests__/utils/shipmentsAccess.test.ts` | 6 | `shipmentsAccess.ts` 15.26%. |
 
----
+### Components
 
-## Running Tests
+| File | Tests | Coverage |
+|---|---|---|
+| `__tests__/components/auth/AuthGuard.test.tsx` | 17 | `AuthGuard.tsx` 95%. |
+| `__tests__/components/inventory/StockStatusChip.test.tsx` | 8 | `StockStatusChip.tsx` covered indirectly. |
+| `__tests__/components/parts/UnitOfMeasurementSelect.test.tsx` | 7 | `UnitOfMeasurementSelect.tsx` 79.59%. |
+| `__tests__/components/auth/AdminGuard.test.tsx` | 6 | `AdminGuard.tsx` 90%. |
+| `__tests__/components/auth/ChangePassword.test.tsx` | 6 | `ChangePassword.tsx` 83.14%. |
+| `__tests__/components/layout/Sidebar.test.tsx` | 6 | `Sidebar.tsx` 95.23%. |
+| `__tests__/components/parts/PartForm.test.tsx` | 5 | `PartForm.tsx` 46.42%. |
+| `__tests__/components/customers/CustomerForm.test.tsx` | 4 | `CustomerForm.tsx` 51.11%. |
 
-### Frontend (Vitest)
+### Library / schema / types / smoke
 
-```bash
-# Run all tests
-pnpm test
+| File | Tests |
+|---|---|
+| `__tests__/types/quote.test.ts` | 23 |
+| `__tests__/lib/supabaseErrors.test.ts` | 21 |
+| `__tests__/lib/partNavStack.test.ts` | 20 |
+| `__tests__/schema/embedCheck.test.ts` | 9 |
+| `__tests__/smoke.test.ts` | 4 |
 
-# Run with UI dashboard
-pnpm test:ui
+## Backend test files (13 files, 151 tests)
 
-# Run with coverage report
-pnpm test:coverage
+### Unit
 
-# Run specific test file
-pnpm test __tests__/utils/quotesAccess.test.ts
-```
+| File | Description |
+|---|---|
+| `api/tests/unit/test_email.py` | Email-sending helpers and templates |
+| `api/tests/unit/test_sql_validator.py` | SQL grammar validation for the read-only insights endpoint |
 
-### Backend (pytest)
+### Integration (require `TEST_SUPABASE_URL` + `TEST_SUPABASE_SECRET_KEY`)
 
-```bash
-cd api
+| File | Description |
+|---|---|
+| `api/tests/integration/test_import_api.py` | 3-phase customer import flow (analyze / validate / execute) |
+| `api/tests/integration/test_parts_import_api.py` | Parts CSV import with AI mapping |
+| `api/tests/integration/test_bom_import_api.py` | BOM structure import |
+| `api/tests/integration/test_vendors_import_api.py` | Vendor CSV import (analyze / validate / execute) |
+| `api/tests/integration/test_work_centers_import_api.py` | Work-center CSV import |
+| `api/tests/integration/test_routings_import_api.py` | Routing CSV import |
+| `api/tests/integration/test_shipment_customer_consistency.py` | Triggers reject cross-customer line items |
+| `api/tests/integration/test_shipment_void_permutations.py` | Shipment void state-machine edge cases |
+| `api/tests/integration/test_insights_chat.py` | AI insights endpoint (skips when `AI_READONLY_DATABASE_URL` unset) |
+| `api/tests/integration/test_sql_executor.py` | Safe SQL execution for insights queries |
 
-# Run all tests
-pytest
+### Smoke
 
-# Run with verbose output
-pytest -v
+| File | Description |
+|---|---|
+| `api/tests/test_smoke.py` | Pytest-infrastructure sanity (collection, async, markers, exceptions) |
 
-# Run specific test file
-pytest tests/integration/test_import_api.py
+## E2E specs (4 files, 5 tests, 2 skipped)
 
-# Run with coverage
-pytest --cov=.
-```
+| File | Tests | Status |
+|---|---|---|
+| `e2e/smoke.spec.ts` | 2 | Passing — dashboard load + login page accessibility |
+| `e2e/quote-to-job.spec.ts` | 1 | Passing — quote create → job conversion (covers the May 2026 `jobs.status` regression path) |
+| `e2e/parts-and-routing.spec.ts` | 1 | **Always-skipped** at line 95 (`test.skip(true, …)`); resolved by sub-PR 3g |
+| `e2e/csv-import.spec.ts` | 1 | **CI-skipped** (`test.skip(!!process.env.CI, …)`); resolved by sub-PR 3g (Anthropic mock) |
 
----
+## Known gaps (unchanged from [checklist.md](checklist.md))
 
-## Known Gaps
+### Untested components — sub-PR 3f+ targets
 
-### Not Yet Tested (Frontend)
+- `components/quotes/QuoteForm.tsx`
+- `components/operations/OperationForm.tsx`
+- `components/auth/Login.tsx`, `components/auth/SignUp.tsx`, `components/auth/CompanySelector.tsx`
+- Import UI: `MappingReviewTable`, `ConflictDialog`, `ConfidenceChip`
+- `components/vendors/VendorAutocomplete.tsx`
 
-- utils/jobAttachmentsAccess.ts
+### Untested access files — sub-PR 3f+ targets
 
-- components/quotes/QuoteForm.tsx
+17 of 24 `utils/*Access.ts` files have no test file. Highest-impact:
+- `bomAccess.ts` (2.67% coverage)
+- `customerContactsAccess.ts` (1.78%)
+- `markupRatesAccess.ts` (6.29%)
+- `quoteLineItemsAccess.ts` (0%)
+- `routingsAccess.ts` (1.34%)
+- `partPricingTiersAccess.ts` (0%)
 
-- components/auth/Login.tsx
+### Backend gaps
 
-- components/auth/SignUp.tsx
-
-- components/auth/CompanySelector.tsx
-
-- components/operations/OperationForm.tsx
-
-- Import components (MappingReviewTable, ConflictDialog, etc.)
-
-### Not Yet Tested (Backend)
-
-- api/routes/operations_import_routes.py
-
-- AI provider unit tests
-
+- `api/routes/operations_import_routes.py` (no direct test file)
+- AI provider unit tests (`api/services/ai/*`)
 - Import framework service unit tests
+- RLS policies — sub-PR 3d
 
-### E2E Tests (Not Implemented)
+### E2E gaps
 
-- Authentication flow
+- Authentication flow (Login, SignUp, password reset, company selector)
+- Quote lifecycle beyond the convert-to-job happy path
+- Import workflows (csv-import covered only when 3g lands)
 
-- Quote lifecycle
+## How to run
 
-- Import workflows
+```bash
+# Frontend
+pnpm test                                    # watch mode
+pnpm test --run                              # one-shot
+pnpm test --run --coverage                   # with coverage
+pnpm test --run __tests__/<path>             # file-scoped
+
+# Backend
+cd api && pytest                             # all (with TEST_SUPABASE_URL set)
+cd api && pytest tests/unit/                 # unit only
+cd api && pytest -m integration              # integration marker
+
+# E2E
+pnpm test:e2e                                # full suite
+pnpm exec playwright test e2e/<spec>.spec.ts --reporter=list
+```

--- a/supabase/migrations/20260527145941_clean_pilot_customer_column_comments.sql
+++ b/supabase/migrations/20260527145941_clean_pilot_customer_column_comments.sql
@@ -1,0 +1,23 @@
+-- Clean up pilot-customer references from COMMENT ON COLUMN metadata.
+--
+-- Why: PR 1 (#300) scrubbed pilot-customer names ("Contour", "Shane") from
+-- application code, docs, marketing pages, and test fixtures. The COMMENT
+-- statements that ship to pg_description were deferred at the time because
+-- updating them requires a new migration. This migration closes that gap.
+--
+-- Three columns are affected. The substance of each comment is preserved;
+-- only the customer-specific identifiers and the pilot-derived statistic
+-- (98.6%) are removed.
+--
+-- Verification after apply:
+--   SELECT * FROM pg_description WHERE description ILIKE '%contour%' OR description ILIKE '%shane%';
+-- Expected: zero rows.
+
+COMMENT ON COLUMN public.companies.name
+    IS 'Display name of the company/shop. Example: "Acme Precision Machining".';
+
+COMMENT ON COLUMN public.companies.slug
+    IS 'URL-friendly unique identifier. Used in routes like /dashboard/{slug}/. Example: "acme-precision".';
+
+COMMENT ON COLUMN public.routing_operations.labor_rate_override
+    IS 'Per-step override of the work_center labor_rate, in dollars per hour. Dominant pattern in real shop data: internal ops typically override the work-center default rather than inherit it. NULL = inherit work_center.labor_rate. Used for kind=internal only.';


### PR DESCRIPTION
Sub-PR **3a** in the [PR 3 series](../../.claude/plans/i-d-like-to-do-radiant-token.md) (testing infrastructure overhaul). Bundles two mostly-independent threads with no runtime impact:

## (1) docs/testing/* refresh

The checklist and registry were last touched in December 2025 and have drifted significantly. Concrete updates from measured-today values:

- **checklist.md** — rewrote end-to-end. Old "Frontend 20 / Backend 19+ / E2E 0" replaced with **25 files / 348 tests + 9 skipped** (frontend), **13 files / 151 tests** (backend), **4 specs / 5 tests, 2 skipped** (E2E). Old "Phase 1 (Deferred)" rows replaced with sub-PR pointers. Added a Sub-PR-sequence table and a coverage section with measured numbers (statements 47.4%, branches 42.3%, functions 43.44%, lines 48.64% — two of four are under the configured 45% threshold; sub-PR 3e enforces the gate, sub-PR 3f closes the gap).

- **test-registry.md** — rewrote the inventory. Old registry referenced \`operationsAccess.test.ts\` (renamed to \`operatorAccess.test.ts\` long ago), \`quotesAccess\` at 58 tests (current: 29), \`partsAccess\` at 26 (current: 16). New version matches what's on disk with per-file coverage % from \`pnpm test --run --coverage\`.

- **test-matrix.md** — headline counts (22 implemented / 1 partial / 1 not implemented across 24 cases) match the actual matrix rows. No rewrite.

- **README.md / cicd.md / backend-setup.md / database-rls.md** — updated \`TEST_SUPABASE_SERVICE_KEY\` → \`TEST_SUPABASE_SECRET_KEY\` and \`TEST_SUPABASE_ANON_KEY\` → \`TEST_SUPABASE_PUBLISHABLE_KEY\` to match the prod-aligned naming sub-PR #305 adopted in conftest.py.

## (2) DB COMMENT cleanup migration

PR 1 (#300) scrubbed pilot-customer names from code, docs, and marketing pages but deferred the SQL \`COMMENT ON COLUMN\` statements (they require a new migration). This PR adds that migration:

\`supabase/migrations/20260527145941_clean_pilot_customer_column_comments.sql\`

Three columns affected:
- \`companies.name\` — example changed from \"Contour Tool & Machine\" to \"Acme Precision Machining\"
- \`companies.slug\` — example changed from \"contour-tool\" to \"acme-precision\"
- \`routing_operations.labor_rate_override\` — drops the \"98.6% of comparable Contour rows override\" phrasing (the figure itself is pilot-derived); replaced with \"internal ops typically override the work-center default rather than inherit it\"

### Verification (run after apply)

\`\`\`sql
SELECT * FROM pg_description
 WHERE description ILIKE '%contour%' OR description ILIKE '%shane%';
-- Expected: zero rows.
\`\`\`

### Apply note ⚠️

\`supabase db push --linked\` is currently blocked against staging by migration-history drift (legacy 8-digit timestamps creating duplicate version entries; documented in CLAUDE.md). Sub-PR 3b (migration rebaseline) is the proper fix for that. Until 3b lands, options:
- **(a)** Apply this migration via the Supabase dashboard SQL editor as a one-shot, then verify with the \`pg_description\` query above.
- **(b)** *(Recommended)* Wait for 3b and apply during the rebaseline workflow. 3b dumps prod for the baseline, so applying this migration to prod first keeps the cleaned-up comments in the baseline by construction.

I'd lean on (b) — the rebaseline is the right time to deal with the staging push pipeline anyway.

## Test plan

- [x] \`grep -E \"Phase 1 \\(Deferred\\)|0% coverage|Frontend.*20 |Backend.*19\" docs/testing/checklist.md\` — empty
- [x] \`rg \"TEST_SUPABASE_SERVICE_KEY|TEST_SUPABASE_ANON_KEY\" docs/testing/\` — empty
- [ ] Apply migration via dashboard or rebaseline workflow (see Apply note above)
- [ ] Post-apply: \`SELECT * FROM pg_description WHERE description ILIKE '%contour%' OR description ILIKE '%shane%';\` → zero rows
- [ ] Post-apply: \`python scripts/export_schema.py --env staging\` and \`--env prod\` to refresh the cached schema files

🤖 Generated with [Claude Code](https://claude.com/claude-code)