### PR TITLE
test(rls): 36 cross-tenant RLS policy tests + extend seeded fixture

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -203,11 +203,38 @@ def _create_seeded_user(supabase_admin: Client, company_name_suffix: str) -> dic
 
 
 def _teardown_seeded_user(supabase_admin: Client, seeded: dict) -> None:
-    """Reverse what _create_seeded_user did, in dependency order."""
-    # user_company_access cascades from companies; companies cascades to
-    # everything we own. Cleaning the auth user is the only step that
-    # doesn't cascade automatically.
-    supabase_admin.table("companies").delete().eq("id", seeded["company_id"]).execute()
+    """
+    Reverse what _create_seeded_user did, in dependency order.
+
+    A subset of FKs into `companies` lack ON DELETE CASCADE in the current
+    schema (e.g. shipments.company_id, jobs.company_id). Same drift that
+    test_shipment_void_permutations.py is xfailed against. Delete the
+    known blockers explicitly before the company; the rest cascades.
+    """
+    company_id = seeded["company_id"]
+
+    # Tables with FKs to companies(id) that are NOT ON DELETE CASCADE.
+    # Order matters: shipment_line_items → shipments → (job_parts via
+    # job_part_id) is independent of the company cascade, but PostgreSQL
+    # evaluates the references at the parent-row delete, so wiping
+    # shipments first is sufficient.
+    for table in ("shipment_line_items", "shipments", "job_parts", "jobs"):
+        try:
+            (
+                supabase_admin.table(table)
+                .delete()
+                .eq("company_id", company_id)
+                .execute()
+            )
+        except Exception:
+            # Some of these may not actually have a company_id column
+            # (shipment_line_items doesn't — it inherits via the
+            # shipment FK). Swallow the column-not-found error; the
+            # subsequent company-delete will tell us if anything else
+            # is still referencing us.
+            pass
+
+    supabase_admin.table("companies").delete().eq("id", company_id).execute()
     try:
         supabase_admin.auth.admin.delete_user(seeded["user_id"])
     except Exception:
@@ -319,15 +346,78 @@ def seeded_company_b_graph(
 
     # routing_operations inherits company_id transitively via the routing FK;
     # no company_id column on this table itself.
-    supabase_admin.table("routing_operations").insert(
-        {
-            "routing_id": routing_id,
-            "work_center_id": internal_wc_id,
-            "sequence": 10,
-            "setup_minutes": 30,
-            "cycle_minutes_per_unit": 2,
-        }
-    ).execute()
+    routing_op = (
+        supabase_admin.table("routing_operations")
+        .insert(
+            {
+                "routing_id": routing_id,
+                "work_center_id": internal_wc_id,
+                "sequence": 10,
+                "setup_minutes": 30,
+                "cycle_minutes_per_unit": 2,
+            }
+        )
+        .execute()
+    )
+    routing_operation_id = routing_op.data[0]["id"]
+
+    # Quote — minimum viable to satisfy NOT NULL constraints. The
+    # `set_quote_number` trigger fills quote_number when '' or NULL.
+    quote = (
+        supabase_admin.table("quotes")
+        .insert(
+            {
+                "company_id": company_b_id,
+                "customer_id": customer_id,
+                "quote_number": "",  # filled by trigger
+                "status": "active",
+            }
+        )
+        .execute()
+    )
+    quote_id = quote.data[0]["id"]
+
+    # Job — production_status NOT NULL, fulfillment_status defaults to
+    # 'unshipped' (per migration 20260523). Job number mirrors the quote
+    # number — fill explicitly to avoid relying on quote-conversion.
+    job = (
+        supabase_admin.table("jobs")
+        .insert(
+            {
+                "company_id": company_b_id,
+                "customer_id": customer_id,
+                "job_number": "J-RLS-3D-B",
+                "production_status": "not_started",
+                "fulfillment_status": "unshipped",
+            }
+        )
+        .execute()
+    )
+    job_id = job.data[0]["id"]
+
+    # Shipment — minimum viable. `shipments_one_address_source` CHECK
+    # requires exactly one of (shipping_address_id, one_time_address) to
+    # be set. The customer has no addresses in this fixture, so use the
+    # one_time_address path with a stub JSONB blob.
+    shipment = (
+        supabase_admin.table("shipments")
+        .insert(
+            {
+                "company_id": company_b_id,
+                "customer_id": customer_id,
+                "packing_slip_number": "PS-RLS-3D-B-0001",
+                "one_time_address": {
+                    "name": "RLS-3d Fixture Address",
+                    "line1": "1 Test Street",
+                    "city": "Testville",
+                    "state": "TS",
+                    "postal_code": "00000",
+                },
+            }
+        )
+        .execute()
+    )
+    shipment_id = shipment.data[0]["id"]
 
     yield {
         "company_id": company_b_id,
@@ -337,6 +427,10 @@ def seeded_company_b_graph(
         "customer_id": customer_id,
         "part_id": part_id,
         "routing_id": routing_id,
+        "routing_operation_id": routing_operation_id,
+        "quote_id": quote_id,
+        "job_id": job_id,
+        "shipment_id": shipment_id,
     }
 
     # Teardown order: clean up rows that the company-delete cascade won't

--- a/api/tests/database/test_rls_policies.py
+++ b/api/tests/database/test_rls_policies.py
@@ -1,0 +1,553 @@
+"""
+Row-Level Security policy tests for the multi-tenant model.
+
+Architecture
+------------
+Each test exercises one CRUD verb against a row that user A *should not*
+be able to see or touch. Setup of the cross-tenant row is done by the
+session-scoped `seeded_company_b_graph` fixture using the local-Supabase
+service-role key (publicly known, throwaway local DB). The actual SELECT
+/ INSERT / UPDATE / DELETE attempts go through `seeded_user_a["client"]`
+— an anon-key Supabase client carrying the user A JWT. Exercising the
+policies the same way the production app does is the whole point; if a
+policy regresses, this test file fails loudly.
+
+Expected behaviors when user A targets company B's data
+-------------------------------------------------------
+- SELECT: returns `[]`. RLS silently filters; PostgREST does not raise.
+- INSERT: raises postgrest.exceptions.APIError (the policy's WITH CHECK
+  rejects). The exact code is typically `42501` (insufficient privilege)
+  or PostgREST `PGRST301`.
+- UPDATE: returns `data == []`, not an error. RLS narrows the affected
+  set to empty.
+- DELETE: same shape — `data == []`.
+
+Coverage
+--------
+Tables covered (in matrix form: rows = tables, columns = verbs):
+
+  customers      SELECT INSERT UPDATE DELETE
+  parts          SELECT INSERT UPDATE DELETE
+  quotes         SELECT INSERT UPDATE DELETE
+  jobs           SELECT INSERT UPDATE DELETE
+  routings       SELECT INSERT UPDATE DELETE
+  vendors        SELECT INSERT UPDATE DELETE
+  work_centers   SELECT INSERT UPDATE DELETE
+  shipments      SELECT INSERT UPDATE DELETE
+  companies      SELECT INSERT UPDATE DELETE   # last-line-of-defense
+
+Child tables (routing_operations, shipment_line_items, user_company_access)
+inherit isolation transitively via their parents; the parent tests cover
+them implicitly. Direct tests for child tables can be added in a
+follow-up if specific bypass routes are suspected.
+"""
+from __future__ import annotations
+
+import pytest
+from postgrest.exceptions import APIError
+
+pytestmark = pytest.mark.integration
+
+
+# Common helpers ---------------------------------------------------------------
+
+
+def _expect_blocked_insert(call):
+    """
+    Run `call()` and require it to raise APIError (RLS WITH CHECK violated).
+    Accepts either a true raise or PostgREST's 401/403-style error payload.
+    """
+    with pytest.raises(APIError) as exc_info:
+        call()
+    # We don't pin on a specific code because PostgREST varies between
+    # versions and providers (42501 for direct PG, PGRST301 for missing
+    # JWT, "new row violates row-level security policy" string match).
+    # The fact that it raises at all is the assertion.
+    assert exc_info.value is not None
+
+
+def _user_a_table(seeded_user_a, table_name):
+    """Shortcut: PostgREST `from(table)` chain via user A's anon-key client."""
+    return seeded_user_a["client"].table(table_name)
+
+
+# customers --------------------------------------------------------------------
+
+
+class TestCustomersRLS:
+    def test_select_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "customers")
+            .select("id")
+            .eq("id", seeded_company_b_graph["customer_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_insert_into_other_company_is_blocked(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        _expect_blocked_insert(
+            lambda: _user_a_table(seeded_user_a, "customers")
+            .insert(
+                {
+                    "company_id": seeded_company_b_graph["company_id"],
+                    "name": "RLS Attack — should not land",
+                }
+            )
+            .execute()
+        )
+
+    def test_update_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "customers")
+            .update({"name": "RLS Attack — should not stick"})
+            .eq("id", seeded_company_b_graph["customer_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_delete_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "customers")
+            .delete()
+            .eq("id", seeded_company_b_graph["customer_id"])
+            .execute()
+        )
+        assert result.data == []
+
+
+# parts ------------------------------------------------------------------------
+
+
+class TestPartsRLS:
+    def test_select_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "parts")
+            .select("id")
+            .eq("id", seeded_company_b_graph["part_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_insert_into_other_company_is_blocked(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        _expect_blocked_insert(
+            lambda: _user_a_table(seeded_user_a, "parts")
+            .insert(
+                {
+                    "company_id": seeded_company_b_graph["company_id"],
+                    "part_name": "RLS-ATTACK-PART",
+                    "source": "made",
+                    "primary_unit": "each",
+                }
+            )
+            .execute()
+        )
+
+    def test_update_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "parts")
+            .update({"part_name": "RLS Attack — should not stick"})
+            .eq("id", seeded_company_b_graph["part_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_delete_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "parts")
+            .delete()
+            .eq("id", seeded_company_b_graph["part_id"])
+            .execute()
+        )
+        assert result.data == []
+
+
+# quotes -----------------------------------------------------------------------
+
+
+class TestQuotesRLS:
+    def test_select_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "quotes")
+            .select("id")
+            .eq("id", seeded_company_b_graph["quote_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_insert_into_other_company_is_blocked(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        _expect_blocked_insert(
+            lambda: _user_a_table(seeded_user_a, "quotes")
+            .insert(
+                {
+                    "company_id": seeded_company_b_graph["company_id"],
+                    "customer_id": seeded_company_b_graph["customer_id"],
+                    "quote_number": "",
+                    "status": "active",
+                }
+            )
+            .execute()
+        )
+
+    def test_update_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "quotes")
+            .update({"status": "expired"})
+            .eq("id", seeded_company_b_graph["quote_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_delete_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "quotes")
+            .delete()
+            .eq("id", seeded_company_b_graph["quote_id"])
+            .execute()
+        )
+        assert result.data == []
+
+
+# jobs -------------------------------------------------------------------------
+
+
+class TestJobsRLS:
+    def test_select_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "jobs")
+            .select("id")
+            .eq("id", seeded_company_b_graph["job_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_insert_into_other_company_is_blocked(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        _expect_blocked_insert(
+            lambda: _user_a_table(seeded_user_a, "jobs")
+            .insert(
+                {
+                    "company_id": seeded_company_b_graph["company_id"],
+                    "customer_id": seeded_company_b_graph["customer_id"],
+                    "job_number": "J-RLS-ATTACK",
+                    "production_status": "not_started",
+                    "fulfillment_status": "unshipped",
+                }
+            )
+            .execute()
+        )
+
+    def test_update_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "jobs")
+            .update({"production_status": "in_progress"})
+            .eq("id", seeded_company_b_graph["job_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_delete_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "jobs")
+            .delete()
+            .eq("id", seeded_company_b_graph["job_id"])
+            .execute()
+        )
+        assert result.data == []
+
+
+# routings ---------------------------------------------------------------------
+
+
+class TestRoutingsRLS:
+    def test_select_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "routings")
+            .select("id")
+            .eq("id", seeded_company_b_graph["routing_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_insert_into_other_company_is_blocked(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        _expect_blocked_insert(
+            lambda: _user_a_table(seeded_user_a, "routings")
+            .insert(
+                {
+                    "company_id": seeded_company_b_graph["company_id"],
+                    "part_id": seeded_company_b_graph["part_id"],
+                    "name": "RLS Attack Routing",
+                }
+            )
+            .execute()
+        )
+
+    def test_update_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "routings")
+            .update({"name": "RLS Attack — should not stick"})
+            .eq("id", seeded_company_b_graph["routing_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_delete_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "routings")
+            .delete()
+            .eq("id", seeded_company_b_graph["routing_id"])
+            .execute()
+        )
+        assert result.data == []
+
+
+# vendors ----------------------------------------------------------------------
+
+
+class TestVendorsRLS:
+    def test_select_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "vendors")
+            .select("id")
+            .eq("id", seeded_company_b_graph["vendor_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_insert_into_other_company_is_blocked(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        _expect_blocked_insert(
+            lambda: _user_a_table(seeded_user_a, "vendors")
+            .insert(
+                {
+                    "company_id": seeded_company_b_graph["company_id"],
+                    "name": "RLS Attack Vendor",
+                }
+            )
+            .execute()
+        )
+
+    def test_update_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "vendors")
+            .update({"name": "RLS Attack — should not stick"})
+            .eq("id", seeded_company_b_graph["vendor_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_delete_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "vendors")
+            .delete()
+            .eq("id", seeded_company_b_graph["vendor_id"])
+            .execute()
+        )
+        assert result.data == []
+
+
+# work_centers -----------------------------------------------------------------
+
+
+class TestWorkCentersRLS:
+    def test_select_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "work_centers")
+            .select("id")
+            .eq("id", seeded_company_b_graph["work_center_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_insert_into_other_company_is_blocked(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        _expect_blocked_insert(
+            lambda: _user_a_table(seeded_user_a, "work_centers")
+            .insert(
+                {
+                    "company_id": seeded_company_b_graph["company_id"],
+                    "name": "RLS Attack WC",
+                    "kind": "internal",
+                    "labor_rate": 0,
+                }
+            )
+            .execute()
+        )
+
+    def test_update_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "work_centers")
+            .update({"name": "RLS Attack — should not stick"})
+            .eq("id", seeded_company_b_graph["work_center_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_delete_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "work_centers")
+            .delete()
+            .eq("id", seeded_company_b_graph["work_center_id"])
+            .execute()
+        )
+        assert result.data == []
+
+
+# shipments --------------------------------------------------------------------
+
+
+class TestShipmentsRLS:
+    def test_select_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "shipments")
+            .select("id")
+            .eq("id", seeded_company_b_graph["shipment_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_insert_into_other_company_is_blocked(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        _expect_blocked_insert(
+            lambda: _user_a_table(seeded_user_a, "shipments")
+            .insert(
+                {
+                    "company_id": seeded_company_b_graph["company_id"],
+                    "customer_id": seeded_company_b_graph["customer_id"],
+                    "packing_slip_number": "PS-RLS-ATTACK",
+                }
+            )
+            .execute()
+        )
+
+    def test_update_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "shipments")
+            .update({"notes": "RLS Attack — should not stick"})
+            .eq("id", seeded_company_b_graph["shipment_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_delete_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "shipments")
+            .delete()
+            .eq("id", seeded_company_b_graph["shipment_id"])
+            .execute()
+        )
+        assert result.data == []
+
+
+# companies --------------------------------------------------------------------
+# Last line of defense: even if user A could somehow target the companies table
+# directly, RLS must not let them read/write company B's row.
+
+
+class TestCompaniesRLS:
+    def test_select_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "companies")
+            .select("id")
+            .eq("id", seeded_company_b_graph["company_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_insert_into_other_company_is_blocked(self, seeded_user_a):
+        # Companies have no `company_id` — they ARE the tenant. But the
+        # insert policy still restricts to the authenticated user creating
+        # their own company; user A trying to manufacture a fake company
+        # they're not linked to should fail (the trigger on companies links
+        # creator → access).
+        # In the current schema, INSERT on companies is gated by an after-
+        # insert trigger that requires the auth user; service-role bypasses
+        # this. Anon-key + JWT users hit the policy. We assert it raises.
+        _expect_blocked_insert(
+            lambda: _user_a_table(seeded_user_a, "companies")
+            .insert({"name": "RLS Attack Company"})
+            .execute()
+        )
+
+    def test_update_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "companies")
+            .update({"name": "RLS Attack — should not stick"})
+            .eq("id", seeded_company_b_graph["company_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_delete_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "companies")
+            .delete()
+            .eq("id", seeded_company_b_graph["company_id"])
+            .execute()
+        )
+        assert result.data == []


### PR DESCRIPTION
Sub-PR **3d** in the [PR 3 series](.claude/plans/i-d-like-to-do-radiant-token.md). Closes the highest-severity gap from the testing audit: zero automated coverage on multi-tenant data isolation, with a pilot customer live on prod.

## Coverage

36 tests in \`api/tests/database/test_rls_policies.py\` — one TestClass per high-risk table, four tests per class:

| Table | SELECT | INSERT | UPDATE | DELETE |
|---|---|---|---|---|
| customers | ✓ | ✓ | ✓ | ✓ |
| parts | ✓ | ✓ | ✓ | ✓ |
| quotes | ✓ | ✓ | ✓ | ✓ |
| jobs | ✓ | ✓ | ✓ | ✓ |
| routings | ✓ | ✓ | ✓ | ✓ |
| vendors | ✓ | ✓ | ✓ | ✓ |
| work_centers | ✓ | ✓ | ✓ | ✓ |
| shipments | ✓ | ✓ | ✓ | ✓ |
| companies | ✓ | ✓ | ✓ | ✓ |

Each test:
1. **Setup**: cross-tenant row already exists in company B (from \`seeded_company_b_graph\`, session-scoped, set up via service-role).
2. **Action**: user A attempts the operation via \`seeded_user_a["client"]\` — anon-key client carrying user A's JWT.
3. **Assertion**:
   - SELECT → returns \`[]\` (RLS silently filters; PostgREST does not raise)
   - INSERT → raises \`postgrest.exceptions.APIError\` (WITH CHECK rejects)
   - UPDATE → \`data == []\` (RLS narrows the set to empty)
   - DELETE → \`data == []\`

**No service-role bypass in the action paths** — tests exercise policies the same way the production app does. If a future migration weakens any of these policies, this file fails loudly.

## Fixture extension

\`seeded_company_b_graph\` (in \`api/tests/conftest.py\`) now also creates:
- quote (\`status='active'\`, uses \`set_quote_number\` trigger)
- job (\`J-RLS-3D-B\`, \`production_status='not_started'\`, \`fulfillment_status='unshipped'\`)
- shipment (with stub \`one_time_address\` JSONB to satisfy the \`shipments_one_address_source\` XOR check)

Yield gained: \`quote_id\`, \`job_id\`, \`shipment_id\`, \`routing_operation_id\`.

## Teardown hardening

A subset of FKs into \`companies(id)\` lack \`ON DELETE CASCADE\` in the current schema (\`shipments.company_id\`, \`jobs.company_id\`) — same drift that \`test_shipment_void_permutations.py\` was xfailed against in 3c. \`_teardown_seeded_user\` now wipes shipment_line_items / shipments / job_parts / jobs for the company explicitly before deleting the company row, so fixtures clean up reliably.

## Test counts

| Suite | Before 3d | After 3d |
|---|---|---|
| pytest (backend) | 136 passed, 5 skipped, 12 xfailed, 1 xpassed | **172 passed**, 5 skipped, 12 xfailed, 1 xpassed |
| Database tests specifically | 3 (smoke) | **39** (3 smoke + 36 RLS) |

## Out of scope (follow-up)

- Direct RLS tests for child tables (\`routing_operations\`, \`shipment_line_items\`, \`user_company_access\`) — they inherit isolation transitively via parent RLS; parent tests cover them implicitly. Direct coverage can be added if a specific bypass route is suspected.
- Fixing the missing \`ON DELETE CASCADE\` on \`shipments.company_id\` / \`jobs.company_id\` — separate hygiene PR, no longer blocking the test fixtures.

## Test plan

- [x] \`pytest tests/database/ -v\` → 39 passed, 0 failed
- [x] Full pytest run → 172 passed, 5 skipped, 12 xfailed, 1 xpassed, 0 failed
- [x] Every RLS class covers all 4 CRUD verbs
- [ ] CI runs the new tests against local Supabase (validated on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)