### PR TITLE
test(auth): cover Login, SignUp, CompanySelector + ratchet vitest thresholds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,4 @@ docs/usability-tests/
 scripts/data/
 
 # Supabase
-supabase/.temp/
+supabase/.temp/api/.coverage

--- a/__tests__/components/auth/CompanySelector.test.tsx
+++ b/__tests__/components/auth/CompanySelector.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, routerMocks, resetRouterMocks } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import CompanySelector from '@/components/auth/CompanySelector';
+
+const useAuthMock = vi.fn();
+vi.mock('@/components/providers/AuthProvider', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+const getUserCompanies = vi.fn();
+const setLastCompany = vi.fn();
+vi.mock('@/utils/companyAccess', () => ({
+  getUserCompanies: (...args: unknown[]) => getUserCompanies(...args),
+  setLastCompany: (...args: unknown[]) => setLastCompany(...args),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+describe('CompanySelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetRouterMocks();
+    useAuthMock.mockReturnValue({ user: { id: 'user-1', email: 'a@b.co' } });
+    getUserCompanies.mockResolvedValue([
+      { user_id: 'user-1', company_id: 'co-a', role: 'admin', companies: { id: 'co-a', name: 'Acme Corp' } },
+      { user_id: 'user-1', company_id: 'co-b', role: 'user', companies: { id: 'co-b', name: 'Beta LLC' } },
+    ]);
+    setLastCompany.mockResolvedValue(undefined);
+  });
+
+  it('renders the company list with names and roles', async () => {
+    render(<CompanySelector />);
+
+    expect(await screen.findByText('Acme Corp')).toBeInTheDocument();
+    expect(screen.getByText('Beta LLC')).toBeInTheDocument();
+    expect(screen.getByText('Role: admin')).toBeInTheDocument();
+    expect(screen.getByText('Role: user')).toBeInTheDocument();
+  });
+
+  it('shows a loading spinner before companies resolve', () => {
+    // Don't resolve — leave the promise hanging
+    getUserCompanies.mockReturnValueOnce(new Promise(() => {}));
+    render(<CompanySelector />);
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /select company/i })).not.toBeInTheDocument();
+  });
+
+  it('redirects to /no-access when the user has zero companies', async () => {
+    getUserCompanies.mockResolvedValueOnce([]);
+    render(<CompanySelector />);
+
+    await waitFor(() => {
+      expect(routerMocks.replace).toHaveBeenCalledWith('/no-access');
+    });
+  });
+
+  it('shows an error message when company fetch fails', async () => {
+    getUserCompanies.mockRejectedValueOnce(new Error('Network blew up'));
+    render(<CompanySelector />);
+
+    expect(
+      await screen.findByText(/failed to load companies/i),
+    ).toBeInTheDocument();
+  });
+
+  it('calls setLastCompany + navigates to the selected dashboard on click', async () => {
+    render(<CompanySelector />);
+    const acme = await screen.findByText('Acme Corp');
+
+    const user = userEvent.setup();
+    await user.click(acme);
+
+    await waitFor(() => {
+      expect(setLastCompany).toHaveBeenCalledWith('user-1', 'co-a');
+      expect(routerMocks.push).toHaveBeenCalledWith('/dashboard/co-a');
+    });
+  });
+
+  it('shows an error when setLastCompany fails (does not navigate)', async () => {
+    setLastCompany.mockRejectedValueOnce(new Error('DB unreachable'));
+    render(<CompanySelector />);
+
+    const acme = await screen.findByText('Acme Corp');
+    const user = userEvent.setup();
+    await user.click(acme);
+
+    expect(await screen.findByText(/failed to select company/i)).toBeInTheDocument();
+    expect(routerMocks.push).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch companies when user is null', async () => {
+    useAuthMock.mockReturnValue({ user: null });
+    render(<CompanySelector />);
+
+    // The loading spinner stays visible because the early-return in the
+    // effect skips both the fetch and the setLoading(false). That's the
+    // intended behavior — the component expects to be rendered only after
+    // auth resolves.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(getUserCompanies).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/auth/Login.test.tsx
+++ b/__tests__/components/auth/Login.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, routerMocks, resetRouterMocks } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import Login from '@/components/auth/Login';
+
+const sharedSupabase = {
+  auth: {
+    signInWithPassword: vi.fn(),
+  },
+};
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => sharedSupabase,
+}));
+
+const getPostLoginRoute = vi.fn();
+vi.mock('@/utils/companyAccess', () => ({
+  getPostLoginRoute: (...args: unknown[]) => getPostLoginRoute(...args),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+describe('Login', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetRouterMocks();
+    sharedSupabase.auth.signInWithPassword.mockResolvedValue({
+      data: { user: { id: 'user-1', email: 'test@example.com' } },
+      error: null,
+    });
+    getPostLoginRoute.mockResolvedValue('/dashboard/test-company');
+    // Login.isValidReturnTo reads window.location.origin — jsdom provides
+    // about:blank by default, which makes URL parsing flaky. Pin the origin
+    // so the allowlist check is deterministic.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: new URL('http://localhost:3000/login'),
+    });
+  });
+
+  async function fillAndSubmit(email = 'test@example.com', password = 'hunter2') {
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/email/i), email);
+    await user.type(screen.getByLabelText(/password/i), password);
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+  }
+
+  it('renders the sign-in form', () => {
+    render(<Login />);
+    expect(screen.getByRole('heading', { name: /sign in/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+  });
+
+  it('shows expired banner when expired prop is true', () => {
+    render(<Login expired />);
+    expect(screen.getByText(/your session expired/i)).toBeInTheDocument();
+  });
+
+  it('does NOT show expired banner by default', () => {
+    render(<Login />);
+    expect(screen.queryByText(/your session expired/i)).not.toBeInTheDocument();
+  });
+
+  it('signs in with email + password on submit', async () => {
+    render(<Login />);
+    await fillAndSubmit('me@example.com', 'pw');
+
+    await waitFor(() => {
+      expect(sharedSupabase.auth.signInWithPassword).toHaveBeenCalledWith({
+        email: 'me@example.com',
+        password: 'pw',
+      });
+    });
+  });
+
+  it('redirects to getPostLoginRoute on success when no returnTo', async () => {
+    render(<Login />);
+    await fillAndSubmit();
+
+    await waitFor(() => {
+      expect(getPostLoginRoute).toHaveBeenCalledWith('user-1');
+      expect(routerMocks.push).toHaveBeenCalledWith('/dashboard/test-company');
+    });
+  });
+
+  it('redirects to returnTo when it is a valid /dashboard path', async () => {
+    render(<Login returnTo="/dashboard/abc/quotes" />);
+    await fillAndSubmit();
+
+    await waitFor(() => {
+      expect(routerMocks.push).toHaveBeenCalledWith('/dashboard/abc/quotes');
+    });
+    // getPostLoginRoute should not be consulted when returnTo is valid
+    expect(getPostLoginRoute).not.toHaveBeenCalled();
+  });
+
+  it('falls back to getPostLoginRoute when returnTo is an open-redirect attempt', async () => {
+    render(<Login returnTo="https://evil.example.com/steal" />);
+    await fillAndSubmit();
+
+    await waitFor(() => {
+      expect(getPostLoginRoute).toHaveBeenCalled();
+      expect(routerMocks.push).toHaveBeenCalledWith('/dashboard/test-company');
+    });
+    // Never navigates to the attacker URL
+    expect(routerMocks.push).not.toHaveBeenCalledWith('https://evil.example.com/steal');
+  });
+
+  it('falls back to getPostLoginRoute when returnTo points at a non-allowlisted path', async () => {
+    render(<Login returnTo="/login" />);
+    await fillAndSubmit();
+
+    await waitFor(() => {
+      expect(routerMocks.push).toHaveBeenCalledWith('/dashboard/test-company');
+    });
+    expect(routerMocks.push).not.toHaveBeenCalledWith('/login');
+  });
+
+  it('shows the error from Supabase when sign-in fails', async () => {
+    // signInWithPassword resolves with the error nested in the response; the
+    // component throws it inside the try, which lands in the catch and runs
+    // `err instanceof Error ? err.message : ...`.
+    sharedSupabase.auth.signInWithPassword.mockResolvedValueOnce({
+      data: { user: null },
+      error: new Error('Invalid login credentials'),
+    });
+
+    render(<Login />);
+    await fillAndSubmit('wrong@example.com', 'wrong');
+
+    expect(
+      await screen.findByText('Invalid login credentials'),
+    ).toBeInTheDocument();
+    expect(routerMocks.push).not.toHaveBeenCalled();
+  });
+
+  it('does not push to a route when Supabase returns no user', async () => {
+    sharedSupabase.auth.signInWithPassword.mockResolvedValueOnce({
+      data: { user: null },
+      error: null,
+    });
+
+    render(<Login />);
+    await fillAndSubmit();
+
+    // Give async work a tick to settle without long waits.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(routerMocks.push).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/auth/SignUp.test.tsx
+++ b/__tests__/components/auth/SignUp.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import SignUp from '@/components/auth/SignUp';
+
+const sharedSupabase = {
+  auth: {
+    signUp: vi.fn(),
+  },
+};
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => sharedSupabase,
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+describe('SignUp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sharedSupabase.auth.signUp.mockResolvedValue({ data: { user: { id: 'u-1' } }, error: null });
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: new URL('http://localhost:3000/signup'),
+    });
+  });
+
+  async function fillForm(opts: {
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    password?: string;
+    confirm?: string;
+  } = {}) {
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/first name/i), opts.firstName ?? 'Ada');
+    await user.type(screen.getByLabelText(/last name/i), opts.lastName ?? 'Lovelace');
+    await user.type(screen.getByLabelText(/email/i), opts.email ?? 'ada@example.com');
+    await user.type(screen.getByLabelText(/^password/i), opts.password ?? 'hunter22');
+    await user.type(
+      screen.getByLabelText(/confirm password/i),
+      opts.confirm ?? opts.password ?? 'hunter22',
+    );
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+  }
+
+  it('renders the create-account form', () => {
+    render(<SignUp />);
+    expect(screen.getByRole('heading', { name: /create account/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/first name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+  });
+
+  it('rejects empty first/last names', async () => {
+    const user = userEvent.setup();
+    render(<SignUp />);
+    // Skip names; HTML `required` would normally block submit, but the
+    // component re-validates trimmed values too. Bypass HTML required by
+    // typing whitespace.
+    await user.type(screen.getByLabelText(/first name/i), '   ');
+    await user.type(screen.getByLabelText(/last name/i), '   ');
+    await user.type(screen.getByLabelText(/email/i), 'a@b.co');
+    await user.type(screen.getByLabelText(/^password/i), 'hunter22');
+    await user.type(screen.getByLabelText(/confirm password/i), 'hunter22');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    expect(
+      await screen.findByText(/first name and last name are required/i),
+    ).toBeInTheDocument();
+    expect(sharedSupabase.auth.signUp).not.toHaveBeenCalled();
+  });
+
+  it('rejects mismatched passwords', async () => {
+    render(<SignUp />);
+    await fillForm({ password: 'hunter22', confirm: 'hunter23' });
+
+    // The confirm-password field also shows an inline "Passwords do not match"
+    // hint while typing, so match the Alert role specifically.
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/passwords do not match/i);
+    expect(sharedSupabase.auth.signUp).not.toHaveBeenCalled();
+  });
+
+  it('rejects passwords shorter than 6 characters', async () => {
+    render(<SignUp />);
+    await fillForm({ password: 'pw1', confirm: 'pw1' });
+
+    expect(
+      await screen.findByText(/password must be at least 6 characters/i),
+    ).toBeInTheDocument();
+    expect(sharedSupabase.auth.signUp).not.toHaveBeenCalled();
+  });
+
+  it('calls signUp with metadata on valid submit', async () => {
+    render(<SignUp />);
+    await fillForm({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      email: 'ada@example.com',
+      password: 'analytical-engine',
+    });
+
+    await waitFor(() => {
+      expect(sharedSupabase.auth.signUp).toHaveBeenCalledWith({
+        email: 'ada@example.com',
+        password: 'analytical-engine',
+        options: {
+          emailRedirectTo: 'http://localhost:3000/auth/callback',
+          data: {
+            first_name: 'Ada',
+            last_name: 'Lovelace',
+            display_name: 'Ada Lovelace',
+          },
+        },
+      });
+    });
+  });
+
+  it('shows the success screen after signUp resolves', async () => {
+    render(<SignUp />);
+    await fillForm({ email: 'ada@example.com', password: 'hunter22' });
+
+    expect(await screen.findByText(/check your email/i)).toBeInTheDocument();
+    expect(screen.getByText('ada@example.com')).toBeInTheDocument();
+  });
+
+  it('shows the error message when signUp fails', async () => {
+    sharedSupabase.auth.signUp.mockResolvedValueOnce({
+      data: { user: null },
+      error: new Error('Email already registered'),
+    });
+
+    render(<SignUp />);
+    await fillForm();
+
+    expect(await screen.findByText(/email already registered/i)).toBeInTheDocument();
+    // Stays on the form (no success screen).
+    expect(screen.queryByText(/check your email/i)).not.toBeInTheDocument();
+  });
+
+  it('trims whitespace on first/last name before sending to Supabase', async () => {
+    render(<SignUp />);
+    await fillForm({
+      firstName: '  Grace  ',
+      lastName: '  Hopper  ',
+      password: 'hunter22',
+    });
+
+    await waitFor(() => {
+      const call = sharedSupabase.auth.signUp.mock.calls[0][0];
+      expect(call.options.data.first_name).toBe('Grace');
+      expect(call.options.data.last_name).toBe('Hopper');
+      expect(call.options.data.display_name).toBe('Grace Hopper');
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,17 +19,17 @@ export default defineConfig({
         '**/types/**',
       ],
       thresholds: {
-        // Floors set 3-5pp below measured-current on 2026-05-27 so natural
-        // fluctuation doesn't break builds, but adding untested code does.
-        // 3f sub-PRs ratchet these upward — bump in the same PR that adds
-        // the tests, never as a separate "increase threshold" PR.
+        // Ratchet: each 3f sub-PR that adds tests bumps these floors so the
+        // gain is locked in. Never lowered without a documented reason.
         //
-        // Measured 2026-05-27: statements 47.4%, branches 42.3%,
-        // functions 43.4%, lines 48.6%.
-        statements: 45,
-        branches: 38,
-        functions: 40,
-        lines: 45,
+        // 2026-05-27 (3e baseline): statements 47.4 / branches 42.3 /
+        //                           functions 43.4 / lines 48.6
+        // 2026-05-28 (3f auth): statements 50.0 / branches 44.85 /
+        //                       functions 45.95 / lines 51.36
+        statements: 48,
+        branches: 42,
+        functions: 43,
+        lines: 48,
       },
     },
   },


### PR DESCRIPTION
First sub-PR in the **3f series** (component coverage gaps). Auth flows are the entry point of the app — a regression locks every user out — so they're the highest-priority cluster from the plan.

## What's added

**25 new tests** across three previously-zero-coverage components:

| Component | Tests | What's covered |
|---|---|---|
| \`Login.tsx\` | 10 | Form render, expired prop, sign-in happy path, returnTo allowlist (including open-redirect rejection), error display, no-user response |
| \`SignUp.tsx\` | 8 | Form render, whitespace-name rejection, password mismatch, password length, signUp call shape, success screen, error display, whitespace trimming on metadata |
| \`CompanySelector.tsx\` | 7 | List render with roles, loading spinner, zero-company → /no-access redirect, fetch error, click → setLastCompany + navigate, setLastCompany failure → no nav, null-user skip |

The Login \`isValidReturnTo\` open-redirect guard is the most important test — it prevents an attacker from getting a victim to a malicious redirect after sign-in. Now has explicit coverage.

## Coverage ratchet

Vitest thresholds bumped (vitest.config.ts):

| Metric | 3e baseline | 3f (this PR) | Measured | Headroom |
|---|---|---|---|---|
| Statements | 45 | **48** | 50.00 | 2.00pp |
| Branches | 38 | **42** | 44.85 | 2.85pp |
| Functions | 40 | **43** | 45.95 | 2.95pp |
| Lines | 45 | **48** | 51.36 | 3.36pp |

Per the plan: bump the threshold in the same PR that adds the tests, never as a standalone "increase threshold" PR. Floor only goes up from here.

## Test counts

- Vitest: 356 → **381** (+25)
- Test files: 25 → **28** (+3)
- Skipped: 0 (no .skip / .todo)

## Out of scope (follow-up 3f sub-PRs)

Per the plan's priority list, next clusters are:
1. \`QuoteForm.tsx\` (core revenue flow)
2. \`StationQRCode.tsx\` / operations
3. Import UI — \`MappingReviewTable\`, \`ConflictDialog\`, \`ConfidenceChip\`
4. Untested \`utils/*Access.ts\` (bomAccess, jobsAccess, markupRatesAccess, routingsAccess, etc.)

Each will follow the same ratchet pattern.

## Test plan

- [x] \`pnpm test --run __tests__/components/auth/\` → 41 tests pass (10+8+7 new + 16 existing for AuthGuard/AdminGuard/ChangePassword)
- [x] \`pnpm test --run --coverage\` → all four metrics above the new thresholds
- [x] No \`.skip\` / \`.todo\` introduced
- [ ] CI passes (validated on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)