### PR TITLE
test(quotes): add 11 QuoteForm tests + ratchet thresholds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,7 @@ docs/usability-tests/
 scripts/data/
 
 # Supabase
-supabase/.temp/api/.coverage
+supabase/.temp/
+
+# pytest-cov artifact
+api/.coverage

--- a/__tests__/components/quotes/QuoteForm.test.tsx
+++ b/__tests__/components/quotes/QuoteForm.test.tsx
@@ -1,0 +1,277 @@
+/**
+ * QuoteForm tests focus on the contract between the form and its access
+ * layer — the calls to createQuote/updateQuote on submit, the cancel
+ * paths, and the validation gate. The component is large (~1k LOC) and
+ * mostly wires MUI inputs to state; exhaustive UI-interaction coverage
+ * isn't valuable here. The tests below assert behavior that would
+ * silently regress if the form changed: submit payload shape, navigation
+ * targets, and the no-customer/no-parts validation gates.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, routerMocks, resetRouterMocks } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import QuoteForm from '@/components/quotes/QuoteForm';
+import type { QuoteFormData } from '@/types/quote';
+
+// Quote access — primary surface under test
+const createQuote = vi.fn();
+const updateQuote = vi.fn();
+vi.mock('@/utils/quotesAccess', () => ({
+  createQuote: (...args: unknown[]) => createQuote(...args),
+  updateQuote: (...args: unknown[]) => updateQuote(...args),
+}));
+
+// Parts: hydrating initial part_ids on edit + by-id lookup
+const getPartsForSelectByIds = vi.fn();
+vi.mock('@/utils/partsAccess', () => ({
+  getPartsForSelectByIds: (...args: unknown[]) => getPartsForSelectByIds(...args),
+}));
+
+// Customers: dropdown + defaults
+const getAllCustomers = vi.fn();
+vi.mock('@/utils/customerAccess', () => ({
+  getAllCustomers: (...args: unknown[]) => getAllCustomers(...args),
+  pickBillingAddress: vi.fn(() => null),
+  pickShippingAddress: vi.fn(() => null),
+  pickPrimaryContact: vi.fn(() => null),
+}));
+
+// Pricing tiers — return non-empty so the validation tier-check passes
+const getTiersWithComputedPrices = vi.fn();
+vi.mock('@/utils/partPricingTiersAccess', () => ({
+  getTiersWithComputedPrices: (...args: unknown[]) => getTiersWithComputedPrices(...args),
+}));
+
+vi.mock('@/utils/quotePricingResolver', () => ({
+  // Always-resolves stub so validation only blocks on the cases this file tests.
+  resolveTier: vi.fn(() => ({
+    qty_break: 1,
+    markup_percent: 25,
+    unit_price: 50,
+  })),
+}));
+
+// Modal/autocomplete children — render nothing so the surface stays clean
+vi.mock('@/components/customers/CustomerFormModal', () => ({
+  default: () => null,
+}));
+vi.mock('@/components/parts/PartFormModal', () => ({
+  default: () => null,
+}));
+vi.mock('@/components/parts/PartAutocomplete', () => ({
+  default: () => null,
+}));
+
+const initialBlank: QuoteFormData = {
+  customer_id: '',
+  contact_id: '',
+  billing_address_id: '',
+  shipping_address_id: '',
+  parts: [],
+  lead_time_days: '',
+  expiration_date: '',
+};
+
+const initialPopulated: QuoteFormData = {
+  customer_id: 'cust-1',
+  contact_id: '',
+  billing_address_id: '',
+  shipping_address_id: '',
+  parts: [{ part_id: 'part-1', order_quantity: 5 }],
+  lead_time_days: '14',
+  expiration_date: '',
+};
+
+const hydratedPart = {
+  id: 'part-1',
+  part_name: 'BRKT-001',
+  description: 'Steel bracket',
+  has_routing: true,
+  is_stocked: false,
+  source: 'made' as const,
+  primary_unit: 'each',
+  quantity: 0,
+};
+
+describe('QuoteForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetRouterMocks();
+    getAllCustomers.mockResolvedValue([
+      { id: 'cust-1', name: 'Acme Corp', addresses: [], contacts: [] },
+      { id: 'cust-2', name: 'Beta LLC', addresses: [], contacts: [] },
+    ]);
+    getPartsForSelectByIds.mockResolvedValue([hydratedPart]);
+    getTiersWithComputedPrices.mockResolvedValue([
+      { id: 't1', part_id: 'part-1', qty_break: 1, markup_percent: 25, unit_price: 50 },
+    ]);
+    createQuote.mockResolvedValue({ quote: { id: 'new-quote-id' } });
+    updateQuote.mockResolvedValue({ id: 'edit-quote-id' });
+  });
+
+  it('renders the Create-quote button label in create mode', async () => {
+    render(<QuoteForm mode="create" initialData={initialBlank} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create quote/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /save changes/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the Save-changes button label in edit mode', async () => {
+    render(
+      <QuoteForm mode="edit" quoteId="q-1" initialData={initialPopulated} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /create quote/i })).not.toBeInTheDocument();
+  });
+
+  it('disables submit when validation fails (no customer)', async () => {
+    render(<QuoteForm mode="create" initialData={initialBlank} />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create quote/i })).toBeDisabled();
+    });
+  });
+
+  it('disables submit when validation passes initial guard but parts array is empty', async () => {
+    // Customer set, parts empty → "Add at least one part to the quote."
+    render(
+      <QuoteForm
+        mode="create"
+        initialData={{ ...initialBlank, customer_id: 'cust-1', lead_time_days: '14' }}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create quote/i })).toBeDisabled();
+    });
+  });
+
+  it('enables submit when initial data is fully valid (populated edit mode)', async () => {
+    render(
+      <QuoteForm mode="edit" quoteId="q-1" initialData={initialPopulated} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+  });
+
+  it('calls createQuote with the payload and navigates on success', async () => {
+    render(<QuoteForm mode="create" initialData={initialPopulated} />);
+
+    // Wait for hydration + tiers
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create quote/i })).toBeEnabled();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /create quote/i }));
+
+    await waitFor(() => {
+      expect(createQuote).toHaveBeenCalledTimes(1);
+    });
+    const [companyId, payload] = createQuote.mock.calls[0];
+    expect(companyId).toBe('test-company-id'); // from test-utils useParams mock
+    expect(payload.customer_id).toBe('cust-1');
+    expect(payload.lead_time_days).toBe('14');
+    expect(payload.parts).toEqual([{ part_id: 'part-1', order_quantity: 5 }]);
+
+    await waitFor(() => {
+      expect(routerMocks.push).toHaveBeenCalledWith(
+        '/dashboard/test-company-id/quotes/new-quote-id',
+      );
+    });
+  });
+
+  it('calls updateQuote with the payload and navigates on success', async () => {
+    render(
+      <QuoteForm mode="edit" quoteId="q-existing" initialData={initialPopulated} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(updateQuote).toHaveBeenCalledTimes(1);
+    });
+    const [quoteId, payload] = updateQuote.mock.calls[0];
+    expect(quoteId).toBe('q-existing');
+    expect(payload.customer_id).toBe('cust-1');
+
+    await waitFor(() => {
+      expect(routerMocks.push).toHaveBeenCalledWith(
+        '/dashboard/test-company-id/quotes/q-existing',
+      );
+    });
+    expect(createQuote).not.toHaveBeenCalled();
+  });
+
+  it('shows an error Alert when createQuote rejects', async () => {
+    createQuote.mockRejectedValueOnce(new Error('Quote-number trigger failed'));
+    render(<QuoteForm mode="create" initialData={initialPopulated} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create quote/i })).toBeEnabled();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /create quote/i }));
+
+    expect(
+      await screen.findByText(/quote-number trigger failed/i),
+    ).toBeInTheDocument();
+    expect(routerMocks.push).not.toHaveBeenCalled();
+  });
+
+  it('calls onCancel when provided and does not navigate back', async () => {
+    const onCancel = vi.fn();
+    render(
+      <QuoteForm mode="create" initialData={initialBlank} onCancel={onCancel} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(routerMocks.back).not.toHaveBeenCalled();
+  });
+
+  it('calls router.back when cancelled without an onCancel prop', async () => {
+    render(<QuoteForm mode="create" initialData={initialBlank} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(routerMocks.back).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onSave callback after a successful create', async () => {
+    const onSave = vi.fn();
+    render(
+      <QuoteForm mode="create" initialData={initialPopulated} onSave={onSave} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create quote/i })).toBeEnabled();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /create quote/i }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,14 +22,18 @@ export default defineConfig({
         // Ratchet: each 3f sub-PR that adds tests bumps these floors so the
         // gain is locked in. Never lowered without a documented reason.
         //
-        // 2026-05-27 (3e baseline): statements 47.4 / branches 42.3 /
-        //                           functions 43.4 / lines 48.6
-        // 2026-05-28 (3f auth): statements 50.0 / branches 44.85 /
-        //                       functions 45.95 / lines 51.36
-        statements: 48,
-        branches: 42,
+        // 2026-05-27 (3e baseline):  statements 47.4 / branches 42.3 /
+        //                            functions 43.4 / lines 48.6
+        // 2026-05-28 (3f auth):      statements 50.0 / branches 44.85 /
+        //                            functions 45.95 / lines 51.36
+        // 2026-05-28 (3f QuoteForm): statements 50.37 / branches 45.65 /
+        //                            functions 44.77 / lines 51.78
+        // (functions dropped because QuoteForm added more uncovered
+        // functions than the 11 new tests covered. Floor stays at 43.)
+        statements: 49,
+        branches: 44,
         functions: 43,
-        lines: 48,
+        lines: 50,
       },
     },
   },


### PR DESCRIPTION
Second sub-PR in the **3f series** (component coverage gaps). \`QuoteForm.tsx\` is the core revenue flow per the plan's priority list; previously had zero coverage.

## What's added

**11 tests** in \`__tests__/components/quotes/QuoteForm.test.tsx\`, focused on the contract between the form and its access layer rather than exhaustive UI-interaction coverage. The component is ~1k LOC; the tests assert behavior that would silently regress on a refactor:

| Area | Tests | Notes |
|---|---|---|
| Render | 2 | Create-mode button label, edit-mode button label |
| Validation gates | 3 | No-customer disables submit, empty parts disables submit, populated initial data enables submit |
| Submit happy path | 2 | \`createQuote\` + router.push for create; \`updateQuote\` + router.push for edit; payload shape asserted |
| Submit error | 1 | \`createQuote\` rejection → Alert, no navigation |
| Cancel | 2 | \`onCancel\` prop wins over \`router.back\`; \`router.back\` fires when no \`onCancel\` |
| Callbacks | 1 | \`onSave\` fires after successful create |

Child modals (\`CustomerFormModal\`, \`PartFormModal\`, \`PartAutocomplete\`) are stubbed to render nothing — keeps the test surface focused on QuoteForm's own behavior.

## Coverage ratchet

Measured 2026-05-28 (this PR): statements 50.37 / branches 45.65 / functions 44.77 / lines 51.78.

**Functions dropped 1.18pp** (45.95 → 44.77) because adding QuoteForm.tsx to the analyzed denominator outpaced the 11 new tests. Floor stays at 43. Other metrics ratchet:

| Metric | Prior (3f-auth) | This PR | Measured | Headroom |
|---|---|---|---|---|
| Statements | 48 | **49** | 50.37 | 1.37pp |
| Branches | 42 | **44** | 45.65 | 1.65pp |
| Functions | 43 | **43** (held) | 44.77 | 1.77pp |
| Lines | 48 | **50** | 51.78 | 1.78pp |

Per the plan: ratchet what improved, hold what regressed. Future 3f sub-PRs add QuoteForm interaction tests (line-item add/remove, customer-modal flow, address resolution) which will recover the function-coverage drop.

## Test counts

- Vitest: 381 → **392** (+11)
- Test files: 28 → **29** (+1)
- 0 skips, 0 failures

## Cleanup

\`.gitignore\` fixed: 3f-auth's add accidentally joined \`supabase/.temp/\` and \`api/.coverage\` into a single nonsense path. Both are now ignored correctly.

## Out of scope

Per the priority list, next clusters:
1. \`StationQRCode\` / operations
2. Import UI (\`MappingReviewTable\`, \`ConflictDialog\`, \`ConfidenceChip\`)
3. Untested \`utils/*Access.ts\` (bom, jobs, markup-rates, routings, vendors, work-centers, shipments, …)

Each follows the same ratchet pattern.

## Test plan

- [x] \`pnpm test --run __tests__/components/quotes/QuoteForm.test.tsx\` → 11 passed
- [x] \`pnpm test --run --coverage\` → all four metrics ≥ new thresholds
- [x] 0 .skip / .todo introduced
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)