### PR TITLE
test(operations): add 11 StationQRCode tests + ratchet functions floor

### DIFF
--- a/__tests__/components/operations/StationQRCode.test.tsx
+++ b/__tests__/components/operations/StationQRCode.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * StationQRCode renders a QR code linking to /operator/{companyId}/login
+ * and exposes a "Download PDF" button that bundles the QR + station name
+ * into a printable sheet. These tests assert:
+ *   - the QR's encoded URL matches the station-link contract
+ *   - the "Open Operator View" link mirrors the QR URL
+ *   - the PDF flow respects the optional companyName / operationCode props
+ *     (file name, text blocks added)
+ *   - the PDF button is a no-op when the canvas isn't yet in the DOM
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import StationQRCode from '@/components/operations/StationQRCode';
+
+// Stub qrcode.react: render a div carrying the encoded value as data-attr
+// so we can assert against it without depending on canvas internals.
+vi.mock('qrcode.react', () => ({
+  QRCodeCanvas: ({ value, size }: { value: string; size: number }) => (
+    <div data-testid="qr-canvas" data-value={value} data-size={size}>
+      <canvas data-testid="qr-canvas-element" />
+    </div>
+  ),
+}));
+
+// Stub jsPDF — capture every call so the test can assert on the PDF
+// content shape without parsing PDF bytes. The component uses `new jsPDF(...)`
+// so the export must be a constructable function (not an arrow).
+const pdfText = vi.fn();
+const pdfAddImage = vi.fn();
+const pdfSave = vi.fn();
+const pdfSetFontSize = vi.fn();
+const pdfSetTextColor = vi.fn();
+const pdfGetWidth = vi.fn(() => 210); // A4 width in mm
+const pdfGetHeight = vi.fn(() => 297);
+vi.mock('jspdf', () => ({
+  jsPDF: function MockJsPdf() {
+    return {
+      setFontSize: pdfSetFontSize,
+      setTextColor: pdfSetTextColor,
+      text: pdfText,
+      addImage: pdfAddImage,
+      save: pdfSave,
+      internal: {
+        pageSize: { getWidth: pdfGetWidth, getHeight: pdfGetHeight },
+      },
+    };
+  },
+}));
+
+const baseProps = {
+  operationTypeId: 'wc-lathe-01',
+  operationName: 'CNC Lathe 1',
+  companyId: 'co-acme',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Pin the origin so the QR URL is deterministic.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: new URL('http://localhost:3000/dashboard/co-acme/work-centers/wc-lathe-01'),
+  });
+  // Stub HTMLCanvasElement.toDataURL since jsdom returns "" for it.
+  HTMLCanvasElement.prototype.toDataURL = vi.fn(
+    () => 'data:image/png;base64,stub-canvas',
+  );
+});
+
+describe('StationQRCode', () => {
+  it('renders the QR code with the operator-login URL', () => {
+    render(<StationQRCode {...baseProps} />);
+
+    const qr = screen.getByTestId('qr-canvas');
+    expect(qr.getAttribute('data-value')).toBe(
+      'http://localhost:3000/operator/co-acme/login?station=wc-lathe-01',
+    );
+  });
+
+  it('uses the size prop on the QR canvas (default 200)', () => {
+    const { rerender } = render(<StationQRCode {...baseProps} />);
+    expect(screen.getByTestId('qr-canvas').getAttribute('data-size')).toBe('200');
+
+    rerender(<StationQRCode {...baseProps} size={350} />);
+    expect(screen.getByTestId('qr-canvas').getAttribute('data-size')).toBe('350');
+  });
+
+  it('"Open Operator View" link points at the same operator URL', () => {
+    render(<StationQRCode {...baseProps} />);
+    const link = screen.getByRole('link', { name: /open operator view/i });
+    expect(link).toHaveAttribute(
+      'href',
+      'http://localhost:3000/operator/co-acme/login?station=wc-lathe-01',
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('downloads a PDF with operationName-derived filename on button click', async () => {
+    render(<StationQRCode {...baseProps} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /download pdf/i }));
+
+    expect(pdfSave).toHaveBeenCalledTimes(1);
+    expect(pdfSave).toHaveBeenCalledWith('CNC-Lathe-1-station-qr.pdf');
+    expect(pdfAddImage).toHaveBeenCalledWith(
+      'data:image/png;base64,stub-canvas',
+      'PNG',
+      expect.any(Number),
+      expect.any(Number),
+      80,
+      80,
+    );
+  });
+
+  it('writes the station name into the PDF at all times', async () => {
+    render(<StationQRCode {...baseProps} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /download pdf/i }));
+
+    // Station name appears in pdf.text calls
+    const textCalls = pdfText.mock.calls;
+    expect(textCalls.some((c) => c[0] === 'CNC Lathe 1')).toBe(true);
+  });
+
+  it('writes companyName above the station name when provided', async () => {
+    render(<StationQRCode {...baseProps} companyName="Acme Precision" />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /download pdf/i }));
+
+    const textCalls = pdfText.mock.calls;
+    expect(textCalls.some((c) => c[0] === 'Acme Precision')).toBe(true);
+  });
+
+  it('omits companyName from the PDF when not provided', async () => {
+    render(<StationQRCode {...baseProps} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /download pdf/i }));
+
+    const textCalls = pdfText.mock.calls;
+    expect(textCalls.some((c) => c[0] === 'Acme Precision')).toBe(false);
+  });
+
+  it('writes operationCode under the QR when provided', async () => {
+    render(<StationQRCode {...baseProps} operationCode="WC-001" />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /download pdf/i }));
+
+    const textCalls = pdfText.mock.calls;
+    expect(textCalls.some((c) => c[0] === 'WC-001')).toBe(true);
+  });
+
+  it('omits operationCode from the PDF when not provided', async () => {
+    render(<StationQRCode {...baseProps} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /download pdf/i }));
+
+    // No call with a code-shaped second arg "WC-xxx". Spot-check that the
+    // station name is the only large-font text.
+    const textCalls = pdfText.mock.calls;
+    expect(textCalls.some((c) => c[0] === 'WC-001')).toBe(false);
+  });
+
+  it('replaces whitespace in the filename with hyphens', async () => {
+    render(<StationQRCode {...baseProps} operationName="  Heat Treat   Bay 3 " />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /download pdf/i }));
+
+    expect(pdfSave).toHaveBeenCalledWith('-Heat-Treat-Bay-3--station-qr.pdf');
+  });
+
+  it('is a no-op when no canvas is present (defensive guard)', async () => {
+    // Re-stub QRCodeCanvas to NOT render a <canvas> inside the ref'd div.
+    // The handleDownloadPDF guard returns early if querySelector('canvas')
+    // is null.
+    vi.doMock('qrcode.react', () => ({
+      QRCodeCanvas: () => <div data-testid="qr-canvas" />,
+    }));
+    // Need a fresh import; reset the module registry.
+    vi.resetModules();
+    const { default: Comp } = await import('@/components/operations/StationQRCode');
+
+    render(<Comp {...baseProps} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /download pdf/i }));
+
+    expect(pdfSave).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,13 +26,13 @@ export default defineConfig({
         //                            functions 43.4 / lines 48.6
         // 2026-05-28 (3f auth):      statements 50.0 / branches 44.85 /
         //                            functions 45.95 / lines 51.36
-        // 2026-05-28 (3f QuoteForm): statements 50.37 / branches 45.65 /
-        //                            functions 44.77 / lines 51.78
-        // (functions dropped because QuoteForm added more uncovered
-        // functions than the 11 new tests covered. Floor stays at 43.)
+        // 2026-05-28 (3f QuoteForm):   statements 50.37 / branches 45.65 /
+        //                              functions 44.77 / lines 51.78
+        // 2026-05-28 (3f StationQRCode): statements 50.83 / branches 45.89 /
+        //                                functions 45.07 / lines 52.26
         statements: 49,
         branches: 44,
-        functions: 43,
+        functions: 44,
         lines: 50,
       },
     },


### PR DESCRIPTION
Third sub-PR in the **3f series**. \`StationQRCode\` is the only file in \`components/operations/\`; previously zero coverage. The component renders a QR code operators scan to open the per-station Operator View, plus a "Download PDF" button to print the QR onto an A4 sheet.

## What's added

11 tests in \`__tests__/components/operations/StationQRCode.test.tsx\`:

| Area | Coverage |
|---|---|
| QR contract | Encoded URL matches \`/operator/{companyId}/login?station={typeId}\`; size prop forwarded; "Open Operator View" link mirrors the QR URL |
| PDF generation | Filename derived from operationName (whitespace → hyphens); station name always present; companyName + operationCode conditionally included/omitted |
| Defensive guard | No-op when no \`<canvas>\` is present (e.g. QR mid-mount) |

## Mocks

- \`qrcode.react\` → stub \`QRCodeCanvas\` as \`<div>\` + inner \`<canvas>\` so the encoded value is assertable and the canvas is reachable via the component's \`qrRef.querySelector\` guard
- \`jspdf\` → stub as a regular function (not arrow — arrow functions can't be \`new\`'d). Captures every \`text\` / \`addImage\` / \`save\` call so tests assert on PDF shape without parsing PDF bytes
- \`HTMLCanvasElement.prototype.toDataURL\` → stub to a deterministic data URL (jsdom returns \`""\`)
- \`window.location\` → pinned origin so the QR URL is reproducible

## Coverage ratchet

Measured 2026-05-28 (this PR): statements 50.83 / branches 45.89 / functions 45.07 / lines 52.26.

| Metric | Prior (3f-QuoteForm) | This PR | Measured | Headroom |
|---|---|---|---|---|
| Statements | 49 | **49** (held) | 50.83 | 1.83pp |
| Branches | 44 | **44** (held) | 45.89 | 1.89pp |
| Functions | 43 | **44** | 45.07 | 1.07pp |
| Lines | 50 | **50** (held) | 52.26 | 2.26pp |

Functions bump locks in the recovery from QuoteForm's earlier 1.18pp drop. Other metrics gained < 0.5pp — not worth threshold churn.

## Test counts

- Vitest: 392 → **403** (+11)
- Test files: 29 → **30** (+1)
- 0 skips, 0 failures

## Out of scope (next 3f sub-PRs)

1. **Import UI** — \`MappingReviewTable\`, \`ConflictDialog\`, \`ConfidenceChip\` (zero coverage, AI-mapping path is complex)
2. **Untested \`utils/*Access.ts\`** — bom, jobs, markup-rates, routings, vendors, work-centers, shipments

## Test plan

- [x] \`pnpm test --run __tests__/components/operations/StationQRCode.test.tsx\` → 11 passed
- [x] \`pnpm test --run --coverage\` → all four metrics ≥ thresholds
- [x] 0 \`.skip\` / \`.todo\` introduced
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)