### PR TITLE
test(import,utils): 67 tests for import UI + 6 access files + ratchet

### DIFF
--- a/__tests__/components/import/ConfidenceChip.test.tsx
+++ b/__tests__/components/import/ConfidenceChip.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '../../test-utils';
+import ConfidenceChip from '@/components/import/ConfidenceChip';
+
+/**
+ * ConfidenceChip rules:
+ *   isManual → "Manual" + "Selected by user" tooltip
+ *   confidence ≥ 0.8 → color="success", label="{pct}%"
+ *   confidence ≥ 0.5 → color="warning"
+ *   confidence < 0.5 → color="error"
+ *   reasoning prop wraps the chip in a Tooltip
+ *
+ * Asserting on the rendered color class avoids depending on MUI internals;
+ * the chip role is exposed via role="generic" by MUI, so we anchor on label
+ * text + class names.
+ */
+describe('ConfidenceChip', () => {
+  it('renders the percentage label for high-confidence scores', () => {
+    render(<ConfidenceChip confidence={0.95} />);
+    expect(screen.getByText('95%')).toBeInTheDocument();
+  });
+
+  it('renders the percentage label for medium-confidence scores', () => {
+    render(<ConfidenceChip confidence={0.65} />);
+    expect(screen.getByText('65%')).toBeInTheDocument();
+  });
+
+  it('renders the percentage label for low-confidence scores', () => {
+    render(<ConfidenceChip confidence={0.30} />);
+    expect(screen.getByText('30%')).toBeInTheDocument();
+  });
+
+  it('uses success color at exactly the 0.8 threshold', () => {
+    const { container } = render(<ConfidenceChip confidence={0.8} />);
+    const chip = container.querySelector('.MuiChip-colorSuccess');
+    expect(chip).not.toBeNull();
+  });
+
+  it('uses warning color at exactly the 0.5 threshold (below 0.8)', () => {
+    const { container } = render(<ConfidenceChip confidence={0.5} />);
+    const chip = container.querySelector('.MuiChip-colorWarning');
+    expect(chip).not.toBeNull();
+  });
+
+  it('uses error color just below 0.5', () => {
+    const { container } = render(<ConfidenceChip confidence={0.49} />);
+    const chip = container.querySelector('.MuiChip-colorError');
+    expect(chip).not.toBeNull();
+  });
+
+  it('rounds confidence to nearest whole percent', () => {
+    render(<ConfidenceChip confidence={0.756} />);
+    expect(screen.getByText('76%')).toBeInTheDocument();
+  });
+
+  it('shows the Manual chip + tooltip when isManual=true regardless of confidence', () => {
+    render(<ConfidenceChip confidence={0.42} isManual />);
+    expect(screen.getByText('Manual')).toBeInTheDocument();
+    // Confidence label suppressed.
+    expect(screen.queryByText('42%')).not.toBeInTheDocument();
+  });
+
+  it('honors the size prop (medium) on the chip element', () => {
+    const { container } = render(<ConfidenceChip confidence={0.9} size="medium" />);
+    // MUI uses .MuiChip-sizeSmall by default; medium drops that class.
+    expect(container.querySelector('.MuiChip-sizeSmall')).toBeNull();
+  });
+});

--- a/__tests__/components/import/ConflictDialog.test.tsx
+++ b/__tests__/components/import/ConflictDialog.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import ConflictDialog from '@/components/import/ConflictDialog';
+
+interface TestConflict {
+  row_number: number;
+  customer_code?: string;
+  name?: string;
+  existing_value?: string;
+}
+
+interface TestError {
+  row_number: number;
+  message?: string;
+  field?: string;
+}
+
+const conflictColumns = [
+  { key: 'customer_code' as const, label: 'Code' },
+  { key: 'name' as const, label: 'Name' },
+];
+
+function renderDialog(overrides: Partial<React.ComponentProps<typeof ConflictDialog<TestConflict, TestError>>> = {}) {
+  const onCancel = vi.fn();
+  const onConfirm = vi.fn();
+  const props = {
+    open: true,
+    conflicts: [] as TestConflict[],
+    validationErrors: [] as TestError[],
+    validRowsCount: 0,
+    totalRows: 0,
+    onCancel,
+    onConfirm,
+    entityName: 'Customers',
+    conflictColumns,
+    getConflictLabel: (c: TestConflict) => `Duplicate code ${c.customer_code}`,
+    getErrorMessage: (e: TestError) => e.message ?? 'Unknown error',
+    ...overrides,
+  } as React.ComponentProps<typeof ConflictDialog<TestConflict, TestError>>;
+  return { onCancel, onConfirm, ...render(<ConflictDialog {...props} />) };
+}
+
+// Capture the genuine createElement ONCE so the spy below doesn't recurse on
+// itself (which would otherwise blow the stack across tests).
+const realCreateElement = document.createElement.bind(document);
+
+describe('ConflictDialog', () => {
+  // Mock the browser download primitives once for the whole suite.
+  const createObjectURL = vi.fn(() => 'blob:mock-url');
+  const revokeObjectURL = vi.fn();
+  const linkClick = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    Object.assign(URL, { createObjectURL, revokeObjectURL });
+    // Hook only the anchor path used by downloadCsv. Everything else uses
+    // the real createElement.
+    vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+      const el = realCreateElement(tag);
+      if (tag === 'a') {
+        el.click = linkClick;
+      }
+      return el;
+    }) as typeof document.createElement);
+  });
+
+  it('renders the headline counts (can-import / will-skip / total)', () => {
+    renderDialog({
+      conflicts: [{ row_number: 2, customer_code: 'DUP' }],
+      validationErrors: [{ row_number: 3, message: 'Missing name' }],
+      validRowsCount: 8,
+      totalRows: 10,
+    });
+
+    // Headline counts render as h4. Anchor on that selector to avoid
+    // matching row numbers in the conflict / error tables.
+    const headlineNumbers = document.querySelectorAll('.MuiTypography-h4');
+    const values = Array.from(headlineNumbers).map((el) => el.textContent);
+    expect(values).toEqual(['8', '2', '10']);
+  });
+
+  it('de-duplicates the skipped count when a row appears in both lists', () => {
+    renderDialog({
+      conflicts: [{ row_number: 5, customer_code: 'DUP' }],
+      validationErrors: [{ row_number: 5, message: 'Missing name' }],
+      validRowsCount: 1,
+      totalRows: 2,
+    });
+
+    // Row 5 in both lists → skipped count should be 1 (de-duped), not 2.
+    const headlineNumbers = document.querySelectorAll('.MuiTypography-h4');
+    const values = Array.from(headlineNumbers).map((el) => el.textContent);
+    // [valid, skipped, total]
+    expect(values).toEqual(['1', '1', '2']);
+  });
+
+  it('disables the import button when validRowsCount is 0', () => {
+    renderDialog({ validRowsCount: 0, totalRows: 3 });
+    const btn = screen.getByRole('button', { name: /import 0 customers/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('enables the import button and labels it with the count', () => {
+    renderDialog({ validRowsCount: 7 });
+    const btn = screen.getByRole('button', { name: /import 7 customers/i });
+    expect(btn).toBeEnabled();
+  });
+
+  it('calls onConfirm when the import button is clicked', async () => {
+    const { onConfirm } = renderDialog({ validRowsCount: 3 });
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /import 3 customers/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when Cancel Import is clicked', async () => {
+    const { onCancel } = renderDialog();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /cancel import/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the conflicts table with row + custom columns', () => {
+    renderDialog({
+      conflicts: [
+        { row_number: 2, customer_code: 'ACME', name: 'Acme Corp', existing_value: 'ACME01' },
+      ],
+      validRowsCount: 0,
+      totalRows: 1,
+    });
+    expect(screen.getByText(/conflicting rows \(1\)/i)).toBeInTheDocument();
+    expect(screen.getByText('ACME')).toBeInTheDocument();
+    expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+    expect(screen.getByText('Duplicate code ACME')).toBeInTheDocument();
+    expect(screen.getByText('ACME01')).toBeInTheDocument();
+  });
+
+  it('renders the validation errors table with error messages', () => {
+    renderDialog({
+      validationErrors: [
+        { row_number: 5, message: 'name is required' },
+        { row_number: 9, message: 'email format invalid' },
+      ],
+      validRowsCount: 0,
+      totalRows: 2,
+    });
+    expect(screen.getByText(/validation errors \(2\)/i)).toBeInTheDocument();
+    expect(screen.getByText('name is required')).toBeInTheDocument();
+    expect(screen.getByText('email format invalid')).toBeInTheDocument();
+  });
+
+  it('downloads a CSV when "Download CSV" for conflicts is clicked', async () => {
+    renderDialog({
+      conflicts: [{ row_number: 2, customer_code: 'ACME', existing_value: 'ACME01' }],
+      validRowsCount: 0,
+      totalRows: 1,
+    });
+    const user = userEvent.setup();
+    const buttons = screen.getAllByRole('button', { name: /download csv/i });
+    await user.click(buttons[0]);
+    expect(createObjectURL).toHaveBeenCalled();
+    expect(linkClick).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('hides the conflicts table when there are no conflicts', () => {
+    renderDialog({
+      conflicts: [],
+      validationErrors: [{ row_number: 1, message: 'bad' }],
+      validRowsCount: 0,
+      totalRows: 1,
+    });
+    expect(screen.queryByText(/conflicting rows/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/validation errors/i)).toBeInTheDocument();
+  });
+
+  it('hides the validation-errors table when there are no errors', () => {
+    renderDialog({
+      conflicts: [{ row_number: 1, customer_code: 'X' }],
+      validRowsCount: 0,
+      totalRows: 1,
+    });
+    expect(screen.getByText(/conflicting rows/i)).toBeInTheDocument();
+    expect(screen.queryByText(/validation errors/i)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/import/MappingReviewTable.test.tsx
+++ b/__tests__/components/import/MappingReviewTable.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import MappingReviewTable from '@/components/import/MappingReviewTable';
+import type { ColumnMapping, FieldDefinition } from '@/components/import/types';
+
+const fields: FieldDefinition[] = [
+  { key: 'customer_code', label: 'Customer Code', required: true },
+  { key: 'name', label: 'Company Name', required: true },
+  { key: 'email', label: 'Email', required: false },
+  { key: 'phone', label: 'Phone', required: false },
+];
+
+function makeMapping(overrides: Partial<ColumnMapping> = {}): ColumnMapping {
+  return {
+    csv_column: 'CSV Column',
+    db_field: 'name',
+    confidence: 0.9,
+    reasoning: 'Names match closely',
+    needs_review: false,
+    ...overrides,
+  };
+}
+
+function renderTable(overrides: Partial<React.ComponentProps<typeof MappingReviewTable>> = {}) {
+  const onMappingChange = vi.fn();
+  const props: React.ComponentProps<typeof MappingReviewTable> = {
+    mappings: [makeMapping()],
+    fields,
+    unmappedRequired: [],
+    unmappedOptional: [],
+    discardedColumns: [],
+    onMappingChange,
+    ...overrides,
+  };
+  return { onMappingChange, ...render(<MappingReviewTable {...props} />) };
+}
+
+describe('MappingReviewTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders one row per mapping with csv_column + reasoning', () => {
+    renderTable({
+      mappings: [
+        makeMapping({ csv_column: 'Code', db_field: 'customer_code', reasoning: 'Direct match' }),
+        makeMapping({ csv_column: 'Name', db_field: 'name', reasoning: 'Names match' }),
+      ],
+    });
+
+    expect(screen.getByText('Code')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Direct match')).toBeInTheDocument();
+    expect(screen.getByText('Names match')).toBeInTheDocument();
+  });
+
+  it('hides the needs-review alert when no mappings need review', () => {
+    renderTable({ mappings: [makeMapping({ needs_review: false })] });
+    expect(screen.queryByText(/needs? review/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the needs-review alert with singular wording for one needs-review mapping', () => {
+    renderTable({
+      mappings: [
+        makeMapping({ csv_column: 'Phn', db_field: 'phone', needs_review: true, confidence: 0.4 }),
+      ],
+    });
+    // Plural-vs-singular: "1 column needs review (highlighted in yellow below)"
+    expect(screen.getByText(/^1 column needs review/i)).toBeInTheDocument();
+  });
+
+  it('shows the needs-review alert with plural wording for multiple', () => {
+    renderTable({
+      mappings: [
+        makeMapping({ csv_column: 'A', db_field: 'name', needs_review: true, confidence: 0.4 }),
+        makeMapping({ csv_column: 'B', db_field: 'phone', needs_review: true, confidence: 0.4 }),
+      ],
+    });
+    expect(screen.getByText(/^2 columns need review/i)).toBeInTheDocument();
+  });
+
+  it('ignores needs_review when db_field is null (would-skip mappings)', () => {
+    renderTable({
+      mappings: [makeMapping({ db_field: null, needs_review: true })],
+    });
+    // The "needs review" count gates on `db_field !== null`.
+    expect(screen.queryByText(/needs? review/i)).not.toBeInTheDocument();
+  });
+
+  it('calls onMappingChange with the new db_field when the user changes the dropdown', async () => {
+    const { onMappingChange } = renderTable({
+      mappings: [
+        makeMapping({ csv_column: 'CodeCol', db_field: 'name' }),
+      ],
+    });
+    const user = userEvent.setup();
+    // Open the Select; MUI renders as combobox role
+    const select = screen.getByRole('combobox');
+    await user.click(select);
+    // The listbox is rendered as a portal — query against `document` rather
+    // than the existing render tree.
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText('Customer Code *'));
+
+    expect(onMappingChange).toHaveBeenCalledWith('CodeCol', 'customer_code');
+  });
+
+  it('calls onMappingChange with null when "Skip" is selected', async () => {
+    const { onMappingChange } = renderTable({
+      mappings: [makeMapping({ csv_column: 'Extra', db_field: 'phone' })],
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('combobox'));
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText(/skip \(don't import\)/i));
+
+    expect(onMappingChange).toHaveBeenCalledWith('Extra', null);
+  });
+
+  it('opens the reassignment dialog when the user picks an already-assigned db_field', async () => {
+    const { onMappingChange } = renderTable({
+      mappings: [
+        makeMapping({ csv_column: 'A', db_field: 'name' }),
+        makeMapping({ csv_column: 'B', db_field: 'email' }),
+      ],
+    });
+    const user = userEvent.setup();
+    // Open the SECOND combobox and try to pick 'name' (already assigned to A)
+    const combos = screen.getAllByRole('combobox');
+    await user.click(combos[1]);
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText('Company Name *'));
+
+    // ReassignmentDialog should open; onMappingChange should NOT fire yet
+    // (it fires after the user confirms in the dialog).
+    expect(onMappingChange).not.toHaveBeenCalled();
+  });
+
+  it('renders a ConfidenceChip in the table only when db_field is non-null', () => {
+    const { container } = renderTable({
+      mappings: [
+        makeMapping({ csv_column: 'Has', db_field: 'name', confidence: 0.9 }),
+        makeMapping({ csv_column: 'Skipped', db_field: null }),
+      ],
+    });
+    // Two rows, one chip — chip lives inside the Confidence column.
+    const chips = container.querySelectorAll('.MuiChip-root');
+    expect(chips.length).toBe(1);
+  });
+});

--- a/__tests__/utils/bomAccess.test.ts
+++ b/__tests__/utils/bomAccess.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
+  const builder: Record<string, ReturnType<typeof vi.fn> | unknown> = {};
+  const chainMethods = [
+    'from', 'select', 'insert', 'update', 'delete',
+    'eq', 'neq', 'or', 'in', 'order', 'limit', 'single', 'maybeSingle',
+  ];
+  chainMethods.forEach((m) => {
+    builder[m] = vi.fn().mockImplementation(() => builder);
+  });
+  builder.data = null;
+  builder.error = null;
+  const supabase = {
+    from: vi.fn().mockImplementation(() => builder),
+  };
+  return { mockQueryBuilder: builder, mockSupabase: supabase };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+
+import {
+  getBomForPart,
+  getBomParents,
+  getPartIdsWithBomLines,
+  checkBomCycle,
+  deleteBomLine,
+} from '@/utils/bomAccess';
+
+describe('bomAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(() => mockQueryBuilder);
+    Object.keys(mockQueryBuilder).forEach((k) => {
+      const v = mockQueryBuilder[k];
+      if (typeof v === 'function' && 'mockClear' in v) {
+        (v as ReturnType<typeof vi.fn>).mockClear();
+        (v as ReturnType<typeof vi.fn>).mockImplementation(() => mockQueryBuilder);
+      }
+    });
+    mockQueryBuilder.data = null;
+    mockQueryBuilder.error = null;
+  });
+
+  describe('getBomForPart', () => {
+    it('queries parts_bom by parent_part_id and shapes the joined child', async () => {
+      mockQueryBuilder.data = [
+        {
+          id: 'b1',
+          parent_part_id: 'p1',
+          child_part_id: 'c1',
+          quantity: '2.5',
+          unit: 'EA',
+          sequence: 10,
+          created_at: null,
+          updated_at: null,
+          child_part: {
+            id: 'c1',
+            part_name: 'Screw',
+            description: null,
+            primary_unit: 'EA',
+            is_stocked: true,
+            source: 'bought',
+          },
+        },
+      ];
+      const rows = await getBomForPart('p1');
+      expect(mockSupabase.from).toHaveBeenCalledWith('parts_bom');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('parent_part_id', 'p1');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].quantity).toBe(2.5);
+      expect(rows[0].child_part.part_name).toBe('Screw');
+    });
+
+    it('drops rows where the joined child is missing', async () => {
+      mockQueryBuilder.data = [
+        {
+          id: 'b1',
+          parent_part_id: 'p1',
+          child_part_id: 'c1',
+          quantity: '1',
+          unit: 'EA',
+          sequence: 10,
+          created_at: null,
+          updated_at: null,
+          child_part: null,
+        },
+      ];
+      const rows = await getBomForPart('p1');
+      expect(rows).toEqual([]);
+    });
+
+    it('throws when supabase returns an error', async () => {
+      mockQueryBuilder.error = { message: 'boom' };
+      await expect(getBomForPart('p1')).rejects.toBeTruthy();
+    });
+  });
+
+  describe('getBomParents', () => {
+    it('queries parts_bom by child_part_id', async () => {
+      mockQueryBuilder.data = [];
+      await getBomParents('c1');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('child_part_id', 'c1');
+    });
+  });
+
+  describe('getPartIdsWithBomLines', () => {
+    it('returns a Set of distinct parent_part_id values', async () => {
+      mockQueryBuilder.data = [
+        { parent_part_id: 'p1' },
+        { parent_part_id: 'p2' },
+        { parent_part_id: 'p1' },
+      ];
+      const ids = await getPartIdsWithBomLines('co-1');
+      expect(ids).toBeInstanceOf(Set);
+      expect(Array.from(ids).sort()).toEqual(['p1', 'p2']);
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('parent_part.company_id', 'co-1');
+    });
+  });
+
+  describe('checkBomCycle', () => {
+    it('flags an immediate self-edge as a cycle without hitting the DB', async () => {
+      const result = await checkBomCycle('p1', 'p1');
+      expect(result.would_create_cycle).toBe(true);
+      expect(result.cycle_path).toEqual(['p1', 'p1']);
+      expect(mockSupabase.from).not.toHaveBeenCalled();
+    });
+
+    it('returns no-cycle when the child has no descendants', async () => {
+      mockQueryBuilder.data = [];
+      const result = await checkBomCycle('parentA', 'childB');
+      expect(result.would_create_cycle).toBe(false);
+    });
+  });
+
+  describe('deleteBomLine', () => {
+    it('deletes by id', async () => {
+      mockQueryBuilder.data = null;
+      mockQueryBuilder.error = null;
+      await deleteBomLine('b1');
+      expect(mockSupabase.from).toHaveBeenCalledWith('parts_bom');
+      expect(mockQueryBuilder.delete).toHaveBeenCalled();
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'b1');
+    });
+
+    it('throws when supabase returns an error', async () => {
+      mockQueryBuilder.error = { message: 'boom' };
+      await expect(deleteBomLine('b1')).rejects.toBeTruthy();
+    });
+  });
+});

--- a/__tests__/utils/jobsAccess.test.ts
+++ b/__tests__/utils/jobsAccess.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
+  const builder: Record<string, ReturnType<typeof vi.fn> | unknown> = {};
+  const chainMethods = [
+    'from', 'select', 'insert', 'update', 'delete',
+    'eq', 'neq', 'or', 'in', 'order', 'range', 'limit', 'lt', 'not', 'single', 'maybeSingle',
+  ];
+  chainMethods.forEach((m) => {
+    builder[m] = vi.fn().mockImplementation(() => builder);
+  });
+  builder.data = null;
+  builder.error = null;
+  builder.count = null;
+  const supabase = {
+    from: vi.fn().mockImplementation(() => builder),
+    rpc: vi.fn(),
+  };
+  return { mockQueryBuilder: builder, mockSupabase: supabase };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+
+import {
+  deleteJob,
+  bulkDeleteJobs,
+  getCustomersForSelect,
+  getOverdueJobsCount,
+  getReadyOperationsForJobs,
+  searchJobsByIdentifier,
+} from '@/utils/jobsAccess';
+
+describe('jobsAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(() => mockQueryBuilder);
+    Object.keys(mockQueryBuilder).forEach((k) => {
+      const v = mockQueryBuilder[k];
+      if (typeof v === 'function' && 'mockClear' in v) {
+        (v as ReturnType<typeof vi.fn>).mockClear();
+        (v as ReturnType<typeof vi.fn>).mockImplementation(() => mockQueryBuilder);
+      }
+    });
+    mockQueryBuilder.data = null;
+    mockQueryBuilder.error = null;
+    mockQueryBuilder.count = null;
+  });
+
+  describe('deleteJob', () => {
+    it('deletes by job id scoped to company_id', async () => {
+      mockQueryBuilder.error = null;
+      await deleteJob('j1', 'co-1');
+      expect(mockSupabase.from).toHaveBeenCalledWith('jobs');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'j1');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'co-1');
+    });
+
+    it('throws when supabase returns an error', async () => {
+      mockQueryBuilder.error = { message: 'boom' };
+      await expect(deleteJob('j1', 'co-1')).rejects.toBeTruthy();
+    });
+  });
+
+  describe('bulkDeleteJobs', () => {
+    it('short-circuits on empty input without calling supabase', async () => {
+      await bulkDeleteJobs([], 'co-1');
+      expect(mockSupabase.from).not.toHaveBeenCalled();
+    });
+
+    it('filters out non-string ids before issuing the delete', async () => {
+      mockQueryBuilder.error = null;
+      // @ts-expect-error — runtime defense exercise; the function filters
+      // out anything that isn't a non-empty string.
+      await bulkDeleteJobs(['j1', null, '', 'j2'], 'co-1');
+      const inCall = (mockQueryBuilder.in as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(inCall[0]).toBe('id');
+      expect(inCall[1]).toEqual(['j1', 'j2']);
+    });
+
+    it('throws when supabase returns an error', async () => {
+      mockQueryBuilder.error = { message: 'permission denied' };
+      await expect(bulkDeleteJobs(['j1'], 'co-1')).rejects.toThrow(/permission denied/);
+    });
+  });
+
+  describe('getCustomersForSelect', () => {
+    it('queries customers by company_id and orders by name', async () => {
+      mockQueryBuilder.data = [
+        { id: 'cu1', name: 'Acme' },
+        { id: 'cu2', name: 'Beta' },
+      ];
+      const customers = await getCustomersForSelect('co-1');
+      expect(mockSupabase.from).toHaveBeenCalledWith('customers');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'co-1');
+      expect(mockQueryBuilder.order).toHaveBeenCalledWith('name');
+      expect(customers).toHaveLength(2);
+    });
+
+    it('returns [] when data is null', async () => {
+      mockQueryBuilder.data = null;
+      const customers = await getCustomersForSelect('co-1');
+      expect(customers).toEqual([]);
+    });
+  });
+
+  describe('getOverdueJobsCount', () => {
+    it('uses count: exact head:true with company + due_date + status filters', async () => {
+      mockQueryBuilder.count = 4;
+      const count = await getOverdueJobsCount('co-1');
+      expect(count).toBe(4);
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'co-1');
+      expect(mockQueryBuilder.not).toHaveBeenCalledWith('due_date', 'is', null);
+      expect(mockQueryBuilder.lt).toHaveBeenCalledWith('due_date', expect.any(String));
+      expect(mockQueryBuilder.not).toHaveBeenCalledWith('fulfillment_status', 'eq', 'fully_shipped');
+      expect(mockQueryBuilder.not).toHaveBeenCalledWith('production_status', 'eq', 'cancelled');
+    });
+
+    it('returns 0 when supabase returns null count', async () => {
+      mockQueryBuilder.count = null;
+      const count = await getOverdueJobsCount('co-1');
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('getReadyOperationsForJobs', () => {
+    it('short-circuits on empty input without calling RPC', async () => {
+      const result = await getReadyOperationsForJobs([]);
+      expect(result.size).toBe(0);
+      expect(mockSupabase.rpc).not.toHaveBeenCalled();
+    });
+
+    it('maps RPC rows into a Map<job_id, CurrentOperationInfo>', async () => {
+      (mockSupabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: [
+          { job_id: 'j1', operation_name: 'Mill', ready_count: 2 },
+          { job_id: 'j2', operation_name: 'Drill', ready_count: 1 },
+        ],
+        error: null,
+      });
+      const result = await getReadyOperationsForJobs(['j1', 'j2']);
+      expect(mockSupabase.rpc).toHaveBeenCalledWith('get_ready_operations_batch', {
+        p_job_ids: ['j1', 'j2'],
+      });
+      expect(result.get('j1')).toEqual({ operationName: 'Mill', readyCount: 2 });
+      expect(result.get('j2')).toEqual({ operationName: 'Drill', readyCount: 1 });
+    });
+
+    it('returns an empty Map when RPC errors (defensive — dashboard tile should not crash)', async () => {
+      (mockSupabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: null,
+        error: { message: 'timeout' },
+      });
+      const result = await getReadyOperationsForJobs(['j1']);
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe('searchJobsByIdentifier', () => {
+    it('short-circuits on empty/whitespace queries', async () => {
+      const result = await searchJobsByIdentifier('co-1', '   ');
+      expect(result).toEqual([]);
+      expect(mockSupabase.rpc).not.toHaveBeenCalled();
+    });
+
+    it('passes the trimmed query to the RPC and returns its rows', async () => {
+      (mockSupabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: [{ job_id: 'j1', match_source: 'job_number' }],
+        error: null,
+      });
+      const result = await searchJobsByIdentifier('co-1', '  ADP-001  ');
+      expect(mockSupabase.rpc).toHaveBeenCalledWith('search_jobs_by_identifier', {
+        p_company_id: 'co-1',
+        p_query: 'ADP-001',
+      });
+      expect(result).toEqual([{ job_id: 'j1', match_source: 'job_number' }]);
+    });
+
+    it('throws when the RPC returns an error', async () => {
+      (mockSupabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: null,
+        error: { message: 'invalid query' },
+      });
+      await expect(searchJobsByIdentifier('co-1', 'x')).rejects.toThrow(/invalid query/);
+    });
+  });
+});

--- a/__tests__/utils/markupRatesAccess.test.ts
+++ b/__tests__/utils/markupRatesAccess.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
+  const builder: Record<string, ReturnType<typeof vi.fn> | unknown> = {};
+  const chainMethods = [
+    'from', 'select', 'insert', 'update', 'delete',
+    'eq', 'neq', 'ilike', 'in', 'order', 'single', 'maybeSingle',
+  ];
+  chainMethods.forEach((m) => {
+    builder[m] = vi.fn().mockImplementation(() => builder);
+  });
+  builder.data = null;
+  builder.error = null;
+  builder.count = null;
+  const supabase = {
+    from: vi.fn().mockImplementation(() => builder),
+    rpc: vi.fn(),
+  };
+  return { mockQueryBuilder: builder, mockSupabase: supabase };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+
+vi.mock('@/utils/partPricingTiersAccess', () => ({
+  replaceTiersForPart: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  getAllMarkupRates,
+  getMarkupRate,
+  getDefaultMarkupRate,
+  deleteMarkupRate,
+  bulkDeleteMarkupRates,
+  checkMarkupRateNameExists,
+  bulkApplyMarkupRate,
+} from '@/utils/markupRatesAccess';
+
+describe('markupRatesAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(() => mockQueryBuilder);
+    Object.keys(mockQueryBuilder).forEach((k) => {
+      const v = mockQueryBuilder[k];
+      if (typeof v === 'function' && 'mockClear' in v) {
+        (v as ReturnType<typeof vi.fn>).mockClear();
+        (v as ReturnType<typeof vi.fn>).mockImplementation(() => mockQueryBuilder);
+      }
+    });
+    mockQueryBuilder.data = null;
+    mockQueryBuilder.error = null;
+    mockQueryBuilder.count = null;
+  });
+
+  describe('getAllMarkupRates', () => {
+    it('selects from markup_rates filtered by company_id and ordered by name', async () => {
+      mockQueryBuilder.data = [
+        { id: 'r1', name: 'Default', company_id: 'co-1', breakpoints: [], is_default: true },
+      ];
+      const rates = await getAllMarkupRates('co-1');
+      expect(mockSupabase.from).toHaveBeenCalledWith('markup_rates');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'co-1');
+      expect(mockQueryBuilder.order).toHaveBeenCalledWith('name', { ascending: true });
+      expect(rates).toHaveLength(1);
+    });
+
+    it('returns [] when supabase returns null data', async () => {
+      mockQueryBuilder.data = null;
+      const rates = await getAllMarkupRates('co-1');
+      expect(rates).toEqual([]);
+    });
+  });
+
+  describe('getMarkupRate', () => {
+    it('returns the row when found', async () => {
+      mockQueryBuilder.data = { id: 'r1', name: 'Default', breakpoints: [] };
+      const rate = await getMarkupRate('r1');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'r1');
+      expect(rate).toMatchObject({ id: 'r1' });
+    });
+
+    it('returns null on PGRST116', async () => {
+      mockQueryBuilder.error = { code: 'PGRST116' };
+      const rate = await getMarkupRate('missing');
+      expect(rate).toBeNull();
+    });
+  });
+
+  describe('getDefaultMarkupRate', () => {
+    it('queries by company_id + is_default=true', async () => {
+      mockQueryBuilder.data = null;
+      await getDefaultMarkupRate('co-1');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'co-1');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('is_default', true);
+      expect(mockQueryBuilder.maybeSingle).toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteMarkupRate', () => {
+    it('deletes by id', async () => {
+      mockQueryBuilder.error = null;
+      await deleteMarkupRate('r1');
+      expect(mockQueryBuilder.delete).toHaveBeenCalled();
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'r1');
+    });
+
+    it('throws when supabase returns an error', async () => {
+      mockQueryBuilder.error = { message: 'boom' };
+      await expect(deleteMarkupRate('r1')).rejects.toBeTruthy();
+    });
+  });
+
+  describe('bulkDeleteMarkupRates', () => {
+    it('short-circuits on empty input', async () => {
+      await bulkDeleteMarkupRates([]);
+      expect(mockSupabase.from).not.toHaveBeenCalled();
+    });
+
+    it('deletes using .in(id, [...])', async () => {
+      mockQueryBuilder.error = null;
+      await bulkDeleteMarkupRates(['r1', 'r2']);
+      expect(mockQueryBuilder.in).toHaveBeenCalledWith('id', ['r1', 'r2']);
+    });
+  });
+
+  describe('checkMarkupRateNameExists', () => {
+    it('returns true when count > 0', async () => {
+      mockQueryBuilder.count = 1;
+      const exists = await checkMarkupRateNameExists('co-1', 'Default');
+      expect(exists).toBe(true);
+      expect(mockQueryBuilder.ilike).toHaveBeenCalledWith('name', 'Default');
+    });
+
+    it('returns false when count is 0/null', async () => {
+      mockQueryBuilder.count = 0;
+      const exists = await checkMarkupRateNameExists('co-1', 'Nope');
+      expect(exists).toBe(false);
+    });
+
+    it('honors excludeId via neq', async () => {
+      mockQueryBuilder.count = 0;
+      await checkMarkupRateNameExists('co-1', 'Default', 'r-skip');
+      expect(mockQueryBuilder.neq).toHaveBeenCalledWith('id', 'r-skip');
+    });
+  });
+
+  describe('bulkApplyMarkupRate', () => {
+    it('short-circuits on empty partIds without calling RPC', async () => {
+      const result = await bulkApplyMarkupRate('co-1', [], 'r1');
+      expect(result).toEqual({ updated: 0, failed: [], priceUncomputed: 0 });
+      expect(mockSupabase.rpc).not.toHaveBeenCalled();
+    });
+
+    it('aggregates RPC results across chunks', async () => {
+      (mockSupabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: { updated: 3, price_uncomputed: 1, failed: [{ part_id: 'p9', error: 'oh no' }] },
+        error: null,
+      });
+      const result = await bulkApplyMarkupRate('co-1', ['p1', 'p2', 'p3'], 'r1');
+      expect(mockSupabase.rpc).toHaveBeenCalledWith('bulk_apply_markup_rate', {
+        p_company_id: 'co-1',
+        p_part_ids: ['p1', 'p2', 'p3'],
+        p_rate_id: 'r1',
+      });
+      expect(result.updated).toBe(3);
+      expect(result.priceUncomputed).toBe(1);
+      expect(result.failed).toEqual([{ partId: 'p9', error: 'oh no' }]);
+    });
+
+    it('records every part in a chunk as failed when the RPC errors', async () => {
+      (mockSupabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: null,
+        error: { message: 'timeout' },
+      });
+      const result = await bulkApplyMarkupRate('co-1', ['p1', 'p2'], 'r1');
+      expect(result.updated).toBe(0);
+      expect(result.failed).toEqual([
+        { partId: 'p1', error: 'timeout' },
+        { partId: 'p2', error: 'timeout' },
+      ]);
+    });
+  });
+});

--- a/__tests__/utils/routingsAccess.test.ts
+++ b/__tests__/utils/routingsAccess.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
+  const builder: Record<string, ReturnType<typeof vi.fn> | unknown> = {};
+  const chainMethods = [
+    'from', 'select', 'insert', 'update', 'delete',
+    'eq', 'neq', 'or', 'in', 'order', 'range', 'limit', 'single', 'maybeSingle',
+  ];
+  chainMethods.forEach((m) => {
+    builder[m] = vi.fn().mockImplementation(() => builder);
+  });
+  builder.data = null;
+  builder.error = null;
+  const supabase = {
+    from: vi.fn().mockImplementation(() => builder),
+  };
+  return { mockQueryBuilder: builder, mockSupabase: supabase };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+
+import {
+  getRouting,
+  getRoutingSummaryForPart,
+  deleteRouting,
+  createRoutingOperation,
+  deleteRoutingOperation,
+} from '@/utils/routingsAccess';
+
+describe('routingsAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(() => mockQueryBuilder);
+    Object.keys(mockQueryBuilder).forEach((k) => {
+      const v = mockQueryBuilder[k];
+      if (typeof v === 'function' && 'mockClear' in v) {
+        (v as ReturnType<typeof vi.fn>).mockClear();
+        (v as ReturnType<typeof vi.fn>).mockImplementation(() => mockQueryBuilder);
+      }
+    });
+    mockQueryBuilder.data = null;
+    mockQueryBuilder.error = null;
+  });
+
+  describe('getRouting', () => {
+    it('returns the row when found', async () => {
+      mockQueryBuilder.data = { id: 'r1', name: 'Routing - Widget', part: { id: 'p1', part_name: 'Widget' } };
+      const result = await getRouting('r1');
+      expect(mockSupabase.from).toHaveBeenCalledWith('routings');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'r1');
+      expect(result).toMatchObject({ id: 'r1' });
+    });
+
+    it('returns null on PGRST116', async () => {
+      mockQueryBuilder.error = { code: 'PGRST116' };
+      const result = await getRouting('missing');
+      expect(result).toBeNull();
+    });
+
+    it('throws on non-PGRST116 errors', async () => {
+      mockQueryBuilder.error = { code: '42P01', message: 'relation not found' };
+      await expect(getRouting('r1')).rejects.toBeTruthy();
+    });
+  });
+
+  describe('getRoutingSummaryForPart', () => {
+    it('sums cycle_minutes_per_unit across operations', async () => {
+      mockQueryBuilder.data = {
+        id: 'r1',
+        routing_operations: [
+          { id: 'o1', cycle_minutes_per_unit: 2 },
+          { id: 'o2', cycle_minutes_per_unit: 3 },
+          { id: 'o3', cycle_minutes_per_unit: null },
+        ],
+      };
+      const summary = await getRoutingSummaryForPart('p1');
+      expect(summary).toEqual({ id: 'r1', nodeCount: 3, totalRunTime: 5 });
+    });
+
+    it('returns null when no routing exists for the part', async () => {
+      mockQueryBuilder.data = null;
+      const summary = await getRoutingSummaryForPart('p1');
+      expect(summary).toBeNull();
+    });
+
+    it('returns null totalRunTime when sum is zero', async () => {
+      mockQueryBuilder.data = {
+        id: 'r1',
+        routing_operations: [{ id: 'o1', cycle_minutes_per_unit: null }],
+      };
+      const summary = await getRoutingSummaryForPart('p1');
+      expect(summary).toEqual({ id: 'r1', nodeCount: 1, totalRunTime: null });
+    });
+  });
+
+  describe('deleteRouting', () => {
+    it('deletes by id', async () => {
+      mockQueryBuilder.error = null;
+      await deleteRouting('r1');
+      expect(mockQueryBuilder.delete).toHaveBeenCalled();
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'r1');
+    });
+  });
+
+  describe('createRoutingOperation', () => {
+    it('parses numeric form fields and falls back to 0 for setup_minutes', async () => {
+      // First .from() call is for getNextOperationSequence -> maybeSingle returns {sequence: 20}
+      // Second .from() call is for the insert .single() returning the inserted row.
+      // The shared builder lets both calls run through the chain; we control via .data switch.
+      mockQueryBuilder.data = { sequence: 20 };
+      // Use a sequence override to avoid the getNextOperationSequence query;
+      // that way the single .single() resolves to the insert result.
+      mockQueryBuilder.data = { id: 'op-new', routing_id: 'r1', sequence: 30 };
+
+      await createRoutingOperation(
+        'r1',
+        {
+          work_center_id: 'wc1',
+          setup_minutes: '',
+          cycle_minutes_per_unit: '2.5',
+          labor_rate_override: '',
+          external_unit_price: '',
+          external_setup_cost: '',
+          instructions: '  do the thing  ',
+        },
+        30,
+      );
+
+      const insertCall = (mockQueryBuilder.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(insertCall.routing_id).toBe('r1');
+      expect(insertCall.sequence).toBe(30);
+      expect(insertCall.setup_minutes).toBe(0);
+      expect(insertCall.cycle_minutes_per_unit).toBe(2.5);
+      expect(insertCall.labor_rate_override).toBeNull();
+      expect(insertCall.instructions).toBe('do the thing');
+      expect(insertCall.metadata).toEqual({});
+    });
+  });
+
+  describe('deleteRoutingOperation', () => {
+    it('deletes the operation by id', async () => {
+      mockQueryBuilder.error = null;
+      await deleteRoutingOperation('op-1');
+      expect(mockSupabase.from).toHaveBeenCalledWith('routing_operations');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'op-1');
+    });
+
+    it('throws when supabase returns an error', async () => {
+      mockQueryBuilder.error = { message: 'boom' };
+      await expect(deleteRoutingOperation('op-1')).rejects.toBeTruthy();
+    });
+  });
+});

--- a/__tests__/utils/vendorsAccess.test.ts
+++ b/__tests__/utils/vendorsAccess.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
+  const builder: Record<string, ReturnType<typeof vi.fn> | unknown> = {};
+  const chainMethods = [
+    'from', 'select', 'insert', 'update', 'delete',
+    'eq', 'neq', 'or', 'in', 'order', 'range', 'single', 'maybeSingle',
+  ];
+  chainMethods.forEach((m) => {
+    builder[m] = vi.fn().mockImplementation(() => builder);
+  });
+  builder.data = null;
+  builder.error = null;
+  const supabase = {
+    from: vi.fn().mockImplementation(() => builder),
+  };
+  return { mockQueryBuilder: builder, mockSupabase: supabase };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+
+import { getAllVendors, getVendor, createVendor, deleteVendor } from '@/utils/vendorsAccess';
+
+describe('vendorsAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(() => mockQueryBuilder);
+    Object.keys(mockQueryBuilder).forEach((k) => {
+      const v = mockQueryBuilder[k];
+      if (typeof v === 'function' && 'mockClear' in v) {
+        (v as ReturnType<typeof vi.fn>).mockClear();
+        (v as ReturnType<typeof vi.fn>).mockImplementation(() => mockQueryBuilder);
+      }
+    });
+    mockQueryBuilder.data = null;
+    mockQueryBuilder.error = null;
+  });
+
+  describe('getAllVendors', () => {
+    it('queries the vendors table filtered by company_id', async () => {
+      mockQueryBuilder.data = [{ id: 'v1', name: 'Acme', company_id: 'co-1' }];
+      await getAllVendors('co-1');
+      expect(mockSupabase.from).toHaveBeenCalledWith('vendors');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'co-1');
+    });
+
+    it('applies name + city ilike when search is non-empty', async () => {
+      mockQueryBuilder.data = [];
+      await getAllVendors('co-1', 'acme');
+      expect(mockQueryBuilder.or).toHaveBeenCalledWith(
+        'name.ilike.%acme%,city.ilike.%acme%',
+      );
+    });
+
+    it('skips the or() filter when search is whitespace', async () => {
+      mockQueryBuilder.data = [];
+      await getAllVendors('co-1', '   ');
+      expect(mockQueryBuilder.or).not.toHaveBeenCalled();
+    });
+
+    it('throws when supabase returns an error', async () => {
+      mockQueryBuilder.data = null;
+      mockQueryBuilder.error = { message: 'boom' };
+      await expect(getAllVendors('co-1')).rejects.toBeTruthy();
+    });
+  });
+
+  describe('getVendor', () => {
+    it('queries by id and returns the row', async () => {
+      mockQueryBuilder.data = { id: 'v1', name: 'Acme' };
+      const result = await getVendor('v1');
+      expect(mockSupabase.from).toHaveBeenCalledWith('vendors');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'v1');
+      expect(result).toEqual({ id: 'v1', name: 'Acme' });
+    });
+
+    it('returns null when supabase returns PGRST116 not-found', async () => {
+      mockQueryBuilder.data = null;
+      mockQueryBuilder.error = { code: 'PGRST116', message: 'not found' };
+      const result = await getVendor('missing');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('createVendor', () => {
+    it('inserts a vendor row with company_id stitched on', async () => {
+      mockQueryBuilder.data = { id: 'new-id', name: 'Acme', company_id: 'co-1' };
+      await createVendor('co-1', {
+        name: 'Acme',
+        address_line1: '1 Test St',
+        address_line2: '',
+        city: 'Detroit',
+        state: 'MI',
+        postal_code: '48201',
+        country: 'USA',
+      });
+      expect(mockSupabase.from).toHaveBeenCalledWith('vendors');
+      expect(mockQueryBuilder.insert).toHaveBeenCalled();
+      const insertCall = (mockQueryBuilder.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(insertCall.company_id).toBe('co-1');
+      expect(insertCall.name).toBe('Acme');
+    });
+  });
+
+  describe('deleteVendor', () => {
+    it('deletes by vendor id', async () => {
+      mockQueryBuilder.data = null;
+      mockQueryBuilder.error = null;
+      await deleteVendor('v1');
+      expect(mockQueryBuilder.delete).toHaveBeenCalled();
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'v1');
+    });
+
+    it('throws with a friendly message on FK violation (23503)', async () => {
+      mockQueryBuilder.error = { code: '23503', message: 'fk violation' };
+      await expect(deleteVendor('v1')).rejects.toThrow();
+    });
+  });
+});

--- a/__tests__/utils/workCentersAccess.test.ts
+++ b/__tests__/utils/workCentersAccess.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
+  const builder: Record<string, ReturnType<typeof vi.fn> | unknown> = {};
+  const chainMethods = [
+    'from', 'select', 'insert', 'update', 'delete',
+    'eq', 'neq', 'or', 'ilike', 'in', 'order', 'range', 'single', 'maybeSingle',
+  ];
+  chainMethods.forEach((m) => {
+    builder[m] = vi.fn().mockImplementation(() => builder);
+  });
+  builder.data = null;
+  builder.error = null;
+  builder.count = null;
+  const supabase = {
+    from: vi.fn().mockImplementation(() => builder),
+  };
+  return { mockQueryBuilder: builder, mockSupabase: supabase };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+
+import {
+  getAllWorkCenters,
+  getWorkCentersByKind,
+  getWorkCenter,
+  checkWorkCenterNameExists,
+  createWorkCenter,
+  deleteWorkCenter,
+} from '@/utils/workCentersAccess';
+
+describe('workCentersAccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(() => mockQueryBuilder);
+    Object.keys(mockQueryBuilder).forEach((k) => {
+      const v = mockQueryBuilder[k];
+      if (typeof v === 'function' && 'mockClear' in v) {
+        (v as ReturnType<typeof vi.fn>).mockClear();
+        (v as ReturnType<typeof vi.fn>).mockImplementation(() => mockQueryBuilder);
+      }
+    });
+    mockQueryBuilder.data = null;
+    mockQueryBuilder.error = null;
+    mockQueryBuilder.count = null;
+  });
+
+  describe('getAllWorkCenters', () => {
+    it('queries the work_centers table filtered by company_id', async () => {
+      mockQueryBuilder.data = [{ id: 'wc1', name: 'Mill', company_id: 'co-1' }];
+      await getAllWorkCenters('co-1');
+      expect(mockSupabase.from).toHaveBeenCalledWith('work_centers');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'co-1');
+    });
+
+    it('applies name ilike when search is non-empty', async () => {
+      mockQueryBuilder.data = [];
+      await getAllWorkCenters('co-1', 'mill');
+      expect(mockQueryBuilder.or).toHaveBeenCalledWith('name.ilike.%mill%');
+    });
+
+    it('skips the or() filter when search is whitespace', async () => {
+      mockQueryBuilder.data = [];
+      await getAllWorkCenters('co-1', '   ');
+      expect(mockQueryBuilder.or).not.toHaveBeenCalled();
+    });
+
+    it('throws when supabase returns an error', async () => {
+      mockQueryBuilder.error = { message: 'boom' };
+      await expect(getAllWorkCenters('co-1')).rejects.toBeTruthy();
+    });
+  });
+
+  describe('getWorkCentersByKind', () => {
+    it('filters by kind in addition to company', async () => {
+      mockQueryBuilder.data = [];
+      await getWorkCentersByKind('co-1', 'external');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'co-1');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('kind', 'external');
+    });
+  });
+
+  describe('getWorkCenter', () => {
+    it('returns the row when found', async () => {
+      mockQueryBuilder.data = { id: 'wc1', name: 'Mill' };
+      const result = await getWorkCenter('wc1');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'wc1');
+      expect(result).toEqual({ id: 'wc1', name: 'Mill' });
+    });
+
+    it('returns null on PGRST116 not-found', async () => {
+      mockQueryBuilder.error = { code: 'PGRST116' };
+      const result = await getWorkCenter('missing');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('checkWorkCenterNameExists', () => {
+    it('returns true when one or more rows match', async () => {
+      mockQueryBuilder.data = [{ id: 'wc1' }];
+      const exists = await checkWorkCenterNameExists('co-1', 'Mill');
+      expect(exists).toBe(true);
+      expect(mockQueryBuilder.ilike).toHaveBeenCalledWith('name', 'Mill');
+    });
+
+    it('excludes a specific id when excludeId is set', async () => {
+      mockQueryBuilder.data = [];
+      await checkWorkCenterNameExists('co-1', 'Mill', 'wc-skip');
+      expect(mockQueryBuilder.neq).toHaveBeenCalledWith('id', 'wc-skip');
+    });
+  });
+
+  describe('createWorkCenter', () => {
+    it('inserts a work center with parsed labor_rate and nulled vendor_id for internal kind', async () => {
+      mockQueryBuilder.data = { id: 'new', name: 'Mill', kind: 'internal' };
+      await createWorkCenter('co-1', {
+        name: 'Mill',
+        kind: 'internal',
+        vendor_id: null,
+        labor_rate: '85.50',
+        description: '  big lathe ',
+      });
+      const insertCall = (mockQueryBuilder.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(insertCall.company_id).toBe('co-1');
+      expect(insertCall.kind).toBe('internal');
+      expect(insertCall.vendor_id).toBeNull();
+      expect(insertCall.labor_rate).toBe(85.5);
+      expect(insertCall.description).toBe('big lathe');
+    });
+  });
+
+  describe('deleteWorkCenter', () => {
+    it('throws a friendly error on FK violation (23503)', async () => {
+      mockQueryBuilder.error = { code: '23503', message: 'fk violation' };
+      await expect(deleteWorkCenter('wc1')).rejects.toThrow(/routing operations/i);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,10 +30,12 @@ export default defineConfig({
         //                              functions 44.77 / lines 51.78
         // 2026-05-28 (3f StationQRCode): statements 50.83 / branches 45.89 /
         //                                functions 45.07 / lines 52.26
-        statements: 49,
-        branches: 44,
-        functions: 44,
-        lines: 50,
+        // 2026-05-28 (3f import-ui + access files):
+        //   statements 50.99 / branches 46.09 / functions 48.91 / lines 52.37
+        statements: 50,
+        branches: 45,
+        functions: 47,
+        lines: 51,
       },
     },
   },


### PR DESCRIPTION
## Summary

Bundles the two remaining 3f sub-PR clusters into one — Import UI components + the six previously-untested `utils/*Access.ts` files. Next (and final) PR in the series is **3g** (E2E migrates to local Supabase).

- **Import UI** (29 tests across `ConfidenceChip`, `ConflictDialog`, `MappingReviewTable`): the AI-mapping path was the largest zero-coverage component cluster left in the frontend.
- **Access layer** (38 tests across `bomAccess`, `jobsAccess`, `markupRatesAccess`, `routingsAccess`, `vendorsAccess`, `workCentersAccess`): focused on the public read/delete/check surface + the most-used create paths. Cycle pre-check (`checkBomCycle`), RPC aggregation (`bulkApplyMarkupRate`), and error-swallow defenses (`getReadyOperationsForJobs`) are exercised.
- **Threshold ratchet**: statements 49→50, branches 44→45, functions 44→47, lines 50→51 (measured at 50.99 / 46.09 / 48.91 / 52.37 — ~1pp floor below actual so noise doesn't trip CI).

After this lands, only **3g** remains in the PR-series plan.

## Test plan

- [x] `pnpm exec vitest run __tests__/components/import/` — 29 passing
- [x] `pnpm exec vitest run __tests__/utils/{bom,jobs,markupRates,routings,vendors,workCenters}Access.test.ts` — 69 passing
- [x] `pnpm exec vitest run --coverage` — full suite 501/501, all four thresholds clear
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)