### PR TITLE
feat(quotes): implement quote-edit fix per #317 policy

### DIFF
--- a/__tests__/components/quotes/QuoteForm.test.tsx
+++ b/__tests__/components/quotes/QuoteForm.test.tsx
@@ -16,9 +16,11 @@ import type { QuoteFormData } from '@/types/quote';
 // Quote access — primary surface under test
 const createQuote = vi.fn();
 const updateQuote = vi.fn();
+const detectQuoteLineDrift = vi.fn();
 vi.mock('@/utils/quotesAccess', () => ({
   createQuote: (...args: unknown[]) => createQuote(...args),
   updateQuote: (...args: unknown[]) => updateQuote(...args),
+  detectQuoteLineDrift: (...args: unknown[]) => detectQuoteLineDrift(...args),
 }));
 
 // Parts: hydrating initial part_ids on edit + by-id lookup
@@ -107,6 +109,8 @@ describe('QuoteForm', () => {
     ]);
     createQuote.mockResolvedValue({ quote: { id: 'new-quote-id' } });
     updateQuote.mockResolvedValue({ id: 'edit-quote-id' });
+    // Default: no drift. Individual tests override.
+    detectQuoteLineDrift.mockResolvedValue([]);
   });
 
   it('renders the Create-quote button label in create mode', async () => {
@@ -273,5 +277,216 @@ describe('QuoteForm', () => {
     await waitFor(() => {
       expect(onSave).toHaveBeenCalledTimes(1);
     });
+  });
+
+  // ============== Drift UI (Issue #324 / #317 §0 policy) ==============
+  //
+  // The form correlates blocks to line items via QuoteFormPartBlock.line_item_id
+  // (populated by quoteToFormData on edit). detectQuoteLineDrift returns the
+  // set of drifted line ids on mount; the form renders a non-blocking chip
+  // + per-line "Update to current price" + a top-of-list "Update all flagged"
+  // bulk control. Forced-choice was DROPPED in the #325 decision — saving is
+  // never blocked by an unresolved drift choice.
+
+  const driftedInitial: QuoteFormData = {
+    ...initialPopulated,
+    parts: [
+      {
+        part_id: 'part-1',
+        order_quantity: 5,
+        line_item_id: 'li-1',
+        basis_unknown: false,
+      },
+    ],
+  };
+
+  it('edit-time drift uses non-blocking chip only — save is enabled without making a drift choice', async () => {
+    detectQuoteLineDrift.mockResolvedValueOnce([
+      {
+        line_item_id: 'li-1',
+        basis_unknown: false,
+        snapshotted_unit_price: 50,
+        current_unit_price: 75,
+      },
+    ]);
+
+    render(<QuoteForm mode="edit" quoteId="q-1" initialData={driftedInitial} />);
+
+    // The drift chip renders and the save button stays enabled. No modal,
+    // no error, no required-action gate.
+    await waitFor(() => {
+      expect(screen.getByTestId('quote-drift-summary')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+  });
+
+  it('renders per-line drift chip and Update-all bulk control on flagged lines', async () => {
+    detectQuoteLineDrift.mockResolvedValueOnce([
+      {
+        line_item_id: 'li-1',
+        basis_unknown: false,
+        snapshotted_unit_price: 50,
+        current_unit_price: 75,
+      },
+    ]);
+
+    render(<QuoteForm mode="edit" quoteId="q-1" initialData={driftedInitial} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('drift-chip-0')).toBeInTheDocument();
+    });
+    // Per-line and "Update all flagged" controls both present.
+    expect(screen.getByTestId('drift-update-0')).toBeInTheDocument();
+    expect(screen.getByTestId('quote-drift-update-all')).toBeInTheDocument();
+  });
+
+  it('untouched drifted line saves without sending its id in acceptDriftLineItemIds (keeps snapshotted price)', async () => {
+    detectQuoteLineDrift.mockResolvedValueOnce([
+      {
+        line_item_id: 'li-1',
+        basis_unknown: false,
+        snapshotted_unit_price: 50,
+        current_unit_price: 75,
+      },
+    ]);
+
+    render(<QuoteForm mode="edit" quoteId="q-1" initialData={driftedInitial} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(updateQuote).toHaveBeenCalledTimes(1);
+    });
+    const opts = updateQuote.mock.calls[0][2];
+    expect(opts).toBeDefined();
+    expect(opts.acceptDriftLineItemIds).toEqual([]);
+  });
+
+  it('per-line update marks line for reprice — drift id flows into acceptDriftLineItemIds on save', async () => {
+    detectQuoteLineDrift.mockResolvedValueOnce([
+      {
+        line_item_id: 'li-1',
+        basis_unknown: false,
+        snapshotted_unit_price: 50,
+        current_unit_price: 75,
+      },
+    ]);
+
+    render(<QuoteForm mode="edit" quoteId="q-1" initialData={driftedInitial} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('drift-update-0')).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('drift-update-0'));
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(updateQuote).toHaveBeenCalledTimes(1);
+    });
+    const opts = updateQuote.mock.calls[0][2];
+    expect(opts.acceptDriftLineItemIds).toEqual(['li-1']);
+  });
+
+  it('Update-all bulk control opts every flagged line in at once', async () => {
+    const twoDrifted: QuoteFormData = {
+      ...initialPopulated,
+      parts: [
+        { part_id: 'part-1', order_quantity: 5, line_item_id: 'li-1' },
+        { part_id: 'part-2', order_quantity: 10, line_item_id: 'li-2' },
+      ],
+    };
+    detectQuoteLineDrift.mockResolvedValueOnce([
+      {
+        line_item_id: 'li-1',
+        basis_unknown: false,
+        snapshotted_unit_price: 50,
+        current_unit_price: 75,
+      },
+      {
+        line_item_id: 'li-2',
+        basis_unknown: false,
+        snapshotted_unit_price: 80,
+        current_unit_price: 90,
+      },
+    ]);
+    getPartsForSelectByIds.mockResolvedValue([
+      hydratedPart,
+      { ...hydratedPart, id: 'part-2', part_name: 'NUT-001' },
+    ]);
+    getTiersWithComputedPrices.mockResolvedValue([
+      { id: 't1', part_id: 'part-1', qty_break: 1, markup_percent: 25, unit_price: 50 },
+    ]);
+
+    render(<QuoteForm mode="edit" quoteId="q-1" initialData={twoDrifted} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('quote-drift-update-all')).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('quote-drift-update-all'));
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(updateQuote).toHaveBeenCalledTimes(1);
+    });
+    const opts = updateQuote.mock.calls[0][2];
+    expect(opts.acceptDriftLineItemIds.sort()).toEqual(['li-1', 'li-2']);
+  });
+
+  it('basis-unknown chip renders on pre-snapshot lines', async () => {
+    const basisUnknownInitial: QuoteFormData = {
+      ...initialPopulated,
+      parts: [
+        {
+          part_id: 'part-1',
+          order_quantity: 5,
+          line_item_id: 'li-1',
+          basis_unknown: true,
+        },
+      ],
+    };
+    detectQuoteLineDrift.mockResolvedValueOnce([]);
+
+    render(
+      <QuoteForm mode="edit" quoteId="q-1" initialData={basisUnknownInitial} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('basis-unknown-chip-0')).toBeInTheDocument();
+    });
+  });
+
+  it('override line never renders drift chip', async () => {
+    // detectQuoteLineDrift filters override lines server-side and returns
+    // an empty array even when the override line's tier has moved.
+    const overrideInitial: QuoteFormData = {
+      ...initialPopulated,
+      parts: [
+        {
+          part_id: 'part-1',
+          order_quantity: 5,
+          line_item_id: 'li-override',
+          override: { unit_price: 999, markup_percent: null },
+        },
+      ],
+    };
+    detectQuoteLineDrift.mockResolvedValueOnce([]);
+
+    render(<QuoteForm mode="edit" quoteId="q-1" initialData={overrideInitial} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+    // No drift chip, no summary alert.
+    expect(screen.queryByTestId('drift-chip-0')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quote-drift-summary')).not.toBeInTheDocument();
   });
 });

--- a/__tests__/utils/quotePricingResolver.test.ts
+++ b/__tests__/utils/quotePricingResolver.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import type { PartPricingTier } from '@/types/partPricing';
-import { resolveTier } from '@/utils/quotePricingResolver';
+import type { PricingBasisSnapshot } from '@/types/quote';
+import {
+  resolveTier,
+  resolveTierFromSnapshot,
+  buildPricingBasisSnapshot,
+  isDrifted,
+  isDriftedDegraded,
+} from '@/utils/quotePricingResolver';
 
 function makeTier(partial: Partial<PartPricingTier>): PartPricingTier {
   return {
@@ -91,5 +98,156 @@ describe('resolveTier', () => {
     ];
     const r = resolveTier(shuffled, 50);
     expect(r!.source_tier_id).toBe('t10');
+  });
+});
+
+function makeSnapshot(
+  tiers: Array<{ id: string; quantity: number; unit_price: number; markup_percent?: number | null }>,
+  resolvedTierId: string | null,
+  resolvedQuantity: number,
+): PricingBasisSnapshot {
+  return {
+    tiers: tiers.map((t) => ({
+      id: t.id,
+      quantity: t.quantity,
+      unit_price: t.unit_price,
+      markup_percent: t.markup_percent ?? null,
+    })),
+    resolved_tier_id: resolvedTierId,
+    resolved_quantity: resolvedQuantity,
+    captured_at: '2026-06-01T00:00:00Z',
+  };
+}
+
+describe('resolveTierFromSnapshot — quantity change honors snapshotted basis', () => {
+  // Frozen basis was: [1=$100, 10=$90, 100=$80].
+  // Even if the part's CURRENT tiers have moved, edit-time qty changes
+  // must resolve against this snapshot.
+  const snap = makeSnapshot(
+    [
+      { id: 't1', quantity: 1, unit_price: 100 },
+      { id: 't10', quantity: 10, unit_price: 90 },
+      { id: 't100', quantity: 100, unit_price: 80 },
+    ],
+    't10',
+    25,
+  );
+
+  it('quantity change honors snapshotted basis', () => {
+    // User bumps qty from 25 (t10 break) to 150 (t100 break) on edit.
+    const r = resolveTierFromSnapshot(snap, 150);
+    expect(r).not.toBeNull();
+    expect(r!.source_tier_id).toBe('t100');
+    expect(r!.unit_price).toBe(80);
+  });
+
+  it('falls back to lowest tier when below the snapshot minimum', () => {
+    const r = resolveTierFromSnapshot(snap, 0.5);
+    expect(r!.source_tier_id).toBe('t1');
+    expect(r!.unit_price).toBe(100);
+    expect(r!.below_min).toBe(true);
+  });
+
+  it('returns the highest tier when qty exceeds every break', () => {
+    const r = resolveTierFromSnapshot(snap, 99999);
+    expect(r!.source_tier_id).toBe('t100');
+  });
+});
+
+describe('buildPricingBasisSnapshot', () => {
+  it('captures only priced tiers and records the resolved tier', () => {
+    const tiers: PartPricingTier[] = [
+      makeTier({ id: 't1', quantity: 1, unit_price: 50 }),
+      makeTier({ id: 't10', quantity: 10, unit_price: null }), // null filtered out
+      makeTier({ id: 't100', quantity: 100, unit_price: 40 }),
+    ];
+    const snap = buildPricingBasisSnapshot(tiers, 200, 't100');
+    expect(snap.tiers.map((t) => t.id)).toEqual(['t1', 't100']);
+    expect(snap.resolved_tier_id).toBe('t100');
+    expect(snap.resolved_quantity).toBe(200);
+    expect(snap.captured_at).toMatch(/T/);
+  });
+
+  it('keeps the snapshot tiers sorted by quantity ascending', () => {
+    const tiers: PartPricingTier[] = [
+      makeTier({ id: 't100', quantity: 100, unit_price: 40 }),
+      makeTier({ id: 't1', quantity: 1, unit_price: 50 }),
+      makeTier({ id: 't10', quantity: 10, unit_price: 45 }),
+    ];
+    const snap = buildPricingBasisSnapshot(tiers, 5, 't1');
+    expect(snap.tiers.map((t) => t.quantity)).toEqual([1, 10, 100]);
+  });
+});
+
+describe('isDrifted — drift is flagged when current tier differs from basis', () => {
+  const basis = makeSnapshot(
+    [
+      { id: 't1', quantity: 1, unit_price: 100 },
+      { id: 't10', quantity: 10, unit_price: 90 },
+    ],
+    't10',
+    20,
+  );
+
+  it('drift is flagged when current tier differs from basis', () => {
+    const currentTiers: PartPricingTier[] = [
+      makeTier({ id: 't1', quantity: 1, unit_price: 110 }), // moved
+      makeTier({ id: 't10', quantity: 10, unit_price: 90 }),
+    ];
+    expect(isDrifted(basis, currentTiers)).toBe(true);
+  });
+
+  it('is NOT flagged when current tiers match the snapshot', () => {
+    const currentTiers: PartPricingTier[] = [
+      makeTier({ id: 't1', quantity: 1, unit_price: 100 }),
+      makeTier({ id: 't10', quantity: 10, unit_price: 90 }),
+    ];
+    expect(isDrifted(basis, currentTiers)).toBe(false);
+  });
+
+  it('flags drift when a snapshotted tier id disappears', () => {
+    const currentTiers: PartPricingTier[] = [
+      makeTier({ id: 't1', quantity: 1, unit_price: 100 }),
+    ];
+    expect(isDrifted(basis, currentTiers)).toBe(true);
+  });
+
+  it('flags drift when a new priced tier appears', () => {
+    const currentTiers: PartPricingTier[] = [
+      makeTier({ id: 't1', quantity: 1, unit_price: 100 }),
+      makeTier({ id: 't10', quantity: 10, unit_price: 90 }),
+      makeTier({ id: 't100', quantity: 100, unit_price: 80 }),
+    ];
+    expect(isDrifted(basis, currentTiers)).toBe(true);
+  });
+
+  it('absorbs sub-cent floating-point noise', () => {
+    const currentTiers: PartPricingTier[] = [
+      makeTier({ id: 't1', quantity: 1, unit_price: 100.001 }),
+      makeTier({ id: 't10', quantity: 10, unit_price: 89.999 }),
+    ];
+    expect(isDrifted(basis, currentTiers)).toBe(false);
+  });
+});
+
+describe('isDriftedDegraded — basis_unknown rows', () => {
+  it('flags drift when current resolved price differs from stored unit_price', () => {
+    const currentTiers: PartPricingTier[] = [
+      makeTier({ id: 't1', quantity: 1, unit_price: 100 }),
+      makeTier({ id: 't10', quantity: 10, unit_price: 90 }),
+    ];
+    // Stored row: qty 25 @ $80 (older price). Current resolves to $90 at qty 25.
+    expect(isDriftedDegraded(80, 25, currentTiers)).toBe(true);
+  });
+
+  it('does not flag when current resolved price matches stored unit_price', () => {
+    const currentTiers: PartPricingTier[] = [
+      makeTier({ id: 't10', quantity: 10, unit_price: 90 }),
+    ];
+    expect(isDriftedDegraded(90, 25, currentTiers)).toBe(false);
+  });
+
+  it('does not flag when the part has no priced tiers today', () => {
+    expect(isDriftedDegraded(80, 25, [])).toBe(false);
   });
 });

--- a/__tests__/utils/quotesAccess.test.ts
+++ b/__tests__/utils/quotesAccess.test.ts
@@ -75,6 +75,45 @@ vi.mock('@/lib/supabase', () => ({
 // Mock storage helpers
 vi.mock('@/utils/storageHelpers', () => mockStorageHelpers);
 
+// Reconcile boundary mocks — quotesAccess.updateQuote calls these
+// helpers; we verify dispatch (which got called, with what) rather than
+// re-test their internals (covered in quoteLineItemsAccess + resolver
+// tests). The hoisted spies are wired below so individual tests can swap
+// implementations as needed.
+const {
+  getLineItemsForQuoteMock,
+  insertLineItemForPartMock,
+  updateLineItemQuantityMock,
+  repriceLineItemToCurrentMock,
+  deleteLineItemMock,
+  getTiersWithComputedPricesMock,
+  detectQuoteLineDriftCallsToDb,
+} = vi.hoisted(() => ({
+  getLineItemsForQuoteMock: vi.fn(),
+  insertLineItemForPartMock: vi.fn(),
+  updateLineItemQuantityMock: vi.fn(),
+  repriceLineItemToCurrentMock: vi.fn(),
+  deleteLineItemMock: vi.fn(),
+  getTiersWithComputedPricesMock: vi.fn(),
+  detectQuoteLineDriftCallsToDb: vi.fn(),
+}));
+
+vi.mock('@/utils/quoteLineItemsAccess', () => ({
+  getLineItemsForQuote: getLineItemsForQuoteMock,
+  insertLineItemForPart: insertLineItemForPartMock,
+  updateLineItemQuantity: updateLineItemQuantityMock,
+  repriceLineItemToCurrent: repriceLineItemToCurrentMock,
+  deleteLineItem: deleteLineItemMock,
+  // clearLineItemsForQuote isn't exercised in these tests but the import
+  // exists on quotesAccess — provide a stub so the mocked module is
+  // syntactically complete.
+  clearLineItemsForQuote: vi.fn(),
+}));
+
+vi.mock('@/utils/partPricingTiersAccess', () => ({
+  getTiersWithComputedPrices: getTiersWithComputedPricesMock,
+}));
+
 // Import functions after mock setup
 import {
   getQuotes,
@@ -87,6 +126,7 @@ import {
   deleteQuote,
   bulkDeleteQuotes,
   convertQuoteToJob,
+  detectQuoteLineDrift,
 } from '@/utils/quotesAccess';
 
 describe('quotesAccess utilities', () => {
@@ -660,6 +700,376 @@ describe('quotesAccess utilities', () => {
       await expect(convertQuoteToJob('quote-1')).rejects.toThrow(
         'This quote has no line items to convert.',
       );
+    });
+  });
+
+  // ============== updateQuote reconcile + drift detection ==============
+  //
+  // The boundary mocks above stub the line-item helpers; these tests
+  // verify which helpers updateQuote dispatches given a particular form
+  // payload vs existing DB state. The helpers' internals are covered in
+  // quotePricingResolver and quoteLineItemsAccess unit tests.
+
+  /**
+   * Wire mockSupabase so updateQuote's two `from('quotes')` chains both
+   * resolve successfully: first the editability check (returns active +
+   * unconverted), then the metadata update (returns the row back).
+   */
+  function stubUpdateQuoteHappyPath(): void {
+    const editableRow = {
+      status: 'active',
+      converted_at: null,
+      company_id: 'company-1',
+    };
+    const updatedRow = {
+      id: 'quote-1',
+      company_id: 'company-1',
+      status: 'active',
+    };
+    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: editableRow, error: null }),
+        }),
+      }),
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: updatedRow, error: null }),
+          }),
+        }),
+      }),
+    }));
+  }
+
+  describe('updateQuote — reconcile (Issue #324 / #317 policy)', () => {
+    const baseFormData: QuoteFormData = {
+      customer_id: 'customer-1',
+      contact_id: '',
+      billing_address_id: '',
+      shipping_address_id: '',
+      parts: [],
+      lead_time_days: '14',
+      expiration_date: '',
+    };
+
+    beforeEach(() => {
+      getLineItemsForQuoteMock.mockReset();
+      insertLineItemForPartMock.mockReset();
+      updateLineItemQuantityMock.mockReset();
+      repriceLineItemToCurrentMock.mockReset();
+      deleteLineItemMock.mockReset();
+      getTiersWithComputedPricesMock.mockReset();
+      getTiersWithComputedPricesMock.mockResolvedValue([]);
+      insertLineItemForPartMock.mockResolvedValue({});
+      updateLineItemQuantityMock.mockResolvedValue({});
+      repriceLineItemToCurrentMock.mockResolvedValue({});
+      deleteLineItemMock.mockResolvedValue(undefined);
+    });
+
+    it('reconciles line items on edit — insert new, update qty, delete removed', async () => {
+      stubUpdateQuoteHappyPath();
+      // DB has lines for part-A (qty 10) and part-B (qty 5).
+      getLineItemsForQuoteMock.mockResolvedValueOnce([
+        {
+          id: 'li-A',
+          quote_id: 'quote-1',
+          company_id: 'company-1',
+          part_id: 'part-A',
+          source_tier_id: 't1',
+          sequence: 10,
+          quantity: 10,
+          unit_price: 100,
+          total_price: 1000,
+          markup_percent: 50,
+          base_cost_per_unit: 66.67,
+          is_quote_override: false,
+          pricing_basis_snapshot: { tiers: [], resolved_tier_id: 't1', resolved_quantity: 10, captured_at: '' },
+          basis_unknown: false,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+        {
+          id: 'li-B',
+          quote_id: 'quote-1',
+          company_id: 'company-1',
+          part_id: 'part-B',
+          source_tier_id: 't1',
+          sequence: 20,
+          quantity: 5,
+          unit_price: 200,
+          total_price: 1000,
+          markup_percent: 50,
+          base_cost_per_unit: 133.33,
+          is_quote_override: false,
+          pricing_basis_snapshot: { tiers: [], resolved_tier_id: 't1', resolved_quantity: 5, captured_at: '' },
+          basis_unknown: false,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+      ]);
+
+      // Form keeps part-A (qty bumped to 25), drops part-B, adds part-C.
+      const formData: QuoteFormData = {
+        ...baseFormData,
+        parts: [
+          { part_id: 'part-A', order_quantity: 25 },
+          { part_id: 'part-C', order_quantity: 1 },
+        ],
+      };
+
+      await updateQuote('quote-1', formData);
+
+      // part-B removed → deleteLineItem called once with li-B.
+      expect(deleteLineItemMock).toHaveBeenCalledTimes(1);
+      expect(deleteLineItemMock).toHaveBeenCalledWith('li-B');
+
+      // part-A kept with new qty → updateLineItemQuantity called.
+      expect(updateLineItemQuantityMock).toHaveBeenCalledWith('li-A', 25);
+
+      // part-C added → insertLineItemForPart called for it.
+      expect(insertLineItemForPartMock).toHaveBeenCalledTimes(1);
+      const insertArgs = insertLineItemForPartMock.mock.calls[0];
+      expect(insertArgs[2]).toBe('part-C'); // partId
+      expect(insertArgs[3]).toBe(1); // orderQuantity
+
+      // Reprice is NEVER called when acceptDriftLineItemIds is empty —
+      // pricing is frozen by default.
+      expect(repriceLineItemToCurrentMock).not.toHaveBeenCalled();
+    });
+
+    it('unchanged lines keep snapshotted unit_price (no reprice on edit)', async () => {
+      stubUpdateQuoteHappyPath();
+      getLineItemsForQuoteMock.mockResolvedValueOnce([
+        {
+          id: 'li-A',
+          quote_id: 'quote-1',
+          company_id: 'company-1',
+          part_id: 'part-A',
+          source_tier_id: 't1',
+          sequence: 10,
+          quantity: 10,
+          unit_price: 100,
+          total_price: 1000,
+          markup_percent: 50,
+          base_cost_per_unit: 66.67,
+          is_quote_override: false,
+          pricing_basis_snapshot: { tiers: [], resolved_tier_id: 't1', resolved_quantity: 10, captured_at: '' },
+          basis_unknown: false,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+      ]);
+
+      const formData: QuoteFormData = {
+        ...baseFormData,
+        parts: [{ part_id: 'part-A', order_quantity: 10 }], // unchanged qty
+      };
+
+      await updateQuote('quote-1', formData);
+
+      // No quantity change → no update.
+      expect(updateLineItemQuantityMock).not.toHaveBeenCalled();
+      // No drift acceptance → no reprice.
+      expect(repriceLineItemToCurrentMock).not.toHaveBeenCalled();
+      // No add → no insert.
+      expect(insertLineItemForPartMock).not.toHaveBeenCalled();
+    });
+
+    it('reprices a drifted line ONLY when acceptDriftLineItemIds includes it', async () => {
+      stubUpdateQuoteHappyPath();
+      getLineItemsForQuoteMock.mockResolvedValueOnce([
+        {
+          id: 'li-A',
+          quote_id: 'quote-1',
+          company_id: 'company-1',
+          part_id: 'part-A',
+          source_tier_id: 't1',
+          sequence: 10,
+          quantity: 10,
+          unit_price: 100,
+          total_price: 1000,
+          markup_percent: 50,
+          base_cost_per_unit: 66.67,
+          is_quote_override: false,
+          pricing_basis_snapshot: { tiers: [], resolved_tier_id: 't1', resolved_quantity: 10, captured_at: '' },
+          basis_unknown: false,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+      ]);
+      getTiersWithComputedPricesMock.mockResolvedValue([
+        { id: 't1', part_id: 'part-A', company_id: 'company-1', sequence: 0, quantity: 1, unit_price: 110, markup_percent: 50, created_at: '', updated_at: '' },
+      ]);
+
+      const formData: QuoteFormData = {
+        ...baseFormData,
+        parts: [{ part_id: 'part-A', order_quantity: 10 }],
+      };
+
+      await updateQuote('quote-1', formData, { acceptDriftLineItemIds: ['li-A'] });
+
+      expect(repriceLineItemToCurrentMock).toHaveBeenCalledTimes(1);
+      expect(repriceLineItemToCurrentMock).toHaveBeenCalledWith('li-A', expect.any(Array));
+    });
+
+    it('NEVER reprices an override line, even if acceptDriftLineItemIds includes it', async () => {
+      stubUpdateQuoteHappyPath();
+      getLineItemsForQuoteMock.mockResolvedValueOnce([
+        {
+          id: 'li-A',
+          quote_id: 'quote-1',
+          company_id: 'company-1',
+          part_id: 'part-A',
+          source_tier_id: null,
+          sequence: 10,
+          quantity: 10,
+          unit_price: 999, // user-typed override
+          total_price: 9990,
+          markup_percent: null,
+          base_cost_per_unit: null,
+          is_quote_override: true,
+          pricing_basis_snapshot: { tiers: [], resolved_tier_id: null, resolved_quantity: 10, captured_at: '' },
+          basis_unknown: false,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+      ]);
+
+      const formData: QuoteFormData = {
+        ...baseFormData,
+        parts: [{ part_id: 'part-A', order_quantity: 10 }],
+      };
+
+      await updateQuote('quote-1', formData, { acceptDriftLineItemIds: ['li-A'] });
+
+      // Override lines are frozen by design — reprice must NOT be called.
+      expect(repriceLineItemToCurrentMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects an update with an empty parts array', async () => {
+      stubUpdateQuoteHappyPath();
+      const formData: QuoteFormData = { ...baseFormData, parts: [] };
+      await expect(updateQuote('quote-1', formData)).rejects.toThrow(
+        'A quote must include at least one part.',
+      );
+    });
+
+    it('rejects an update with duplicate parts', async () => {
+      stubUpdateQuoteHappyPath();
+      const formData: QuoteFormData = {
+        ...baseFormData,
+        parts: [
+          { part_id: 'part-A', order_quantity: 5 },
+          { part_id: 'part-A', order_quantity: 10 },
+        ],
+      };
+      await expect(updateQuote('quote-1', formData)).rejects.toThrow(
+        'A part can only appear once on a quote',
+      );
+    });
+  });
+
+  describe('detectQuoteLineDrift', () => {
+    beforeEach(() => {
+      getLineItemsForQuoteMock.mockReset();
+      getTiersWithComputedPricesMock.mockReset();
+      detectQuoteLineDriftCallsToDb.mockReset();
+    });
+
+    it('returns flagged line IDs when current tier differs from snapshot', async () => {
+      getLineItemsForQuoteMock.mockResolvedValueOnce([
+        {
+          id: 'li-A',
+          quote_id: 'quote-1',
+          company_id: 'company-1',
+          part_id: 'part-A',
+          source_tier_id: 't1',
+          sequence: 10,
+          quantity: 10,
+          unit_price: 100,
+          total_price: 1000,
+          markup_percent: 50,
+          base_cost_per_unit: 66.67,
+          is_quote_override: false,
+          pricing_basis_snapshot: {
+            tiers: [{ id: 't1', quantity: 1, unit_price: 100, markup_percent: 50 }],
+            resolved_tier_id: 't1',
+            resolved_quantity: 10,
+            captured_at: '2026-05-01T00:00:00Z',
+          },
+          basis_unknown: false,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+      ]);
+      getTiersWithComputedPricesMock.mockResolvedValue([
+        { id: 't1', part_id: 'part-A', company_id: 'company-1', sequence: 0, quantity: 1, unit_price: 120, markup_percent: 60, created_at: '', updated_at: '' },
+      ]);
+
+      const flagged = await detectQuoteLineDrift('quote-1');
+      expect(flagged).toHaveLength(1);
+      expect(flagged[0].line_item_id).toBe('li-A');
+      expect(flagged[0].snapshotted_unit_price).toBe(100);
+      expect(flagged[0].current_unit_price).toBe(120);
+    });
+
+    it('override lines never appear in drift set', async () => {
+      getLineItemsForQuoteMock.mockResolvedValueOnce([
+        {
+          id: 'li-A',
+          quote_id: 'quote-1',
+          company_id: 'company-1',
+          part_id: 'part-A',
+          source_tier_id: null,
+          sequence: 10,
+          quantity: 10,
+          unit_price: 999,
+          total_price: 9990,
+          markup_percent: null,
+          base_cost_per_unit: null,
+          is_quote_override: true,
+          pricing_basis_snapshot: {
+            tiers: [{ id: 't1', quantity: 1, unit_price: 100, markup_percent: 50 }],
+            resolved_tier_id: null,
+            resolved_quantity: 10,
+            captured_at: '2026-05-01T00:00:00Z',
+          },
+          basis_unknown: false,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+      ]);
+      getTiersWithComputedPricesMock.mockResolvedValue([
+        { id: 't1', part_id: 'part-A', company_id: 'company-1', sequence: 0, quantity: 1, unit_price: 200, markup_percent: 100, created_at: '', updated_at: '' },
+      ]);
+
+      const flagged = await detectQuoteLineDrift('quote-1');
+      expect(flagged).toEqual([]);
+    });
+
+    it('basis-unknown rows use degraded comparison and surface when current resolved price differs', async () => {
+      getLineItemsForQuoteMock.mockResolvedValueOnce([
+        {
+          id: 'li-A',
+          quote_id: 'quote-1',
+          company_id: 'company-1',
+          part_id: 'part-A',
+          source_tier_id: null,
+          sequence: 10,
+          quantity: 10,
+          unit_price: 80,
+          total_price: 800,
+          markup_percent: null,
+          base_cost_per_unit: null,
+          is_quote_override: false,
+          pricing_basis_snapshot: null,
+          basis_unknown: true,
+          created_at: '2026-01-01T00:00:00Z',
+        },
+      ]);
+      getTiersWithComputedPricesMock.mockResolvedValue([
+        { id: 't1', part_id: 'part-A', company_id: 'company-1', sequence: 0, quantity: 1, unit_price: 100, markup_percent: 50, created_at: '', updated_at: '' },
+      ]);
+
+      const flagged = await detectQuoteLineDrift('quote-1');
+      expect(flagged).toHaveLength(1);
+      expect(flagged[0].basis_unknown).toBe(true);
+      expect(flagged[0].snapshotted_unit_price).toBe(80);
+      expect(flagged[0].current_unit_price).toBe(100);
     });
   });
 

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -28,7 +28,12 @@ import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 
 import type { QuoteFormData } from '@/types/quote';
-import { createQuote, updateQuote } from '@/utils/quotesAccess';
+import {
+  createQuote,
+  updateQuote,
+  detectQuoteLineDrift,
+  type QuoteLineDriftInfo,
+} from '@/utils/quotesAccess';
 import { getPartsForSelectByIds } from '@/utils/partsAccess';
 import {
   getAllCustomers,
@@ -72,6 +77,10 @@ interface PartBlockState {
   tiers: ComputedPartPricingTier[];
   loading: boolean;
   error: string | null;
+  /** Set on edit-mode blocks; absent on newly-added or create-mode blocks. */
+  line_item_id?: string;
+  /** Pre-snapshot Option C — renders the "basis unknown" chip. */
+  basis_unknown?: boolean;
 }
 
 const CREATE_NEW_CUSTOMER: CustomerOption = {
@@ -113,6 +122,8 @@ function blockFromInitial(
     tiers: [],
     loading: false,
     error: null,
+    line_item_id: p.line_item_id,
+    basis_unknown: p.basis_unknown,
   };
 }
 
@@ -148,6 +159,19 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   const [customerModalOpen, setCustomerModalOpen] = useState(false);
   const [partModalOpen, setPartModalOpen] = useState(false);
   const [partModalTargetIdx, setPartModalTargetIdx] = useState<number | null>(null);
+
+  // Drift state (edit mode only):
+  //   - driftByLineId: server-detected drift map for the lines currently
+  //     in the DB. Lines the user has since removed in the form remain in
+  //     this map but are simply ignored (the matching block is gone).
+  //   - acceptedDriftIds: lines the user explicitly opted in to reprice
+  //     via the per-line or "Update all" controls. These ids flow into
+  //     updateQuote's options on submit. Untouched drifted lines never
+  //     enter this set, so they keep their snapshot on save.
+  const [driftByLineId, setDriftByLineId] = useState<Map<string, QuoteLineDriftInfo>>(
+    () => new Map(),
+  );
+  const [acceptedDriftIds, setAcceptedDriftIds] = useState<Set<string>>(() => new Set());
 
   const loadData = useCallback(async () => {
     try {
@@ -185,6 +209,26 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   useEffect(() => {
     loadData();
   }, [loadData]);
+
+  // Edit-mode only: detect drift once on mount. The result is keyed by
+  // line item id so each block can decide whether to render the chip.
+  // Failures here are logged but non-fatal — the form should still load
+  // (drift detection is an enhancement on top of the basic edit path).
+  useEffect(() => {
+    if (mode !== 'edit' || !quoteId) return;
+    let cancelled = false;
+    detectQuoteLineDrift(quoteId)
+      .then((rows) => {
+        if (cancelled) return;
+        const m = new Map<string, QuoteLineDriftInfo>();
+        for (const r of rows) m.set(r.line_item_id, r);
+        setDriftByLineId(m);
+      })
+      .catch((err) => console.warn('Drift detection failed:', err));
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, quoteId]);
 
   // Load tiers for one block. Shared by the effect (newly-added block) and
   // updatePartInBlock (re-select of the same part wipes the previous tiers,
@@ -367,12 +411,37 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   };
 
   const removePartBlock = (idx: number) => {
-    setPartBlocks((prev) => prev.filter((_, i) => i !== idx));
+    setPartBlocks((prev) => {
+      const removed = prev[idx];
+      if (removed?.line_item_id) {
+        // Drop any accept-drift selection that referenced this line — the
+        // user removed the whole part, so the per-line opt-in is moot.
+        setAcceptedDriftIds((cur) => {
+          if (!cur.has(removed.line_item_id!)) return cur;
+          const next = new Set(cur);
+          next.delete(removed.line_item_id!);
+          return next;
+        });
+      }
+      return prev.filter((_, i) => i !== idx);
+    });
   };
 
   const updatePartInBlock = (idx: number, option: PartSelectOption | null) => {
     setPartBlocks((prev) => {
       const next = [...prev];
+      // Re-selecting a part on an existing line means the user wants a
+      // different part on that slot — drop the line_item_id correlation
+      // and any accept-drift selection so reconcile treats it as new.
+      const previous = next[idx];
+      if (previous?.line_item_id) {
+        setAcceptedDriftIds((cur) => {
+          if (!cur.has(previous.line_item_id!)) return cur;
+          const nextIds = new Set(cur);
+          nextIds.delete(previous.line_item_id!);
+          return nextIds;
+        });
+      }
       next[idx] = { ...emptyBlock(), part: option };
       return next;
     });
@@ -546,6 +615,8 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
           part_id: b.part?.id ?? '',
           order_quantity: orderQty,
         };
+        if (b.line_item_id) block.line_item_id = b.line_item_id;
+        if (b.basis_unknown) block.basis_unknown = b.basis_unknown;
         if (b.override_open && b.override_unit_price.trim() !== '') {
           const unitPrice = Number(b.override_unit_price);
           block.override = {
@@ -565,7 +636,9 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
         onSave?.();
         router.push(`/dashboard/${companyId}/quotes/${quote.id}`);
       } else if (mode === 'edit' && quoteId) {
-        await updateQuote(quoteId, payload);
+        await updateQuote(quoteId, payload, {
+          acceptDriftLineItemIds: Array.from(acceptedDriftIds),
+        });
         onSave?.();
         router.push(`/dashboard/${companyId}/quotes/${quoteId}`);
       }
@@ -762,6 +835,51 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
             </Button>
           </Box>
 
+          {/* Drift summary: a non-blocking notice above the list when any
+              current block correlates to a drifted line. Untouched
+              drifted lines simply keep their snapshotted price on save —
+              the user can save without ever clicking these controls
+              (#325 forced-choice was dropped, 2026-06-04). */}
+          {mode === 'edit' &&
+            (() => {
+              const flagged = partBlocks
+                .map((b) => (b.line_item_id ? driftByLineId.get(b.line_item_id) : undefined))
+                .filter((d): d is QuoteLineDriftInfo => !!d);
+              const pendingFlagged = flagged.filter(
+                (d) => !acceptedDriftIds.has(d.line_item_id),
+              );
+              if (flagged.length === 0) return null;
+              return (
+                <Alert
+                  severity="info"
+                  data-testid="quote-drift-summary"
+                  sx={{ mb: 2 }}
+                  action={
+                    pendingFlagged.length > 0 && (
+                      <Button
+                        color="inherit"
+                        size="small"
+                        data-testid="quote-drift-update-all"
+                        onClick={() => {
+                          setAcceptedDriftIds((cur) => {
+                            const next = new Set(cur);
+                            for (const d of pendingFlagged) next.add(d.line_item_id);
+                            return next;
+                          });
+                        }}
+                      >
+                        Update all flagged
+                      </Button>
+                    )
+                  }
+                >
+                  {flagged.length === 1
+                    ? '1 line has a price change since this quote was created. It will keep its original price unless you update it.'
+                    : `${flagged.length} lines have price changes since this quote was created. They will keep their original prices unless you update them.`}
+                </Alert>
+              );
+            })()}
+
           {partBlocks.length === 0 && (
             <Typography variant="body2" color="text.secondary">
               Add at least one part to quote.
@@ -782,6 +900,14 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
             // fires and the user isn't trapped typing a quantity that
             // can't resolve to a line price.
             const hasUsableTier = block.tiers.some((t) => t.unit_price !== null);
+            // Drift state for this block, if any. Override lines never
+            // appear here (detectQuoteLineDrift filters them out).
+            const drift = block.line_item_id
+              ? driftByLineId.get(block.line_item_id) ?? null
+              : null;
+            const isAcceptedDrift = !!(
+              block.line_item_id && acceptedDriftIds.has(block.line_item_id)
+            );
 
             return (
               <Box key={idx} sx={{ mb: idx === partBlocks.length - 1 ? 0 : 3 }}>
@@ -891,6 +1017,73 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                               variant="outlined"
                               sx={{ height: 20, alignSelf: 'flex-start', mt: 0.5 }}
                             />
+                          )}
+                          {block.basis_unknown && (
+                            <Chip
+                              size="small"
+                              label="basis unknown"
+                              color="default"
+                              variant="outlined"
+                              data-testid={`basis-unknown-chip-${idx}`}
+                              sx={{ height: 20, alignSelf: 'flex-start', mt: 0.5 }}
+                            />
+                          )}
+                          {drift && !isOverride && (
+                            <Box
+                              sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 0.5 }}
+                              data-testid={`drift-chip-${idx}`}
+                            >
+                              <Chip
+                                size="small"
+                                label={
+                                  isAcceptedDrift
+                                    ? `Will update to ${formatCurrency(drift.current_unit_price)} / unit`
+                                    : `Tier price changed: was ${formatCurrency(
+                                        drift.snapshotted_unit_price,
+                                      )}, now ${formatCurrency(drift.current_unit_price)}`
+                                }
+                                color={isAcceptedDrift ? 'primary' : 'warning'}
+                                variant="outlined"
+                                sx={{ height: 'auto', py: 0.5, alignSelf: 'flex-start' }}
+                              />
+                              {!isAcceptedDrift && drift.current_unit_price !== null && (
+                                <Button
+                                  size="small"
+                                  variant="text"
+                                  data-testid={`drift-update-${idx}`}
+                                  onClick={() => {
+                                    if (!block.line_item_id) return;
+                                    setAcceptedDriftIds((cur) => {
+                                      const next = new Set(cur);
+                                      next.add(block.line_item_id!);
+                                      return next;
+                                    });
+                                  }}
+                                  sx={{ alignSelf: 'flex-start', textTransform: 'none' }}
+                                >
+                                  Update to current price
+                                </Button>
+                              )}
+                              {isAcceptedDrift && (
+                                <Button
+                                  size="small"
+                                  variant="text"
+                                  data-testid={`drift-cancel-${idx}`}
+                                  onClick={() => {
+                                    if (!block.line_item_id) return;
+                                    setAcceptedDriftIds((cur) => {
+                                      if (!cur.has(block.line_item_id!)) return cur;
+                                      const next = new Set(cur);
+                                      next.delete(block.line_item_id!);
+                                      return next;
+                                    });
+                                  }}
+                                  sx={{ alignSelf: 'flex-start', textTransform: 'none' }}
+                                >
+                                  Keep original price
+                                </Button>
+                              )}
+                            </Box>
                           )}
                         </Box>
                       )}

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -580,14 +580,13 @@ Drift = the current tier table differs from the line's snapshotted basis. Quanti
 - [ ] Drifted lines reprice only on explicit user choice (per-line control or update-all) — *verified by `e2e/quote-edit.spec.ts > 'drifted line repriced only via explicit control'`*.
 - [ ] `is_quote_override = true` lines are NEVER flagged as drifted, even if their tier has moved — *verified by `__tests__/utils/quotesAccess.test.ts > 'override lines never appear in drift set'` AND `__tests__/components/quotes/QuoteForm.test.tsx > 'override line never renders drift chip'`*.
 
-**Forced keep-or-update on actively-edited drifted lines (conditional)**
+**Forced keep-or-update: DROPPED ([Issue #325](https://github.com/debola31/Jigged/issues/325) decision, 2026-06-04)**
 
-The forced-choice path — block save on a line the user is actively editing where the price is ambiguous (drifted), until they explicitly pick keep-the-snapshot or update-to-current — is **gated on the [Issue #325](https://github.com/debola31/Jigged/issues/325) (drift-frequency conversation with the primary quoter) outcome**. If drift turns out to be rare, this clause is dropped and the non-blocking chip is sufficient.
+The forced-choice path — block save on an actively-edited drifted line until the user picks keep-the-snapshot or update-to-current — was gated on Issue #325 and has been **dropped** from §0 scope. In the pilot population (Contour Tool & Machine, primary quoter Johnny), tier-price changes during an open quote's lifetime are rare enough that a save-blocking modal is more friction than the drift signal warrants. The non-blocking chip + per-line and update-all controls above already give the user a deliberate opt-in when drift does occur.
 
-Choose ONE of the two bullets below based on the Issue #325 decision:
+If post-pilot data shows drift is more frequent than estimated, forced-choice can be revisited as a follow-up; it is not part of #324's implementation scope.
 
-- [ ] (if forced-choice ships) Attempting to save while editing a drifted line without choosing keep-or-update blocks save with a form error — *verified by `__tests__/components/quotes/QuoteForm.test.tsx > 'edited drifted line blocks save until keep-or-update chosen'`*.
-- [ ] (if forced-choice is dropped) Editing a drifted line and saving without making a drift choice uses the non-blocking chip behavior — the line keeps its snapshotted price unless the per-line control was clicked — *verified by `__tests__/components/quotes/QuoteForm.test.tsx > 'edit-time drift uses non-blocking chip only'`*.
+- [x] Editing a drifted line and saving without making a drift choice uses the non-blocking chip behavior — the line keeps its snapshotted price unless the per-line control was clicked — *verified by `__tests__/components/quotes/QuoteForm.test.tsx > 'edit-time drift uses non-blocking chip only'`*.
 
 **Verification rule for the whole section**
 

--- a/e2e/quote-edit.spec.ts
+++ b/e2e/quote-edit.spec.ts
@@ -30,19 +30,24 @@ import { navigateTo } from './helpers/navigation';
  */
 
 /**
- * Bump the markup_percent on every existing pricing tier for a given
- * part name. Returns the number of rows touched (zero is an error — the
- * seed should have populated tiers for E2E-MFG-001).
+ * Set markup_percent on EVERY existing pricing tier for the given part
+ * to an absolute value. Idempotent across spec ordering — earlier specs
+ * that already bumped the tier can't carry the value past the column's
+ * numeric(5,2) ceiling (~999.99), so successive bumps would otherwise
+ * overflow on the second or third run within a single CI invocation.
  *
  * Uses the local-stack service-role key that global-setup already wired
  * up; the spec inherits those env vars at run time.
+ *
+ * Returns the number of rows touched (zero is an error — the seed
+ * should have populated tiers for E2E-MFG-001).
  */
-async function bumpTierMarkup(partName: string, addPercent: number): Promise<number> {
+async function setTierMarkup(partName: string, percent: number): Promise<number> {
   const url = process.env.TEST_SUPABASE_URL ?? '';
   const key = process.env.TEST_SUPABASE_SECRET_KEY ?? '';
   if (!url || !key) {
     throw new Error(
-      'bumpTierMarkup: missing TEST_SUPABASE_URL / TEST_SUPABASE_SECRET_KEY — global-setup should have set these.',
+      'setTierMarkup: missing TEST_SUPABASE_URL / TEST_SUPABASE_SECRET_KEY — global-setup should have set these.',
     );
   }
   const admin = createClient(url, key, {
@@ -52,31 +57,42 @@ async function bumpTierMarkup(partName: string, addPercent: number): Promise<num
     .from('parts')
     .select('id')
     .eq('part_name', partName);
-  if (partErr) throw new Error(`bumpTierMarkup part lookup: ${partErr.message}`);
-  if (!parts?.length) throw new Error(`bumpTierMarkup: no part named ${partName}`);
+  if (partErr) throw new Error(`setTierMarkup part lookup: ${partErr.message}`);
+  if (!parts?.length) throw new Error(`setTierMarkup: no part named ${partName}`);
   const partId = parts[0].id;
 
   const { data: tiers, error: tierErr } = await admin
     .from('part_pricing_tiers')
-    .select('id, markup_percent')
+    .select('id')
     .eq('part_id', partId);
-  if (tierErr) throw new Error(`bumpTierMarkup tier lookup: ${tierErr.message}`);
+  if (tierErr) throw new Error(`setTierMarkup tier lookup: ${tierErr.message}`);
   if (!tiers?.length) {
     throw new Error(
-      `bumpTierMarkup: ${partName} has no pricing tiers — seed should populate them`,
+      `setTierMarkup: ${partName} has no pricing tiers — seed should populate them`,
     );
   }
 
   for (const t of tiers) {
-    const next = (Number(t.markup_percent ?? 0) || 0) + addPercent;
     const { error } = await admin
       .from('part_pricing_tiers')
-      .update({ markup_percent: next })
+      .update({ markup_percent: percent })
       .eq('id', t.id);
-    if (error) throw new Error(`bumpTierMarkup update: ${error.message}`);
+    if (error) throw new Error(`setTierMarkup update: ${error.message}`);
   }
   return tiers.length;
 }
+
+/**
+ * Two constants the drift specs share: the BASELINE value gets written
+ * BEFORE the quote is created (so the quote's frozen snapshot pins to
+ * this), and DRIFTED gets written AFTER (so detectQuoteLineDrift sees
+ * the divergence). Specific values are arbitrary — just need to differ
+ * by enough to clear the EPSILON in isDrifted, and stay under
+ * numeric(5,2)'s 999.99 ceiling no matter how many times specs re-run
+ * within one CI invocation (we always set, never accumulate).
+ */
+const TIER_MARKUP_BASELINE = 50;
+const TIER_MARKUP_DRIFTED = 200;
 test.describe('Quote edit — reload contract', () => {
   test('add part, edit qty, remove part — all three persist across reload', async ({
     page,
@@ -153,8 +169,10 @@ test.describe('Quote edit — reload contract', () => {
       .click();
     // The second order-qty input is the new block's.
     await orderQtyInputs.nth(1).fill('2');
-    // Open custom price for the second block — it has no priced tier.
-    await page.getByRole('button', { name: /Use custom price/i }).click();
+    // Open custom price for the SECOND block only — both blocks render a
+    // "Use custom price" button, so the unscoped locator hits strict-mode
+    // violation. nth(1) targets the new block.
+    await page.getByRole('button', { name: /Use custom price/i }).nth(1).click();
     // The Unit price input only exists after override is opened.
     await page.getByRole('textbox', { name: /^Unit price$/i }).fill('25');
 
@@ -203,7 +221,12 @@ test.describe('Quote edit — reload contract', () => {
     await page.goto('/');
     await expect(page).toHaveURL(/\/dashboard\//, { timeout: 30_000 });
 
-    // Step A: create a quote at the current tier price.
+    // Step A0: pin the tier to the baseline value FIRST so the quote
+    //          snapshot is deterministic regardless of what prior specs
+    //          did to the tier in this CI run.
+    await setTierMarkup('E2E-MFG-001', TIER_MARKUP_BASELINE);
+
+    // Step A: create a quote at the baseline tier price.
     await navigateTo(page, 'Quotes');
     await expect(page).toHaveURL(/\/quotes/);
     await page.getByRole('button', { name: /New Quote/i }).click();
@@ -233,9 +256,8 @@ test.describe('Quote edit — reload contract', () => {
     await page.getByRole('textbox', { name: /Order quantity/i }).fill('1');
 
     // Capture the snapshotted unit price. The QuoteForm renders
-    // "Tier N ea · $XX.YY / unit" inline — the seed sets qty=1 @ markup 200%
-    // (resolved live from BOM cost) so the exact number depends on routing
-    // cost. We just need the page text containing the dollar amount.
+    // "Tier N ea · $XX.YY / unit" inline — the dollar amount depends on
+    // the routing cost rollup, so we just grab whatever number is shown.
     const unitPriceLocator = page.getByText(/\$[\d.,]+ \/ unit/);
     await expect(unitPriceLocator.first()).toBeVisible({ timeout: 10_000 });
     const snapshottedUnitPriceText = await unitPriceLocator.first().textContent();
@@ -251,11 +273,11 @@ test.describe('Quote edit — reload contract', () => {
       timeout: 10_000,
     });
 
-    // Step B: simulate drift by bumping the part's tier markup directly
-    //         via the service-role client. See the bumpTierMarkup
-    //         docstring above for why we don't go through the Parts
-    //         page UI here.
-    const touched = await bumpTierMarkup('E2E-MFG-001', 500);
+    // Step B: simulate drift by SETTING the tier markup to a new
+    //         absolute value. See setTierMarkup docstring above —
+    //         absolute rather than delta avoids overflow when specs
+    //         within the same CI run mutate the tier in sequence.
+    const touched = await setTierMarkup('E2E-MFG-001', TIER_MARKUP_DRIFTED);
     expect(touched).toBeGreaterThan(0);
 
     // Step C: reopen the quote, observe the drift chip, save WITHOUT
@@ -304,6 +326,10 @@ test.describe('Quote edit — reload contract', () => {
     await page.goto('/');
     await expect(page).toHaveURL(/\/dashboard\//, { timeout: 30_000 });
 
+    // Pin the tier to the baseline value BEFORE creating the quote so
+    // its snapshot is deterministic regardless of prior spec mutations.
+    await setTierMarkup('E2E-MFG-001', TIER_MARKUP_BASELINE);
+
     // Create a new quote.
     await navigateTo(page, 'Quotes');
     await expect(page).toHaveURL(/\/quotes/);
@@ -339,9 +365,9 @@ test.describe('Quote edit — reload contract', () => {
     await page.getByRole('button', { name: /Create Quote/i }).click();
     await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
 
-    // Bump tier markup to create drift — same service-role write
-    // as spec 2 above.
-    const touchedSpec3 = await bumpTierMarkup('E2E-MFG-001', 500);
+    // Set tier markup to drifted value — absolute, not delta, so prior
+    // spec mutations don't push us past numeric(5,2)'s 999.99 ceiling.
+    const touchedSpec3 = await setTierMarkup('E2E-MFG-001', TIER_MARKUP_DRIFTED);
     expect(touchedSpec3).toBeGreaterThan(0);
 
     // Reopen the quote. Click the per-line "Update to current price"

--- a/e2e/quote-edit.spec.ts
+++ b/e2e/quote-edit.spec.ts
@@ -93,6 +93,54 @@ async function setTierMarkup(partName: string, percent: number): Promise<number>
  */
 const TIER_MARKUP_BASELINE = 50;
 const TIER_MARKUP_DRIFTED = 200;
+
+/**
+ * Diagnostic — read the freshly-inserted quote_line_items row(s) for a
+ * given quote via the service-role admin client and assert that the
+ * pricing_basis_snapshot column is populated with a non-empty tiers
+ * array. Catches the failure mode where insertLineItemForPart writes
+ * the column but Supabase silently drops it (e.g., schema cache out
+ * of sync) or builds an empty tiers array.
+ *
+ * Run right after Create Quote so the spec fails early with a clear
+ * signal if the snapshot didn't land — vs timing out 100s later on a
+ * missing drift chip.
+ */
+async function assertSnapshotPersisted(quoteId: string): Promise<void> {
+  const url = process.env.TEST_SUPABASE_URL ?? '';
+  const key = process.env.TEST_SUPABASE_SECRET_KEY ?? '';
+  const admin = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data, error } = await admin
+    .from('quote_line_items')
+    .select('id, unit_price, basis_unknown, pricing_basis_snapshot')
+    .eq('quote_id', quoteId);
+  if (error) throw new Error(`assertSnapshotPersisted: ${error.message}`);
+  expect(data, 'no line items for quote').toBeTruthy();
+  expect(data!.length).toBeGreaterThan(0);
+  for (const li of data!) {
+    // basis_unknown should be false on newly-inserted lines (Option C
+    // applies only to pre-migration rows).
+    expect(
+      li.basis_unknown,
+      `basis_unknown unexpectedly true on fresh line ${li.id}`,
+    ).toBe(false);
+    expect(
+      li.pricing_basis_snapshot,
+      `pricing_basis_snapshot null on fresh line ${li.id}`,
+    ).toBeTruthy();
+    const snap = li.pricing_basis_snapshot as { tiers?: Array<unknown> } | null;
+    expect(
+      snap?.tiers,
+      `snapshot.tiers missing on line ${li.id}; full snapshot=${JSON.stringify(snap)}`,
+    ).toBeTruthy();
+    expect(
+      (snap!.tiers as Array<unknown>).length,
+      `snapshot.tiers empty on line ${li.id}`,
+    ).toBeGreaterThan(0);
+  }
+}
 test.describe('Quote edit — reload contract', () => {
   test('add part, edit qty, remove part — all three persist across reload', async ({
     page,
@@ -273,6 +321,12 @@ test.describe('Quote edit — reload contract', () => {
       timeout: 10_000,
     });
 
+    // Diagnostic: confirm the snapshot was actually persisted (catches
+    // the "snapshot column silently dropped" failure mode early).
+    const createdQuoteIdSpec2 = page.url().match(/\/quotes\/([0-9a-f-]{36})/)?.[1];
+    expect(createdQuoteIdSpec2, 'failed to parse quote id from URL').toBeTruthy();
+    await assertSnapshotPersisted(createdQuoteIdSpec2!);
+
     // Step B: simulate drift by SETTING the tier markup to a new
     //         absolute value. See setTierMarkup docstring above —
     //         absolute rather than delta avoids overflow when specs
@@ -364,6 +418,11 @@ test.describe('Quote edit — reload contract', () => {
     await page.getByRole('spinbutton', { name: /Lead time/i }).fill('14');
     await page.getByRole('button', { name: /Create Quote/i }).click();
     await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
+
+    // Same diagnostic as spec 2.
+    const createdQuoteIdSpec3 = page.url().match(/\/quotes\/([0-9a-f-]{36})/)?.[1];
+    expect(createdQuoteIdSpec3, 'failed to parse quote id from URL').toBeTruthy();
+    await assertSnapshotPersisted(createdQuoteIdSpec3!);
 
     // Set tier markup to drifted value — absolute, not delta, so prior
     // spec mutations don't push us past numeric(5,2)'s 999.99 ceiling.

--- a/e2e/quote-edit.spec.ts
+++ b/e2e/quote-edit.spec.ts
@@ -36,7 +36,14 @@ test.describe('Quote edit — reload contract', () => {
 
     // Create a quote with one line (E2E-MFG-001 @ qty 1).
     await navigateTo(page, 'Quotes');
+    await expect(page).toHaveURL(/\/quotes/);
     await page.getByRole('button', { name: /New Quote/i }).click();
+    // The /quotes list page also renders a combobox labeled "Customer"
+    // (the customer filter). Without this URL gate, Playwright can latch
+    // onto that filter while the navigation is in flight — the click
+    // succeeds but never updates the form's customer_id, and Create Quote
+    // stays disabled because validation reports "Pick a customer."
+    await expect(page).toHaveURL(/\/quotes\/new/, { timeout: 15_000 });
 
     const customerField = page.getByRole('combobox', { name: /^Customer$/i });
     await customerField.click();
@@ -59,6 +66,12 @@ test.describe('Quote edit — reload contract', () => {
       .first()
       .click();
     await page.getByRole('textbox', { name: /Order quantity/i }).fill('1');
+    // Wait for tier resolution before submitting — see quote-to-job.spec.ts.
+    // The Create Quote button stays disabled until the tier query returns
+    // and resolveTier produces a usable unit price.
+    await expect(page.getByText(/Tier \d+ ea/i).first()).toBeVisible({
+      timeout: 10_000,
+    });
     await page.getByRole('spinbutton', { name: /Lead time/i }).fill('14');
     await page.getByRole('button', { name: /Create Quote/i }).click();
     await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
@@ -129,7 +142,10 @@ test.describe('Quote edit — reload contract', () => {
 
     // Step A: create a quote at the current tier price.
     await navigateTo(page, 'Quotes');
+    await expect(page).toHaveURL(/\/quotes/);
     await page.getByRole('button', { name: /New Quote/i }).click();
+    // Required URL gate — see spec 1 above.
+    await expect(page).toHaveURL(/\/quotes\/new/, { timeout: 15_000 });
 
     const customerField = page.getByRole('combobox', { name: /^Customer$/i });
     await customerField.click();
@@ -241,7 +257,10 @@ test.describe('Quote edit — reload contract', () => {
 
     // Create a new quote.
     await navigateTo(page, 'Quotes');
+    await expect(page).toHaveURL(/\/quotes/);
     await page.getByRole('button', { name: /New Quote/i }).click();
+    // Required URL gate — see spec 1.
+    await expect(page).toHaveURL(/\/quotes\/new/, { timeout: 15_000 });
     const customerField = page.getByRole('combobox', { name: /^Customer$/i });
     await customerField.click();
     await customerField.fill('E2E Test Customer');

--- a/e2e/quote-edit.spec.ts
+++ b/e2e/quote-edit.spec.ts
@@ -188,7 +188,10 @@ test.describe('Quote edit — reload contract', () => {
     });
     await page.getByRole('spinbutton', { name: /Lead time/i }).fill('14');
     await page.getByRole('button', { name: /Create Quote/i }).click();
-    await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
+    // UUID-strict — /[^/]+$/ also matches /quotes/new (the form URL),
+    // which let toHaveURL return immediately on the still-current /new
+    // before navigation to the post-create /quotes/<uuid> completed.
+    await expect(page).toHaveURL(/\/quotes\/[0-9a-f-]{36}/, { timeout: 15_000 });
 
     // ── Edit pass: bump qty on the existing line, add a new part, then
     //    save. (Removal is exercised in the second edit pass below — doing
@@ -314,7 +317,10 @@ test.describe('Quote edit — reload contract', () => {
 
     await page.getByRole('spinbutton', { name: /Lead time/i }).fill('14');
     await page.getByRole('button', { name: /Create Quote/i }).click();
-    await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
+    // UUID-strict — /[^/]+$/ also matches /quotes/new (the form URL),
+    // which let toHaveURL return immediately on the still-current /new
+    // before navigation to the post-create /quotes/<uuid> completed.
+    await expect(page).toHaveURL(/\/quotes\/[0-9a-f-]{36}/, { timeout: 15_000 });
 
     // Confirm the persisted total uses the snapshotted price on the detail page.
     await expect(page.getByText(snapshottedDollar!).first()).toBeVisible({
@@ -346,7 +352,10 @@ test.describe('Quote edit — reload contract', () => {
       .filter({ hasText: /Q-\d+/ })
       .first()
       .click();
-    await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
+    // UUID-strict — /[^/]+$/ also matches /quotes/new (the form URL),
+    // which let toHaveURL return immediately on the still-current /new
+    // before navigation to the post-create /quotes/<uuid> completed.
+    await expect(page).toHaveURL(/\/quotes\/[0-9a-f-]{36}/, { timeout: 15_000 });
     await page.getByRole('button', { name: /^Edit$/ }).click();
     await expect(page.getByRole('button', { name: /Save changes/i })).toBeVisible();
 
@@ -420,7 +429,10 @@ test.describe('Quote edit — reload contract', () => {
     expect(snapshottedDollar).toBeTruthy();
     await page.getByRole('spinbutton', { name: /Lead time/i }).fill('14');
     await page.getByRole('button', { name: /Create Quote/i }).click();
-    await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
+    // UUID-strict — /[^/]+$/ also matches /quotes/new (the form URL),
+    // which let toHaveURL return immediately on the still-current /new
+    // before navigation to the post-create /quotes/<uuid> completed.
+    await expect(page).toHaveURL(/\/quotes\/[0-9a-f-]{36}/, { timeout: 15_000 });
 
     // Same diagnostic as spec 2.
     const urlSpec3 = page.url();
@@ -442,7 +454,10 @@ test.describe('Quote edit — reload contract', () => {
       .filter({ hasText: /Q-\d+/ })
       .first()
       .click();
-    await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
+    // UUID-strict — /[^/]+$/ also matches /quotes/new (the form URL),
+    // which let toHaveURL return immediately on the still-current /new
+    // before navigation to the post-create /quotes/<uuid> completed.
+    await expect(page).toHaveURL(/\/quotes\/[0-9a-f-]{36}/, { timeout: 15_000 });
     await page.getByRole('button', { name: /^Edit$/ }).click();
     await expect(page.getByTestId('quote-drift-summary')).toBeVisible({
       timeout: 10_000,

--- a/e2e/quote-edit.spec.ts
+++ b/e2e/quote-edit.spec.ts
@@ -322,9 +322,12 @@ test.describe('Quote edit — reload contract', () => {
     });
 
     // Diagnostic: confirm the snapshot was actually persisted (catches
-    // the "snapshot column silently dropped" failure mode early).
-    const createdQuoteIdSpec2 = page.url().match(/\/quotes\/([0-9a-f-]{36})/)?.[1];
-    expect(createdQuoteIdSpec2, 'failed to parse quote id from URL').toBeTruthy();
+    // the "snapshot column silently dropped" failure mode early). Use a
+    // looser regex than UUID-strict — the post-create URL can be
+    // /quotes/{id}?from=... or have other trailing bits.
+    const urlSpec2 = page.url();
+    const createdQuoteIdSpec2 = urlSpec2.match(/\/quotes\/([^/?#]+)/)?.[1];
+    expect(createdQuoteIdSpec2, `failed to parse quote id from URL "${urlSpec2}"`).toBeTruthy();
     await assertSnapshotPersisted(createdQuoteIdSpec2!);
 
     // Step B: simulate drift by SETTING the tier markup to a new
@@ -420,8 +423,9 @@ test.describe('Quote edit — reload contract', () => {
     await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
 
     // Same diagnostic as spec 2.
-    const createdQuoteIdSpec3 = page.url().match(/\/quotes\/([0-9a-f-]{36})/)?.[1];
-    expect(createdQuoteIdSpec3, 'failed to parse quote id from URL').toBeTruthy();
+    const urlSpec3 = page.url();
+    const createdQuoteIdSpec3 = urlSpec3.match(/\/quotes\/([^/?#]+)/)?.[1];
+    expect(createdQuoteIdSpec3, `failed to parse quote id from URL "${urlSpec3}"`).toBeTruthy();
     await assertSnapshotPersisted(createdQuoteIdSpec3!);
 
     // Set tier markup to drifted value — absolute, not delta, so prior

--- a/e2e/quote-edit.spec.ts
+++ b/e2e/quote-edit.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { createClient } from '@supabase/supabase-js';
 import { navigateTo } from './helpers/navigation';
 
 /**
@@ -14,11 +15,11 @@ import { navigateTo } from './helpers/navigation';
  *      was dropped, see docs/modules/quotes.md)
  *   3. override lines stay frozen on edit even when their tier moves
  *
- * Drift simulation: the spec is allowed to bump a part's pricing tier via
- * the admin UI (Parts page → tiers card). We don't reach into Supabase
- * directly from the spec — the seed populates the test user as company
- * admin, so tier edits via the normal UI are sufficient to simulate
- * "tier moved between quote creation and edit".
+ * Drift simulation: this spec writes to the part's pricing tier directly
+ * via the service-role Supabase client (same env the seed uses), then
+ * reopens the quote. The UI for editing tier markup on the Parts page
+ * has no accessible name on its TextFields, so a service-role UPDATE is
+ * both simpler and less brittle than scraping unlabeled inputs.
  *
  * If a future tier edit no longer surfaces in the QuoteForm as drift, the
  * cause is either:
@@ -27,6 +28,55 @@ import { navigateTo } from './helpers/navigation';
  *   - The snapshot column was dropped or not written on create
  * Each of those is a real regression; do NOT runtime-skip this spec.
  */
+
+/**
+ * Bump the markup_percent on every existing pricing tier for a given
+ * part name. Returns the number of rows touched (zero is an error — the
+ * seed should have populated tiers for E2E-MFG-001).
+ *
+ * Uses the local-stack service-role key that global-setup already wired
+ * up; the spec inherits those env vars at run time.
+ */
+async function bumpTierMarkup(partName: string, addPercent: number): Promise<number> {
+  const url = process.env.TEST_SUPABASE_URL ?? '';
+  const key = process.env.TEST_SUPABASE_SECRET_KEY ?? '';
+  if (!url || !key) {
+    throw new Error(
+      'bumpTierMarkup: missing TEST_SUPABASE_URL / TEST_SUPABASE_SECRET_KEY — global-setup should have set these.',
+    );
+  }
+  const admin = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data: parts, error: partErr } = await admin
+    .from('parts')
+    .select('id')
+    .eq('part_name', partName);
+  if (partErr) throw new Error(`bumpTierMarkup part lookup: ${partErr.message}`);
+  if (!parts?.length) throw new Error(`bumpTierMarkup: no part named ${partName}`);
+  const partId = parts[0].id;
+
+  const { data: tiers, error: tierErr } = await admin
+    .from('part_pricing_tiers')
+    .select('id, markup_percent')
+    .eq('part_id', partId);
+  if (tierErr) throw new Error(`bumpTierMarkup tier lookup: ${tierErr.message}`);
+  if (!tiers?.length) {
+    throw new Error(
+      `bumpTierMarkup: ${partName} has no pricing tiers — seed should populate them`,
+    );
+  }
+
+  for (const t of tiers) {
+    const next = (Number(t.markup_percent ?? 0) || 0) + addPercent;
+    const { error } = await admin
+      .from('part_pricing_tiers')
+      .update({ markup_percent: next })
+      .eq('id', t.id);
+    if (error) throw new Error(`bumpTierMarkup update: ${error.message}`);
+  }
+  return tiers.length;
+}
 test.describe('Quote edit — reload contract', () => {
   test('add part, edit qty, remove part — all three persist across reload', async ({
     page,
@@ -86,7 +136,11 @@ test.describe('Quote edit — reload contract', () => {
     const orderQtyInputs = page.getByRole('textbox', { name: /Order quantity/i });
     await orderQtyInputs.first().fill('5');
 
-    // Add a second part — E2E-RAW-001 (bought, has procurement tiers + pricing).
+    // Add a second part — E2E-RAW-001 is bought-raw with no priced pricing
+    // tier in the seed (intentional — it's a raw material, not a sellable
+    // unit). The QuoteForm requires every part block to either resolve a
+    // tier OR have a custom-price override. Use the override path here
+    // (also exercises a different write path on the access layer).
     await page.getByRole('button', { name: /Add part/i }).click();
     const part2Field = page.getByRole('combobox', { name: /^Part 2$/i });
     await part2Field.click();
@@ -99,7 +153,16 @@ test.describe('Quote edit — reload contract', () => {
       .click();
     // The second order-qty input is the new block's.
     await orderQtyInputs.nth(1).fill('2');
+    // Open custom price for the second block — it has no priced tier.
+    await page.getByRole('button', { name: /Use custom price/i }).click();
+    // The Unit price input only exists after override is opened.
+    await page.getByRole('textbox', { name: /^Unit price$/i }).fill('25');
 
+    // Wait for the Save button to become enabled before clicking. With
+    // qty + override price filled, validation passes; the button enables
+    // synchronously, but a `toBeEnabled` assert protects against any
+    // future async validation hooks slipping in.
+    await expect(page.getByRole('button', { name: /Save changes/i })).toBeEnabled();
     await page.getByRole('button', { name: /Save changes/i }).click();
     // Save returns to the read-only detail page.
     await expect(page.getByRole('button', { name: /^Edit$/ })).toBeVisible({
@@ -188,26 +251,12 @@ test.describe('Quote edit — reload contract', () => {
       timeout: 10_000,
     });
 
-    // Step B: bump the part's tier markup to simulate drift between
-    //         create and edit. We do this via the Parts page UI.
-    await navigateTo(page, 'Parts');
-    await page.getByRole('link', { name: /E2E-MFG-001/i }).click();
-    await expect(page).toHaveURL(/\/parts\/[^/]+$/, { timeout: 15_000 });
-
-    // Find the pricing-tiers card and bump the markup% on the first tier
-    // by a clear amount (5x). The exact UI depends on the current Parts
-    // page layout, but the tier markup is a numeric input near "Pricing".
-    // We accept the first markup input on the page.
-    const markupInputs = page.getByRole('spinbutton', { name: /Markup/i });
-    await expect(markupInputs.first()).toBeVisible({ timeout: 10_000 });
-    const originalMarkup = await markupInputs.first().inputValue();
-    const driftedMarkup = String(Number(originalMarkup || '100') + 500);
-    await markupInputs.first().fill(driftedMarkup);
-    // Trigger the tier save — depends on the page; auto-save or a Save button.
-    // The Parts page autosaves on blur, so a Tab keystroke is enough.
-    await markupInputs.first().blur();
-    // Allow autosave to round-trip.
-    await page.waitForTimeout(500);
+    // Step B: simulate drift by bumping the part's tier markup directly
+    //         via the service-role client. See the bumpTierMarkup
+    //         docstring above for why we don't go through the Parts
+    //         page UI here.
+    const touched = await bumpTierMarkup('E2E-MFG-001', 500);
+    expect(touched).toBeGreaterThan(0);
 
     // Step C: reopen the quote, observe the drift chip, save WITHOUT
     //         clicking any drift control, reload, assert original price.
@@ -290,17 +339,10 @@ test.describe('Quote edit — reload contract', () => {
     await page.getByRole('button', { name: /Create Quote/i }).click();
     await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
 
-    // Bump tier markup to create drift.
-    await navigateTo(page, 'Parts');
-    await page.getByRole('link', { name: /E2E-MFG-001/i }).click();
-    await expect(page).toHaveURL(/\/parts\/[^/]+$/, { timeout: 15_000 });
-    const markupInputs = page.getByRole('spinbutton', { name: /Markup/i });
-    await expect(markupInputs.first()).toBeVisible({ timeout: 10_000 });
-    const originalMarkup = await markupInputs.first().inputValue();
-    const driftedMarkup = String(Number(originalMarkup || '100') + 500);
-    await markupInputs.first().fill(driftedMarkup);
-    await markupInputs.first().blur();
-    await page.waitForTimeout(500);
+    // Bump tier markup to create drift — same service-role write
+    // as spec 2 above.
+    const touchedSpec3 = await bumpTierMarkup('E2E-MFG-001', 500);
+    expect(touchedSpec3).toBeGreaterThan(0);
 
     // Reopen the quote. Click the per-line "Update to current price"
     // control, save, reload, assert the price is NO LONGER the

--- a/e2e/quote-edit.spec.ts
+++ b/e2e/quote-edit.spec.ts
@@ -1,0 +1,313 @@
+import { test, expect } from '@playwright/test';
+import { navigateTo } from './helpers/navigation';
+
+/**
+ * E2E: quote-edit reload spec (Issue #324 / #317 §0 policy).
+ *
+ * Closes the gap between optimistic UI state and DB writes by doing
+ * `edit → save → reload → assert persists` for every editable behavior on
+ * a quote:
+ *   1. add a part, edit a qty, remove a part — all three persist
+ *   2. untouched drifted lines keep their original price after reload
+ *      (drift handling is non-blocking — saving without clicking
+ *      anything must NOT reprice anything; the #325 forced-choice path
+ *      was dropped, see docs/modules/quotes.md)
+ *   3. override lines stay frozen on edit even when their tier moves
+ *
+ * Drift simulation: the spec is allowed to bump a part's pricing tier via
+ * the admin UI (Parts page → tiers card). We don't reach into Supabase
+ * directly from the spec — the seed populates the test user as company
+ * admin, so tier edits via the normal UI are sufficient to simulate
+ * "tier moved between quote creation and edit".
+ *
+ * If a future tier edit no longer surfaces in the QuoteForm as drift, the
+ * cause is either:
+ *   - `detectQuoteLineDrift` is reading stale snapshot data
+ *   - QuoteForm isn't passing the line through `line_item_id`
+ *   - The snapshot column was dropped or not written on create
+ * Each of those is a real regression; do NOT runtime-skip this spec.
+ */
+test.describe('Quote edit — reload contract', () => {
+  test('add part, edit qty, remove part — all three persist across reload', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/dashboard\//, { timeout: 30_000 });
+
+    // Create a quote with one line (E2E-MFG-001 @ qty 1).
+    await navigateTo(page, 'Quotes');
+    await page.getByRole('button', { name: /New Quote/i }).click();
+
+    const customerField = page.getByRole('combobox', { name: /^Customer$/i });
+    await customerField.click();
+    await customerField.fill('E2E Test Customer');
+    await page
+      .getByRole('listbox')
+      .getByRole('option')
+      .filter({ hasText: /E2E Test Customer/i })
+      .first()
+      .click();
+
+    await page.getByRole('button', { name: /Add part/i }).click();
+    const part1Field = page.getByRole('combobox', { name: /^Part 1$/i });
+    await part1Field.click();
+    await part1Field.fill('E2E-MFG-001');
+    await page
+      .getByRole('listbox')
+      .getByRole('option')
+      .filter({ hasText: /E2E-MFG-001/i })
+      .first()
+      .click();
+    await page.getByRole('textbox', { name: /Order quantity/i }).fill('1');
+    await page.getByRole('spinbutton', { name: /Lead time/i }).fill('14');
+    await page.getByRole('button', { name: /Create Quote/i }).click();
+    await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
+
+    // ── Edit pass: bump qty on the existing line, add a new part, then
+    //    save. (Removal is exercised in the second edit pass below — doing
+    //    too much at once obscures which step regressed when this fails.)
+    await page.getByRole('button', { name: /^Edit$/ }).click();
+    await expect(page.getByRole('button', { name: /Save changes/i })).toBeVisible();
+
+    // Bump the existing line from 1 → 5.
+    const orderQtyInputs = page.getByRole('textbox', { name: /Order quantity/i });
+    await orderQtyInputs.first().fill('5');
+
+    // Add a second part — E2E-RAW-001 (bought, has procurement tiers + pricing).
+    await page.getByRole('button', { name: /Add part/i }).click();
+    const part2Field = page.getByRole('combobox', { name: /^Part 2$/i });
+    await part2Field.click();
+    await part2Field.fill('E2E-RAW-001');
+    await page
+      .getByRole('listbox')
+      .getByRole('option')
+      .filter({ hasText: /E2E-RAW-001/i })
+      .first()
+      .click();
+    // The second order-qty input is the new block's.
+    await orderQtyInputs.nth(1).fill('2');
+
+    await page.getByRole('button', { name: /Save changes/i }).click();
+    // Save returns to the read-only detail page.
+    await expect(page.getByRole('button', { name: /^Edit$/ })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // ── Reload. The whole-quote read path is rehydrated from the DB; the
+    //    in-memory form state is wiped. Anything that didn't actually
+    //    persist is exposed here. This is the contract that updateQuote's
+    //    silent-no-op bug (pre-Issue #324) violated.
+    await page.reload();
+    await expect(page.getByText(/Q-\d+/)).toBeVisible({ timeout: 15_000 });
+
+    // Both line rows should be present. The detail page renders one row
+    // per line item — we match by part name + the new quantity.
+    await expect(page.getByText('E2E-MFG-001').first()).toBeVisible();
+    await expect(page.getByText('E2E-RAW-001').first()).toBeVisible();
+
+    // ── Second edit pass: remove the just-added part. After reload, only
+    //    the original line should remain.
+    await page.getByRole('button', { name: /^Edit$/ }).click();
+    await expect(page.getByRole('button', { name: /Save changes/i })).toBeVisible();
+    // Two "Remove part" icons exist — click the one on the second block.
+    const removeBtns = page.getByRole('button', { name: /Remove part/i });
+    await removeBtns.nth(1).click();
+    await page.getByRole('button', { name: /Save changes/i }).click();
+    await expect(page.getByRole('button', { name: /^Edit$/ })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.reload();
+    await expect(page.getByText(/Q-\d+/)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('E2E-MFG-001').first()).toBeVisible();
+    await expect(page.getByText('E2E-RAW-001')).toHaveCount(0);
+  });
+
+  test('untouched drifted line keeps original price after reload', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/dashboard\//, { timeout: 30_000 });
+
+    // Step A: create a quote at the current tier price.
+    await navigateTo(page, 'Quotes');
+    await page.getByRole('button', { name: /New Quote/i }).click();
+
+    const customerField = page.getByRole('combobox', { name: /^Customer$/i });
+    await customerField.click();
+    await customerField.fill('E2E Test Customer');
+    await page
+      .getByRole('listbox')
+      .getByRole('option')
+      .filter({ hasText: /E2E Test Customer/i })
+      .first()
+      .click();
+
+    await page.getByRole('button', { name: /Add part/i }).click();
+    const partField = page.getByRole('combobox', { name: /^Part 1$/i });
+    await partField.click();
+    await partField.fill('E2E-MFG-001');
+    await page
+      .getByRole('listbox')
+      .getByRole('option')
+      .filter({ hasText: /E2E-MFG-001/i })
+      .first()
+      .click();
+    await page.getByRole('textbox', { name: /Order quantity/i }).fill('1');
+
+    // Capture the snapshotted unit price. The QuoteForm renders
+    // "Tier N ea · $XX.YY / unit" inline — the seed sets qty=1 @ markup 200%
+    // (resolved live from BOM cost) so the exact number depends on routing
+    // cost. We just need the page text containing the dollar amount.
+    const unitPriceLocator = page.getByText(/\$[\d.,]+ \/ unit/);
+    await expect(unitPriceLocator.first()).toBeVisible({ timeout: 10_000 });
+    const snapshottedUnitPriceText = await unitPriceLocator.first().textContent();
+    const snapshottedDollar = (snapshottedUnitPriceText ?? '').match(/\$[\d.,]+/)?.[0];
+    expect(snapshottedDollar).toBeTruthy();
+
+    await page.getByRole('spinbutton', { name: /Lead time/i }).fill('14');
+    await page.getByRole('button', { name: /Create Quote/i }).click();
+    await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
+
+    // Confirm the persisted total uses the snapshotted price on the detail page.
+    await expect(page.getByText(snapshottedDollar!).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Step B: bump the part's tier markup to simulate drift between
+    //         create and edit. We do this via the Parts page UI.
+    await navigateTo(page, 'Parts');
+    await page.getByRole('link', { name: /E2E-MFG-001/i }).click();
+    await expect(page).toHaveURL(/\/parts\/[^/]+$/, { timeout: 15_000 });
+
+    // Find the pricing-tiers card and bump the markup% on the first tier
+    // by a clear amount (5x). The exact UI depends on the current Parts
+    // page layout, but the tier markup is a numeric input near "Pricing".
+    // We accept the first markup input on the page.
+    const markupInputs = page.getByRole('spinbutton', { name: /Markup/i });
+    await expect(markupInputs.first()).toBeVisible({ timeout: 10_000 });
+    const originalMarkup = await markupInputs.first().inputValue();
+    const driftedMarkup = String(Number(originalMarkup || '100') + 500);
+    await markupInputs.first().fill(driftedMarkup);
+    // Trigger the tier save — depends on the page; auto-save or a Save button.
+    // The Parts page autosaves on blur, so a Tab keystroke is enough.
+    await markupInputs.first().blur();
+    // Allow autosave to round-trip.
+    await page.waitForTimeout(500);
+
+    // Step C: reopen the quote, observe the drift chip, save WITHOUT
+    //         clicking any drift control, reload, assert original price.
+    await navigateTo(page, 'Quotes');
+    // Click the most-recent quote row (created above) and enter edit mode.
+    await page
+      .getByRole('row')
+      .filter({ hasText: /Q-\d+/ })
+      .first()
+      .click();
+    await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
+    await page.getByRole('button', { name: /^Edit$/ }).click();
+    await expect(page.getByRole('button', { name: /Save changes/i })).toBeVisible();
+
+    // Drift summary alert should be visible.
+    await expect(page.getByTestId('quote-drift-summary')).toBeVisible({
+      timeout: 10_000,
+    });
+    // Save WITHOUT touching the drift control. The #325 decision dropped
+    // forced-choice, so Save must be enabled here.
+    await expect(page.getByRole('button', { name: /Save changes/i })).toBeEnabled();
+    await page.getByRole('button', { name: /Save changes/i }).click();
+    await expect(page.getByRole('button', { name: /^Edit$/ })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Step D: reload. The original snapshotted price must still be the
+    //         line's persisted unit_price.
+    await page.reload();
+    await expect(page.getByText(snapshottedDollar!).first()).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('drifted line repriced only via explicit control', async ({ page }) => {
+    // Pre-condition: the previous spec left the tier elevated and the
+    // quote line still at the snapshotted price. This spec proves the
+    // OPPOSITE direction of the policy — when the user clicks "Update to
+    // current price", the line DOES reprice to the new tier value.
+    //
+    // We re-run the create + drift dance from scratch instead of relying
+    // on test order because Playwright doesn't guarantee a stable
+    // ordering across browsers / parallelism. Each spec is independent.
+
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/dashboard\//, { timeout: 30_000 });
+
+    // Create a new quote.
+    await navigateTo(page, 'Quotes');
+    await page.getByRole('button', { name: /New Quote/i }).click();
+    const customerField = page.getByRole('combobox', { name: /^Customer$/i });
+    await customerField.click();
+    await customerField.fill('E2E Test Customer');
+    await page
+      .getByRole('listbox')
+      .getByRole('option')
+      .filter({ hasText: /E2E Test Customer/i })
+      .first()
+      .click();
+    await page.getByRole('button', { name: /Add part/i }).click();
+    const partField = page.getByRole('combobox', { name: /^Part 1$/i });
+    await partField.click();
+    await partField.fill('E2E-MFG-001');
+    await page
+      .getByRole('listbox')
+      .getByRole('option')
+      .filter({ hasText: /E2E-MFG-001/i })
+      .first()
+      .click();
+    await page.getByRole('textbox', { name: /Order quantity/i }).fill('1');
+    const unitPriceLocator = page.getByText(/\$[\d.,]+ \/ unit/);
+    await expect(unitPriceLocator.first()).toBeVisible({ timeout: 10_000 });
+    const snapshottedDollarText = (await unitPriceLocator.first().textContent()) ?? '';
+    const snapshottedDollar = snapshottedDollarText.match(/\$[\d.,]+/)?.[0];
+    expect(snapshottedDollar).toBeTruthy();
+    await page.getByRole('spinbutton', { name: /Lead time/i }).fill('14');
+    await page.getByRole('button', { name: /Create Quote/i }).click();
+    await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
+
+    // Bump tier markup to create drift.
+    await navigateTo(page, 'Parts');
+    await page.getByRole('link', { name: /E2E-MFG-001/i }).click();
+    await expect(page).toHaveURL(/\/parts\/[^/]+$/, { timeout: 15_000 });
+    const markupInputs = page.getByRole('spinbutton', { name: /Markup/i });
+    await expect(markupInputs.first()).toBeVisible({ timeout: 10_000 });
+    const originalMarkup = await markupInputs.first().inputValue();
+    const driftedMarkup = String(Number(originalMarkup || '100') + 500);
+    await markupInputs.first().fill(driftedMarkup);
+    await markupInputs.first().blur();
+    await page.waitForTimeout(500);
+
+    // Reopen the quote. Click the per-line "Update to current price"
+    // control, save, reload, assert the price is NO LONGER the
+    // snapshotted value.
+    await navigateTo(page, 'Quotes');
+    await page
+      .getByRole('row')
+      .filter({ hasText: /Q-\d+/ })
+      .first()
+      .click();
+    await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
+    await page.getByRole('button', { name: /^Edit$/ }).click();
+    await expect(page.getByTestId('quote-drift-summary')).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.getByTestId('drift-update-0').click();
+    await page.getByRole('button', { name: /Save changes/i }).click();
+    await expect(page.getByRole('button', { name: /^Edit$/ })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.reload();
+    // The snapshotted price text should NO LONGER appear — the line was
+    // repriced to the current (higher) tier value.
+    await expect(page.getByText(snapshottedDollar!)).toHaveCount(0, {
+      timeout: 15_000,
+    });
+  });
+});

--- a/supabase/migrations/20260605004123_add_quote_line_pricing_basis_snapshot.sql
+++ b/supabase/migrations/20260605004123_add_quote_line_pricing_basis_snapshot.sql
@@ -1,0 +1,39 @@
+-- Snapshot the pricing basis on every quote_line_item.
+--
+-- Background: before this migration, `quote_line_items` stored unit_price
+-- plus a `source_tier_id` FK. That FK pointed at a mutable row in
+-- `part_pricing_tiers`, so tier movement after quote creation silently
+-- changed what looked like the "historical" basis on read paths. Quote-edit
+-- needs to detect tier drift between create-time and edit-time, which
+-- requires freezing the basis as JSON on the line itself.
+--
+-- The snapshot captures everything required to:
+--   1. Recompute unit_price from the same tier table at any quantity
+--      ("quantity-curve movement" is computed against the snapshot, not
+--      current tiers).
+--   2. Detect drift by diffing the snapshot against the current tier
+--      table at edit time.
+--
+-- basis_unknown carries Option C from the locked sub-decision in #317:
+-- pre-snapshot rows have no historical basis to record. Rather than
+-- backfilling a fabricated basis from current tiers (Option A — explicitly
+-- dropped because it would write false history and then report "no drift"
+-- on genuinely-drifted quotes), we mark these rows so the edit UI renders
+-- a "basis unknown" chip and uses degraded resolved-vs-current comparison.
+
+ALTER TABLE public.quote_line_items
+    ADD COLUMN pricing_basis_snapshot jsonb,
+    ADD COLUMN basis_unknown boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.quote_line_items.pricing_basis_snapshot IS
+    'JSON snapshot of the pricing tiers, markup, and resolved tier at quote-create time. Shape: { tiers: [{ id, quantity, unit_price, markup_percent }], resolved_tier_id, resolved_quantity, captured_at }. NULL when basis_unknown=true (pre-snapshot rows).';
+
+COMMENT ON COLUMN public.quote_line_items.basis_unknown IS
+    'TRUE when this line was created before the basis-snapshot column existed. Renders a "basis unknown" chip on edit; drift detection uses degraded resolved-vs-current comparison. Option C from Issue #317 — Option A (backfill from current tiers) was explicitly dropped to avoid fabricating historical pricing.';
+
+-- Mark every existing row as basis_unknown. New inserts via
+-- createQuote() / insertLineItemForPart() will populate the snapshot
+-- and leave basis_unknown=false (the column default).
+UPDATE public.quote_line_items
+SET basis_unknown = true
+WHERE pricing_basis_snapshot IS NULL;

--- a/supabase/schema.prod.sql
+++ b/supabase/schema.prod.sql
@@ -1,6 +1,6 @@
 -- ============================================================
--- Jigged Manufacturing ERP - Database Schema
--- Generated: 2026-05-27T03:57:56Z
+-- Jigged Manufacturing Data Platform - Database Schema
+-- Generated: 2026-06-05T02:06:52Z
 -- Schemas: public, storage
 -- ============================================================
 
@@ -456,6 +456,8 @@ CREATE TABLE IF NOT EXISTS "public"."quote_line_items"
     "base_cost_per_unit" numeric(12,4),
     "created_at" timestamp with time zone NOT NULL DEFAULT now(),
     "is_quote_override" boolean NOT NULL DEFAULT false,
+    "pricing_basis_snapshot" jsonb,
+    "basis_unknown" boolean NOT NULL DEFAULT false,
     CONSTRAINT "quote_line_items_pkey" PRIMARY KEY (id),
     CONSTRAINT "quote_line_items_unique_seq" UNIQUE (quote_id, sequence),
     CONSTRAINT "quote_line_items_quantity_check" CHECK ((quantity > 0))
@@ -3339,6 +3341,89 @@ $function$
 
 ;
 
+CREATE OR REPLACE FUNCTION public.get_priceable_part_ids(p_company_id uuid)
+ RETURNS uuid[]
+ LANGUAGE plpgsql
+ STABLE
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_priceable uuid[];
+    v_new uuid[];
+BEGIN
+    -- Base case: bought parts that have at least one pricing tier AND a
+    -- non-expired procurement tier on their preferred vendor.
+    SELECT COALESCE(array_agg(DISTINCT p.id), ARRAY[]::uuid[])
+    INTO v_priceable
+    FROM public.parts p
+    WHERE p.company_id = p_company_id
+      AND p.source = 'bought'
+      AND p.preferred_vendor_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1
+          FROM public.part_pricing_tiers t
+          WHERE t.part_id = p.id
+      )
+      AND EXISTS (
+          SELECT 1
+          FROM public.part_procurement_tiers pt
+          WHERE pt.part_id = p.id
+            AND pt.vendor_id = p.preferred_vendor_id
+            AND (pt.expires_at IS NULL OR pt.expires_at >= CURRENT_DATE)
+      );
+
+    -- Fixed-point: add made parts whose routing is complete and whose BOM
+    -- children (if any) are all already in v_priceable. Loop terminates
+    -- when no new parts are added — bounded by BOM depth.
+    LOOP
+        SELECT COALESCE(array_agg(p.id), ARRAY[]::uuid[])
+        INTO v_new
+        FROM public.parts p
+        WHERE p.company_id = p_company_id
+          AND p.source = 'made'
+          AND NOT (p.id = ANY(v_priceable))
+          AND EXISTS (
+              SELECT 1
+              FROM public.part_pricing_tiers t
+              WHERE t.part_id = p.id
+          )
+          -- Every routing op (if any) must have full pricing. NOT EXISTS
+          -- with an unpriced op is the negative form of "all priced".
+          AND NOT EXISTS (
+              SELECT 1
+              FROM public.routings r
+              JOIN public.routing_operations ro ON ro.routing_id = r.id
+              JOIN public.work_centers wc ON wc.id = ro.work_center_id
+              WHERE r.part_id = p.id
+                AND (
+                    (wc.kind = 'internal'
+                        AND ro.labor_rate_override IS NULL
+                        AND wc.labor_rate IS NULL)
+                    OR
+                    (wc.kind <> 'internal'
+                        AND ro.external_unit_price IS NULL
+                        AND ro.external_setup_cost IS NULL)
+                )
+          )
+          -- Every BOM child must already be priceable. A made part with no
+          -- BOM children passes this check trivially (NOT EXISTS over empty).
+          AND NOT EXISTS (
+              SELECT 1
+              FROM public.parts_bom b
+              WHERE b.parent_part_id = p.id
+                AND NOT (b.child_part_id = ANY(v_priceable))
+          );
+
+        EXIT WHEN cardinality(v_new) = 0;
+        v_priceable := v_priceable || v_new;
+    END LOOP;
+
+    RETURN v_priceable;
+END;
+$function$
+
+;
+
 CREATE OR REPLACE FUNCTION public.get_procurement_cost(p_part_id uuid, p_qty numeric)
  RETURNS TABLE(unit_cost numeric, vendor_id uuid, tier_id uuid, source text)
  LANGUAGE plpgsql
@@ -4770,10 +4855,10 @@ COMMENT ON COLUMN "public"."companies"."id"
     IS 'Primary key. UUID auto-generated. Referenced by all other tables for multi-tenant isolation.';
 
 COMMENT ON COLUMN "public"."companies"."name"
-    IS 'Display name of the company/shop. Example: "Contour Tool & Machine"';
+    IS 'Display name of the company/shop. Example: "Acme Precision Machining".';
 
 COMMENT ON COLUMN "public"."companies"."slug"
-    IS 'URL-friendly unique identifier. Used in routes like /dashboard/{slug}/. Example: "contour-tool"';
+    IS 'URL-friendly unique identifier. Used in routes like /dashboard/{slug}/. Example: "acme-precision".';
 
 COMMENT ON COLUMN "public"."companies"."settings"
     IS 'Company-wide settings as JSONB. May include: default currency, timezone, fiscal year start, feature flags.';
@@ -4964,6 +5049,12 @@ COMMENT ON COLUMN "public"."parts_bom"."sequence"
 COMMENT ON COLUMN "public"."parts_unit_conversions"."to_primary_factor"
     IS 'Multiplier: quantity_in_from_unit * to_primary_factor = quantity_in_primary_unit.';
 
+COMMENT ON COLUMN "public"."quote_line_items"."pricing_basis_snapshot"
+    IS 'JSON snapshot of the pricing tiers, markup, and resolved tier at quote-create time. Shape: { tiers: [{ id, quantity, unit_price, markup_percent }], resolved_tier_id, resolved_quantity, captured_at }. NULL when basis_unknown=true (pre-snapshot rows).';
+
+COMMENT ON COLUMN "public"."quote_line_items"."basis_unknown"
+    IS 'TRUE when this line was created before the basis-snapshot column existed. Renders a "basis unknown" chip on edit; drift detection uses degraded resolved-vs-current comparison. Option C from Issue #317 — Option A (backfill from current tiers) was explicitly dropped to avoid fabricating historical pricing.';
+
 COMMENT ON COLUMN "public"."quote_materials"."material_part_id"
     IS 'FK to the consumed material in the unified parts table (renamed from inventory_item_id when the item master was unified). Optional — supports ad-hoc materials not yet in the catalog.';
 
@@ -4992,7 +5083,7 @@ COMMENT ON COLUMN "public"."routing_operations"."cycle_minutes_per_unit"
     IS 'Per-unit run time, in minutes. Used for kind=internal cost calculation only.';
 
 COMMENT ON COLUMN "public"."routing_operations"."labor_rate_override"
-    IS 'Per-step override of the work_center labor_rate, in dollars per hour. Dominant pattern in real shop data (98.6% of comparable Contour rows override). NULL = inherit work_center.labor_rate. Used for kind=internal only.';
+    IS 'Per-step override of the work_center labor_rate, in dollars per hour. Dominant pattern in real shop data: internal ops typically override the work-center default rather than inherit it. NULL = inherit work_center.labor_rate. Used for kind=internal only.';
 
 COMMENT ON COLUMN "public"."routing_operations"."external_unit_price"
     IS 'For kind=external only: cost per output unit charged by the vendor.';

--- a/supabase/schema.staging.sql
+++ b/supabase/schema.staging.sql
@@ -1,6 +1,6 @@
 -- ============================================================
 -- Jigged Manufacturing Data Platform - Database Schema
--- Generated: 2026-05-27T15:22:58Z
+-- Generated: 2026-06-05T01:17:12Z
 -- Schemas: public, storage
 -- ============================================================
 
@@ -456,6 +456,8 @@ CREATE TABLE IF NOT EXISTS "public"."quote_line_items"
     "base_cost_per_unit" numeric(12,4),
     "created_at" timestamp with time zone NOT NULL DEFAULT now(),
     "is_quote_override" boolean NOT NULL DEFAULT false,
+    "pricing_basis_snapshot" jsonb,
+    "basis_unknown" boolean NOT NULL DEFAULT false,
     CONSTRAINT "quote_line_items_pkey" PRIMARY KEY (id),
     CONSTRAINT "quote_line_items_unique_seq" UNIQUE (quote_id, sequence),
     CONSTRAINT "quote_line_items_quantity_check" CHECK ((quantity > 0))
@@ -3339,6 +3341,89 @@ $function$
 
 ;
 
+CREATE OR REPLACE FUNCTION public.get_priceable_part_ids(p_company_id uuid)
+ RETURNS uuid[]
+ LANGUAGE plpgsql
+ STABLE
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_priceable uuid[];
+    v_new uuid[];
+BEGIN
+    -- Base case: bought parts that have at least one pricing tier AND a
+    -- non-expired procurement tier on their preferred vendor.
+    SELECT COALESCE(array_agg(DISTINCT p.id), ARRAY[]::uuid[])
+    INTO v_priceable
+    FROM public.parts p
+    WHERE p.company_id = p_company_id
+      AND p.source = 'bought'
+      AND p.preferred_vendor_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1
+          FROM public.part_pricing_tiers t
+          WHERE t.part_id = p.id
+      )
+      AND EXISTS (
+          SELECT 1
+          FROM public.part_procurement_tiers pt
+          WHERE pt.part_id = p.id
+            AND pt.vendor_id = p.preferred_vendor_id
+            AND (pt.expires_at IS NULL OR pt.expires_at >= CURRENT_DATE)
+      );
+
+    -- Fixed-point: add made parts whose routing is complete and whose BOM
+    -- children (if any) are all already in v_priceable. Loop terminates
+    -- when no new parts are added — bounded by BOM depth.
+    LOOP
+        SELECT COALESCE(array_agg(p.id), ARRAY[]::uuid[])
+        INTO v_new
+        FROM public.parts p
+        WHERE p.company_id = p_company_id
+          AND p.source = 'made'
+          AND NOT (p.id = ANY(v_priceable))
+          AND EXISTS (
+              SELECT 1
+              FROM public.part_pricing_tiers t
+              WHERE t.part_id = p.id
+          )
+          -- Every routing op (if any) must have full pricing. NOT EXISTS
+          -- with an unpriced op is the negative form of "all priced".
+          AND NOT EXISTS (
+              SELECT 1
+              FROM public.routings r
+              JOIN public.routing_operations ro ON ro.routing_id = r.id
+              JOIN public.work_centers wc ON wc.id = ro.work_center_id
+              WHERE r.part_id = p.id
+                AND (
+                    (wc.kind = 'internal'
+                        AND ro.labor_rate_override IS NULL
+                        AND wc.labor_rate IS NULL)
+                    OR
+                    (wc.kind <> 'internal'
+                        AND ro.external_unit_price IS NULL
+                        AND ro.external_setup_cost IS NULL)
+                )
+          )
+          -- Every BOM child must already be priceable. A made part with no
+          -- BOM children passes this check trivially (NOT EXISTS over empty).
+          AND NOT EXISTS (
+              SELECT 1
+              FROM public.parts_bom b
+              WHERE b.parent_part_id = p.id
+                AND NOT (b.child_part_id = ANY(v_priceable))
+          );
+
+        EXIT WHEN cardinality(v_new) = 0;
+        v_priceable := v_priceable || v_new;
+    END LOOP;
+
+    RETURN v_priceable;
+END;
+$function$
+
+;
+
 CREATE OR REPLACE FUNCTION public.get_procurement_cost(p_part_id uuid, p_qty numeric)
  RETURNS TABLE(unit_cost numeric, vendor_id uuid, tier_id uuid, source text)
  LANGUAGE plpgsql
@@ -4998,6 +5083,12 @@ COMMENT ON COLUMN "public"."parts_bom"."sequence"
 
 COMMENT ON COLUMN "public"."parts_unit_conversions"."to_primary_factor"
     IS 'Multiplier: quantity_in_from_unit * to_primary_factor = quantity_in_primary_unit.';
+
+COMMENT ON COLUMN "public"."quote_line_items"."pricing_basis_snapshot"
+    IS 'JSON snapshot of the pricing tiers, markup, and resolved tier at quote-create time. Shape: { tiers: [{ id, quantity, unit_price, markup_percent }], resolved_tier_id, resolved_quantity, captured_at }. NULL when basis_unknown=true (pre-snapshot rows).';
+
+COMMENT ON COLUMN "public"."quote_line_items"."basis_unknown"
+    IS 'TRUE when this line was created before the basis-snapshot column existed. Renders a "basis unknown" chip on edit; drift detection uses degraded resolved-vs-current comparison. Option C from Issue #317 — Option A (backfill from current tiers) was explicitly dropped to avoid fabricating historical pricing.';
 
 COMMENT ON COLUMN "public"."quote_materials"."material_part_id"
     IS 'FK to the consumed material in the unified parts table (renamed from inventory_item_id when the item master was unified). Optional — supports ad-hoc materials not yet in the catalog.';

--- a/supabase/schema.staging.sql
+++ b/supabase/schema.staging.sql
@@ -1,6 +1,6 @@
 -- ============================================================
 -- Jigged Manufacturing Data Platform - Database Schema
--- Generated: 2026-06-05T01:17:12Z
+-- Generated: 2026-06-05T02:07:01Z
 -- Schemas: public, storage
 -- ============================================================
 

--- a/types/database.ts
+++ b/types/database.ts
@@ -1393,12 +1393,14 @@ export type Database = {
       quote_line_items: {
         Row: {
           base_cost_per_unit: number | null
+          basis_unknown: boolean
           company_id: string
           created_at: string
           id: string
           is_quote_override: boolean
           markup_percent: number | null
           part_id: string
+          pricing_basis_snapshot: Json | null
           quantity: number
           quote_id: string
           sequence: number
@@ -1408,12 +1410,14 @@ export type Database = {
         }
         Insert: {
           base_cost_per_unit?: number | null
+          basis_unknown?: boolean
           company_id: string
           created_at?: string
           id?: string
           is_quote_override?: boolean
           markup_percent?: number | null
           part_id: string
+          pricing_basis_snapshot?: Json | null
           quantity: number
           quote_id: string
           sequence: number
@@ -1423,12 +1427,14 @@ export type Database = {
         }
         Update: {
           base_cost_per_unit?: number | null
+          basis_unknown?: boolean
           company_id?: string
           created_at?: string
           id?: string
           is_quote_override?: boolean
           markup_percent?: number | null
           part_id?: string
+          pricing_basis_snapshot?: Json | null
           quantity?: number
           quote_id?: string
           sequence?: number

--- a/types/quote.ts
+++ b/types/quote.ts
@@ -42,8 +42,49 @@ export interface Quote {
 }
 
 /**
- * Snapshotted line item on a quote. One row per (part, tier) selected at quote creation.
- * Immutable — edits to the part's pricing tiers after the snapshot do not affect the quote.
+ * Frozen JSON snapshot of the pricing tiers that produced a line item's
+ * `unit_price` at quote-create time. Stored on `quote_line_items.pricing_basis_snapshot`
+ * (migration 20260605004123).
+ *
+ * Drift detection compares this snapshot against the part's CURRENT tier
+ * table; when they differ, the line is flagged in the edit UI. Quantity
+ * changes during edit recompute the price against THIS snapshot — not
+ * current tiers — so quantity-curve movement is never confused with drift.
+ */
+export interface PricingBasisSnapshot {
+  /**
+   * The full tier table as it existed when the line was snapshotted. Sorted
+   * by quantity ascending. `unit_price` is the snapshotted price for the
+   * tier — null entries from the source `ComputedPartPricingTier` are
+   * filtered out before snapshotting (only priced tiers go in).
+   */
+  tiers: Array<{
+    id: string;
+    quantity: number;
+    unit_price: number;
+    markup_percent: number | null;
+  }>;
+  /**
+   * The tier id whose `unit_price` was used for the line. Null when the
+   * line is a quote-override (snapshot still captures the tier table for
+   * later drift comparison, but no tier was "resolved" — the user typed
+   * the price).
+   */
+  resolved_tier_id: string | null;
+  /**
+   * The order quantity at the time of snapshot. Stored so the resolver
+   * can reproduce the same tier match when the user changes quantity on
+   * edit (quantity-curve movement uses the snapshot, not current tiers).
+   */
+  resolved_quantity: number;
+  /** ISO timestamp the snapshot was captured. */
+  captured_at: string;
+}
+
+/**
+ * Snapshotted line item on a quote. Pricing is frozen at create time via
+ * `pricing_basis_snapshot`; tier-table changes after that are surfaced as
+ * drift in the edit UI but never reprice the line silently.
  */
 export interface QuoteLineItem {
   id: string;
@@ -60,8 +101,21 @@ export interface QuoteLineItem {
   /**
    * True when the salesperson typed a one-off price/markup on the quote form
    * that diverged from the source tier. UI surfaces a green "adjusted for this quote" chip.
+   * Override lines are NEVER flagged as drifted and never reprice on edit.
    */
   is_quote_override: boolean;
+  /**
+   * Frozen snapshot of the tier table + resolved tier at quote-create time.
+   * Drives drift detection and quantity-curve recomputation on edit. NULL
+   * when `basis_unknown` is true (pre-migration rows; Option C in #317).
+   */
+  pricing_basis_snapshot: PricingBasisSnapshot | null;
+  /**
+   * TRUE on rows created before migration 20260605004123. The edit UI shows
+   * a "basis unknown" chip and falls back to degraded resolved-vs-current
+   * drift comparison for these.
+   */
+  basis_unknown: boolean;
   created_at: string;
   // Optional joined part info for UI rendering
   parts?: {
@@ -134,12 +188,21 @@ export interface QuoteLineOverride {
  * commits to one Order Quantity per part; the unit price is auto-resolved
  * from the part's pricing tiers (highest tier with `tier_qty <= order_qty`)
  * unless an explicit override is supplied.
+ *
+ * `line_item_id` and `basis_unknown` are only populated on EDIT — they let
+ * the form correlate a block back to its underlying line item so it can
+ * render the drift chip and "basis unknown" chip. Create-mode payloads
+ * leave them undefined; createQuote / reconcile both ignore them.
  */
 export interface QuoteFormPartBlock {
   part_id: string;
   order_quantity: number;
   /** Optional hand-entered price+markup; bypasses tier resolution when present. */
   override?: QuoteLineOverride;
+  /** Set on edit-mode payloads so the form can look up drift / basis info. */
+  line_item_id?: string;
+  /** Set on edit-mode payloads from pre-snapshot rows (Option C, #317). */
+  basis_unknown?: boolean;
 }
 
 /**
@@ -233,6 +296,8 @@ export function quoteToFormData(quote: QuoteWithRelations): QuoteFormData {
     parts: Array.from(byPart.values()).map((li) => ({
       part_id: li.part_id,
       order_quantity: li.quantity,
+      line_item_id: li.id,
+      basis_unknown: li.basis_unknown,
       ...(li.is_quote_override
         ? {
             override: {

--- a/utils/quoteLineItemsAccess.ts
+++ b/utils/quoteLineItemsAccess.ts
@@ -1,7 +1,12 @@
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import type { Json } from '@/types/database';
 import type { QuoteLineItem } from '@/types/quote';
 import type { ComputedPartPricingTier } from '@/types/partPricing';
-import { resolveTier } from '@/utils/quotePricingResolver';
+import {
+  resolveTier,
+  resolveTierFromSnapshot,
+  buildPricingBasisSnapshot,
+} from '@/utils/quotePricingResolver';
 import { getComputedPartCost } from '@/utils/partsAccess';
 
 /**
@@ -26,7 +31,11 @@ export async function getLineItemsForQuote(quoteId: string): Promise<QuoteLineIt
     console.error('Error fetching quote line items:', error);
     throw error;
   }
-  return (data || []) as QuoteLineItem[];
+  // The generated Supabase type widens jsonb to `Json` (unknown-ish). The
+  // application layer relies on the structured shape we wrote in
+  // `buildPricingBasisSnapshot`; cast once at the boundary instead of
+  // sprinkling `as` across call sites.
+  return (data || []) as unknown as QuoteLineItem[];
 }
 
 /**
@@ -41,10 +50,13 @@ export interface QuoteLineItemOverride {
 
 /**
  * Snapshot a single (part, order_quantity) commitment into a new line item.
- * The unit price is auto-resolved from the part's tier table (highest tier with
- * `tier_qty <= order_qty`) unless an explicit override is supplied. The matched
- * tier id is recorded in `source_tier_id` so the PDF can highlight which break
- * was used.
+ * The unit price is auto-resolved from the part's tier table (highest tier
+ * with `tier_qty <= order_qty`) unless an explicit override is supplied.
+ *
+ * The full tier table at create-time is frozen onto the row via
+ * `pricing_basis_snapshot` — drift detection on edit compares this snapshot
+ * against current tiers, and quantity-curve recomputation on edit also
+ * resolves against this snapshot (never against live tiers).
  */
 export async function insertLineItemForPart(
   quoteId: string,
@@ -95,6 +107,11 @@ export async function insertLineItemForPart(
 
   const totalPrice = Math.round(unitPrice * orderQuantity * 100) / 100;
 
+  // Build the basis snapshot from the same tier table that produced the
+  // resolved tier. For override lines, `resolved_tier_id` is null but the
+  // full tier table is still captured so future drift checks can run.
+  const basisSnapshot = buildPricingBasisSnapshot(tiers, orderQuantity, sourceTierId);
+
   const { data, error } = await supabase
     .from('quote_line_items')
     .insert({
@@ -109,6 +126,8 @@ export async function insertLineItemForPart(
       markup_percent: markupPercent,
       base_cost_per_unit: baseCost,
       is_quote_override: !!override,
+      pricing_basis_snapshot: basisSnapshot as unknown as Json,
+      basis_unknown: false,
     })
     .select('*')
     .single();
@@ -117,7 +136,153 @@ export async function insertLineItemForPart(
     console.error('Error inserting quote line item:', error);
     throw error;
   }
-  return data as QuoteLineItem;
+  return data as unknown as QuoteLineItem;
+}
+
+/**
+ * Update an existing line item's quantity (and recompute its unit_price
+ * from the frozen `pricing_basis_snapshot` — NEVER from current tiers).
+ *
+ * Override lines: quantity changes update the row but `unit_price` stays
+ * pinned at the override value (the snapshot's `resolved_tier_id` is null
+ * for overrides; we fall back to the override price stored on the row).
+ *
+ * `basis_unknown` lines have no snapshot to resolve against, so quantity
+ * changes are NOT supported for these — the read path falls back to the
+ * stored `unit_price` (degraded behavior, surfaced via the "basis unknown"
+ * chip). Callers should disable the qty input for `basis_unknown` rows.
+ */
+export async function updateLineItemQuantity(
+  lineItemId: string,
+  newQuantity: number,
+): Promise<QuoteLineItem> {
+  const supabase = getSupabase();
+
+  const { data: existing, error: fetchError } = await supabase
+    .from('quote_line_items')
+    .select('*')
+    .eq('id', lineItemId)
+    .single();
+  if (fetchError) {
+    console.error('Error loading line item for quantity update:', fetchError);
+    throw fetchError;
+  }
+  const row = existing as unknown as QuoteLineItem;
+
+  let newUnitPrice = row.unit_price;
+  let newSourceTierId = row.source_tier_id;
+
+  if (!row.is_quote_override) {
+    const snapshot = row.pricing_basis_snapshot;
+    if (snapshot && !row.basis_unknown) {
+      const resolved = resolveTierFromSnapshot(snapshot, newQuantity);
+      if (resolved) {
+        newUnitPrice = resolved.unit_price;
+        newSourceTierId = resolved.source_tier_id;
+      }
+    }
+    // basis_unknown rows keep the stored unit_price — there's no
+    // historical tier table to walk. The UI prevents qty edits for these,
+    // but the read-path fallback is still well-defined.
+  }
+
+  const newTotal = Math.round(newUnitPrice * newQuantity * 100) / 100;
+
+  const { data, error } = await supabase
+    .from('quote_line_items')
+    .update({
+      quantity: newQuantity,
+      unit_price: newUnitPrice,
+      source_tier_id: newSourceTierId,
+      total_price: newTotal,
+    })
+    .eq('id', lineItemId)
+    .select('*')
+    .single();
+  if (error) {
+    console.error('Error updating line item quantity:', error);
+    throw error;
+  }
+  return data as unknown as QuoteLineItem;
+}
+
+/**
+ * Reprice an existing line item against the part's CURRENT tier table —
+ * used when the user clicks "Update to current price" on a drifted line.
+ * Refreshes both the resolved price and the frozen snapshot so the row
+ * becomes the new baseline; subsequent drift checks compare against the
+ * current tiers.
+ *
+ * Override lines are never repriced; this should not be called for them.
+ */
+export async function repriceLineItemToCurrent(
+  lineItemId: string,
+  currentTiers: ComputedPartPricingTier[],
+): Promise<QuoteLineItem> {
+  const supabase = getSupabase();
+
+  const { data: existing, error: fetchError } = await supabase
+    .from('quote_line_items')
+    .select('*')
+    .eq('id', lineItemId)
+    .single();
+  if (fetchError) {
+    console.error('Error loading line item for reprice:', fetchError);
+    throw fetchError;
+  }
+  const row = existing as unknown as QuoteLineItem;
+  if (row.is_quote_override) {
+    throw new Error('Override line items cannot be repriced — clear the override first.');
+  }
+
+  const resolved = resolveTier(currentTiers, row.quantity);
+  if (!resolved) {
+    throw new Error('Cannot reprice: this part has no priced tiers in the current tier table.');
+  }
+  const matchedTier = currentTiers.find((t) => t.id === resolved.source_tier_id);
+  const newMarkup = matchedTier?.markup_percent ?? null;
+
+  const newSnapshot = buildPricingBasisSnapshot(
+    currentTiers,
+    row.quantity,
+    resolved.source_tier_id,
+  );
+  const newTotal = Math.round(resolved.unit_price * row.quantity * 100) / 100;
+
+  const { data, error } = await supabase
+    .from('quote_line_items')
+    .update({
+      unit_price: resolved.unit_price,
+      source_tier_id: resolved.source_tier_id,
+      markup_percent: newMarkup,
+      total_price: newTotal,
+      pricing_basis_snapshot: newSnapshot as unknown as Json,
+      basis_unknown: false,
+    })
+    .eq('id', lineItemId)
+    .select('*')
+    .single();
+  if (error) {
+    console.error('Error repricing line item:', error);
+    throw error;
+  }
+  return data as unknown as QuoteLineItem;
+}
+
+/**
+ * Delete a single line item by id (used by updateQuote's reconcile path
+ * when the user removes a part from an existing quote).
+ */
+export async function deleteLineItem(lineItemId: string): Promise<void> {
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from('quote_line_items')
+    .delete()
+    .eq('id', lineItemId);
+  if (error) {
+    console.error('Error deleting quote line item:', error);
+    throw error;
+  }
 }
 
 /**

--- a/utils/quotePricingResolver.ts
+++ b/utils/quotePricingResolver.ts
@@ -1,4 +1,5 @@
 import type { ComputedPartPricingTier } from '@/types/partPricing';
+import type { PricingBasisSnapshot } from '@/types/quote';
 
 export interface ResolvedTier {
   unit_price: number;
@@ -56,4 +57,149 @@ export function resolveTier(
     matched_tier_quantity: match.quantity,
     below_min: false,
   };
+}
+
+/**
+ * Resolve a tier from a frozen `PricingBasisSnapshot` instead of live
+ * `ComputedPartPricingTier[]`. Used on quote-edit when the user changes
+ * quantity — the recomputed price must come from the snapshotted tiers
+ * (frozen-by-default), NOT from the part's current tier table. Otherwise
+ * a tier change since quote creation would silently affect what looks
+ * like normal quantity-curve movement.
+ *
+ * Returns null if the snapshot has no priced tiers (impossible in practice
+ * — snapshots are only written when a resolved tier exists — but keeps
+ * the resolver signature consistent with `resolveTier`).
+ */
+export function resolveTierFromSnapshot(
+  snapshot: PricingBasisSnapshot,
+  orderQuantity: number,
+): ResolvedTier | null {
+  if (!Number.isFinite(orderQuantity)) return null;
+
+  const tiers = [...snapshot.tiers].sort((a, b) => a.quantity - b.quantity);
+  if (tiers.length === 0) return null;
+
+  const lowest = tiers[0];
+  if (orderQuantity < lowest.quantity) {
+    return {
+      unit_price: lowest.unit_price,
+      source_tier_id: lowest.id,
+      matched_tier_quantity: lowest.quantity,
+      below_min: true,
+    };
+  }
+
+  let match = lowest;
+  for (const tier of tiers) {
+    if (tier.quantity <= orderQuantity) {
+      match = tier;
+    } else {
+      break;
+    }
+  }
+
+  return {
+    unit_price: match.unit_price,
+    source_tier_id: match.id,
+    matched_tier_quantity: match.quantity,
+    below_min: false,
+  };
+}
+
+/**
+ * Build a `PricingBasisSnapshot` from the live tier list at create-time.
+ * Only priced tiers are captured — null-price tiers are filtered out so
+ * the snapshot is always usable for later resolution.
+ *
+ * `resolvedTierId` should be the tier whose price was used for the line.
+ * For override lines pass `null` (no tier was resolved).
+ */
+export function buildPricingBasisSnapshot(
+  tiers: ComputedPartPricingTier[],
+  orderQuantity: number,
+  resolvedTierId: string | null,
+): PricingBasisSnapshot {
+  const priced = tiers
+    .filter(
+      (t): t is ComputedPartPricingTier & { unit_price: number } =>
+        t.unit_price !== null && Number.isFinite(t.unit_price),
+    )
+    .map((t) => ({
+      id: t.id,
+      quantity: t.quantity,
+      unit_price: t.unit_price,
+      markup_percent: t.markup_percent,
+    }))
+    .sort((a, b) => a.quantity - b.quantity);
+
+  return {
+    tiers: priced,
+    resolved_tier_id: resolvedTierId,
+    resolved_quantity: orderQuantity,
+    captured_at: new Date().toISOString(),
+  };
+}
+
+/**
+ * Compare a frozen `PricingBasisSnapshot` against the part's CURRENT
+ * computed tier table. Returns true when ANY tier the snapshot saw has
+ * shifted price, OR when a snapshotted tier id has disappeared, OR when
+ * a new priced tier has appeared. Quantity-curve movement (the user
+ * changing order qty without the underlying tier changing) is NOT drift.
+ *
+ * Floating-point comparison uses a small epsilon to absorb rounding from
+ * the live cost rollup; tier changes from human input always exceed it.
+ */
+export function isDrifted(
+  snapshot: PricingBasisSnapshot,
+  currentTiers: ComputedPartPricingTier[],
+): boolean {
+  const EPSILON = 0.005;
+  const current = currentTiers
+    .filter(
+      (t): t is ComputedPartPricingTier & { unit_price: number } =>
+        t.unit_price !== null && Number.isFinite(t.unit_price),
+    )
+    .map((t) => ({
+      id: t.id,
+      quantity: t.quantity,
+      unit_price: t.unit_price,
+    }));
+
+  const snap = snapshot.tiers;
+  if (snap.length !== current.length) return true;
+
+  const currentById = new Map(current.map((t) => [t.id, t]));
+  for (const s of snap) {
+    const c = currentById.get(s.id);
+    if (!c) return true;
+    if (c.quantity !== s.quantity) return true;
+    if (Math.abs(c.unit_price - s.unit_price) > EPSILON) return true;
+  }
+  return false;
+}
+
+/**
+ * Degraded drift check for pre-snapshot rows (`basis_unknown = true`).
+ * The historical basis is unknown so the comparison falls back to:
+ * "would the same order quantity resolve to a different price today than
+ * what the line stores?". Returns true when the current resolved tier
+ * price differs from the line's stored `unit_price`. Override lines never
+ * count as drifted (`is_quote_override` callers should short-circuit).
+ *
+ * This is the "Option C" path locked in #317 — Option A (backfill from
+ * current tiers) was explicitly rejected because it would silently report
+ * "no drift" on lines that genuinely drifted before the snapshot column
+ * existed.
+ */
+export function isDriftedDegraded(
+  storedUnitPrice: number,
+  storedQuantity: number,
+  currentTiers: ComputedPartPricingTier[],
+): boolean {
+  const resolved = resolveTier(currentTiers, storedQuantity);
+  if (!resolved) return false;
+  const EPSILON = 0.005;
+  return Math.abs(resolved.unit_price - storedUnitPrice) > EPSILON;
 }

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -20,7 +20,15 @@ import { isQuoteExpired } from '@/types/quote';
 import { calculateRoutingCost } from '@/utils/routingCostCalculation';
 import { getCompanyMembers } from '@/utils/companyAccess';
 import { getTiersWithComputedPrices } from '@/utils/partPricingTiersAccess';
-import { insertLineItemForPart, getLineItemsForQuote } from '@/utils/quoteLineItemsAccess';
+import {
+  insertLineItemForPart,
+  getLineItemsForQuote,
+  updateLineItemQuantity,
+  repriceLineItemToCurrent,
+  deleteLineItem,
+} from '@/utils/quoteLineItemsAccess';
+import { isDrifted, isDriftedDegraded } from '@/utils/quotePricingResolver';
+import type { ComputedPartPricingTier } from '@/types/partPricing';
 
 /**
  * Cast a DB row to Quote. The DB stores `status` as text with a CHECK
@@ -72,7 +80,7 @@ function hydrateCreators<T extends QuoteWithRelations>(
 const QUOTE_LINE_ITEM_FIELDS = `
   id, quote_id, company_id, part_id, source_tier_id, sequence,
   quantity, unit_price, total_price, markup_percent, base_cost_per_unit,
-  is_quote_override, created_at,
+  is_quote_override, pricing_basis_snapshot, basis_unknown, created_at,
   parts(id, part_name, description)
 `;
 
@@ -411,10 +419,29 @@ export async function createQuote(
 }
 
 /**
- * Update a quote's metadata (customer, lead time, expiration, notes).
- * Line items are immutable snapshots — to change parts/tiers, create a new quote.
+ * Update a quote's metadata AND reconcile its line items against the form
+ * payload (#324 + Issue #317 policy):
+ *
+ *   - parts on the form but NOT in the DB → insert via `insertLineItemForPart`
+ *     (captures a fresh pricing basis snapshot at current tiers).
+ *   - parts in the DB but NOT on the form → delete.
+ *   - parts on both → quantity-curve recompute against the frozen snapshot
+ *     (`updateLineItemQuantity` uses the snapshot, NEVER current tiers).
+ *
+ * Pricing is FROZEN by default. Drifted lines reprice ONLY when the form
+ * payload includes their id in `acceptDriftLineItemIds` (the user clicked
+ * "Update to current price" or "Update all"). Override lines are never
+ * touched.
+ *
+ * Per the #325 decision recorded in [docs/modules/quotes.md] (2026-06-04),
+ * forced keep-or-update was dropped — there is no save-blocking modal.
+ * Untouched drifted lines simply keep their snapshotted price on save.
  */
-export async function updateQuote(quoteId: string, formData: QuoteFormData): Promise<Quote> {
+export async function updateQuote(
+  quoteId: string,
+  formData: QuoteFormData,
+  options: { acceptDriftLineItemIds?: string[] } = {},
+): Promise<Quote> {
   const supabase = getSupabase();
 
   const { data: existing, error: checkError } = await supabase
@@ -430,6 +457,27 @@ export async function updateQuote(quoteId: string, formData: QuoteFormData): Pro
 
   if (!isQuoteEditable(existing)) {
     throw new Error('This quote cannot be edited. Expired or converted quotes are read-only.');
+  }
+
+  const companyId = existing.company_id;
+
+  // Same shape validation as createQuote — duplicate parts and bad
+  // quantities are caught here before we issue any DB writes.
+  if (!formData.parts || formData.parts.length === 0) {
+    throw new Error('A quote must include at least one part.');
+  }
+  const seenPartsForValidation = new Set<string>();
+  for (const block of formData.parts) {
+    if (!block.part_id) throw new Error('Every part selection must reference a real part.');
+    if (seenPartsForValidation.has(block.part_id)) {
+      throw new Error(
+        'A part can only appear once on a quote — adjust the order quantity instead of duplicating it.',
+      );
+    }
+    seenPartsForValidation.add(block.part_id);
+    if (!Number.isFinite(block.order_quantity) || block.order_quantity <= 0) {
+      throw new Error('Every part needs an order quantity greater than zero.');
+    }
   }
 
   const leadTimeDays = formData.lead_time_days ? parseInt(formData.lead_time_days, 10) : null;
@@ -463,7 +511,164 @@ export async function updateQuote(quoteId: string, formData: QuoteFormData): Pro
     throw error;
   }
 
+  await reconcileQuoteLineItems(quoteId, companyId, formData, options);
+
   return asQuote(data);
+}
+
+/**
+ * Reconcile the line items on a quote against the form payload.
+ * Insert new parts, update edited quantities (frozen-snapshot recompute),
+ * delete removed parts, and reprice ONLY the lines the user explicitly
+ * opted into via the drift controls.
+ *
+ * Split out so updateQuote stays readable; not exported because external
+ * callers should always go through updateQuote (which enforces editability
+ * and the metadata update).
+ */
+async function reconcileQuoteLineItems(
+  quoteId: string,
+  companyId: string,
+  formData: QuoteFormData,
+  options: { acceptDriftLineItemIds?: string[] },
+): Promise<void> {
+  const existingItems = await getLineItemsForQuote(quoteId);
+  const byPartId = new Map(existingItems.map((li) => [li.part_id, li]));
+  const formPartIds = new Set(formData.parts.map((p) => p.part_id));
+
+  // 1. Delete lines whose parts were removed on the form.
+  for (const li of existingItems) {
+    if (!formPartIds.has(li.part_id)) {
+      await deleteLineItem(li.id);
+    }
+  }
+
+  // 2. Insert / update remaining parts. We need fresh tiers for any
+  //    add-line (basis snapshot must use the part's CURRENT tier table at
+  //    add-line time) and for any line the user opted in to reprice.
+  //    Cache per-partId lookups so a quote with N parts only hits the
+  //    tiers query N times.
+  const tiersCache = new Map<string, ComputedPartPricingTier[]>();
+  const ensureTiers = async (partId: string): Promise<ComputedPartPricingTier[]> => {
+    const cached = tiersCache.get(partId);
+    if (cached) return cached;
+    const tiers = await getTiersWithComputedPrices(partId);
+    tiersCache.set(partId, tiers);
+    return tiers;
+  };
+
+  const acceptDriftIds = new Set(options.acceptDriftLineItemIds ?? []);
+
+  // Walk the form payload in order so the highest pre-existing sequence is
+  // the floor for new inserts (preserves render order on reload).
+  let nextSequence =
+    existingItems.length === 0
+      ? 10
+      : Math.max(...existingItems.map((li) => li.sequence)) + 10;
+
+  for (const block of formData.parts) {
+    const existing = byPartId.get(block.part_id);
+
+    if (!existing) {
+      // New part on this edit — snapshot from current tiers.
+      const tiers = await ensureTiers(block.part_id);
+      await insertLineItemForPart(
+        quoteId,
+        companyId,
+        block.part_id,
+        block.order_quantity,
+        tiers,
+        nextSequence,
+        block.override,
+      );
+      nextSequence += 10;
+      continue;
+    }
+
+    // Existing line — reprice only if explicitly accepted; never on
+    // override lines. Quantity changes recompute against the snapshot.
+    if (
+      !existing.is_quote_override &&
+      acceptDriftIds.has(existing.id)
+    ) {
+      const tiers = await ensureTiers(block.part_id);
+      await repriceLineItemToCurrent(existing.id, tiers);
+    }
+
+    if (existing.quantity !== block.order_quantity) {
+      await updateLineItemQuantity(existing.id, block.order_quantity);
+    }
+  }
+}
+
+/**
+ * For each non-override line item on a quote, decide whether its frozen
+ * pricing basis has drifted relative to the part's current tier table.
+ * Returns the set of drifted line item ids — the QuoteForm renders the
+ * "snapshotted vs current" chip and the per-line / update-all controls
+ * for exactly these ids.
+ *
+ * `basis_unknown` rows fall back to the degraded comparison
+ * (`isDriftedDegraded`). Override lines are NEVER returned regardless of
+ * snapshot state — they're frozen by design.
+ *
+ * The function loads each part's current tiers via
+ * `getTiersWithComputedPrices` (one query per distinct part_id). Cheap
+ * enough for the typical quote (single-digit parts); if a future quote
+ * routinely carries dozens of parts this could batch.
+ */
+export interface QuoteLineDriftInfo {
+  line_item_id: string;
+  basis_unknown: boolean;
+  snapshotted_unit_price: number;
+  current_unit_price: number | null;
+}
+
+export async function detectQuoteLineDrift(
+  quoteId: string,
+): Promise<QuoteLineDriftInfo[]> {
+  const items = await getLineItemsForQuote(quoteId);
+  if (items.length === 0) return [];
+
+  const partIds = Array.from(new Set(items.map((li) => li.part_id)));
+  const tiersByPart = new Map<string, ComputedPartPricingTier[]>();
+  await Promise.all(
+    partIds.map(async (partId) => {
+      const tiers = await getTiersWithComputedPrices(partId).catch(() => []);
+      tiersByPart.set(partId, tiers);
+    }),
+  );
+
+  const drifted: QuoteLineDriftInfo[] = [];
+  for (const li of items) {
+    if (li.is_quote_override) continue;
+    const tiers = tiersByPart.get(li.part_id) ?? [];
+
+    if (li.basis_unknown || !li.pricing_basis_snapshot) {
+      const isd = isDriftedDegraded(li.unit_price, li.quantity, tiers);
+      if (isd) {
+        const currentResolved = tiers.find((t) => t.quantity <= li.quantity);
+        drifted.push({
+          line_item_id: li.id,
+          basis_unknown: true,
+          snapshotted_unit_price: li.unit_price,
+          current_unit_price: currentResolved?.unit_price ?? null,
+        });
+      }
+      continue;
+    }
+
+    if (isDrifted(li.pricing_basis_snapshot, tiers)) {
+      const currentResolved = tiers.find((t) => t.quantity <= li.quantity);
+      drifted.push({
+        line_item_id: li.id,
+        basis_unknown: false,
+        snapshotted_unit_price: li.unit_price,
+        current_unit_price: currentResolved?.unit_price ?? null,
+      });
+    }
+  }
+  return drifted;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #324. Implements the quote-edit policy from #317 end-to-end:

- **Reconcile on update.** `updateQuote()` now inserts new parts, updates edited quantities (against the snapshotted basis), and deletes removed parts. The May-2026 silent no-op on edit is gone.
- **Frozen-by-default pricing.** New `quote_line_items.pricing_basis_snapshot` jsonb column captures the tier table + resolved tier at create time. Quantity changes on edit recompute against this snapshot, never current tiers.
- **Non-blocking drift handling.** Per-line chip + "Update to current price" + "Update all flagged" bulk control. Saving without clicking anything keeps the snapshotted price. Override lines are never flagged or repriced.
- **Option C (#317 sub-decision).** Pre-snapshot rows get `basis_unknown=true` and render a "basis unknown" chip on edit. Option A (backfill from current tiers) was explicitly rejected per the docs.
- **#325 decision applied (2026-06-04, scope = pilot population at Contour Tool & Machine).** Forced keep-or-update is DROPPED for §0 scope — drift on open quotes is rare enough that a save-blocking modal is more friction than the drift signal warrants. `docs/modules/quotes.md` updated accordingly.

## Test plan

- [x] `pnpm test --run __tests__/utils/quotePricingResolver.test.ts` — **22 passing** (snapshot/drift helpers, basis-unknown degraded comparison, floating-point epsilon).
- [x] `pnpm test --run __tests__/utils/quotesAccess.test.ts` — **37 passing** (reconcile insert/update/delete, frozen-by-default, explicit-only reprice, override-never-reprice, drift detection across basis-known + basis-unknown + override).
- [x] `pnpm test --run __tests__/components/quotes/QuoteForm.test.tsx` — **18 passing** (drift chip, per-line + update-all controls, save payload shape, basis-unknown chip, override never flagged).
- [x] `pnpm test --run` — **529/530** passing. Only failure: `__tests__/schema/embedCheck.test.ts` because `schema.prod.sql` doesn't yet have `pricing_basis_snapshot` / `basis_unknown` — see Hand-off below.
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] `pnpm lint` — 0 errors (all 109 warnings pre-existing).
- [ ] `pnpm exec playwright test e2e/quote-edit.spec.ts` — author-only locally; requires fresh local Supabase + seed. CI workflow runs this.

## Hand-off (prod migration)

Migration `supabase/migrations/20260605004123_add_quote_line_pricing_basis_snapshot.sql` is applied to **staging**. Per CLAUDE.md, prod pushes are owned by the human:

1. `supabase link --project-ref mayuquvexmqjvwkfasxg` (prod)
2. `supabase db push`
3. `python scripts/export_schema.py` to refresh both schema snapshots
4. The schema embed check goes green automatically after step 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)