### PR TITLE
feat(quotes): multiple quantities per part (firm order vs price-options menu)

### DIFF
--- a/__tests__/components/quotes/QuoteForm.test.tsx
+++ b/__tests__/components/quotes/QuoteForm.test.tsx
@@ -489,4 +489,67 @@ describe('QuoteForm', () => {
     expect(screen.queryByTestId('drift-chip-0')).not.toBeInTheDocument();
     expect(screen.queryByTestId('quote-drift-summary')).not.toBeInTheDocument();
   });
+
+  // ============== Multi-quantity (price-options) behavior ==============
+
+  it('adding a second quantity turns the quote into a price-options quote (no grand total)', async () => {
+    render(<QuoteForm mode="edit" quoteId="q-1" initialData={initialPopulated} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+
+    // One quantity → firm quote → grand total caption shown.
+    expect(screen.getByText('Quote total')).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /add quantity/i }));
+
+    // Two quantities for one part → price-options quote, grand total hidden.
+    await waitFor(() => {
+      expect(screen.getByText('Price options quote')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Quote total')).not.toBeInTheDocument();
+  });
+
+  it('blocks save when the same quantity is entered twice for one part', async () => {
+    render(<QuoteForm mode="edit" quoteId="q-1" initialData={initialPopulated} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /add quantity/i }));
+
+    // First row already holds qty 5; type 5 into the new (empty) second row.
+    const qtyInputs = await screen.findAllByLabelText('Order quantity');
+    expect(qtyInputs).toHaveLength(2);
+    await user.type(qtyInputs[1], '5');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled();
+    });
+  });
+
+  it('shows a single part-level "Use custom price" control regardless of how many quantities', async () => {
+    render(<QuoteForm mode="edit" quoteId="q-1" initialData={initialPopulated} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+
+    // One quantity row → exactly one custom-price toggle.
+    expect(screen.getAllByRole('button', { name: /use custom price/i })).toHaveLength(1);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /add quantity/i }));
+    await user.click(screen.getByRole('button', { name: /add quantity/i }));
+
+    // Three quantity rows → STILL exactly one custom-price toggle (per part).
+    await waitFor(() => {
+      expect(screen.getAllByLabelText('Order quantity')).toHaveLength(3);
+    });
+    expect(screen.getAllByRole('button', { name: /use custom price/i })).toHaveLength(1);
+  });
 });

--- a/__tests__/types/quote.test.ts
+++ b/__tests__/types/quote.test.ts
@@ -2,7 +2,9 @@ import {
   calculateUnitPriceFromMarkup,
   calculateMarkupFromUnitPrice,
   calculateTotalPrice,
+  quoteToFormData,
 } from '@/types/quote';
+import type { QuoteWithRelations } from '@/types/quote';
 
 describe('calculateUnitPriceFromMarkup', () => {
   it('calculates 0% markup correctly', () => {
@@ -107,5 +109,76 @@ describe('calculateTotalPrice', () => {
 
   it('returns null for negative quantity', () => {
     expect(calculateTotalPrice(-1, 25)).toBeNull();
+  });
+});
+
+describe('quoteToFormData', () => {
+  function makeQuote(lineItems: QuoteWithRelations['line_items']): QuoteWithRelations {
+    return {
+      id: 'quote-1',
+      company_id: 'company-1',
+      quote_number: 'Q-0001',
+      customer_id: 'customer-1',
+      billing_address_id: 'addr-1',
+      shipping_address_id: 'addr-1',
+      contact_id: 'contact-1',
+      lead_time_days: 14,
+      expiration_date: '2099-12-31',
+      status: 'active',
+      status_changed_at: null,
+      converted_at: null,
+      created_by: null,
+      created_at: '2026-06-01T00:00:00Z',
+      updated_at: '2026-06-01T00:00:00Z',
+      line_items: lineItems,
+    };
+  }
+
+  const baseLine = {
+    quote_id: 'quote-1',
+    company_id: 'company-1',
+    part_id: 'part-A',
+    source_tier_id: 't1',
+    unit_price: 100,
+    total_price: 1000,
+    markup_percent: 50,
+    base_cost_per_unit: 66.67,
+    is_quote_override: false,
+    pricing_basis_snapshot: null,
+    basis_unknown: false,
+    created_at: '2026-06-01T00:00:00Z',
+  };
+
+  it('emits one entry per line item, sorted by sequence (multiple per part for options quotes)', () => {
+    const quote = makeQuote([
+      { ...baseLine, id: 'li-2', sequence: 20, quantity: 25 },
+      { ...baseLine, id: 'li-1', sequence: 10, quantity: 5 },
+    ]);
+
+    const form = quoteToFormData(quote);
+
+    // Both entries share the same part_id; order follows sequence.
+    expect(form.parts).toHaveLength(2);
+    expect(form.parts[0]).toMatchObject({ part_id: 'part-A', order_quantity: 5, line_item_id: 'li-1' });
+    expect(form.parts[1]).toMatchObject({ part_id: 'part-A', order_quantity: 25, line_item_id: 'li-2' });
+  });
+
+  it('carries the override block through for override lines', () => {
+    const quote = makeQuote([
+      {
+        ...baseLine,
+        id: 'li-1',
+        sequence: 10,
+        quantity: 10,
+        is_quote_override: true,
+        unit_price: 999,
+        markup_percent: null,
+      },
+    ]);
+
+    const form = quoteToFormData(quote);
+
+    expect(form.parts).toHaveLength(1);
+    expect(form.parts[0].override).toEqual({ unit_price: 999, markup_percent: null });
   });
 });

--- a/__tests__/utils/quotePdf.test.ts
+++ b/__tests__/utils/quotePdf.test.ts
@@ -377,66 +377,37 @@ describe('generateQuotePdf', () => {
     expect(rendered).toContain('SHIPPING ADDRESS');
   });
 
-  it('renders a separate Pricing Tiers section for multi-tier parts', async () => {
-    const tierMockModule = await import('@/utils/partPricingTiersAccess');
-    const getTiersMock = vi.mocked(tierMockModule.getTiersWithComputedPrices);
-    getTiersMock.mockResolvedValueOnce([
-      {
-        id: 't1', part_id: 'part-1', company_id: 'company-1', sequence: 1, quantity: 1,
-        markup_percent: 40, unit_price: 70,
-        created_at: '', updated_at: '',
-      },
-      {
-        id: 't10', part_id: 'part-1', company_id: 'company-1', sequence: 2, quantity: 10,
-        markup_percent: 40, unit_price: 65,
-        created_at: '', updated_at: '',
-      },
-    ]);
-
-    const quoteWithTier: QuoteWithRelations = {
+  it('renders ONE table with the part spanning its quantity rows (no grand total) for an options quote', async () => {
+    // Two quantities for the SAME part → a price-options quote.
+    const optionsQuote: QuoteWithRelations = {
       ...baseQuote,
       line_items: [
-        { ...baseQuote.line_items![0], source_tier_id: 't10' },
+        { ...baseQuote.line_items![0], id: 'li-1', sequence: 10, quantity: 5, unit_price: 80, total_price: 400 },
+        { ...baseQuote.line_items![0], id: 'li-2', sequence: 20, quantity: 25, unit_price: 60, total_price: 1500 },
       ],
     };
 
-    await generateQuotePdf(quoteWithTier, baseCompany);
+    await generateQuotePdf(optionsQuote, baseCompany);
+
+    // A single unified table (firm-style head) — NOT separate per-part tables.
+    expect(autoTableFn).toHaveBeenCalledTimes(1);
+    const config = autoTableFn.mock.calls[0][1];
+    expect(config.head).toEqual([['Part', 'Description', 'Order qty', 'Unit price', 'Total']]);
+
+    // Two body rows; the part name + description span both quantities (rowSpan
+    // on the first row), and the first row also carries the first quantity.
+    expect(config.body).toHaveLength(2);
+    expect(config.body[0][0]).toMatchObject({ content: 'BRKT-001', rowSpan: 2 });
+    expect(config.body[0][2]).toBe('5'); // [part, desc, qty, unit, total]
+    expect(config.body[1][0]).toBe('25'); // continuation row: [qty, unit, total]
 
     const docInstance = jsPDFCtor.mock.results[0].value;
     const rendered = docInstance.text.mock.calls
       .map((c: unknown[]) => c[0])
       .filter((t: unknown): t is string => typeof t === 'string');
 
-    // Section header is drawn outside autoTable
-    expect(rendered.some((t: string) => t.includes('PRICING TIERS'))).toBe(true);
-
-    // The tier sub-table is rendered as the SECOND autoTable call
-    expect(autoTableFn.mock.calls.length).toBeGreaterThanOrEqual(2);
-    const tierCall = autoTableFn.mock.calls[1];
-    const tierBody = tierCall[1].body;
-    // Each row shape: [marker, qty, "{price} each", caption]
-    const rowFor10 = tierBody.find((r: string[]) => r[1] === '10');
-    expect(rowFor10).toBeDefined();
-    expect(rowFor10[2]).toMatch(/each$/);
-    expect(rowFor10[0]).toBe('>');
-
-    getTiersMock.mockReset();
-  });
-
-  it('does not render a Pricing Tiers section for an overridden line', async () => {
-    const overrideQuote: QuoteWithRelations = {
-      ...baseQuote,
-      line_items: [{ ...baseQuote.line_items![0], is_quote_override: true }],
-    };
-
-    await generateQuotePdf(overrideQuote, baseCompany);
-
-    const docInstance = jsPDFCtor.mock.results[0].value;
-    const rendered = docInstance.text.mock.calls
-      .map((c: unknown[]) => c[0])
-      .filter((t: unknown): t is string => typeof t === 'string');
-
-    expect(rendered.some((t: string) => t.includes('PRICING TIERS'))).toBe(false);
+    // No grand-total "Total" line is drawn for a price-options quote.
+    expect(rendered.some((t: string) => t === 'Total')).toBe(false);
   });
 });
 

--- a/__tests__/utils/quotesAccess.test.ts
+++ b/__tests__/utils/quotesAccess.test.ts
@@ -398,7 +398,28 @@ describe('quotesAccess utilities', () => {
       ).rejects.toThrow('Every part selection must reference a real part.');
     });
 
-    it('rejects duplicate part_id within the same quote', async () => {
+    it('allows the same part with multiple quantities (price-options quote)', async () => {
+      // Each (part, quantity) becomes its own line item now — no dup-part guard.
+      (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) => {
+        if (table === 'quotes') {
+          return {
+            insert: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { id: 'quote-new', company_id: 'company-1' },
+                  error: null,
+                }),
+              }),
+            }),
+          };
+        }
+        // writeCostSnapshotsForPart hits other tables; the default chainable
+        // builder (data: null) lets it no-op, and it's wrapped in try/catch.
+        return mockQueryBuilder;
+      });
+      getTiersWithComputedPricesMock.mockResolvedValue([]);
+      insertLineItemForPartMock.mockResolvedValue({});
+
       await expect(
         createQuote('company-1', {
           ...baseForm,
@@ -407,7 +428,12 @@ describe('quotesAccess utilities', () => {
             { part_id: 'part-1', order_quantity: 10 },
           ],
         }),
-      ).rejects.toThrow('A part can only appear once on a quote');
+      ).resolves.toBeDefined();
+
+      // One line item inserted per quantity (same part_id).
+      expect(insertLineItemForPartMock).toHaveBeenCalledTimes(2);
+      expect(insertLineItemForPartMock.mock.calls[0][3]).toBe(5);
+      expect(insertLineItemForPartMock.mock.calls[1][3]).toBe(10);
     });
 
     it('rejects order_quantity <= 0', async () => {
@@ -701,6 +727,32 @@ describe('quotesAccess utilities', () => {
         'This quote has no line items to convert.',
       );
     });
+
+    it('rejects an options quote (2+ quantities for one part) without a selection', async () => {
+      (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+        ...mockQueryBuilder,
+        select: vi.fn().mockReturnValue({
+          ...mockQueryBuilder,
+          eq: vi.fn().mockReturnValue({
+            ...mockQueryBuilder,
+            single: vi.fn().mockReturnValue({
+              data: {
+                ...mockQuote,
+                converted_at: null,
+                line_items: [
+                  { id: 'li-1', part_id: 'part-A', sequence: 10, quantity: 5, unit_price: 20, total_price: 100 },
+                  { id: 'li-2', part_id: 'part-A', sequence: 20, quantity: 10, unit_price: 18, total_price: 180 },
+                ],
+              },
+              error: null,
+            }),
+          }),
+        }),
+      }));
+
+      // No selectedLineItemIds → both lines for part-A would convert → guard fires.
+      await expect(convertQuoteToJob('quote-1')).rejects.toThrow('price-options quote');
+    });
   });
 
   // ============== updateQuote reconcile + drift detection ==============
@@ -807,11 +859,12 @@ describe('quotesAccess utilities', () => {
         },
       ]);
 
-      // Form keeps part-A (qty bumped to 25), drops part-B, adds part-C.
+      // Form keeps part-A (qty bumped to 25, carries its line_item_id), drops
+      // part-B (absent → delete), adds part-C (no line_item_id → insert).
       const formData: QuoteFormData = {
         ...baseFormData,
         parts: [
-          { part_id: 'part-A', order_quantity: 25 },
+          { part_id: 'part-A', order_quantity: 25, line_item_id: 'li-A' },
           { part_id: 'part-C', order_quantity: 1 },
         ],
       };
@@ -860,7 +913,7 @@ describe('quotesAccess utilities', () => {
 
       const formData: QuoteFormData = {
         ...baseFormData,
-        parts: [{ part_id: 'part-A', order_quantity: 10 }], // unchanged qty
+        parts: [{ part_id: 'part-A', order_quantity: 10, line_item_id: 'li-A' }], // unchanged qty
       };
 
       await updateQuote('quote-1', formData);
@@ -900,7 +953,7 @@ describe('quotesAccess utilities', () => {
 
       const formData: QuoteFormData = {
         ...baseFormData,
-        parts: [{ part_id: 'part-A', order_quantity: 10 }],
+        parts: [{ part_id: 'part-A', order_quantity: 10, line_item_id: 'li-A' }],
       };
 
       await updateQuote('quote-1', formData, { acceptDriftLineItemIds: ['li-A'] });
@@ -933,7 +986,7 @@ describe('quotesAccess utilities', () => {
 
       const formData: QuoteFormData = {
         ...baseFormData,
-        parts: [{ part_id: 'part-A', order_quantity: 10 }],
+        parts: [{ part_id: 'part-A', order_quantity: 10, line_item_id: 'li-A' }],
       };
 
       await updateQuote('quote-1', formData, { acceptDriftLineItemIds: ['li-A'] });
@@ -950,18 +1003,46 @@ describe('quotesAccess utilities', () => {
       );
     });
 
-    it('rejects an update with duplicate parts', async () => {
+    it('allows multiple quantities for one part — adds the new quantity as a line', async () => {
       stubUpdateQuoteHappyPath();
+      // DB has one line for part-A at qty 10.
+      getLineItemsForQuoteMock.mockResolvedValueOnce([
+        {
+          id: 'li-A',
+          quote_id: 'quote-1',
+          company_id: 'company-1',
+          part_id: 'part-A',
+          source_tier_id: 't1',
+          sequence: 10,
+          quantity: 10,
+          unit_price: 100,
+          total_price: 1000,
+          markup_percent: 50,
+          base_cost_per_unit: 66.67,
+          is_quote_override: false,
+          pricing_basis_snapshot: { tiers: [], resolved_tier_id: 't1', resolved_quantity: 10, captured_at: '' },
+          basis_unknown: false,
+          created_at: '2026-05-01T00:00:00Z',
+        },
+      ]);
+
+      // Keep the existing qty-10 line and add a second quantity (25) for the
+      // same part — a price-options quote. The new entry has no line_item_id.
       const formData: QuoteFormData = {
         ...baseFormData,
         parts: [
-          { part_id: 'part-A', order_quantity: 5 },
-          { part_id: 'part-A', order_quantity: 10 },
+          { part_id: 'part-A', order_quantity: 10, line_item_id: 'li-A' },
+          { part_id: 'part-A', order_quantity: 25 },
         ],
       };
-      await expect(updateQuote('quote-1', formData)).rejects.toThrow(
-        'A part can only appear once on a quote',
-      );
+
+      await updateQuote('quote-1', formData);
+
+      // The new quantity is inserted as its own line; nothing deleted.
+      expect(insertLineItemForPartMock).toHaveBeenCalledTimes(1);
+      expect(insertLineItemForPartMock.mock.calls[0][2]).toBe('part-A');
+      expect(insertLineItemForPartMock.mock.calls[0][3]).toBe(25);
+      expect(deleteLineItemMock).not.toHaveBeenCalled();
     });
   });
 

--- a/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
+++ b/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
@@ -33,14 +33,12 @@ import QuotePdfPreviewDialog from '@/components/quotes/QuotePdfPreviewDialog';
 import SendQuoteEmailDialog from '@/components/quotes/SendQuoteEmailDialog';
 import EmailIcon from '@mui/icons-material/Email';
 import Snackbar from '@mui/material/Snackbar';
-import { getTiersWithComputedPrices } from '@/utils/partPricingTiersAccess';
 import {
   quoteToFormData,
   isQuoteExpired,
   daysUntilExpiration,
 } from '@/types/quote';
-import type { QuoteWithRelations } from '@/types/quote';
-import type { ComputedPartPricingTier } from '@/types/partPricing';
+import type { QuoteLineItem, QuoteWithRelations } from '@/types/quote';
 import QuoteStatusChip from '@/components/quotes/QuoteStatusChip';
 import QuoteForm from '@/components/quotes/QuoteForm';
 import ConvertToJobModal from '@/components/quotes/ConvertToJobModal';
@@ -66,8 +64,6 @@ export default function QuoteDetailPage() {
   const [company, setCompany] = useState<Company | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [emailSuccess, setEmailSuccess] = useState<string | null>(null);
-  /** Tier reference data: part_id → all tiers for that part. */
-  const [tiersByPart, setTiersByPart] = useState<Record<string, ComputedPartPricingTier[]>>({});
 
   const fetchQuote = useCallback(async () => {
     try {
@@ -85,29 +81,6 @@ export default function QuoteDetailPage() {
   useEffect(() => {
     fetchQuote();
   }, [fetchQuote]);
-
-  // Once the quote loads, fetch the master tier list for each part on it
-  // (read-only reference for the PRICING TIERS section).
-  useEffect(() => {
-    if (!quote) return;
-    const partIds = Array.from(new Set((quote.line_items ?? []).map((li) => li.part_id)));
-    const missing = partIds.filter((id) => !(id in tiersByPart));
-    if (missing.length === 0) return;
-    let cancelled = false;
-    Promise.all(missing.map((id) => getTiersWithComputedPrices(id).then((tiers) => [id, tiers] as const)))
-      .then((entries) => {
-        if (cancelled) return;
-        setTiersByPart((prev) => {
-          const next = { ...prev };
-          for (const [id, tiers] of entries) next[id] = tiers;
-          return next;
-        });
-      })
-      .catch((err) => console.warn('Failed to load tiers for quote detail page:', err));
-    return () => {
-      cancelled = true;
-    };
-  }, [quote, tiersByPart]);
 
   const handleDelete = async () => {
     setActionLoading(true);
@@ -195,6 +168,32 @@ export default function QuoteDetailPage() {
     (sum, li) => sum + (li.total_price ?? li.unit_price * li.quantity),
     0,
   );
+
+  // Group line items by part (first-appearance order). A part with a single
+  // quantity is a firm line; 2+ quantities is a price-options menu. The whole
+  // quote is "firm" (grand total shown) only when EVERY part has one quantity.
+  const partGroups: {
+    part_id: string;
+    part_name: string;
+    description: string | null;
+    items: QuoteLineItem[];
+  }[] = [];
+  const partGroupIndex = new Map<string, number>();
+  for (const li of lineItems) {
+    let gi = partGroupIndex.get(li.part_id);
+    if (gi === undefined) {
+      gi = partGroups.length;
+      partGroupIndex.set(li.part_id, gi);
+      partGroups.push({
+        part_id: li.part_id,
+        part_name: li.parts?.part_name ?? 'Part',
+        description: li.parts?.description ?? null,
+        items: [],
+      });
+    }
+    partGroups[gi].items.push(li);
+  }
+  const isFirmQuote = partGroups.length > 0 && partGroups.every((g) => g.items.length === 1);
 
   if (editMode && isEditable) {
     const handleSaveSuccess = async () => {
@@ -414,7 +413,14 @@ export default function QuoteDetailPage() {
                     sx={{
                       width: '100%',
                       borderCollapse: 'collapse',
-                      '& th, & td': { textAlign: 'left', py: 1, px: 1, borderBottom: '1px solid', borderColor: 'divider' },
+                      '& th, & td': {
+                        textAlign: 'left',
+                        py: 1,
+                        px: 1,
+                        borderBottom: '1px solid',
+                        borderColor: 'divider',
+                        verticalAlign: 'top',
+                      },
                       '& th.num, & td.num': { textAlign: 'right' },
                     }}
                   >
@@ -428,74 +434,52 @@ export default function QuoteDetailPage() {
                       </tr>
                     </thead>
                     <tbody>
-                      {lineItems.map((li) => (
-                        <tr key={li.id}>
-                          <td style={{ fontWeight: 600 }}>{li.parts?.part_name ?? 'Part'}</td>
-                          <td>{li.parts?.description ?? ''}</td>
-                          <td className="num">{li.quantity}</td>
-                          <td className="num">
-                            {formatCurrency(li.unit_price)}
-                            {li.is_quote_override && (
-                              <Chip
-                                size="small"
-                                label="custom"
-                                color="success"
-                                variant="outlined"
-                                sx={{ ml: 1, height: 18 }}
-                              />
+                      {/* One table for the whole quote. A part with several
+                          quantities shows its name + description once (spanning
+                          its quantity rows); each quantity gets its own line. */}
+                      {partGroups.map((group) => {
+                        const rows = [...group.items].sort((a, b) => a.quantity - b.quantity);
+                        return rows.map((li, i) => (
+                          <tr key={li.id}>
+                            {i === 0 && (
+                              <td rowSpan={rows.length} style={{ fontWeight: 600 }}>
+                                {group.part_name}
+                              </td>
                             )}
+                            {i === 0 && (
+                              <td rowSpan={rows.length}>{group.description ?? ''}</td>
+                            )}
+                            <td className="num">{li.quantity}</td>
+                            <td className="num">
+                              {formatCurrency(li.unit_price)}
+                              {li.is_quote_override && (
+                                <Chip
+                                  size="small"
+                                  label="custom"
+                                  color="success"
+                                  variant="outlined"
+                                  sx={{ ml: 1, height: 18 }}
+                                />
+                              )}
+                            </td>
+                            <td className="num">
+                              {formatCurrency(li.total_price ?? li.unit_price * li.quantity)}
+                            </td>
+                          </tr>
+                        ));
+                      })}
+                      {isFirmQuote && (
+                        <tr>
+                          <td colSpan={4} style={{ textAlign: 'right', fontWeight: 700, paddingTop: 12 }}>
+                            Total
                           </td>
-                          <td className="num">{formatCurrency(li.total_price)}</td>
+                          <td className="num" style={{ fontWeight: 700, paddingTop: 12 }}>
+                            {formatCurrency(grandTotal)}
+                          </td>
                         </tr>
-                      ))}
-                      <tr>
-                        <td colSpan={4} style={{ textAlign: 'right', fontWeight: 700, paddingTop: 12 }}>
-                          Total
-                        </td>
-                        <td className="num" style={{ fontWeight: 700, paddingTop: 12 }}>
-                          {formatCurrency(grandTotal)}
-                        </td>
-                      </tr>
+                      )}
                     </tbody>
                   </Box>
-                </Box>
-              )}
-
-              {/* Pricing tiers reference per part */}
-              {lineItems.some(
-                (li) => (tiersByPart[li.part_id]?.length ?? 0) > 1 && !li.is_quote_override,
-              ) && (
-                <Box sx={{ mt: 3 }}>
-                  <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1 }}>
-                    Pricing tiers (reference)
-                  </Typography>
-                  {lineItems.map((li) => {
-                    const tiers = tiersByPart[li.part_id];
-                    if (!tiers || tiers.length <= 1) return null;
-                    if (li.is_quote_override) return null;
-                    const sorted = [...tiers].sort((a, b) => a.quantity - b.quantity);
-                    return (
-                      <Box key={li.id} sx={{ mb: 1.5 }}>
-                        <Typography variant="body2" sx={{ fontWeight: 500, mb: 0.5 }}>
-                          {li.parts?.part_name ?? 'Part'}
-                        </Typography>
-                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                          {sorted.map((tier) => {
-                            const matched = tier.id === li.source_tier_id;
-                            return (
-                              <Chip
-                                key={tier.id}
-                                size="small"
-                                label={`${tier.quantity} · ${formatCurrency(tier.unit_price)} each`}
-                                color={matched ? 'primary' : 'default'}
-                                variant={matched ? 'filled' : 'outlined'}
-                              />
-                            );
-                          })}
-                        </Box>
-                      </Box>
-                    );
-                  })}
                 </Box>
               )}
             </CardContent>

--- a/app/dashboard/[companyId]/quotes/page.tsx
+++ b/app/dashboard/[companyId]/quotes/page.tsx
@@ -242,11 +242,6 @@ export default function QuotesPage() {
     }
   };
 
-  const formatCurrency = (value: number | null): string => {
-    if (value === null) return '—';
-    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
-  };
-
   const formatDate = (dateStr: string): string => {
     return new Date(dateStr).toLocaleDateString();
   };
@@ -264,22 +259,6 @@ export default function QuotesPage() {
       flex: 1,
       minWidth: 160,
       valueGetter: (params) => params.data?.customers?.name || '—',
-    },
-    {
-      colId: 'total',
-      headerName: 'Total',
-      width: 140,
-      valueGetter: (params) => {
-        const items = params.data?.line_items ?? [];
-        if (items.length === 1) {
-          return items[0].total_price ?? items[0].unit_price * items[0].quantity;
-        }
-        return null;
-      },
-      valueFormatter: (params: ValueFormatterParams) =>
-        params.value == null ? '—' : formatCurrency(params.value),
-      tooltipValueGetter: (params) =>
-        (params.data?.line_items?.length ?? 0) > 1 ? 'Multi-tier quote — pick qty to confirm total' : undefined,
     },
     {
       field: 'status',

--- a/components/quotes/ConvertToJobModal.tsx
+++ b/components/quotes/ConvertToJobModal.tsx
@@ -12,7 +12,12 @@ import Alert from '@mui/material/Alert';
 import Divider from '@mui/material/Divider';
 import CircularProgress from '@mui/material/CircularProgress';
 import TextField from '@mui/material/TextField';
-import type { QuoteWithRelations } from '@/types/quote';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormLabel from '@mui/material/FormLabel';
+import type { QuoteLineItem, QuoteWithRelations } from '@/types/quote';
 import { isQuoteExpired } from '@/types/quote';
 import { convertQuoteToJob } from '@/utils/quotesAccess';
 
@@ -27,6 +32,11 @@ interface ConvertToJobModalProps {
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '—';
   return new Date(dateStr).toLocaleDateString();
+}
+
+function formatCurrency(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
 }
 
 /** Today + N days as an ISO date string (yyyy-mm-dd) for the date input. */
@@ -65,12 +75,42 @@ export default function ConvertToJobModal({
     [quote.line_items],
   );
 
+  // Group line items by part (first-appearance order). A part with one
+  // quantity converts as-is; a part with several quantities (price options)
+  // needs the salesperson to pick the accepted quantity before converting.
+  const partGroups = useMemo(() => {
+    const groups: { part_id: string; part_name: string; items: QuoteLineItem[] }[] = [];
+    const index = new Map<string, number>();
+    for (const li of lineItems) {
+      let gi = index.get(li.part_id);
+      if (gi === undefined) {
+        gi = groups.length;
+        index.set(li.part_id, gi);
+        groups.push({ part_id: li.part_id, part_name: li.parts?.part_name ?? 'Part', items: [] });
+      }
+      groups[gi].items.push(li);
+    }
+    return groups;
+  }, [lineItems]);
+
+  const isOptionsQuote = partGroups.some((g) => g.items.length > 1);
+
+  // part_id → chosen line_item_id. Single-quantity parts are auto-selected;
+  // multi-quantity parts start empty so the user must pick deliberately.
+  const [selectedByPart, setSelectedByPart] = useState<Record<string, string>>({});
+  const allPartsChosen = partGroups.every((g) => !!selectedByPart[g.part_id]);
+
   useEffect(() => {
     if (!open) return;
     setDueDateInput(defaultDueDateISO(quote.lead_time_days));
     setCustomerPoInput('');
     setError(null);
-  }, [open, quote.lead_time_days]);
+    const initial: Record<string, string> = {};
+    for (const g of partGroups) {
+      if (g.items.length === 1) initial[g.part_id] = g.items[0].id;
+    }
+    setSelectedByPart(initial);
+  }, [open, quote.lead_time_days, partGroups]);
 
   const dueDateValid = dueDateInput === '' || !isNaN(new Date(dueDateInput).getTime());
 
@@ -80,9 +120,13 @@ export default function ConvertToJobModal({
     setLoading(true);
     setError(null);
     try {
+      const selectedLineItemIds = partGroups
+        .map((g) => selectedByPart[g.part_id])
+        .filter((id): id is string => !!id);
       const result = await convertQuoteToJob(quote.id, {
         dueDate: dueDateInput || null,
         customerPoNumber: customerPoInput,
+        selectedLineItemIds,
       });
       onConverted(result.job.id);
     } catch (err) {
@@ -127,7 +171,7 @@ export default function ConvertToJobModal({
             Customer: {quote.customers?.name || '—'}
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            Parts: {lineItems.length}
+            Parts: {partGroups.length}
           </Typography>
 
           <Divider sx={{ my: 2 }} />
@@ -136,6 +180,61 @@ export default function ConvertToJobModal({
             One job will be created with one work cell per part. Each part&apos;s routing will be
             cloned into its own operations + materials list.
           </Typography>
+
+          {isOptionsQuote && (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              This is a price-options quote. Pick the quantity the customer accepted for each part.
+            </Alert>
+          )}
+
+          {partGroups.length > 0 && (
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mb: 1 }}>
+              {partGroups.map((group) =>
+                group.items.length === 1 ? (
+                  <Box key={group.part_id}>
+                    <Typography variant="body2" fontWeight={600}>
+                      {group.part_name}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {group.items[0].quantity} ea @ {formatCurrency(group.items[0].unit_price)} ={' '}
+                      {formatCurrency(
+                        group.items[0].total_price ??
+                          group.items[0].unit_price * group.items[0].quantity,
+                      )}
+                    </Typography>
+                  </Box>
+                ) : (
+                  <FormControl key={group.part_id}>
+                    <FormLabel sx={{ fontWeight: 600, color: 'text.primary' }}>
+                      {group.part_name} — choose quantity
+                    </FormLabel>
+                    <RadioGroup
+                      value={selectedByPart[group.part_id] ?? ''}
+                      onChange={(e) =>
+                        setSelectedByPart((prev) => ({
+                          ...prev,
+                          [group.part_id]: e.target.value,
+                        }))
+                      }
+                    >
+                      {[...group.items]
+                        .sort((a, b) => a.quantity - b.quantity)
+                        .map((li) => (
+                          <FormControlLabel
+                            key={li.id}
+                            value={li.id}
+                            control={<Radio size="small" />}
+                            label={`${li.quantity} ea @ ${formatCurrency(
+                              li.unit_price,
+                            )} = ${formatCurrency(li.total_price ?? li.unit_price * li.quantity)}`}
+                          />
+                        ))}
+                    </RadioGroup>
+                  </FormControl>
+                ),
+              )}
+            </Box>
+          )}
 
           {lineItems.length === 0 && (
             <Alert severity="warning">
@@ -191,7 +290,7 @@ export default function ConvertToJobModal({
         <Button
           variant="contained"
           onClick={handleConvert}
-          disabled={loading || lineItems.length === 0 || !dueDateValid}
+          disabled={loading || lineItems.length === 0 || !dueDateValid || !allPartsChosen}
           startIcon={loading ? <CircularProgress size={20} /> : null}
         >
           {loading ? 'Creating…' : `Create ${expectedJobNumber}`}

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -68,19 +68,38 @@ interface CustomerOption {
   isCreateNew?: boolean;
 }
 
+/**
+ * One quoted quantity within a part block. A block with a single row is a firm
+ * line; a block with several rows is a price-options menu for that part. Each
+ * row carries (on edit) its own line item id + drift state, because each
+ * (part, quantity) is an independent quote_line_items row. The custom-price
+ * override is part-level (see PartBlockState), not per row.
+ */
+interface QtyRowState {
+  /** Stable React key for the row (mirrors RoutingOperationsList temp ids). */
+  rowKey: string;
+  /** Working-copy string so the input can be empty mid-edit. */
+  quantity: string;
+  /** Set on edit-mode rows; absent on newly-added or create-mode rows. */
+  line_item_id?: string;
+  /** Pre-snapshot Option C — renders the "basis unknown" chip. */
+  basis_unknown?: boolean;
+}
+
 interface PartBlockState {
   part: PartSelectOption | null;
-  /** Working-copy string so the input can be empty mid-edit. */
-  order_quantity: string;
+  /** One row per quoted quantity; always at least one row. */
+  rows: QtyRowState[];
+  /**
+   * Part-level custom price. When open, the typed unit price applies to
+   * EVERY quantity row of this part (bypassing tier resolution) and is
+   * written as an override onto each resulting line item.
+   */
   override_open: boolean;
   override_unit_price: string;
   tiers: ComputedPartPricingTier[];
   loading: boolean;
   error: string | null;
-  /** Set on edit-mode blocks; absent on newly-added or create-mode blocks. */
-  line_item_id?: string;
-  /** Pre-snapshot Option C — renders the "basis unknown" chip. */
-  basis_unknown?: boolean;
 }
 
 const CREATE_NEW_CUSTOMER: CustomerOption = {
@@ -98,10 +117,19 @@ function formatCurrency(value: number | null | undefined): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
 }
 
+const newRowKey = () => `temp-qty-${crypto.randomUUID()}`;
+
+function emptyRow(): QtyRowState {
+  return {
+    rowKey: newRowKey(),
+    quantity: '',
+  };
+}
+
 function emptyBlock(): PartBlockState {
   return {
     part: null,
-    order_quantity: '',
+    rows: [emptyRow()],
     override_open: false,
     override_unit_price: '',
     tiers: [],
@@ -110,21 +138,50 @@ function emptyBlock(): PartBlockState {
   };
 }
 
-function blockFromInitial(
-  p: QuoteFormData['parts'][number],
-  hydrated: PartSelectOption | undefined,
-): PartBlockState {
+function rowFromInitial(p: QuoteFormData['parts'][number]): QtyRowState {
   return {
-    part: hydrated ?? null,
-    order_quantity: String(p.order_quantity),
-    override_open: !!p.override,
-    override_unit_price: p.override ? String(p.override.unit_price) : '',
-    tiers: [],
-    loading: false,
-    error: null,
+    rowKey: newRowKey(),
+    quantity: String(p.order_quantity),
     line_item_id: p.line_item_id,
     basis_unknown: p.basis_unknown,
   };
+}
+
+/**
+ * Group the flat form payload (one entry per (part, quantity)) into one block
+ * per part, preserving first-seen order, with one quantity row per entry. The
+ * part is a stub carrying only the id; loadData replaces it with the hydrated
+ * option (the form renders a spinner until then, so the stub is never shown).
+ *
+ * The custom-price override is part-level: if any entry carries an override,
+ * the whole part is treated as overridden at that unit price (on save every
+ * entry for the part is written with the same override).
+ */
+function groupPartsIntoBlocks(parts: QuoteFormData['parts']): PartBlockState[] {
+  const blocks: PartBlockState[] = [];
+  const indexByPart = new Map<string, number>();
+  for (const p of parts) {
+    let idx = indexByPart.get(p.part_id);
+    if (idx === undefined) {
+      idx = blocks.length;
+      indexByPart.set(p.part_id, idx);
+      blocks.push({
+        part: { id: p.part_id } as PartSelectOption,
+        rows: [],
+        override_open: false,
+        override_unit_price: '',
+        tiers: [],
+        loading: false,
+        error: null,
+      });
+    }
+    if (p.override && !blocks[idx].override_open) {
+      blocks[idx].override_open = true;
+      blocks[idx].override_unit_price = String(p.override.unit_price);
+    }
+    blocks[idx].rows.push(rowFromInitial(p));
+  }
+  return blocks;
 }
 
 export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave }: QuoteFormProps) {
@@ -133,8 +190,8 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   const companyId = params.companyId as string;
 
   const [formData, setFormData] = useState<QuoteFormData>(initialData);
-  const [partBlocks, setPartBlocks] = useState<PartBlockState[]>(
-    initialData.parts.map((p) => blockFromInitial(p, undefined)),
+  const [partBlocks, setPartBlocks] = useState<PartBlockState[]>(() =>
+    groupPartsIntoBlocks(initialData.parts),
   );
 
   const [customers, setCustomers] = useState<CustomerOption[]>([]);
@@ -176,7 +233,10 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   const loadData = useCallback(async () => {
     try {
       setLoadingData(true);
-      const initialPartIds = initialData.parts.map((p) => p.part_id).filter(Boolean);
+      // Dedupe ids — a price-options quote repeats a part_id across rows.
+      const initialPartIds = Array.from(
+        new Set(initialData.parts.map((p) => p.part_id).filter(Boolean)),
+      );
       const [customersData, hydratedParts] = await Promise.all([
         getAllCustomers(companyId),
         initialPartIds.length > 0
@@ -190,11 +250,13 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
       setCustomersById(new Map(customersData.map((c) => [c.id, c])));
       if (hydratedParts.length > 0) {
         const byId = new Map(hydratedParts.map((p) => [p.id, p]));
+        // Replace each block's stub part (carrying only the id) with the
+        // hydrated option, matched by part_id (blocks no longer align by
+        // index with the flat initialData.parts payload).
         setPartBlocks((prev) =>
-          prev.map((block, idx) => {
-            if (block.part) return block;
-            const initialId = initialData.parts[idx]?.part_id;
-            const hydrated = initialId ? byId.get(initialId) : undefined;
+          prev.map((block) => {
+            const partId = block.part?.id;
+            const hydrated = partId ? byId.get(partId) : undefined;
             return hydrated ? { ...block, part: hydrated } : block;
           }),
         );
@@ -413,13 +475,16 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   const removePartBlock = (idx: number) => {
     setPartBlocks((prev) => {
       const removed = prev[idx];
-      if (removed?.line_item_id) {
-        // Drop any accept-drift selection that referenced this line — the
-        // user removed the whole part, so the per-line opt-in is moot.
+      // Drop any accept-drift selections referencing this part's rows — the
+      // user removed the whole part, so those per-line opt-ins are moot.
+      const ids = (removed?.rows ?? [])
+        .map((r) => r.line_item_id)
+        .filter((id): id is string => !!id);
+      if (ids.length > 0) {
         setAcceptedDriftIds((cur) => {
-          if (!cur.has(removed.line_item_id!)) return cur;
+          if (!ids.some((id) => cur.has(id))) return cur;
           const next = new Set(cur);
-          next.delete(removed.line_item_id!);
+          for (const id of ids) next.delete(id);
           return next;
         });
       }
@@ -430,15 +495,18 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   const updatePartInBlock = (idx: number, option: PartSelectOption | null) => {
     setPartBlocks((prev) => {
       const next = [...prev];
-      // Re-selecting a part on an existing line means the user wants a
-      // different part on that slot — drop the line_item_id correlation
-      // and any accept-drift selection so reconcile treats it as new.
+      // Re-selecting a part on an existing block means the user wants a
+      // different part there — drop the line_item_id correlations and any
+      // accept-drift selections so reconcile treats every row as new.
       const previous = next[idx];
-      if (previous?.line_item_id) {
+      const ids = (previous?.rows ?? [])
+        .map((r) => r.line_item_id)
+        .filter((id): id is string => !!id);
+      if (ids.length > 0) {
         setAcceptedDriftIds((cur) => {
-          if (!cur.has(previous.line_item_id!)) return cur;
+          if (!ids.some((id) => cur.has(id))) return cur;
           const nextIds = new Set(cur);
-          nextIds.delete(previous.line_item_id!);
+          for (const id of ids) nextIds.delete(id);
           return nextIds;
         });
       }
@@ -458,15 +526,65 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     setPartModalOpen(true);
   };
 
-  const updateBlockField = (
-    idx: number,
+  const addRow = (blockIdx: number) => {
+    setPartBlocks((prev) => {
+      const block = prev[blockIdx];
+      if (!block) return prev;
+      const next = [...prev];
+      next[blockIdx] = { ...block, rows: [...block.rows, emptyRow()] };
+      return next;
+    });
+  };
+
+  const removeRow = (blockIdx: number, rowIdx: number) => {
+    setPartBlocks((prev) => {
+      const block = prev[blockIdx];
+      if (!block || block.rows.length <= 1) return prev;
+      const removed = block.rows[rowIdx];
+      if (removed?.line_item_id) {
+        setAcceptedDriftIds((cur) => {
+          if (!cur.has(removed.line_item_id!)) return cur;
+          const nextIds = new Set(cur);
+          nextIds.delete(removed.line_item_id!);
+          return nextIds;
+        });
+      }
+      const next = [...prev];
+      next[blockIdx] = { ...block, rows: block.rows.filter((_, i) => i !== rowIdx) };
+      return next;
+    });
+  };
+
+  const updateRow = (
+    blockIdx: number,
+    rowIdx: number,
+    patch: Partial<QtyRowState> | ((prev: QtyRowState) => Partial<QtyRowState>),
+  ) => {
+    setPartBlocks((prev) => {
+      const block = prev[blockIdx];
+      if (!block) return prev;
+      const current = block.rows[rowIdx];
+      if (!current) return prev;
+      const delta = typeof patch === 'function' ? patch(current) : patch;
+      const rows = [...block.rows];
+      rows[rowIdx] = { ...current, ...delta };
+      const next = [...prev];
+      next[blockIdx] = { ...block, rows };
+      return next;
+    });
+  };
+
+  /** Patch block-level fields (the part-level custom-price override). */
+  const updateBlock = (
+    blockIdx: number,
     patch: Partial<PartBlockState> | ((prev: PartBlockState) => Partial<PartBlockState>),
   ) => {
     setPartBlocks((prev) => {
+      const block = prev[blockIdx];
+      if (!block) return prev;
+      const delta = typeof patch === 'function' ? patch(block) : patch;
       const next = [...prev];
-      const current = next[idx];
-      const delta = typeof patch === 'function' ? patch(current) : patch;
-      next[idx] = { ...current, ...delta };
+      next[blockIdx] = { ...block, ...delta };
       return next;
     });
   };
@@ -515,48 +633,66 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     }
   };
 
-  /** Per-block live preview of the resolved tier + total. */
+  /** Per-row live preview of the resolved tier + total: blockPreviews[block][row].
+   *  A part-level custom price (block.override_*) applies to every row. */
   const blockPreviews = useMemo(() => {
     return partBlocks.map((block) => {
-      const orderQty = Number(block.order_quantity);
-      if (!Number.isFinite(orderQty) || orderQty <= 0) {
-        return { resolved: null as ReturnType<typeof resolveTier>, total: null as number | null };
-      }
-      if (block.override_open && block.override_unit_price.trim() !== '') {
-        const overridePrice = Number(block.override_unit_price);
-        if (Number.isFinite(overridePrice) && overridePrice >= 0) {
+      const overridePrice =
+        block.override_open && block.override_unit_price.trim() !== ''
+          ? Number(block.override_unit_price)
+          : null;
+      const overrideValid =
+        overridePrice !== null && Number.isFinite(overridePrice) && overridePrice >= 0;
+      return block.rows.map((row) => {
+        const orderQty = Number(row.quantity);
+        if (!Number.isFinite(orderQty) || orderQty <= 0) {
           return {
-            resolved: null,
-            total: Math.round(overridePrice * orderQty * 100) / 100,
-            overridePrice,
+            resolved: null as ReturnType<typeof resolveTier>,
+            total: null as number | null,
           };
         }
-      }
-      const resolved = resolveTier(block.tiers, orderQty);
-      return {
-        resolved,
-        total: resolved ? Math.round(resolved.unit_price * orderQty * 100) / 100 : null,
-      };
+        if (overrideValid) {
+          return {
+            resolved: null as ReturnType<typeof resolveTier>,
+            total: Math.round((overridePrice as number) * orderQty * 100) / 100,
+          };
+        }
+        const resolved = resolveTier(block.tiers, orderQty);
+        return {
+          resolved,
+          total: resolved ? Math.round(resolved.unit_price * orderQty * 100) / 100 : null,
+        };
+      });
     });
   }, [partBlocks]);
 
-  /** Quote total = sum of every part block that has a computable total. */
+  /**
+   * Firm order = every part has exactly one quantity → show a grand total.
+   * Any part with 2+ quantities makes this a price-options quote (no total).
+   */
+  const isFirmQuote = useMemo(
+    () => partBlocks.length > 0 && partBlocks.every((b) => b.rows.length === 1),
+    [partBlocks],
+  );
+
+  /** Grand total (firm quotes only) = sum of every row with a computable total. */
   const quoteTotal = useMemo(() => {
     let sum = 0;
     let allComputable = true;
-    for (let i = 0; i < partBlocks.length; i++) {
-      const block = partBlocks[i];
+    partBlocks.forEach((block, bIdx) => {
       if (!block.part) {
         allComputable = false;
-        continue;
+        return;
       }
-      const total = blockPreviews[i]?.total;
-      if (total === null || total === undefined) {
-        allComputable = false;
-      } else {
-        sum += total;
-      }
-    }
+      block.rows.forEach((_row, rIdx) => {
+        const total = blockPreviews[bIdx]?.[rIdx]?.total;
+        if (total === null || total === undefined) {
+          allComputable = false;
+        } else {
+          sum += total;
+        }
+      });
+    });
     return { sum: Math.round(sum * 100) / 100, allComputable };
   }, [partBlocks, blockPreviews]);
 
@@ -577,26 +713,41 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     ) {
       return 'Enter a lead time (whole number of days).';
     }
-    const seen = new Set<string>();
+    const seenParts = new Set<string>();
     for (const block of partBlocks) {
       if (!block.part) return 'Every part block must have a part selected.';
-      if (seen.has(block.part.id)) return 'A part can only appear once on a quote.';
-      seen.add(block.part.id);
-      const orderQty = Number(block.order_quantity);
-      if (!Number.isFinite(orderQty) || orderQty <= 0) {
-        return 'Every part needs an order quantity greater than zero.';
+      // A part lives in ONE block; multiple quantities are rows within it.
+      if (seenParts.has(block.part.id)) {
+        return 'A part can only appear in one block — add its quantities as rows in a single block.';
       }
-      if (!Number.isInteger(orderQty)) return 'Order quantity must be a whole number.';
+      seenParts.add(block.part.id);
+      if (block.loading) return 'Loading pricing tiers…';
+      if (block.rows.length === 0) return 'Every part needs at least one quantity.';
+      // Part-level custom price: validate once; when active it covers every row.
       if (block.override_open) {
         const overridePrice = Number(block.override_unit_price);
-        if (!Number.isFinite(overridePrice) || overridePrice < 0) {
-          return 'Override unit price must be a non-negative number.';
+        if (
+          block.override_unit_price.trim() === '' ||
+          !Number.isFinite(overridePrice) ||
+          overridePrice < 0
+        ) {
+          return 'Custom unit price must be a non-negative number.';
         }
-      } else {
-        if (block.loading) return 'Loading pricing tiers…';
-        const resolved = resolveTier(block.tiers, orderQty);
-        if (!resolved) {
-          return 'At least one part has no priced tiers — add tiers on the part page or use a custom price.';
+      }
+      const seenQty = new Set<number>();
+      for (const row of block.rows) {
+        const orderQty = Number(row.quantity);
+        if (!Number.isFinite(orderQty) || orderQty <= 0) {
+          return 'Every quantity must be greater than zero.';
+        }
+        if (!Number.isInteger(orderQty)) return 'Quantity must be a whole number.';
+        if (seenQty.has(orderQty)) return 'Each quantity can appear only once per part.';
+        seenQty.add(orderQty);
+        if (!block.override_open) {
+          const resolved = resolveTier(block.tiers, orderQty);
+          if (!resolved) {
+            return 'At least one part has no priced tiers — add tiers on the part page or use a custom price.';
+          }
         }
       }
     }
@@ -609,23 +760,27 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
 
     const payload: QuoteFormData = {
       ...formData,
-      parts: partBlocks.map((b) => {
-        const orderQty = Number(b.order_quantity);
-        const block: QuoteFormData['parts'][number] = {
-          part_id: b.part?.id ?? '',
-          order_quantity: orderQty,
-        };
-        if (b.line_item_id) block.line_item_id = b.line_item_id;
-        if (b.basis_unknown) block.basis_unknown = b.basis_unknown;
-        if (b.override_open && b.override_unit_price.trim() !== '') {
-          const unitPrice = Number(b.override_unit_price);
-          block.override = {
-            unit_price: unitPrice,
-            // Markup % is no longer a quote-form input — leave it null on overrides.
-            markup_percent: null,
+      parts: partBlocks.flatMap((b) => {
+        const overrideActive = b.override_open && b.override_unit_price.trim() !== '';
+        const overrideUnitPrice = overrideActive ? Number(b.override_unit_price) : null;
+        return b.rows.map((r) => {
+          const orderQty = Number(r.quantity);
+          const entry: QuoteFormData['parts'][number] = {
+            part_id: b.part?.id ?? '',
+            order_quantity: orderQty,
           };
-        }
-        return block;
+          if (r.line_item_id) entry.line_item_id = r.line_item_id;
+          if (r.basis_unknown) entry.basis_unknown = r.basis_unknown;
+          if (overrideUnitPrice !== null) {
+            // Part-level custom price → same override on every row of the part.
+            entry.override = {
+              unit_price: overrideUnitPrice,
+              // Markup % is no longer a quote-form input — leave it null on overrides.
+              markup_percent: null,
+            };
+          }
+          return entry;
+        });
       }),
     };
 
@@ -843,7 +998,8 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
           {mode === 'edit' &&
             (() => {
               const flagged = partBlocks
-                .map((b) => (b.line_item_id ? driftByLineId.get(b.line_item_id) : undefined))
+                .flatMap((b) => b.rows)
+                .map((r) => (r.line_item_id ? driftByLineId.get(r.line_item_id) : undefined))
                 .filter((d): d is QuoteLineDriftInfo => !!d);
               const pendingFlagged = flagged.filter(
                 (d) => !acceptedDriftIds.has(d.line_item_id),
@@ -887,12 +1043,6 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
           )}
 
           {partBlocks.map((block, idx) => {
-            const preview = blockPreviews[idx];
-            const orderQtyNum = Number(block.order_quantity);
-            const hasOrderQty =
-              block.order_quantity !== '' && Number.isFinite(orderQtyNum) && orderQtyNum > 0;
-            const matched = preview?.resolved ?? null;
-            const isOverride = block.override_open && block.override_unit_price.trim() !== '';
             // A tier with unit_price=null exists in the DB when
             // `replaceTiersForPart` couldn't compute a cost — e.g. a BOM
             // material has no priced procurement tier. Treat that as the
@@ -900,14 +1050,9 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
             // fires and the user isn't trapped typing a quantity that
             // can't resolve to a line price.
             const hasUsableTier = block.tiers.some((t) => t.unit_price !== null);
-            // Drift state for this block, if any. Override lines never
-            // appear here (detectQuoteLineDrift filters them out).
-            const drift = block.line_item_id
-              ? driftByLineId.get(block.line_item_id) ?? null
-              : null;
-            const isAcceptedDrift = !!(
-              block.line_item_id && acceptedDriftIds.has(block.line_item_id)
-            );
+            // Part-level custom price — when active it overrides every row.
+            const blockOverrideActive =
+              block.override_open && block.override_unit_price.trim() !== '';
 
             return (
               <Box key={idx} sx={{ mb: idx === partBlocks.length - 1 ? 0 : 3 }}>
@@ -957,202 +1102,260 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
 
                 {!block.loading && block.part && (
                   <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-                    <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start', flexWrap: 'wrap' }}>
-                      <TextField
-                        size="small"
-                        label="Order quantity"
-                        value={block.order_quantity}
-                        onChange={(e) => {
-                          const v = e.target.value;
-                          if (v !== '' && !/^\d+$/.test(v)) return;
-                          updateBlockField(idx, { order_quantity: v });
-                        }}
-                        inputMode="numeric"
-                        sx={{ width: 160 }}
-                        helperText={
-                          hasOrderQty && matched && matched.below_min
-                            ? `Below minimum break (${matched.matched_tier_quantity} ea) — using lowest tier price`
-                            : ' '
-                        }
-                        error={hasOrderQty && matched?.below_min === true}
-                      />
-                      {hasOrderQty && (
-                        <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 200 }}>
-                          {isOverride ? (
-                            <>
-                              <Typography variant="body2">
-                                Custom price{' '}
-                                <Box component="span" sx={{ fontWeight: 600 }}>
-                                  {formatCurrency(Number(block.override_unit_price))}
-                                </Box>{' '}
-                                / unit
-                              </Typography>
-                              <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                                Total {formatCurrency(preview?.total ?? null)}
-                              </Typography>
-                            </>
-                          ) : matched ? (
-                            <>
-                              <Typography variant="body2">
-                                Tier {matched.matched_tier_quantity} ea ·{' '}
-                                <Box component="span" sx={{ fontWeight: 600 }}>
-                                  {formatCurrency(matched.unit_price)}
-                                </Box>{' '}
-                                / unit
-                              </Typography>
-                              <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                                Total {formatCurrency(preview?.total ?? null)}
-                              </Typography>
-                            </>
-                          ) : (
-                            <Typography variant="body2" color="text.secondary">
-                              No priced tier matches — add a tier or use a custom price.
-                            </Typography>
-                          )}
-                          {isOverride && (
-                            <Chip
-                              size="small"
-                              label="adjusted for this quote"
-                              color="success"
-                              variant="outlined"
-                              sx={{ height: 20, alignSelf: 'flex-start', mt: 0.5 }}
-                            />
-                          )}
-                          {block.basis_unknown && (
-                            <Chip
-                              size="small"
-                              label="basis unknown"
-                              color="default"
-                              variant="outlined"
-                              data-testid={`basis-unknown-chip-${idx}`}
-                              sx={{ height: 20, alignSelf: 'flex-start', mt: 0.5 }}
-                            />
-                          )}
-                          {drift && !isOverride && (
-                            <Box
-                              sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 0.5 }}
-                              data-testid={`drift-chip-${idx}`}
-                            >
-                              <Chip
-                                size="small"
-                                label={
-                                  isAcceptedDrift
-                                    ? `Will update to ${formatCurrency(drift.current_unit_price)} / unit`
-                                    : `Tier price changed: was ${formatCurrency(
-                                        drift.snapshotted_unit_price,
-                                      )}, now ${formatCurrency(drift.current_unit_price)}`
-                                }
-                                color={isAcceptedDrift ? 'primary' : 'warning'}
-                                variant="outlined"
-                                sx={{ height: 'auto', py: 0.5, alignSelf: 'flex-start' }}
-                              />
-                              {!isAcceptedDrift && drift.current_unit_price !== null && (
-                                <Button
-                                  size="small"
-                                  variant="text"
-                                  data-testid={`drift-update-${idx}`}
-                                  onClick={() => {
-                                    if (!block.line_item_id) return;
-                                    setAcceptedDriftIds((cur) => {
-                                      const next = new Set(cur);
-                                      next.add(block.line_item_id!);
-                                      return next;
-                                    });
-                                  }}
-                                  sx={{ alignSelf: 'flex-start', textTransform: 'none' }}
-                                >
-                                  Update to current price
-                                </Button>
-                              )}
-                              {isAcceptedDrift && (
-                                <Button
-                                  size="small"
-                                  variant="text"
-                                  data-testid={`drift-cancel-${idx}`}
-                                  onClick={() => {
-                                    if (!block.line_item_id) return;
-                                    setAcceptedDriftIds((cur) => {
-                                      if (!cur.has(block.line_item_id!)) return cur;
-                                      const next = new Set(cur);
-                                      next.delete(block.line_item_id!);
-                                      return next;
-                                    });
-                                  }}
-                                  sx={{ alignSelf: 'flex-start', textTransform: 'none' }}
-                                >
-                                  Keep original price
-                                </Button>
-                              )}
-                            </Box>
-                          )}
-                        </Box>
-                      )}
-                    </Box>
-
-                    {/* Pricing tiers reference (only when at least one tier
-                        has a usable unit price — a tier with unit_price=null
-                        rendered as "1 · — each" before, which contradicted
-                        the warning above). */}
-                    {hasUsableTier && (
-                      <Box>
+                    {/* Compact quantity-break table — column labels appear once
+                        as a header, then one tight row per quantity. */}
+                    <Box>
+                      <Box
+                        sx={{ display: 'flex', alignItems: 'center', gap: 2, px: 0.5, pb: 0.5 }}
+                      >
+                        <Typography variant="caption" color="text.secondary" sx={{ width: 110 }}>
+                          Qty
+                        </Typography>
                         <Typography
                           variant="caption"
                           color="text.secondary"
-                          sx={{ display: 'block', mb: 0.5 }}
+                          sx={{ flex: 1, minWidth: 120 }}
                         >
-                          Pricing tiers
+                          Unit price
                         </Typography>
-                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                          {[...block.tiers]
-                            .sort((a, b) => a.quantity - b.quantity)
-                            .map((tier) => {
-                              const isMatched =
-                                matched?.source_tier_id === tier.id && !isOverride;
-                              return (
-                                <Chip
-                                  key={tier.id}
-                                  size="small"
-                                  label={`${tier.quantity} · ${formatCurrency(tier.unit_price)} each`}
-                                  color={isMatched ? 'primary' : 'default'}
-                                  variant={isMatched ? 'filled' : 'outlined'}
-                                />
-                              );
-                            })}
-                        </Box>
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ width: 110, textAlign: 'right' }}
+                        >
+                          Total
+                        </Typography>
+                        <Box sx={{ width: 34 }} />
                       </Box>
-                    )}
 
-                    {/* Override toggle */}
+                      {block.rows.map((row, rowIdx) => {
+                        const preview = blockPreviews[idx]?.[rowIdx];
+                        const orderQtyNum = Number(row.quantity);
+                        const hasOrderQty =
+                          row.quantity !== '' && Number.isFinite(orderQtyNum) && orderQtyNum > 0;
+                        const matched = preview?.resolved ?? null;
+                        // Override is part-level — it applies to every row.
+                        const isOverride = blockOverrideActive;
+                        // Drift state for this row, if any. Override lines never
+                        // appear here (detectQuoteLineDrift filters them out).
+                        const drift = row.line_item_id
+                          ? driftByLineId.get(row.line_item_id) ?? null
+                          : null;
+                        const isAcceptedDrift = !!(
+                          row.line_item_id && acceptedDriftIds.has(row.line_item_id)
+                        );
+
+                        return (
+                          <Box
+                            key={row.rowKey}
+                            sx={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 2,
+                              px: 0.5,
+                              py: 0.75,
+                              borderTop: '1px solid',
+                              borderColor: 'divider',
+                            }}
+                          >
+                            <TextField
+                              size="small"
+                              value={row.quantity}
+                              onChange={(e) => {
+                                const v = e.target.value;
+                                if (v !== '' && !/^\d+$/.test(v)) return;
+                                updateRow(idx, rowIdx, { quantity: v });
+                              }}
+                              placeholder="Qty"
+                              inputProps={{ 'aria-label': 'Order quantity', inputMode: 'numeric' }}
+                              sx={{ width: 110 }}
+                              error={hasOrderQty && !isOverride && matched?.below_min === true}
+                            />
+
+                            <Box sx={{ flex: 1, minWidth: 120 }}>
+                              {!hasOrderQty ? (
+                                <Typography variant="body2" color="text.secondary">
+                                  —
+                                </Typography>
+                              ) : isOverride ? (
+                                <>
+                                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                                    {formatCurrency(Number(block.override_unit_price))}
+                                  </Typography>
+                                  <Typography variant="caption" color="text.secondary">
+                                    custom price
+                                  </Typography>
+                                </>
+                              ) : matched ? (
+                                <>
+                                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                                    {formatCurrency(matched.unit_price)}
+                                  </Typography>
+                                  <Typography
+                                    variant="caption"
+                                    color={matched.below_min ? 'warning.main' : 'text.secondary'}
+                                  >
+                                    {matched.below_min
+                                      ? `Below min · Tier ${matched.matched_tier_quantity} ea`
+                                      : `Tier ${matched.matched_tier_quantity} ea`}
+                                  </Typography>
+                                </>
+                              ) : (
+                                <Typography variant="caption" color="warning.main">
+                                  No priced tier — add a tier or use a custom price
+                                </Typography>
+                              )}
+                              {row.basis_unknown && (
+                                <Chip
+                                  size="small"
+                                  label="basis unknown"
+                                  color="default"
+                                  variant="outlined"
+                                  data-testid={`basis-unknown-chip-${idx}`}
+                                  sx={{ height: 20, alignSelf: 'flex-start', mt: 0.5 }}
+                                />
+                              )}
+                              {drift && !isOverride && (
+                                <Box
+                                  sx={{
+                                    display: 'flex',
+                                    flexDirection: 'column',
+                                    gap: 0.5,
+                                    mt: 0.5,
+                                  }}
+                                  data-testid={`drift-chip-${idx}`}
+                                >
+                                  <Chip
+                                    size="small"
+                                    label={
+                                      isAcceptedDrift
+                                        ? `Will update to ${formatCurrency(drift.current_unit_price)} / unit`
+                                        : `Tier price changed: was ${formatCurrency(
+                                            drift.snapshotted_unit_price,
+                                          )}, now ${formatCurrency(drift.current_unit_price)}`
+                                    }
+                                    color={isAcceptedDrift ? 'primary' : 'warning'}
+                                    variant="outlined"
+                                    sx={{ height: 'auto', py: 0.5, alignSelf: 'flex-start' }}
+                                  />
+                                  {!isAcceptedDrift && drift.current_unit_price !== null && (
+                                    <Button
+                                      size="small"
+                                      variant="text"
+                                      data-testid={`drift-update-${idx}`}
+                                      onClick={() => {
+                                        if (!row.line_item_id) return;
+                                        setAcceptedDriftIds((cur) => {
+                                          const next = new Set(cur);
+                                          next.add(row.line_item_id!);
+                                          return next;
+                                        });
+                                      }}
+                                      sx={{ alignSelf: 'flex-start', textTransform: 'none' }}
+                                    >
+                                      Update to current price
+                                    </Button>
+                                  )}
+                                  {isAcceptedDrift && (
+                                    <Button
+                                      size="small"
+                                      variant="text"
+                                      data-testid={`drift-cancel-${idx}`}
+                                      onClick={() => {
+                                        if (!row.line_item_id) return;
+                                        setAcceptedDriftIds((cur) => {
+                                          if (!cur.has(row.line_item_id!)) return cur;
+                                          const next = new Set(cur);
+                                          next.delete(row.line_item_id!);
+                                          return next;
+                                        });
+                                      }}
+                                      sx={{ alignSelf: 'flex-start', textTransform: 'none' }}
+                                    >
+                                      Keep original price
+                                    </Button>
+                                  )}
+                                </Box>
+                              )}
+                            </Box>
+
+                            <Typography
+                              variant="body2"
+                              sx={{ width: 110, textAlign: 'right', fontWeight: 600 }}
+                            >
+                              {hasOrderQty ? formatCurrency(preview?.total ?? null) : '—'}
+                            </Typography>
+
+                            <IconButton
+                              color="error"
+                              size="small"
+                              onClick={() => removeRow(idx, rowIdx)}
+                              aria-label="Remove quantity"
+                              disabled={block.rows.length === 1}
+                            >
+                              <DeleteOutlineIcon fontSize="small" />
+                            </IconButton>
+                          </Box>
+                        );
+                      })}
+                    </Box>
+
+                    {/* Part-level controls: add a quantity, and one custom-price
+                        toggle for the whole part (not per row). */}
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                      <Button size="small" startIcon={<AddIcon />} onClick={() => addRow(idx)}>
+                        Add quantity
+                      </Button>
+                      <Box sx={{ flex: 1 }} />
+                      {blockOverrideActive && (
+                        <Chip
+                          size="small"
+                          label="adjusted for this quote"
+                          color="success"
+                          variant="outlined"
+                          sx={{ height: 20 }}
+                        />
+                      )}
                       <Button
                         size="small"
                         onClick={() =>
-                          updateBlockField(idx, (prev) => ({
-                            override_open: !prev.override_open,
-                            override_unit_price:
-                              !prev.override_open && prev.override_unit_price === '' && matched
-                                ? String(matched.unit_price)
-                                : prev.override_unit_price,
-                          }))
+                          updateBlock(idx, (prev) => {
+                            const firstResolved =
+                              (blockPreviews[idx] ?? [])
+                                .map((p) => p?.resolved)
+                                .find(Boolean) ?? null;
+                            return {
+                              override_open: !prev.override_open,
+                              override_unit_price:
+                                !prev.override_open &&
+                                prev.override_unit_price === '' &&
+                                firstResolved
+                                  ? String(firstResolved.unit_price)
+                                  : prev.override_unit_price,
+                            };
+                          })
                         }
                       >
                         {block.override_open ? 'Cancel custom price' : '✏ Use custom price'}
                       </Button>
                     </Box>
                     {block.override_open && (
-                      <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
                         <TextField
                           size="small"
-                          label="Unit price"
+                          label="Custom unit price"
                           value={block.override_unit_price}
                           onChange={(e) => {
                             const v = e.target.value;
                             if (v !== '' && !/^\d*\.?\d*$/.test(v)) return;
-                            updateBlockField(idx, { override_unit_price: v });
+                            updateBlock(idx, { override_unit_price: v });
                           }}
-                          sx={{ width: 160 }}
+                          sx={{ width: 180 }}
                           inputMode="decimal"
                         />
+                        <Typography variant="caption" color="text.secondary">
+                          Applies to every quantity of this part
+                        </Typography>
                       </Box>
                     )}
                   </Box>
@@ -1216,16 +1419,29 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
         }}
       >
         <Box>
-          <Typography variant="caption" color="text.secondary">
-            Quote total
-          </Typography>
-          <Typography variant="h6" sx={{ fontWeight: 700 }}>
-            {partBlocks.length === 0
-              ? '—'
-              : quoteTotal.allComputable
-                ? formatCurrency(quoteTotal.sum)
-                : `${formatCurrency(quoteTotal.sum)} (incomplete)`}
-          </Typography>
+          {isFirmQuote ? (
+            <>
+              <Typography variant="caption" color="text.secondary">
+                Quote total
+              </Typography>
+              <Typography variant="h6" sx={{ fontWeight: 700 }}>
+                {partBlocks.length === 0
+                  ? '—'
+                  : quoteTotal.allComputable
+                    ? formatCurrency(quoteTotal.sum)
+                    : `${formatCurrency(quoteTotal.sum)} (incomplete)`}
+              </Typography>
+            </>
+          ) : (
+            <>
+              <Typography variant="caption" color="text.secondary">
+                Price options quote
+              </Typography>
+              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                Prices shown per quantity — no grand total
+              </Typography>
+            </>
+          )}
         </Box>
         <Box sx={{ display: 'flex', gap: 2 }}>
           <Button onClick={handleCancel} disabled={loading}>

--- a/docs/modules/jobs.md
+++ b/docs/modules/jobs.md
@@ -136,9 +136,9 @@ Overdue surfaces as:
 Jobs are **only** created via quote conversion. There is no standalone "New Job" form. The `/dashboard/{companyId}/jobs/new` route and "New Job" button were removed in commit d9b7e98; the spec previously here described that flow.
 
 To create a job today:
-1. Build a quote with the desired customer / part / pricing tier.
+1. Build a quote with the desired customer / part(s) / quantities.
 2. Open the quote detail page.
-3. Use the **Convert to Job** action; one job is produced per `(part, selected tier)` line on the quote.
+3. Use the **Convert to Job** action; one job is produced, with one work cell per `(part, selected quantity)` (for a price-options quote, pick the accepted quantity per part in the convert dialog).
 
 The Convert flow lives in [Quotes](quotes.md) — see the "Convert to Job" section there for current behavior.
 

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -4,16 +4,19 @@
 
 The Quotes module handles the sales quoting process — the entry point for work into the shop. Quotes capture what a customer wants, at what price, and when they need it. A quote can be converted directly into one or more jobs at any time; there is no separate approval step.
 
-**The quote is the customer-facing document; the part owns the pricing math.** A quote references parts and snapshots one or more pricing tiers per part into `quote_line_items` at creation, including the tier-break table that produced the price (the **pricing basis**). On edit, the quote line items are reconciled — new parts insert, removed parts delete, edited lines update — but **pricing is frozen by default**: existing lines keep their snapshotted `unit_price` unless the user explicitly chooses to update it, and quantity changes recompute against the snapshotted basis curve, not against the current tier table. The only condition that gets flagged in the UI is **drift** — when the current tier table differs from the snapshot.
+**The quote is the customer-facing document; the part owns the pricing math.** A quote references parts and snapshots one or more **quantities** per part into `quote_line_items` at creation, including the tier-break table that produced each price (the **pricing basis**). The salesperson types whichever quantities they want to present — they need not match the part's tier breakpoints (e.g. quote 5, 15, 25 against tiers of 1/10/20). Each quantity's unit price is resolved by snapping to the highest tier whose breakpoint is ≤ the quantity (`resolveTier`, in [utils/quotePricingResolver.ts](../../utils/quotePricingResolver.ts)); there is no interpolation, and the pricing engine is unchanged. On edit, the quote line items are reconciled **by line item id** — new quantities insert, removed quantities delete, edited quantities update — but **pricing is frozen by default**: existing lines keep their snapshotted `unit_price` unless the user explicitly chooses to update it, and quantity changes recompute against the snapshotted basis curve, not against the current tier table. The only condition that gets flagged in the UI is **drift** — when the current tier table differs from the snapshot.
 
 See the [Edit policy AC section](#edit-policy-line-item-reconcile-frozen-pricing-drift) for the full set of bullets and their verification clauses.
 
 A single quote can include:
 
 - **Multiple parts** (the customer asked for both a holder and a clamp), and
-- **Multiple quantity tiers per part** (e.g., 1, 2, 4 pieces of the holder, each at its own unit price).
+- **Multiple quantities per part** (e.g., 5, 15, 25 pieces of the holder, each at its own unit price).
 
-When the quote has more than one tier overall, the printed PDF intentionally omits a grand total — the customer hasn't yet picked which quantity to order. They pick at conversion time, and one job is created per (part, selected tier).
+**Firm vs. price-options is implicit — decided by quantity count, with no mode toggle:**
+
+- When **every** part has exactly **one** quantity, the quote is a **firm order** — the detail view and PDF show a line-item table with a **grand total**.
+- When **any** part has **two or more** quantities, the quote is a **price-options menu** — the detail view and PDF show one quantity-break table per part and **omit the grand total**; the customer hasn't yet picked which quantity to order. They pick at conversion time, and one job is created per (part, selected quantity).
 
 **Priority:** Must Have (Build Third)
 
@@ -45,7 +48,7 @@ When the quote has more than one tier overall, the printed PDF intentionally omi
 - **Active** — the quote is open. Editable (metadata AND line items, via the reconcile policy below), attachable, convertible.
 - **Expired** — past `expiration_date`. Read-only, but can still be converted with a warning (the price is no longer guaranteed).
 
-**Conversion flag:** `converted_at` is set when the quote becomes one or more jobs. The reverse link lives on `jobs.source_quote_line_item_id` — each created job points at the specific line item (part + tier) it came from. A quote with N selected tiers across M parts becomes M jobs (one per part), each at the tier the user picked. Loading a quote shows every linked job in the "Jobs" banner.
+**Conversion flag:** `converted_at` is set when the quote is converted. Conversion creates **one job** (Q-NNNN → J-NNNN) with one work cell (`job_part`) per selected (part, quantity); each `job_part` records `source_quote_line_item_id` for the line it came from. For a price-options quote the salesperson picks the accepted quantity per part in the convert dialog (firm quotes convert all their lines as-is). Loading a converted quote shows the linked job in the "Jobs" banner; the quote itself stays intact as the record of every option that was offered.
 
 The pending-approval / approved / rejected states were removed in April 2026. For small shops the salesperson and the approver are the same person; the state machine added friction without adding value.
 
@@ -57,11 +60,11 @@ The pending-approval / approved / rejected states were removed in April 2026. Fo
 |---|---|---|
 | Salesperson | Create a quote for a customer | I can respond to customer inquiries |
 | Salesperson | Add multiple parts to a single quote | I can quote a complete request without splitting it across documents |
-| Salesperson | Pick which pricing tiers (1, 2, 4 …) of each part to include | I can present price breaks the customer asked about on one document |
+| Salesperson | Enter the quantities (5, 15, 25 …) I want to present for each part | I can give the customer price breaks at the quantities they're considering, even ones that aren't tier breakpoints |
 | Salesperson | Set a lead time and expiration date | The customer knows when and for how long |
 | Salesperson | Expand a cost breakdown to see per-op / per-material costs grouped by part | I can explain the price if asked |
-| Salesperson | Convert a quote directly to one job per (part, selected tier) | Production can begin without a ceremony step |
-| Salesperson | Pick which quantity tier the customer chose at conversion time | The work order reflects exactly what the customer agreed to |
+| Salesperson | Convert a quote directly to a job (one work cell per part) | Production can begin without a ceremony step |
+| Salesperson | Pick which quantity the customer chose at conversion time | The work order reflects exactly what the customer agreed to |
 | Owner | View all active quotes | I can see the sales pipeline |
 | Owner | Filter quotes by active/expired and customer | I can focus on what's still live |
 | Owner | See per-tier override chips when a price was manually locked | I know which prices are negotiated vs computed |
@@ -94,7 +97,7 @@ The quote is now a thin header. Per-part, per-tier pricing lives on `quote_line_
 
 ### Snapshotted Line Items (`quote_line_items`)
 
-One row per (part, selected tier) on a quote. Created at quote creation by snapshotting selected `part_pricing_tiers` and **never modified after** — even if the source tier changes. Multi-part / multi-tier quotes have multiple rows.
+One row per **(part, quantity)** on a quote. Created at quote creation by resolving each quantity's price against the part's `part_pricing_tiers` (snap to the highest breakpoint ≤ quantity) and freezing the tier-break table that produced it. A part quoted at several quantities (a price-options quote) has several rows sharing a `part_id` — there is **no unique-part constraint**; the only uniqueness rule is `(quote_id, sequence)`. Rows are reconciled on edit per the [Edit policy](#edit-policy-line-item-reconcile-frozen-pricing-drift) (reconcile matches by **line item id**), but each row's `unit_price` is **frozen by default** — never silently repriced when the source tier changes.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -104,7 +107,7 @@ One row per (part, selected tier) on a quote. Created at quote creation by snaps
 | part_id | UUID (FK) | Yes | Snapshot of the part this line item priced |
 | source_tier_id | UUID (FK) | No | Soft reference to the originating `part_pricing_tiers` row (set null if the tier is later deleted) |
 | sequence | Integer | Yes | Display/print order (10, 20, 30 …) |
-| quantity | Integer | Yes | Snapshotted tier quantity, > 0 |
+| quantity | Integer | Yes | Quoted order quantity, > 0 (need not match a tier breakpoint) |
 | unit_price | Decimal(12,4) | Yes | Snapshotted unit price (matches tier or the user's quote-form override) |
 | total_price | Decimal(12,4) | No | `quantity × unit_price` |
 | markup_percent | Decimal(5,2) | No | Snapshotted markup at creation time |
@@ -134,9 +137,9 @@ Each job knows which line item it came from. To list every job spawned from a qu
 
 **Features:**
 
-- Table showing: Quote #, Customer, **Total**, Status, Created By, Expires, Created, **Jobs**
+- Table showing: Quote #, Customer, Status, Created By, Expires, Created, **Jobs**
 
-- Total column shows the line-item total when the quote has exactly one line item; otherwise renders `—` with a tooltip ("Multi-tier quote — pick qty to confirm total")
+- No Total column — many quotes are price-options (no single grand total), so a per-row total is misleading; the total lives on the quote detail page / PDF for firm quotes
 
 - Jobs column shows links to every job spawned from the quote (one per converted line item)
 
@@ -166,7 +169,7 @@ Each job knows which line item it came from. To list every job spawned from a qu
 
 **Route:** `/dashboard/{companyId}/quotes/new` or `/dashboard/{companyId}/quotes/{id}/edit`
 
-**Note:** Edit on an existing quote is **metadata-only** (customer, lead time, expiration). Line items are immutable snapshots — to change parts or tiers, create a new quote.
+**Note:** Both header metadata (customer, lead time, expiration) AND line items are editable while the quote is active and unconverted. Line items are reconciled on save with pricing frozen by default — see the [Edit policy](#edit-policy-line-item-reconcile-frozen-pricing-drift).
 
 **Form Sections:**
 
@@ -176,25 +179,26 @@ Each job knows which line item it came from. To list every job spawned from a qu
 
 ▸ **Parts** (repeating block)
 
-The form has a "Parts" card with one collapsible block per part on the quote, plus an "+ Add part" button at the top of the card.
+The form has a "Parts" card with one block per part on the quote, plus an "+ Add part" button at the top of the card.
 
 Each block:
 
 - Part picker (autocomplete; "+ New Part" opens the inline creator and auto-selects the new part)
-- After a part is selected, the form loads its `part_pricing_tiers` and renders one checkbox per tier:
-  - Label: `Qty {quantity} · {formatCurrency(unit_price)} / unit` with a markup chip when set
-  - User checks one or more tiers to include on the quote
-- "Remove part" trash icon to drop the block
+- An editable **list of quantity rows** — one row per quantity being quoted. A new block starts with a single empty row; an **"Add quantity"** button appends more, and every row past the first has a delete button. The salesperson types any quantities they want (5, 15, 25 …); they need not match the part's tier breakpoints.
+- Each row shows its resolved price inline — `Tier {n} ea · {unit price} / unit` plus the line `Total` (firm) or `Extended` (options). A row whose quantity is below the lowest tier shows a "below minimum break" hint and snaps to the lowest tier price.
+- "Remove part" trash icon to drop the whole block
 
-**Per-quote price overrides (`✏ Adjust price`):** when a tier is checked, an "✏ Adjust price" button appears on the row. Clicking it expands inline `Unit price` and `Markup %` inputs, pre-filled with the tier's current values. Bidirectional editing applies — typing a price back-calculates markup against the tier's base cost; typing a markup recomputes the price. When the typed price diverges from the tier's standing price, the row's chip changes from a markup chip to a green **"adjusted for this quote"** chip so the user can see at a glance which prices are one-off concessions. The override only lives on the resulting `quote_line_items` row (`is_quote_override = true`); the part's tier is never touched.
+There is **no separate "Pricing tiers" reference section** — the editable quantity rows replace it. The block still warns ("This part has no pricing tiers yet…") when the part has no priced tiers, linking to the part page.
 
-If the chosen part has no pricing tiers yet, the block shows a warning ("This part has no pricing tiers yet. Open the part detail page to add them."). Tiers are authored on the part — the quote form is purely a selector with optional one-off overrides.
+**Per-part price override (`✏ Use custom price`):** each part block has a **single** "✏ Use custom price" toggle (not one per quantity) that reveals a `Custom unit price` input applying to **every** quantity of that part. Each resulting `quote_line_items` row carries `is_quote_override = true` at that price, and the block shows a green **"adjusted for this quote"** chip; the part's tier is never touched. (Markup % is no longer a quote-form input.)
 
-**Order matters:** the visual order of part blocks (and the order of tier checkboxes within each block) drives the `sequence` field on the resulting `quote_line_items`, which in turn drives PDF row order.
+**Firm vs. price-options is implicit:** if every part has exactly one quantity row, the sticky footer shows a **grand total**; if any part has two or more rows, the footer shows "Price options quote — prices shown per quantity" with no grand total.
+
+**Order matters:** the order of part blocks, then rows within a block, drives the `sequence` field on the resulting `quote_line_items`, which in turn drives detail/PDF row order.
 
 ▸ **Terms**
 
-- Lead time (days, optional)
+- Lead time (days, required — a whole number)
 - Expiration date (defaults to today + 10 days)
 
 **Actions:**
@@ -204,9 +208,11 @@ If the chosen part has no pricing tiers yet, the block shows a warning ("This pa
 
 **Validation guards:**
 
-- At least one part block is required.
-- Every part block must have a part selected and at least one tier checked.
-- Lead time, if entered, must be 0 – 3,650 days.
+- At least one part block is required; each block must have a part selected.
+- A part may appear in only one block (its quantities go in that block's rows).
+- Every quantity row must be a whole number > 0; quantities must be unique within a part.
+- Each non-override row must resolve to a priced tier, or use a custom price.
+- Lead time is required: a whole number 0 – 3,650 days.
 
 ### 3. Quote Detail View
 
@@ -222,49 +228,50 @@ If the chosen part has no pricing tiers yet, the block shows a warning ("This pa
 
 - **Converted-to-Jobs banner** — only when `converted_at` is set. Lists every linked job by number with click-through links.
 - **Customer card** — name + click-through to the customer record.
-- **Line items table** — Part, Description, Order qty, Unit price, Total (one row per `quote_line_item`, one line item per part). A **Total** row summing every line item is rendered at the bottom of the table.
-- **Pricing tiers (reference)** — beneath the line items table, one row per part with > 1 master tier shows the part's full price-break list as chips, with the matched tier highlighted. Suppressed when a line uses a custom price override.
+- **Line items** — one table for the whole quote (Part, Description, Order qty, Unit price, Total). A part with several quantities shows its name + description **once**, spanning its quantity rows, with one line per quantity.
+  - **Firm quote** (every part has one quantity): a **grand total** row at the bottom.
+  - **Price-options quote** (any part has 2+ quantities): **no grand total** (the customer picks a quantity).
+  - A custom-price line shows a "custom" chip next to its unit price.
+- The old standalone **"Pricing tiers (reference)"** section was removed — the quantity rows are the price-break display now.
 
 **Actions (based on status):**
 
 | Current State | Available Actions |
 |---|---|
-| Active, not converted | Edit (metadata), Convert to Jobs, Delete |
+| Active, not converted | Edit, Convert to Job, Delete |
 | Active, converted | Delete only (line items are frozen) |
 | Expired | Convert with warning, Delete |
 
 **Print PDF** lives in the top-right page toolbar and is available in every status. See [Printing Quotes](#printing-quotes) below.
 
-### 4. Convert to Jobs Modal
+### 4. Convert to Job Modal
 
-**Trigger:** "Convert to Jobs" button on the detail page (active or expired quote).
+**Trigger:** "Convert to Job" button on the detail page (active or expired quote).
 
-**Prerequisite:** Every part on the quote must have a routing. If any does not, conversion is blocked with a link to fix the routing on that part.
+**Prerequisite:** Every part on the quote must have a routing. If any does not, conversion is blocked, reporting how many parts are missing routings.
 
 **Modal Content:**
 
-The modal lists one section per distinct `part_id` on the quote. Each section is a radio group of that part's line items — one radio per available tier:
+The modal groups the quote's line items by part. A part with a single quantity is shown as a fixed line and auto-included. A part with several quantities (a price-options quote) renders a radio group — one radio per quoted quantity — so the salesperson picks the accepted quantity:
 
 ```
-Holder
-  ◯ Qty 1 · $187.00 / unit = $187.00
-  ◯ Qty 2 · $112.00 / unit = $224.00
-  ◉ Qty 4 · $94.00  / unit = $376.00
+Holder — choose quantity
+  ◯ 5 ea @ $20.00 = $100.00
+  ◯ 15 ea @ $18.00 = $270.00
+  ◉ 25 ea @ $16.00 = $400.00
 
 Clamp
-  ◉ Qty 5 · $62.00  / unit = $310.00     (auto-selected — only one tier)
+  100 ea @ $9.00 = $900.00     (single quantity — auto-included)
 ```
 
-If a part has only one line item on the quote, that radio is pre-selected — the user just confirms.
-
-A single **Lead time** input applies to all jobs created in this conversion (defaults to the quote's lead time, editable).
+Multi-quantity parts start with **no** radio selected; the user must pick deliberately. A **Due date** (defaulting to today + the quote's lead time) and an optional **Customer PO #** are captured here.
 
 **Actions:**
 
-- Create Jobs → calls `convertQuoteToJob(quote_id, { selections: [{ line_item_id }, …], leadTimeDays })` → creates one job per selection, copies the routing into each via `create_job_operations_from_routing`, sets `quote.converted_at`, and redirects to the first created job's detail page.
+- Create J-NNNN → calls `convertQuoteToJob(quoteId, { dueDate, customerPoNumber, selectedLineItemIds })`, where `selectedLineItemIds` is the one chosen line per part. Conversion creates **one job** with one `job_part` per selected line, clones each part's routing via the `create_job_part_operations_from_routing` RPC, sets `quote.converted_at`, and redirects to the new job. The quote stays intact as the record of all options offered.
 - Cancel → closes the modal without changes.
 
-The submit button stays disabled until **every** part on the quote has a tier selected.
+The Create button stays disabled until **every** multi-quantity part has a quantity selected (and the due date is valid). `convertQuoteToJob` also hard-rejects any set that resolves to more than one line for a part ("This is a price-options quote. Pick a single quantity per part before converting."), so a malformed job can never be created via the API.
 
 ---
 
@@ -386,19 +393,23 @@ Markup % is the source of truth on a part tier. Typing a unit price in the part 
 
 **On the quote (createQuote):**
 
-For each `(part, selected_tier)` the user checked in the form, insert one `quote_line_items` row:
+For each `(part, quantity)` the user entered in the form, insert one `quote_line_items` row. The unit price is resolved by snapping the entered quantity to the part's tiers (highest breakpoint ≤ quantity, via `resolveTier`):
 
 ```
-quote_line_items.{quantity, unit_price, markup_percent, base_cost_per_unit}
-                = source_tier.{quantity, unit_price, markup_percent, base_cost_per_unit}
-quote_line_items.total_price       = quantity × unit_price
-quote_line_items.source_tier_id    = source_tier.id   (soft reference)
-quote_line_items.is_quote_override = false
+resolved                            = resolveTier(part_tiers, quantity)
+quote_line_items.quantity           = entered quantity
+quote_line_items.unit_price         = resolved.unit_price          (the matched tier's price)
+quote_line_items.markup_percent     = matched tier's markup_percent
+quote_line_items.base_cost_per_unit = getComputedPartCost(part, quantity)  (historical record)
+quote_line_items.total_price        = quantity × unit_price
+quote_line_items.source_tier_id     = resolved.source_tier_id      (soft reference)
+quote_line_items.pricing_basis_snapshot = frozen tier table at create time
+quote_line_items.is_quote_override  = false
 ```
 
-If the salesperson typed a one-off price in the form's "✏ Adjust price" editor, the matching `quote_line_items` row instead carries the typed values (and any back-calculated markup) plus `is_quote_override = true`. The part tier itself is never modified.
+A quantity below the lowest tier snaps to the lowest tier's price (flagged `below_min` in the UI). If the salesperson typed a one-off price in the row's "✏ Use custom price" editor, that `quote_line_items` row instead carries the typed `unit_price` plus `is_quote_override = true`; the part tier is never modified.
 
-Cost snapshots (`quote_operations`, `quote_materials`) are written once per **distinct part** in the quote, so a quote with three tiers of the same Holder still only stores one Holder cost snapshot.
+Cost snapshots (`quote_operations`, `quote_materials`) are keyed by `(quote_id, part_id)` and written once per **distinct part** — a part quoted at three quantities still stores one cost snapshot, captured at the lowest quoted quantity (a price-options quote has no single "the" quantity).
 
 ### Setup amortization is visible
 
@@ -428,7 +439,7 @@ Stored on `part_pricing_tiers`:
 | 2 | 98.75 (62.50 + 5 + 31.25) | 25 | 123.44 |
 | 4 | 83.13 (62.50 + 5 + 15.625) | 25 | 103.91 |
 
-When the user creates a quote selecting all three tiers, three `quote_line_items` are snapshotted with these values; subsequent edits to the part's tiers do not mutate the quote.
+If the salesperson quotes this part at quantities 1, 2, and 4, three `quote_line_items` are snapshotted with the resolved prices above; subsequent edits to the part's tiers do not mutate the quote. (Quoting an in-between quantity like 3 snaps to the qty-2 tier price.)
 
 ---
 
@@ -440,24 +451,24 @@ When the user creates a quote selecting all three tiers, three `quote_line_items
 | Active | Expired | Background sweep when `expiration_date` passes (idempotent on every list/detail load) |
 | Active or Expired | (converted, status unchanged) | `convertQuoteToJob` sets `converted_at`; status stays where it is |
 
-**Editing rule:** the metadata (customer, lead time, expiration) is editable while `status === 'active'` and `converted_at IS NULL`. Line items are never editable — they're snapshots.
+**Editing rule:** a quote is editable (metadata AND line items) while `status === 'active'` and `converted_at IS NULL`. Line items are reconciled on save (insert/update/delete by line item id) with pricing frozen by default — see the [Edit policy](#edit-policy-line-item-reconcile-frozen-pricing-drift).
 
 ---
 
-## Convert to Jobs Function
+## Convert to Job Function
 
-`convertQuoteToJob(quote_id, { selections: [{ line_item_id }, …], leadTimeDays })`:
+`convertQuoteToJob(quoteId, { dueDate?, customerPoNumber?, selectedLineItemIds? })`:
 
-1. Refuse if `converted_at` is already set.
-2. Validate selections: exactly one `line_item_id` per distinct `part_id` on the quote.
-3. Resolve lead time (override > quote default > null) and compute due date.
-4. For each selected line item:
-   - Insert a `jobs` row carrying `quote_id`, `customer_id`, `part_id`, `source_quote_line_item_id = line_item.id`, `due_date`, `lead_time_days`, `status = 'not_started'`.
-   - Call the `create_job_operations_from_routing(job_id, routing_id)` RPC to clone the part's routing into `job_operations`.
-5. Set `quote.converted_at` (status unchanged).
-6. Return `{ quote, jobs: [{ id, job_number, line_item_id, part_id, quantity }, …] }`.
+1. Refuse if `converted_at` is already set, or if the quote has no line items.
+2. Resolve which lines to convert: `selectedLineItemIds` when provided (a price-options quote — one chosen line per part), else all lines (a firm quote). **Reject if the resolved set has more than one line for any `part_id`** ("This is a price-options quote. Pick a single quantity per part before converting.").
+3. Pre-flight: every part must have a routing, else fail before any write.
+4. Resolve the due date (explicit override > today + the quote's `lead_time_days` > null) and capture the optional `customer_po_number`.
+5. Insert **one** `jobs` row (job number Q-NNNN → J-NNNN) carrying `quote_id`, `customer_id`, `due_date`, `lead_time_days`, `customer_po_number`, `production_status = 'not_started'`.
+6. For each resolved line, insert a `job_parts` row (`part_id`, `quantity = line.quantity`, `source_quote_line_item_id = line.id`) and clone the part's routing via the `create_job_part_operations_from_routing(job_part_id, routing_id)` RPC.
+7. Set `quote.converted_at` (status unchanged); the quote keeps all its line items as the record of every option offered.
+8. Return `{ quote, job: { id, job_number, parts: [{ id, part_id, quantity, source_quote_line_item_id }, …] } }`.
 
-A multi-part quote with three parts becomes three jobs. Each job's `quantity_ordered` matches the quantity of the line item the user picked, and the per-job lead time is the same value across the batch (single input on the modal).
+A quote with three distinct parts becomes one job with three work cells; each cell's quantity is the quantity of the line the user picked for that part.
 
 ---
 
@@ -468,9 +479,9 @@ A multi-part quote with three parts becomes three jobs. Each job's `quantity_ord
 The Quotes module uses direct Supabase calls from the frontend (via `utils/quotesAccess.ts`) for all operations:
 
 - CRUD on quote headers
-- Snapshotting selected `part_pricing_tiers` into `quote_line_items` and per-part cost snapshots into `quote_operations` / `quote_materials`
+- Snapshotting one line item per (part, quantity) into `quote_line_items` (price resolved from `part_pricing_tiers`) and per-part cost snapshots into `quote_operations` / `quote_materials`
 - Lazy expiration sweep (`sweepExpiredQuotes`) called as a fire-and-forget side effect on list/detail loads
-- Convert to Jobs (orchestrated in TypeScript; calls the `create_job_operations_from_routing` RPC for each created job)
+- Convert to Job (orchestrated in TypeScript; calls the `create_job_part_operations_from_routing` RPC for each job part)
 
 This follows the same pattern as Customers, Parts, and Operations:
 
@@ -494,13 +505,13 @@ This follows the same pattern as Customers, Parts, and Operations:
 
 - [ ] Can filter by customer
 
-- [ ] Can create a quote with one or more parts; each part contributes one or more snapshotted tiers
+- [ ] Can create a quote with one or more parts; each part contributes one or more quantity rows (each a snapshotted line item)
 
-- [ ] Form blocks submission until every part block has a part selected and at least one tier checked
+- [ ] Form blocks submission until every part block has a part selected and at least one valid quantity row (quantities unique within a part)
 
 - [ ] Quote header is editable (customer, lead time, expiration). Line items are editable via the [Edit policy](#edit-policy-line-item-reconcile-frozen-pricing-drift) below — reconciled on save, prices frozen by default
 
-- [ ] List page Total column shows the line-item total when there is exactly one line item, otherwise `—`
+- [ ] List page has no Total column (totals live on the detail page / PDF for firm quotes)
 
 - [ ] List page Jobs column shows links to every job spawned from the quote
 
@@ -512,27 +523,26 @@ This follows the same pattern as Customers, Parts, and Operations:
 
 - [ ] Setup-only operations (run = 0, setup > 0) appear in the cost breakdown with `run_cost = 0` and a non-zero setup cost (regression test for #224)
 
-### Convert to Jobs
+### Convert to Job
 
-- [ ] Modal lists one section per distinct part on the quote, with a radio per tier
+- [ ] Modal groups the quote's lines by part; a multi-quantity part shows a radio per quoted quantity
 
-- [ ] When a part has only one tier on the quote, that radio is pre-selected
+- [ ] A single-quantity part is auto-included (no radio to pick)
 
-- [ ] Convert button stays disabled until every part has a tier selected
+- [ ] Convert button stays disabled until every multi-quantity part has a quantity selected
 
-- [ ] Single lead-time input applies to all created jobs
+- [ ] `convertQuoteToJob` rejects a set that resolves to more than one line for any part (options-quote guard)
 
-- [ ] N selected tiers (across distinct parts) produce N jobs, each with `source_quote_line_item_id` set
+- [ ] Conversion creates ONE job with one `job_part` per selected line, each with `source_quote_line_item_id` set
 
-- [ ] Quote sets `converted_at` (status unchanged); detail page shows the linked jobs banner
+- [ ] Quote sets `converted_at` (status unchanged) and keeps all line items; detail page shows the linked job banner
 
-### Per-quote price overrides
+### Per-part price override
 
-- [ ] Each selected tier row exposes an "✏ Adjust price" button on the quote form
-- [ ] Expanding the editor shows Unit price + Markup % inputs pre-filled from the part tier
-- [ ] Bidirectional editing: typing a price back-calculates markup, typing a markup recomputes price
-- [ ] When the typed price diverges from the tier's standing price, the row chip changes to "adjusted for this quote"
-- [ ] The resulting `quote_line_items` row carries `is_quote_override = true` and the typed values
+- [ ] Each part block exposes a single "✏ Use custom price" toggle (one per part, not per quantity)
+- [ ] Expanding the editor shows a Custom unit price input that applies to every quantity of the part (markup % is no longer a quote-form input)
+- [ ] When a custom price is set, the block shows a green "adjusted for this quote" chip
+- [ ] Every resulting `quote_line_items` row for the part carries `is_quote_override = true` and the typed unit price
 - [ ] The cost-breakdown view renders a green "✏ adjusted for this quote" chip on overridden line items
 - [ ] The part's tier is unchanged
 
@@ -601,12 +611,11 @@ Quote detail pages include a **Print PDF** button that generates a customer-faci
 **What the PDF contains:**
 
 - Company logo (if uploaded in Settings → Company Branding) and company name in the header
-- Large "QUOTE" heading with the quote number, date, and status
-- **Bill To** block — customer name, contact person, address, phone, and email (pulled from the customer record; missing fields are skipped cleanly)
-- Line-item table — one row per `quote_line_item` ordered by `sequence`. Columns: Part, Description, Qty, Unit Price, Total.
-- **Conditional grand total**:
-  - Exactly one line item → bottom-line Total renders.
-  - More than one line item → grand total is **omitted** and replaced with the italic note "Select a quantity per part to confirm total." This is the multi-tier flow: the customer hasn't yet picked a quantity, so a single bottom-line price would be misleading.
+- Large "QUOTE" heading with the quote number, date, and validity / lead-time meta
+- **Created By · Customer Contact · Shipping Address** — three columns on one row (names, email, phone, address — the contact's role is not shown) pulled from the quote's snapshotted FKs; missing fields are skipped cleanly
+- **Line items** — one table (Part, Description, Order qty, Unit price, Total), ordered by `sequence`. A part with several quantities spans its name + description across its quantity rows.
+  - **Firm quote** (every part one quantity): a bottom-line **grand total**.
+  - **Price-options quote** (any part 2+ quantities): **no grand total** (the customer hasn't yet picked a quantity, so a single bottom-line price would mislead).
 - Acceptance / signature block + page footer
 
 **Intentionally excluded** (kept off the customer's view):
@@ -619,7 +628,7 @@ Quote detail pages include a **Print PDF** button that generates a customer-faci
 
 **Branding:** Upload your logo at `/dashboard/{companyId}/settings` (admin-only, Company Branding card). PNG, JPG, or WebP up to 2 MB. SVGs are accepted for storage but currently fall back to a text-only header in the PDF — use a raster format for logos that should appear. If no logo is uploaded, the PDF renders with the company name only.
 
-**Immutability:** Line items are frozen at creation, so the printed PDF is a faithful record of the price the customer was quoted. Re-printing the same quote tomorrow produces the same PDF.
+**Immutability:** Line-item prices are frozen by default (never silently repriced when the part's tiers move), so the printed PDF is a faithful record of the price the customer was quoted. Re-printing the same quote tomorrow produces the same PDF.
 
 ---
 
@@ -649,13 +658,15 @@ While creating a quote, users can create new entities without leaving the form:
 
 **Customer:** required
 
-**Parts:** at least one part block; each block must have a part selected and at least one tier checked
+**Parts:** at least one part block; each block must have a part selected. A part may appear in only one block.
 
-**Lead time (days):** integer, 0 – 3,650 (optional)
+**Quantities:** each block needs at least one quantity row; every quantity must be a whole number > 0 and unique within the part. Each non-override row must resolve to a priced tier (or use a custom price).
+
+**Lead time (days):** required — a whole number 0 – 3,650.
 
 **Expiration date:** ISO date (defaults to created + 10 days)
 
-**Tier-level fields** (`quantity`, `markup_percent`, `unit_price`) are validated on the part page when the tier is authored, not on the quote form.
+**Tier-level fields** (`quantity`, `markup_percent`) are validated on the part page when the tier is authored, not on the quote form.
 
 ---
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -54,7 +54,7 @@ Success looks like:
 | Operation Type | A category of operation (e.g., Machining, QC). |
 | Part | A company-wide product with name and description. Cost derived from routing when one exists. Not tied to a specific customer. |
 | Pricing Tier | A quantity break-point on a part with its own markup % (e.g., "Qty 4 @ 25%"). Unit price is derived live as `base_cost × (1 + markup/100)`. |
-| Quote | A cost-plus price estimate. Multi-part, multi-tier; line items snapshot selected pricing tiers (with optional per-quote overrides). Convert produces one job per (part, selected tier). |
+| Quote | A cost-plus price estimate. Multi-part; the salesperson quotes one or more quantities per part (each a snapshotted line item, with optional per-line overrides), and each quantity's price is resolved from the part's tiers. Firm (one qty/part → grand total) or price-options (2+ qtys → per-part break tables, no total) is implicit by quantity count. Convert produces one job, one work cell per (part, selected quantity). |
 
 ### 2. Users and Use Cases
 
@@ -260,7 +260,7 @@ Shop floors are noisy, dirty, and workers may have gloves on. UI elements should
 
 - **Inventory Transaction**: id, item_id, quantity_change, unit, transaction_type (add/deplete/adjust), work_order_id, user_id, notes, created_at
 
-- **Part**: id, company_id, part_name, description, created_at, updated_at (company-wide entity, no customer_id). Pricing is cost-plus and lives on `part_pricing_tiers`: each tier carries its own quantity + markup %; unit price is derived live as `base_cost × (1 + markup/100)` against the routing. Quotes snapshot tiers as immutable `quote_line_items` and may carry per-quote price overrides.
+- **Part**: id, company_id, part_name, description, created_at, updated_at (company-wide entity, no customer_id). Pricing is cost-plus and lives on `part_pricing_tiers`: each tier carries its own quantity + markup %; unit price is derived live as `base_cost × (1 + markup/100)` against the routing. Quotes snapshot one `quote_line_items` row per quoted (part, quantity) — the price resolved from these tiers and frozen by default — and may carry per-line price overrides.
 
 - **Part Pricing Tier**: id, part_id, company_id, sequence, quantity, base_cost_per_unit, markup_percent, unit_price, created_at, updated_at. Markup % is the source of truth; typing a unit price back-calculates markup. No per-tier "lock" — for stable customer prices, override at the quote line item.
 
@@ -290,7 +290,7 @@ Shop floors are noisy, dirty, and workers may have gloves on. UI elements should
 
 - Part → Company (many-to-one; parts are company-wide, not customer-specific)
 
-- Quote → Quote Line Item (one-to-many; immutable snapshots of selected pricing tiers)
+- Quote → Quote Line Item (one-to-many; one snapshot per (part, quantity), reconciled on edit with pricing frozen by default)
 
 - Quote Line Item → Job (one-to-one on conversion via `jobs.source_quote_line_item_id`)
 

--- a/e2e/quote-edit.spec.ts
+++ b/e2e/quote-edit.spec.ts
@@ -221,11 +221,11 @@ test.describe('Quote edit — reload contract', () => {
     // The second order-qty input is the new block's.
     await orderQtyInputs.nth(1).fill('2');
     // Open custom price for the SECOND block only — both blocks render a
-    // "Use custom price" button, so the unscoped locator hits strict-mode
-    // violation. nth(1) targets the new block.
+    // single part-level "Use custom price" button, so the unscoped locator
+    // hits a strict-mode violation. nth(1) targets the new block.
     await page.getByRole('button', { name: /Use custom price/i }).nth(1).click();
-    // The Unit price input only exists after override is opened.
-    await page.getByRole('textbox', { name: /^Unit price$/i }).fill('25');
+    // The "Custom unit price" input only exists after override is opened.
+    await page.getByRole('textbox', { name: /^Custom unit price$/i }).fill('25');
 
     // Wait for the Save button to become enabled before clicking. With
     // qty + override price filled, validation passes; the button enables
@@ -306,10 +306,11 @@ test.describe('Quote edit — reload contract', () => {
       .click();
     await page.getByRole('textbox', { name: /Order quantity/i }).fill('1');
 
-    // Capture the snapshotted unit price. The QuoteForm renders
-    // "Tier N ea · $XX.YY / unit" inline — the dollar amount depends on
-    // the routing cost rollup, so we just grab whatever number is shown.
-    const unitPriceLocator = page.getByText(/\$[\d.,]+ \/ unit/);
+    // Capture the snapshotted unit price. The compact quantity table shows
+    // the unit price as a standalone "$XX.YY" cell (with a "Tier N ea"
+    // caption); the amount depends on the routing cost rollup. At qty 1 the
+    // unit price and extended are equal, so the first dollar cell is fine.
+    const unitPriceLocator = page.getByText(/^\$[\d.,]+$/);
     await expect(unitPriceLocator.first()).toBeVisible({ timeout: 10_000 });
     const snapshottedUnitPriceText = await unitPriceLocator.first().textContent();
     const snapshottedDollar = (snapshottedUnitPriceText ?? '').match(/\$[\d.,]+/)?.[0];
@@ -422,7 +423,7 @@ test.describe('Quote edit — reload contract', () => {
       .first()
       .click();
     await page.getByRole('textbox', { name: /Order quantity/i }).fill('1');
-    const unitPriceLocator = page.getByText(/\$[\d.,]+ \/ unit/);
+    const unitPriceLocator = page.getByText(/^\$[\d.,]+$/);
     await expect(unitPriceLocator.first()).toBeVisible({ timeout: 10_000 });
     const snapshottedDollarText = (await unitPriceLocator.first().textContent()) ?? '';
     const snapshottedDollar = snapshottedDollarText.match(/\$[\d.,]+/)?.[0];

--- a/e2e/quote-to-job.spec.ts
+++ b/e2e/quote-to-job.spec.ts
@@ -76,9 +76,9 @@ test.describe('Quote to Job workflow', () => {
     // tier deterministically.
     const orderQty = page.getByRole('textbox', { name: /Order quantity/i });
     await orderQty.fill('1');
-    // Confirm the tier resolved — the form renders "Tier N ea · $X / unit"
-    // when the match succeeds. If this assertion fails, the seeded part is
-    // missing pricing tiers (check e2e/global-setup.ts).
+    // Confirm the tier resolved — the form renders a "Tier N ea" caption
+    // under the unit price when the match succeeds. If this assertion fails,
+    // the seeded part is missing pricing tiers (check e2e/global-setup.ts).
     await expect(page.getByText(/Tier \d+ ea/i).first()).toBeVisible({
       timeout: 10_000,
     });

--- a/types/quote.ts
+++ b/types/quote.ts
@@ -184,15 +184,17 @@ export interface QuoteLineOverride {
 }
 
 /**
- * Selection shape for a single part inside the quote form. The salesperson
- * commits to one Order Quantity per part; the unit price is auto-resolved
- * from the part's pricing tiers (highest tier with `tier_qty <= order_qty`)
- * unless an explicit override is supplied.
+ * One (part, quantity) entry in the quote form payload — the flat unit the
+ * access layer consumes. A part carrying several quantities (a price-options
+ * quote) contributes several entries that share a part_id; the QuoteForm
+ * groups them into a single part block with one quantity row each. The unit
+ * price is auto-resolved from the part's pricing tiers (highest tier with
+ * `tier_qty <= order_qty`) unless an explicit override is supplied.
  *
  * `line_item_id` and `basis_unknown` are only populated on EDIT — they let
- * the form correlate a block back to its underlying line item so it can
- * render the drift chip and "basis unknown" chip. Create-mode payloads
- * leave them undefined; createQuote / reconcile both ignore them.
+ * the form correlate an entry back to its underlying line item so it can
+ * render the drift chip and "basis unknown" chip, and let reconcile match
+ * existing rows by id. Create-mode payloads leave them undefined.
  */
 export interface QuoteFormPartBlock {
   part_id: string;
@@ -274,18 +276,14 @@ export const EMPTY_QUOTE_FORM: QuoteFormData = {
 
 /**
  * Convert Quote to QuoteFormData for edit forms.
- * Each existing line item maps to one part block (one row per part on the new model).
- * If multiple rows somehow exist for the same part (pre-collapse data), the lowest-qty
- * one wins to mirror the migration's choice.
+ *
+ * Emits one form entry per line item (sorted by sequence). A part carrying
+ * multiple quantities (a price-options quote) therefore produces multiple
+ * entries sharing a part_id — the QuoteForm groups them back into a single
+ * part block with one quantity row each. Firm quotes (one line per part)
+ * round-trip to one entry per part exactly as before.
  */
 export function quoteToFormData(quote: QuoteWithRelations): QuoteFormData {
-  const byPart = new Map<string, QuoteLineItem>();
-  for (const li of quote.line_items || []) {
-    const existing = byPart.get(li.part_id);
-    if (!existing || li.quantity < existing.quantity) {
-      byPart.set(li.part_id, li);
-    }
-  }
   return {
     // customer_id is nullable in the schema but the form treats '' as
     // "unset" — match the same convention as contact / address IDs below.
@@ -293,20 +291,22 @@ export function quoteToFormData(quote: QuoteWithRelations): QuoteFormData {
     contact_id: quote.contact_id ?? '',
     billing_address_id: quote.billing_address_id ?? '',
     shipping_address_id: quote.shipping_address_id ?? '',
-    parts: Array.from(byPart.values()).map((li) => ({
-      part_id: li.part_id,
-      order_quantity: li.quantity,
-      line_item_id: li.id,
-      basis_unknown: li.basis_unknown,
-      ...(li.is_quote_override
-        ? {
-            override: {
-              unit_price: li.unit_price,
-              markup_percent: li.markup_percent,
-            },
-          }
-        : {}),
-    })),
+    parts: [...(quote.line_items || [])]
+      .sort((a, b) => a.sequence - b.sequence)
+      .map((li) => ({
+        part_id: li.part_id,
+        order_quantity: li.quantity,
+        line_item_id: li.id,
+        basis_unknown: li.basis_unknown,
+        ...(li.is_quote_override
+          ? {
+              override: {
+                unit_price: li.unit_price,
+                markup_percent: li.markup_percent,
+              },
+            }
+          : {}),
+      })),
     lead_time_days: quote.lead_time_days !== null ? String(quote.lead_time_days) : '',
     expiration_date: quote.expiration_date || defaultExpirationDate(),
     status: quote.status,

--- a/utils/quotePdf.ts
+++ b/utils/quotePdf.ts
@@ -6,12 +6,10 @@
  * can get it, and how to accept — nothing more.
  */
 import { jsPDF } from 'jspdf';
-import autoTable from 'jspdf-autotable';
+import autoTable, { type RowInput } from 'jspdf-autotable';
 import type { QuoteWithRelations } from '@/types/quote';
 import type { Company } from '@/utils/companyAccess';
-import type { ComputedPartPricingTier } from '@/types/partPricing';
 import { isQuoteExpired, daysUntilExpiration } from '@/types/quote';
-import { getTiersWithComputedPrices } from '@/utils/partPricingTiersAccess';
 
 const MARGIN = 40;
 
@@ -101,27 +99,6 @@ function findContactById(
 }
 
 /**
- * Human-readable label for a contact role. Single source of truth shared
- * with the quote form's option label so the form and the PDF can't drift.
- */
-function formatContactRoleLabel(role: string): string {
-  switch (role) {
-    case 'accounts_payable':
-      return 'Accounts Payable';
-    case 'shipping_receiving':
-      return 'Shipping & Receiving';
-    case 'buyer':
-      return 'Buyer';
-    case 'engineering':
-      return 'Engineering';
-    case 'quality':
-      return 'Quality';
-    default:
-      return 'Other';
-  }
-}
-
-/**
  * Build the printed address lines for the Shipping Address block.
  * Surfaces ATTN: from customer_addresses.attention_to when set. No
  * contact lines or contact info — the Customer Contact has its own
@@ -151,25 +128,6 @@ function buildShippingAddressLines(
   return lines;
 }
 
-/** Pre-fetch master tier lists for every part that appears on the quote. */
-async function loadTiersForQuote(
-  quote: QuoteWithRelations,
-): Promise<Record<string, ComputedPartPricingTier[]>> {
-  const partIds = Array.from(new Set((quote.line_items ?? []).map((li) => li.part_id)));
-  const out: Record<string, ComputedPartPricingTier[]> = {};
-  await Promise.all(
-    partIds.map(async (id) => {
-      try {
-        out[id] = await getTiersWithComputedPrices(id);
-      } catch (err) {
-        console.warn('Quote PDF: failed to load tiers for part', id, err);
-        out[id] = [];
-      }
-    }),
-  );
-  return out;
-}
-
 /**
  * Filename used both when downloading and when attaching to email.
  * Single source of truth so the preview dialog, download button, and email
@@ -197,7 +155,6 @@ export async function generateQuotePdf(
   const pageWidth = doc.internal.pageSize.getWidth();
   const pageHeight = doc.internal.pageSize.getHeight();
 
-  const tiersByPart = await loadTiersForQuote(quote);
   const expired = isQuoteExpired(quote);
   const daysLeft = daysUntilExpiration(quote.expiration_date);
 
@@ -275,10 +232,11 @@ export async function generateQuotePdf(
   doc.line(MARGIN, cursorY, pageWidth - MARGIN, cursorY);
   cursorY += 20;
 
-  // ---------- CREATED BY (left) + BILL TO (right) ----------
-  const colWidth = (pageWidth - MARGIN * 2) / 2;
-  const leftX = MARGIN;
-  const rightX = MARGIN + colWidth + 8;
+  // ---------- CREATED BY · CUSTOMER CONTACT · SHIPPING ADDRESS (3 columns) ----------
+  const usableWidth = pageWidth - MARGIN * 2;
+  const col1X = MARGIN;
+  const col2X = MARGIN + usableWidth * 0.33;
+  const col3X = MARGIN + usableWidth * 0.66;
 
   const createdByName = quote.created_by_member?.name ?? null;
   const createdByEmail = quote.created_by_member?.email ?? null;
@@ -291,93 +249,110 @@ export async function generateQuotePdf(
   // future invoicing flow but is NOT rendered on the quote document.
   const shippingAddress = findAddressById(quote.customers?.addresses, quote.shipping_address_id);
   const contact = findContactById(quote.customers?.customer_contacts, quote.contact_id);
-
   const shippingLines = buildShippingAddressLines(quote.customers ?? null, shippingAddress);
 
-  // Section labels — left: CREATED BY, right: SHIPPING ADDRESS.
+  // Build each column's body lines as { text, bold }. The lead line of each
+  // column (creator/contact name, customer name) is bold; the rest plain.
+  const createdByLines: Array<{ text: string; bold: boolean }> = [];
+  if (createdByName) createdByLines.push({ text: createdByName, bold: true });
+  if (createdByEmail) createdByLines.push({ text: createdByEmail, bold: false });
+
+  const contactLines: Array<{ text: string; bold: boolean }> = [];
+  if (contact) {
+    contactLines.push({ text: contact.name, bold: true });
+    if (contact.email) contactLines.push({ text: contact.email, bold: false });
+    if (contact.phone) contactLines.push({ text: contact.phone, bold: false });
+  }
+
+  const shippingBody: Array<{ text: string; bold: boolean }> = shippingLines.map(
+    (line: string, i: number) => ({ text: line, bold: i === 0 }),
+  );
+
+  const infoColumns: Array<{
+    x: number;
+    label: string | null;
+    lines: Array<{ text: string; bold: boolean }>;
+  }> = [
+    { x: col1X, label: createdByLines.length > 0 ? 'CREATED BY' : null, lines: createdByLines },
+    { x: col2X, label: contactLines.length > 0 ? 'CUSTOMER CONTACT' : null, lines: contactLines },
+    { x: col3X, label: 'SHIPPING ADDRESS', lines: shippingBody },
+  ];
+
+  // Column labels on one row.
   doc.setFont('helvetica', 'bold');
   doc.setFontSize(9);
   doc.setTextColor(120);
-  if (createdByName || createdByEmail) {
-    doc.text('CREATED BY', leftX, cursorY);
-  }
-  doc.text('SHIPPING ADDRESS', rightX, cursorY);
-
-  // Left column: Created by name + email
-  doc.setFontSize(11);
-  doc.setTextColor(40);
-  let leftLineCount = 0;
-  if (createdByName) {
-    doc.setFont('helvetica', 'bold');
-    doc.text(createdByName, leftX, cursorY + 16 + leftLineCount * 13);
-    leftLineCount += 1;
-  }
-  if (createdByEmail) {
-    doc.setFont('helvetica', 'normal');
-    doc.text(createdByEmail, leftX, cursorY + 16 + leftLineCount * 13);
-    leftLineCount += 1;
+  for (const col of infoColumns) {
+    if (col.label) doc.text(col.label, col.x, cursorY);
   }
 
-  // Right column: Shipping address. First line is the customer name
-  // (bold); subsequent lines (Attn:, address, city/state/zip, country)
-  // render plain.
-  shippingLines.forEach((line: string, i: number) => {
-    doc.setFont('helvetica', i === 0 ? 'bold' : 'normal');
-    doc.setFontSize(11);
-    doc.setTextColor(40);
-    doc.text(line, rightX, cursorY + 16 + i * 13);
-  });
-
-  const rightBlockLines = shippingLines.length;
-  const blockLines = Math.max(leftLineCount, rightBlockLines);
-  cursorY = cursorY + 16 + blockLines * 13 + 16;
-
-  // ---------- Customer Contact section ----------
-  // Sourced from quotes.contact_id. Defaults at quote creation to the
-  // customer's primary contact (see migration 20260522). Renders name,
-  // role, email, phone — only the fields the contact actually has.
-  if (contact) {
-    doc.setFont('helvetica', 'bold');
-    doc.setFontSize(9);
-    doc.setTextColor(120);
-    doc.text('CUSTOMER CONTACT', MARGIN, cursorY);
-    cursorY += 14;
-
-    doc.setFontSize(11);
-    doc.setTextColor(40);
-    doc.setFont('helvetica', 'bold');
-    doc.text(contact.name, MARGIN, cursorY);
-    cursorY += 13;
-
-    doc.setFont('helvetica', 'normal');
-    doc.text(formatContactRoleLabel(contact.role), MARGIN, cursorY);
-    cursorY += 13;
-
-    if (contact.email) {
-      doc.text(contact.email, MARGIN, cursorY);
-      cursorY += 13;
-    }
-    if (contact.phone) {
-      doc.text(contact.phone, MARGIN, cursorY);
-      cursorY += 13;
-    }
-
-    cursorY += 6;
+  // Column bodies; advance the cursor past the tallest column.
+  let maxInfoLines = 0;
+  for (const col of infoColumns) {
+    col.lines.forEach((ln, i) => {
+      doc.setFont('helvetica', ln.bold ? 'bold' : 'normal');
+      doc.setFontSize(11);
+      doc.setTextColor(40);
+      doc.text(ln.text, col.x, cursorY + 16 + i * 13);
+    });
+    maxInfoLines = Math.max(maxInfoLines, col.lines.length);
   }
+
+  cursorY = cursorY + 16 + maxInfoLines * 13 + 16;
 
   // ---------- Line items ----------
   const lineItems = [...(quote.line_items ?? [])].sort((a, b) => a.sequence - b.sequence);
 
-  const body =
-    lineItems.length > 0
-      ? lineItems.map((li) => [
-          li.parts?.part_name ?? 'Part',
-          li.parts?.description?.trim() ?? '',
+  // Group by part (first-appearance order). Both firm and price-options quotes
+  // render as ONE table; a part with 2+ quantities spans its name/description
+  // across its quantity rows. Firm quotes (every part one quantity) add a grand
+  // total; price-options quotes omit it (the customer picks a quantity).
+  const partGroups: { part_name: string; description: string; items: typeof lineItems }[] = [];
+  const groupIndex = new Map<string, number>();
+  for (const li of lineItems) {
+    let gi = groupIndex.get(li.part_id);
+    if (gi === undefined) {
+      gi = partGroups.length;
+      groupIndex.set(li.part_id, gi);
+      partGroups.push({
+        part_name: li.parts?.part_name ?? 'Part',
+        description: li.parts?.description?.trim() ?? '',
+        items: [],
+      });
+    }
+    partGroups[gi].items.push(li);
+  }
+  const isFirmQuote = partGroups.length > 0 && partGroups.every((g) => g.items.length === 1);
+
+  // One table for the whole quote. A part with several quantities shows its
+  // name + description once (a cell spanning its quantity rows) and one line
+  // per quantity; a single-quantity part is a plain one-line row.
+  const body: RowInput[] = [];
+  if (lineItems.length > 0) {
+    for (const group of partGroups) {
+      const rows = [...group.items].sort((a, b) => a.quantity - b.quantity);
+      rows.forEach((li, i) => {
+        const qtyCells = [
           String(li.quantity),
           formatCurrency(li.unit_price),
           formatCurrency(li.total_price ?? li.unit_price * li.quantity),
-        ])
-      : [['', '', '', '', '']];
+        ];
+        if (rows.length === 1) {
+          body.push([group.part_name, group.description, ...qtyCells]);
+        } else if (i === 0) {
+          body.push([
+            { content: group.part_name, rowSpan: rows.length },
+            { content: group.description, rowSpan: rows.length },
+            ...qtyCells,
+          ]);
+        } else {
+          body.push(qtyCells);
+        }
+      });
+    }
+  } else {
+    body.push(['', '', '', '', '']);
+  }
 
   autoTable(doc, {
     startY: cursorY,
@@ -389,6 +364,7 @@ export async function generateQuotePdf(
       fontSize: 10,
       cellPadding: 7,
       textColor: [40, 40, 40],
+      valign: 'top',
     },
     headStyles: {
       fillColor: [240, 240, 240],
@@ -408,11 +384,12 @@ export async function generateQuotePdf(
   });
 
   const afterTableY =
-    (doc as unknown as { lastAutoTable?: { finalY: number } }).lastAutoTable?.finalY ?? cursorY + 60;
+    (doc as unknown as { lastAutoTable?: { finalY: number } }).lastAutoTable?.finalY ??
+    cursorY + 60;
 
-  // ---------- Grand total ----------
+  // ---------- Grand total (firm quotes only) ----------
   cursorY = afterTableY + 20;
-  if (lineItems.length > 0) {
+  if (isFirmQuote && lineItems.length > 0) {
     const grandTotal = lineItems.reduce(
       (sum, li) => sum + (li.total_price ?? li.unit_price * li.quantity),
       0,
@@ -423,89 +400,6 @@ export async function generateQuotePdf(
     doc.text('Total', pageWidth - MARGIN - 100, cursorY, { align: 'right' });
     doc.text(formatCurrency(grandTotal), pageWidth - MARGIN, cursorY, { align: 'right' });
     cursorY += 20;
-  }
-
-  // ---------- Pricing tiers (separate appendix-style table) ----------
-  const partsWithTiers = lineItems.filter((li) => {
-    if (li.is_quote_override) return false;
-    const tiers = tiersByPart[li.part_id] ?? [];
-    return tiers.length > 1;
-  });
-
-  if (partsWithTiers.length > 0) {
-    cursorY += 10;
-
-    doc.setFont('helvetica', 'bold');
-    doc.setFontSize(9);
-    doc.setTextColor(120);
-    doc.text('PRICING TIERS', MARGIN, cursorY);
-    cursorY += 12;
-
-    for (const li of partsWithTiers) {
-      // Page-break guard.
-      const reservedBottom = 160;
-      if (cursorY + 50 > pageHeight - reservedBottom) {
-        doc.addPage();
-        cursorY = MARGIN;
-      }
-
-      const tiers = [...(tiersByPart[li.part_id] ?? [])].sort(
-        (a, b) => a.quantity - b.quantity,
-      );
-      const matchedId = li.source_tier_id;
-
-      // Part header
-      doc.setFont('helvetica', 'bold');
-      doc.setFontSize(10);
-      doc.setTextColor(50);
-      const partLabel = li.parts?.part_name ?? 'Part';
-      const desc = li.parts?.description?.trim();
-      doc.text(desc ? `${partLabel}  —  ${desc}` : partLabel, MARGIN, cursorY + 10);
-      cursorY += 16;
-
-      // Tier sub-table: marker / order qty / unit price (with "each") / note.
-      const tierBody = tiers.map((tier) => {
-        const isMatched = tier.id === matchedId;
-        return [
-          isMatched ? '>' : '',
-          String(tier.quantity),
-          `${formatCurrency(tier.unit_price)} each`,
-          isMatched ? `your order of ${li.quantity}` : '',
-        ];
-      });
-
-      autoTable(doc, {
-        startY: cursorY,
-        margin: { left: MARGIN + 8, right: MARGIN },
-        body: tierBody,
-        styles: {
-          font: 'helvetica',
-          fontSize: 9,
-          cellPadding: { top: 3, bottom: 3, left: 4, right: 4 },
-          textColor: [80, 80, 80],
-          lineColor: [240, 240, 240],
-          lineWidth: 0.4,
-        },
-        columnStyles: {
-          0: { cellWidth: 14, halign: 'center', fontStyle: 'bold', textColor: [30, 30, 30] },
-          1: { cellWidth: 60, halign: 'right' },
-          2: { cellWidth: 100, halign: 'right' },
-          3: { cellWidth: 'auto', textColor: [120, 120, 120], fontStyle: 'italic' },
-        },
-        didParseCell: (data) => {
-          const markerCell = data.row.cells[0];
-          if (markerCell && markerCell.raw === '>') {
-            data.cell.styles.fontStyle = 'bold';
-            data.cell.styles.textColor = [30, 30, 30];
-          }
-        },
-        theme: 'plain',
-      });
-
-      const tierEndY =
-        (doc as unknown as { lastAutoTable?: { finalY: number } }).lastAutoTable?.finalY ?? cursorY;
-      cursorY = tierEndY + 10;
-    }
   }
 
   // ---------- Acceptance block (compact) ----------

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -327,13 +327,10 @@ export async function createQuote(
   if (!formData.parts || formData.parts.length === 0) {
     throw new Error('A quote must include at least one part.');
   }
-  const seenPartsForValidation = new Set<string>();
+  // A part may appear more than once now — each (part, quantity) entry is its
+  // own line item (a price-options quote). Only validate each entry in isolation.
   for (const block of formData.parts) {
     if (!block.part_id) throw new Error('Every part selection must reference a real part.');
-    if (seenPartsForValidation.has(block.part_id)) {
-      throw new Error('A part can only appear once on a quote — adjust the order quantity instead of duplicating it.');
-    }
-    seenPartsForValidation.add(block.part_id);
     if (!Number.isFinite(block.order_quantity) || block.order_quantity <= 0) {
       throw new Error('Every part needs an order quantity greater than zero.');
     }
@@ -385,12 +382,22 @@ export async function createQuote(
     throw error;
   }
 
-  // Snapshot one line item per part (auto-resolving the tier from order qty)
-  // and write per-part cost snapshots.
-  let sequence = 10;
+  // Snapshot one line item per (part, quantity) entry (auto-resolving the
+  // tier from order qty). A price-options quote contributes several entries
+  // for one part; tiers are fetched once per part and reused across its
+  // quantities.
+  const tiersCache = new Map<string, ComputedPartPricingTier[]>();
+  const ensureTiers = async (partId: string): Promise<ComputedPartPricingTier[]> => {
+    const cached = tiersCache.get(partId);
+    if (cached) return cached;
+    const tiers = await getTiersWithComputedPrices(partId);
+    tiersCache.set(partId, tiers);
+    return tiers;
+  };
 
+  let sequence = 10;
   for (const block of formData.parts) {
-    const tiers = await getTiersWithComputedPrices(block.part_id);
+    const tiers = await ensureTiers(block.part_id);
     await insertLineItemForPart(
       quote.id,
       companyId,
@@ -401,16 +408,25 @@ export async function createQuote(
       block.override,
     );
     sequence += 10;
+  }
 
+  // Cost snapshots (quote_operations / quote_materials) are keyed by
+  // (quote_id, part_id), so they're written ONCE per part — never once per
+  // quantity. A price-options quote has no single "the" quantity, so we
+  // snapshot at the lowest quoted quantity (deterministic; the per-unit
+  // material cost depends on qty via procurement tiers).
+  const lowestQtyByPart = new Map<string, number>();
+  for (const block of formData.parts) {
+    const current = lowestQtyByPart.get(block.part_id);
+    if (current === undefined || block.order_quantity < current) {
+      lowestQtyByPart.set(block.part_id, block.order_quantity);
+    }
+  }
+  for (const [partId, qty] of lowestQtyByPart) {
     try {
-      await writeCostSnapshotsForPart(
-        quote.id,
-        companyId,
-        block.part_id,
-        block.order_quantity,
-      );
+      await writeCostSnapshotsForPart(quote.id, companyId, partId, qty);
     } catch (snapshotError) {
-      console.warn('Failed to write cost snapshot for part:', block.part_id, snapshotError);
+      console.warn('Failed to write cost snapshot for part:', partId, snapshotError);
       Sentry.captureException(snapshotError, { level: 'warning' });
     }
   }
@@ -461,20 +477,14 @@ export async function updateQuote(
 
   const companyId = existing.company_id;
 
-  // Same shape validation as createQuote — duplicate parts and bad
-  // quantities are caught here before we issue any DB writes.
+  // Same shape validation as createQuote. A part may appear more than once
+  // now — each (part, quantity) entry is its own line item (a price-options
+  // quote). Only validate each entry in isolation before any DB writes.
   if (!formData.parts || formData.parts.length === 0) {
     throw new Error('A quote must include at least one part.');
   }
-  const seenPartsForValidation = new Set<string>();
   for (const block of formData.parts) {
     if (!block.part_id) throw new Error('Every part selection must reference a real part.');
-    if (seenPartsForValidation.has(block.part_id)) {
-      throw new Error(
-        'A part can only appear once on a quote — adjust the order quantity instead of duplicating it.',
-      );
-    }
-    seenPartsForValidation.add(block.part_id);
     if (!Number.isFinite(block.order_quantity) || block.order_quantity <= 0) {
       throw new Error('Every part needs an order quantity greater than zero.');
     }
@@ -533,21 +543,29 @@ async function reconcileQuoteLineItems(
   options: { acceptDriftLineItemIds?: string[] },
 ): Promise<void> {
   const existingItems = await getLineItemsForQuote(quoteId);
-  const byPartId = new Map(existingItems.map((li) => [li.part_id, li]));
-  const formPartIds = new Set(formData.parts.map((p) => p.part_id));
+  // Each (part, quantity) entry is its own line item, so reconcile by
+  // line_item_id — NOT by part_id (a part can now own several lines). Form
+  // entries with no line_item_id are new lines (add-quantity / new part);
+  // existing lines whose id is absent from the payload were removed.
+  const byId = new Map(existingItems.map((li) => [li.id, li]));
+  const formLineIds = new Set(
+    formData.parts
+      .map((p) => p.line_item_id)
+      .filter((id): id is string => !!id),
+  );
 
-  // 1. Delete lines whose parts were removed on the form.
+  // 1. Delete lines absent from the form payload (removed quantity or part).
   for (const li of existingItems) {
-    if (!formPartIds.has(li.part_id)) {
+    if (!formLineIds.has(li.id)) {
       await deleteLineItem(li.id);
     }
   }
 
-  // 2. Insert / update remaining parts. We need fresh tiers for any
-  //    add-line (basis snapshot must use the part's CURRENT tier table at
+  // 2. Insert new lines / update existing ones. We need fresh tiers for any
+  //    insert (basis snapshot must use the part's CURRENT tier table at
   //    add-line time) and for any line the user opted in to reprice.
-  //    Cache per-partId lookups so a quote with N parts only hits the
-  //    tiers query N times.
+  //    Cache per-partId lookups so a quote with N distinct parts only hits
+  //    the tiers query N times.
   const tiersCache = new Map<string, ComputedPartPricingTier[]>();
   const ensureTiers = async (partId: string): Promise<ComputedPartPricingTier[]> => {
     const cached = tiersCache.get(partId);
@@ -567,10 +585,12 @@ async function reconcileQuoteLineItems(
       : Math.max(...existingItems.map((li) => li.sequence)) + 10;
 
   for (const block of formData.parts) {
-    const existing = byPartId.get(block.part_id);
+    const existing = block.line_item_id ? byId.get(block.line_item_id) : undefined;
 
     if (!existing) {
-      // New part on this edit — snapshot from current tiers.
+      // New line on this edit (add-quantity or new part) — snapshot from
+      // current tiers. A stale/unknown line_item_id also falls through here
+      // and is treated as a fresh insert, which is safe.
       const tiers = await ensureTiers(block.part_id);
       await insertLineItemForPart(
         quoteId,
@@ -587,10 +607,7 @@ async function reconcileQuoteLineItems(
 
     // Existing line — reprice only if explicitly accepted; never on
     // override lines. Quantity changes recompute against the snapshot.
-    if (
-      !existing.is_quote_override &&
-      acceptDriftIds.has(existing.id)
-    ) {
+    if (!existing.is_quote_override && acceptDriftIds.has(existing.id)) {
       const tiers = await ensureTiers(block.part_id);
       await repriceLineItemToCurrent(existing.id, tiers);
     }
@@ -888,6 +905,15 @@ export interface ConvertToJobOptions {
    * NULL/empty is allowed for shops that don't track customer POs.
    */
   customerPoNumber?: string | null;
+  /**
+   * Which quote line items to convert — one per part. A price-options quote
+   * offers several quantities per part with no single committed quantity, so
+   * the salesperson picks the accepted quantity (line item) per part at
+   * conversion. When omitted, ALL line items convert (the firm-quote path —
+   * each part already has exactly one line). Whichever set is used, it must
+   * resolve to exactly one line per part_id or the conversion is rejected.
+   */
+  selectedLineItemIds?: string[];
 }
 
 export interface ConvertToJobResult {
@@ -905,9 +931,12 @@ export interface ConvertToJobResult {
 }
 
 /**
- * Convert a quote into a single job that owns one job_part per quote_line_item.
- * The job number mirrors the quote number (Q-NNNN → J-NNNN). Each part's routing
- * is cloned into job_operations + job_materials via the
+ * Convert a quote into a single job that owns one job_part per converted line
+ * item (one per part). For a price-options quote the caller passes
+ * `options.selectedLineItemIds` to pick the accepted quantity per part; a firm
+ * quote converts all its lines. Either way the set must resolve to exactly one
+ * line per part_id. The job number mirrors the quote number (Q-NNNN → J-NNNN).
+ * Each part's routing is cloned into job_operations + job_materials via the
  * `create_job_part_operations_from_routing` RPC.
  *
  * The flow is sequential because Supabase doesn't expose multi-statement
@@ -948,8 +977,32 @@ export async function convertQuoteToJob(
     throw new Error('This quote has no line items to convert.');
   }
 
+  // Resolve which line items become job parts. A price-options quote offers
+  // several quantities per part, so the caller picks one line per part via
+  // selectedLineItemIds; a firm quote (one line per part) converts them all.
+  const selectedIds = options.selectedLineItemIds;
+  const lineItemsToConvert =
+    selectedIds && selectedIds.length > 0
+      ? lineItems.filter((li) => selectedIds.includes(li.id))
+      : lineItems;
+  if (lineItemsToConvert.length === 0) {
+    throw new Error('No matching line items selected to convert.');
+  }
+  // Exactly one line per part — converting two quantities of the same part
+  // would silently create duplicate job parts. Reject instead (this also
+  // hard-guards any caller that forgot to pick a quantity).
+  const partLineCounts = new Map<string, number>();
+  for (const li of lineItemsToConvert) {
+    partLineCounts.set(li.part_id, (partLineCounts.get(li.part_id) ?? 0) + 1);
+  }
+  if (Array.from(partLineCounts.values()).some((n) => n > 1)) {
+    throw new Error(
+      'This is a price-options quote. Pick a single quantity per part before converting.',
+    );
+  }
+
   // Pre-flight: every part must have a routing. Fail fast before writing anything.
-  const partIds = Array.from(new Set(lineItems.map((li) => li.part_id)));
+  const partIds = Array.from(new Set(lineItemsToConvert.map((li) => li.part_id)));
   const { data: routings, error: routingsErr } = await supabase
     .from('routings')
     .select('id, part_id')
@@ -1025,7 +1078,7 @@ export async function convertQuoteToJob(
   const partsCreated: ConvertToJobResult['job']['parts'] = [];
 
   let sequence = 10;
-  for (const li of lineItems) {
+  for (const li of lineItemsToConvert) {
     const routingId = routingByPart.get(li.part_id);
     if (!routingId) {
       // Should be impossible after the pre-flight, but guard anyway.


### PR DESCRIPTION
## What & why

Salespeople often don't know how much a buyer will order. This adds **price-options quotes**: enter several arbitrary quantities per part (e.g. 5 / 15 / 25 — not limited to tier breakpoints) and present each quantity's price. The existing **firm** (single-quantity) quote is preserved.

**Firm vs. price-options is implicit, by quantity count** — no mode toggle, and **no DB migration** (`quote_line_items` already allows multiple rows per part; firm = every part has exactly one quantity).

## Key decisions
- **Snap-to-tier** pricing — reuses `resolveTier`, the pricing engine is unchanged.
- Custom price is **one override per part**, applied to all of that part's quantities.
- **Convert-to-job** lets the salesperson pick the accepted quantity per part; the quote stays intact as the record of every option offered.

## Changes
- **QuoteForm** — editable quantity table per part (compact rows, column labels once); tier-chip section removed; part-level custom-price override; grand total shown only for firm quotes.
- **Access layer** (`utils/quotesAccess.ts`) — removed duplicate-part guards; cost snapshots deduped per part; reconcile by `line_item_id`; `convertQuoteToJob` gains `selectedLineItemIds` + a one-line-per-part guard.
- **Detail page + PDF** — one unified table; a multi-quantity part spans its name/description across its quantity rows; grand total only for firm. PDF header is now 3 columns (Created By · Customer Contact · Shipping Address); contact role removed.
- **Quotes list** — dropped the Total column (often empty for options quotes).
- **ConvertToJobModal** — per-part quantity picker for price-options quotes.
- Docs updated (`quotes.md`, `prd.md`, `jobs.md`).

## Tests
535 unit tests pass; `tsc` + eslint clean. Updated reconcile / convert / PDF tests; added `quoteToFormData`, part-level override, duplicate-quantity, and options-layout cases. The e2e firm path is preserved (kept the "Order quantity" accessible label + "Tier N ea" readout it asserts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)