### PR TITLE
Billing/shipping address + contact on jobs and quote detail

### DIFF
--- a/__tests__/utils/jobsAccess.test.ts
+++ b/__tests__/utils/jobsAccess.test.ts
@@ -31,6 +31,7 @@ import {
   getOverdueJobsCount,
   getReadyOperationsForJobs,
   searchJobsByIdentifier,
+  updateJobAddressContact,
 } from '@/utils/jobsAccess';
 
 describe('jobsAccess', () => {
@@ -158,6 +159,42 @@ describe('jobsAccess', () => {
       });
       const result = await getReadyOperationsForJobs(['j1']);
       expect(result.size).toBe(0);
+    });
+  });
+
+  describe('updateJobAddressContact', () => {
+    it('writes the three FKs scoped to job + company, translating "" to null', async () => {
+      mockQueryBuilder.data = { id: 'j1' };
+      mockQueryBuilder.error = null;
+      await updateJobAddressContact('j1', 'co-1', {
+        shipping_address_id: 'addr-ship',
+        billing_address_id: '',
+        contact_id: 'contact-1',
+      });
+      expect(mockSupabase.from).toHaveBeenCalledWith('jobs');
+      const patch = (mockQueryBuilder.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(patch.shipping_address_id).toBe('addr-ship');
+      expect(patch.billing_address_id).toBeNull();
+      expect(patch.contact_id).toBe('contact-1');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'j1');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'co-1');
+    });
+
+    it('omits keys left undefined so a partial update does not clobber other FKs', async () => {
+      mockQueryBuilder.data = { id: 'j1' };
+      mockQueryBuilder.error = null;
+      await updateJobAddressContact('j1', 'co-1', { contact_id: 'contact-2' });
+      const patch = (mockQueryBuilder.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(patch.contact_id).toBe('contact-2');
+      expect(patch.shipping_address_id).toBeUndefined();
+      expect(patch.billing_address_id).toBeUndefined();
+    });
+
+    it('throws a friendly (non-raw) error when supabase returns an error', async () => {
+      mockQueryBuilder.error = { message: 'permission denied' };
+      await expect(
+        updateJobAddressContact('j1', 'co-1', { contact_id: 'c1' }),
+      ).rejects.toThrow(/don't have permission/);
     });
   });
 

--- a/app/dashboard/[companyId]/jobs/[jobId]/page.tsx
+++ b/app/dashboard/[companyId]/jobs/[jobId]/page.tsx
@@ -35,7 +35,7 @@ import {
   ProductionStatusChip,
   FulfillmentStatusChip,
 } from '@/components/jobs/JobStatusChip';
-import { OperationsPanel, JobQRCode } from '@/components/jobs';
+import { OperationsPanel, JobQRCode, JobBillingShippingCard } from '@/components/jobs';
 import JobOverdueBadge from '@/components/jobs/JobOverdueBadge';
 import JobStatusBlock from '@/components/jobs/JobStatusBlock';
 import ShipmentHistoryCard from '@/components/jobs/ShipmentHistoryCard';
@@ -323,6 +323,10 @@ export default function JobDetailPage() {
               <JobQRCode jobId={jobId} jobNumber={job.job_number} companyId={companyId} />
             </CardContent>
           </Card>
+        </Grid>
+
+        <Grid size={{ xs: 12 }}>
+          <JobBillingShippingCard job={job} companyId={companyId} onUpdated={fetchJob} />
         </Grid>
 
         <Grid size={{ xs: 12 }}>

--- a/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
+++ b/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
@@ -203,6 +203,10 @@ export default function QuoteDetailPage() {
   const shippingAddress = customerAddresses.find((a) => a.id === quote.shipping_address_id) ?? null;
   const billingAddress = customerAddresses.find((a) => a.id === quote.billing_address_id) ?? null;
   const quoteContact = customerContacts.find((c) => c.id === quote.contact_id) ?? null;
+  // When billing points at the same address as shipping, don't repeat it —
+  // just flag the match.
+  const billingSameAsShipping =
+    !!quote.shipping_address_id && quote.billing_address_id === quote.shipping_address_id;
 
   if (editMode && isEditable) {
     const handleSaveSuccess = async () => {
@@ -440,7 +444,13 @@ export default function QuoteDetailPage() {
                     <Typography variant="body2" color="text.secondary">
                       Billing address
                     </Typography>
-                    <AddressDisplay address={billingAddress} />
+                    {billingSameAsShipping ? (
+                      <Typography variant="body1" color="text.secondary" sx={{ fontStyle: 'italic' }}>
+                        Same as shipping
+                      </Typography>
+                    ) : (
+                      <AddressDisplay address={billingAddress} />
+                    )}
                   </Grid>
                 </Grid>
               ) : (

--- a/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
+++ b/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
@@ -42,6 +42,7 @@ import type { QuoteLineItem, QuoteWithRelations } from '@/types/quote';
 import QuoteStatusChip from '@/components/quotes/QuoteStatusChip';
 import QuoteForm from '@/components/quotes/QuoteForm';
 import ConvertToJobModal from '@/components/quotes/ConvertToJobModal';
+import AddressDisplay from '@/components/common/AddressDisplay';
 
 export default function QuoteDetailPage() {
   const params = useParams();
@@ -194,6 +195,14 @@ export default function QuoteDetailPage() {
     partGroups[gi].items.push(li);
   }
   const isFirmQuote = partGroups.length > 0 && partGroups.every((g) => g.items.length === 1);
+
+  // Resolve the quote's frozen address/contact FKs against the customer's
+  // address book for display. These were captured at quote creation.
+  const customerAddresses = quote.customers?.addresses ?? [];
+  const customerContacts = quote.customers?.customer_contacts ?? [];
+  const shippingAddress = customerAddresses.find((a) => a.id === quote.shipping_address_id) ?? null;
+  const billingAddress = customerAddresses.find((a) => a.id === quote.billing_address_id) ?? null;
+  const quoteContact = customerContacts.find((c) => c.id === quote.contact_id) ?? null;
 
   if (editMode && isEditable) {
     const handleSaveSuccess = async () => {
@@ -382,13 +391,58 @@ export default function QuoteDetailPage() {
               </Typography>
               <Divider sx={{ mb: 2 }} />
               {quote.customers ? (
-                <MuiLink
-                  component={Link}
-                  href={`/dashboard/${companyId}/customers/${quote.customer_id}`}
-                  sx={{ fontWeight: 500 }}
-                >
-                  {quote.customers.name}
-                </MuiLink>
+                <Grid container spacing={2}>
+                  <Grid size={{ xs: 12 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      Customer
+                    </Typography>
+                    <MuiLink
+                      component={Link}
+                      href={`/dashboard/${companyId}/customers/${quote.customer_id}`}
+                      sx={{ fontWeight: 500 }}
+                    >
+                      {quote.customers.name}
+                    </MuiLink>
+                  </Grid>
+                  <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      Contact
+                    </Typography>
+                    {quoteContact ? (
+                      <Box>
+                        <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                          {quoteContact.name}
+                        </Typography>
+                        {quoteContact.email && (
+                          <Typography variant="body2" color="text.secondary">
+                            {quoteContact.email}
+                          </Typography>
+                        )}
+                        {quoteContact.phone && (
+                          <Typography variant="body2" color="text.secondary">
+                            {quoteContact.phone}
+                          </Typography>
+                        )}
+                      </Box>
+                    ) : (
+                      <Typography variant="body1" color="text.secondary">
+                        Not set
+                      </Typography>
+                    )}
+                  </Grid>
+                  <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      Shipping address
+                    </Typography>
+                    <AddressDisplay address={shippingAddress} />
+                  </Grid>
+                  <Grid size={{ xs: 12, sm: 6, md: 4 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      Billing address
+                    </Typography>
+                    <AddressDisplay address={billingAddress} />
+                  </Grid>
+                </Grid>
               ) : (
                 <Typography color="text.secondary">Customer not found</Typography>
               )}

--- a/components/common/AddressDisplay.tsx
+++ b/components/common/AddressDisplay.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+/**
+ * Minimal address shape shared by quotes and jobs — the nested PostgREST
+ * projection of customer_addresses. Matches QuoteWithRelations /
+ * JobWithRelations `customers.addresses[]` entries.
+ */
+export interface DisplayAddress {
+  address_line1: string | null;
+  address_line2: string | null;
+  city: string | null;
+  state: string | null;
+  postal_code: string | null;
+  country: string | null;
+  attention_to?: string | null;
+}
+
+/** Build the human-readable lines for an address (ATTN first, USA dropped). */
+export function addressToLines(a: DisplayAddress): string[] {
+  return [
+    a.attention_to ? `ATTN: ${a.attention_to}` : null,
+    a.address_line1,
+    a.address_line2,
+    [a.city, a.state, a.postal_code].filter(Boolean).join(', ').trim() || null,
+    a.country && a.country.toUpperCase() !== 'USA' ? a.country : null,
+  ].filter((l): l is string => !!l && l.toString().trim().length > 0);
+}
+
+/**
+ * Read-only multi-line address block. Renders an em dash when the address is
+ * null/empty so a missing address reads as an explicit gap, not a blank.
+ */
+export default function AddressDisplay({ address }: { address: DisplayAddress | null | undefined }) {
+  const lines = address ? addressToLines(address) : [];
+  if (lines.length === 0) {
+    return (
+      <Typography variant="body1" color="text.secondary">
+        Not set
+      </Typography>
+    );
+  }
+  return (
+    <Box>
+      {lines.map((line, i) => (
+        <Typography key={i} variant="body1" sx={{ fontWeight: i === 0 ? 500 : 400 }}>
+          {line}
+        </Typography>
+      ))}
+    </Box>
+  );
+}

--- a/components/jobs/JobBillingShippingCard.tsx
+++ b/components/jobs/JobBillingShippingCard.tsx
@@ -1,0 +1,295 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Alert from '@mui/material/Alert';
+import Autocomplete from '@mui/material/Autocomplete';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Checkbox from '@mui/material/Checkbox';
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Grid from '@mui/material/Grid';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import EditIcon from '@mui/icons-material/Edit';
+
+import AddressDisplay, { addressToLines } from '@/components/common/AddressDisplay';
+import { updateJobAddressContact } from '@/utils/jobsAccess';
+import type { JobWithRelations } from '@/types/job';
+
+const ADD_NEW_ADDRESS_ID = '__add_new_address__';
+
+type JobAddress = NonNullable<NonNullable<JobWithRelations['customers']>['addresses']>[number];
+type JobContact = NonNullable<NonNullable<JobWithRelations['customers']>['customer_contacts']>[number];
+
+/**
+ * Billing/shipping address + contact for a job. Read-only by default; the
+ * Edit button reveals dropdowns sourced from the customer's saved address
+ * book (same model as the quote form). Saving writes the FK ids to the job
+ * via updateJobAddressContact; the customer-match trigger guards integrity.
+ */
+export default function JobBillingShippingCard({
+  job,
+  companyId,
+  onUpdated,
+}: {
+  job: JobWithRelations;
+  companyId: string;
+  onUpdated: () => void | Promise<void>;
+}) {
+  const router = useRouter();
+  const addresses: JobAddress[] = job.customers?.addresses ?? [];
+  const contacts: JobContact[] = job.customers?.customer_contacts ?? [];
+
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Draft state (only meaningful while editing).
+  const [shippingId, setShippingId] = useState(job.shipping_address_id ?? '');
+  const [billingId, setBillingId] = useState(job.billing_address_id ?? '');
+  const [contactId, setContactId] = useState(job.contact_id ?? '');
+  const [billingSame, setBillingSame] = useState(
+    !job.billing_address_id || job.billing_address_id === job.shipping_address_id,
+  );
+
+  const shippingAddress = addresses.find((a) => a.id === job.shipping_address_id) ?? null;
+  const billingAddress = addresses.find((a) => a.id === job.billing_address_id) ?? null;
+  const contact = contacts.find((c) => c.id === job.contact_id) ?? null;
+
+  const customerHref = `/dashboard/${companyId}/customers/${job.customer_id}`;
+
+  const startEdit = () => {
+    setShippingId(job.shipping_address_id ?? '');
+    setBillingId(job.billing_address_id ?? '');
+    setContactId(job.contact_id ?? '');
+    setBillingSame(!job.billing_address_id || job.billing_address_id === job.shipping_address_id);
+    setError(null);
+    setEditing(true);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await updateJobAddressContact(job.id, companyId, {
+        shipping_address_id: shippingId,
+        billing_address_id: billingSame ? shippingId : billingId,
+        contact_id: contactId,
+      });
+      setEditing(false);
+      await onUpdated();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const renderAddressValue = (value: string) => {
+    const a = addresses.find((x) => x.id === value);
+    if (!a) return '';
+    return addressToLines(a).join(', ');
+  };
+
+  return (
+    <Card elevation={2} sx={{ height: '100%' }}>
+      <CardContent>
+        <Box
+          sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}
+        >
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            Billing &amp; Shipping
+          </Typography>
+          {!editing && (
+            <Button size="small" startIcon={<EditIcon />} onClick={startEdit}>
+              Edit
+            </Button>
+          )}
+        </Box>
+        <Divider sx={{ mb: 2 }} />
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        {!editing ? (
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <Typography variant="body2" color="text.secondary">
+                Contact
+              </Typography>
+              {contact ? (
+                <Box>
+                  <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                    {contact.name}
+                  </Typography>
+                  {contact.email && (
+                    <Typography variant="body2" color="text.secondary">
+                      {contact.email}
+                    </Typography>
+                  )}
+                  {contact.phone && (
+                    <Typography variant="body2" color="text.secondary">
+                      {contact.phone}
+                    </Typography>
+                  )}
+                </Box>
+              ) : (
+                <Typography variant="body1" color="text.secondary">
+                  Not set
+                </Typography>
+              )}
+            </Grid>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <Typography variant="body2" color="text.secondary">
+                Shipping address
+              </Typography>
+              <AddressDisplay address={shippingAddress} />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 4 }}>
+              <Typography variant="body2" color="text.secondary">
+                Billing address
+              </Typography>
+              <AddressDisplay address={billingAddress} />
+            </Grid>
+          </Grid>
+        ) : (
+          <Box>
+            {addresses.length === 0 && contacts.length === 0 && (
+              <Alert severity="info" sx={{ mb: 2 }}>
+                This customer has no saved addresses or contacts.{' '}
+                <Button size="small" onClick={() => router.push(customerHref)}>
+                  Add on customer
+                </Button>
+              </Alert>
+            )}
+            <Grid container spacing={2}>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <Autocomplete
+                  size="small"
+                  options={contacts}
+                  getOptionLabel={(c) => c.name}
+                  value={contacts.find((c) => c.id === contactId) ?? null}
+                  onChange={(_, v) => setContactId(v?.id ?? '')}
+                  isOptionEqualToValue={(o, v) => o.id === v.id}
+                  renderInput={(params) => <TextField {...params} label="Contact" />}
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <FormControl fullWidth size="small">
+                  <InputLabel id="job-shipping-address-label">Shipping address</InputLabel>
+                  <Select
+                    labelId="job-shipping-address-label"
+                    label="Shipping address"
+                    value={shippingId}
+                    onChange={(e) => {
+                      if (e.target.value === ADD_NEW_ADDRESS_ID) {
+                        router.push(customerHref);
+                        return;
+                      }
+                      setShippingId(e.target.value);
+                    }}
+                    renderValue={renderAddressValue}
+                    sx={{ '& .MuiSelect-select': { whiteSpace: 'normal', py: 1 } }}
+                  >
+                    {addresses.map((a) => (
+                      <MenuItem key={a.id} value={a.id} sx={{ whiteSpace: 'normal' }}>
+                        <Box>
+                          {addressToLines(a).map((line, i) => (
+                            <Typography key={i} variant="body2">
+                              {line}
+                            </Typography>
+                          ))}
+                        </Box>
+                      </MenuItem>
+                    ))}
+                    <MenuItem value={ADD_NEW_ADDRESS_ID} sx={{ fontStyle: 'italic' }}>
+                      + Add new address
+                    </MenuItem>
+                  </Select>
+                </FormControl>
+              </Grid>
+            </Grid>
+
+            <FormControlLabel
+              sx={{ mt: 2, mb: 0 }}
+              control={
+                <Checkbox
+                  checked={billingSame}
+                  onChange={(e) => setBillingSame(e.target.checked)}
+                />
+              }
+              label={
+                <Typography variant="body2" color="text.secondary">
+                  Billing address same as shipping
+                </Typography>
+              }
+            />
+
+            {!billingSame && (
+              <Box sx={{ mt: 1, pl: 4 }}>
+                <FormControl fullWidth size="small">
+                  <InputLabel id="job-billing-address-label">Billing address</InputLabel>
+                  <Select
+                    labelId="job-billing-address-label"
+                    label="Billing address"
+                    value={billingId}
+                    onChange={(e) => {
+                      if (e.target.value === ADD_NEW_ADDRESS_ID) {
+                        router.push(customerHref);
+                        return;
+                      }
+                      setBillingId(e.target.value);
+                    }}
+                    renderValue={renderAddressValue}
+                    sx={{ '& .MuiSelect-select': { whiteSpace: 'normal', py: 1 } }}
+                  >
+                    {addresses.map((a) => (
+                      <MenuItem key={a.id} value={a.id} sx={{ whiteSpace: 'normal' }}>
+                        <Box>
+                          {addressToLines(a).map((line, i) => (
+                            <Typography key={i} variant="body2">
+                              {line}
+                            </Typography>
+                          ))}
+                        </Box>
+                      </MenuItem>
+                    ))}
+                    <MenuItem value={ADD_NEW_ADDRESS_ID} sx={{ fontStyle: 'italic' }}>
+                      + Add new address
+                    </MenuItem>
+                  </Select>
+                </FormControl>
+              </Box>
+            )}
+
+            <Box sx={{ display: 'flex', gap: 1, mt: 3 }}>
+              <Button
+                variant="contained"
+                onClick={handleSave}
+                disabled={saving}
+                startIcon={saving ? <CircularProgress size={16} color="inherit" /> : undefined}
+              >
+                {saving ? 'Saving…' : 'Save'}
+              </Button>
+              <Button onClick={() => setEditing(false)} disabled={saving}>
+                Cancel
+              </Button>
+            </Box>
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/jobs/JobBillingShippingCard.tsx
+++ b/components/jobs/JobBillingShippingCard.tsx
@@ -64,6 +64,8 @@ export default function JobBillingShippingCard({
   const shippingAddress = addresses.find((a) => a.id === job.shipping_address_id) ?? null;
   const billingAddress = addresses.find((a) => a.id === job.billing_address_id) ?? null;
   const contact = contacts.find((c) => c.id === job.contact_id) ?? null;
+  const billingSameAsShipping =
+    !!job.shipping_address_id && job.billing_address_id === job.shipping_address_id;
 
   const customerHref = `/dashboard/${companyId}/customers/${job.customer_id}`;
 
@@ -161,7 +163,13 @@ export default function JobBillingShippingCard({
               <Typography variant="body2" color="text.secondary">
                 Billing address
               </Typography>
-              <AddressDisplay address={billingAddress} />
+              {billingSameAsShipping ? (
+                <Typography variant="body1" color="text.secondary" sx={{ fontStyle: 'italic' }}>
+                  Same as shipping
+                </Typography>
+              ) : (
+                <AddressDisplay address={billingAddress} />
+              )}
             </Grid>
           </Grid>
         ) : (

--- a/components/jobs/index.ts
+++ b/components/jobs/index.ts
@@ -8,3 +8,4 @@ export { default as OperationsPanel } from "./OperationsPanel";
 export { default as CompleteOperationModal } from "./CompleteOperationModal";
 export { default as ViewRoutingModal } from "./ViewRoutingModal";
 export { default as JobQRCode } from "./JobQRCode";
+export { default as JobBillingShippingCard } from "./JobBillingShippingCard";

--- a/supabase/migrations/20260612190922_add_job_address_contact_fks.sql
+++ b/supabase/migrations/20260612190922_add_job_address_contact_fks.sql
@@ -1,0 +1,73 @@
+-- Jobs now carry their own billing/shipping address + contact, mirroring
+-- quotes. Previously these lived ONLY on the quote and were dropped at
+-- conversion, so a job had no shippable address of its own. They are FKs
+-- into the customer's address book (not denormalized text), copied from the
+-- source quote at conversion and editable on the job afterwards.
+
+ALTER TABLE public.jobs
+    ADD COLUMN IF NOT EXISTS billing_address_id uuid,
+    ADD COLUMN IF NOT EXISTS shipping_address_id uuid,
+    ADD COLUMN IF NOT EXISTS contact_id uuid;
+
+ALTER TABLE public.jobs
+    ADD CONSTRAINT jobs_billing_address_id_fkey
+        FOREIGN KEY (billing_address_id) REFERENCES public.customer_addresses(id) ON DELETE SET NULL,
+    ADD CONSTRAINT jobs_shipping_address_id_fkey
+        FOREIGN KEY (shipping_address_id) REFERENCES public.customer_addresses(id) ON DELETE SET NULL,
+    ADD CONSTRAINT jobs_contact_id_fkey
+        FOREIGN KEY (contact_id) REFERENCES public.customer_contacts(id) ON DELETE SET NULL;
+
+-- Backfill existing jobs from their source quote so every pre-existing row
+-- satisfies the new invariant (no runtime "if missing, look at the quote"
+-- fallback in the read path). Manual jobs without a quote keep NULLs, which
+-- the UI surfaces as "not set" — an explicit gap, not a hidden one.
+UPDATE public.jobs j
+   SET billing_address_id  = q.billing_address_id,
+       shipping_address_id = q.shipping_address_id,
+       contact_id          = q.contact_id
+  FROM public.quotes q
+ WHERE j.quote_id = q.id
+   AND j.customer_id = q.customer_id;
+
+-- Same integrity guard quotes use: an address/contact assigned to a job must
+-- belong to that job's customer.
+CREATE OR REPLACE FUNCTION public.enforce_job_address_contact_customer()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    IF NEW.billing_address_id IS NOT NULL THEN
+        PERFORM 1 FROM public.customer_addresses
+         WHERE id = NEW.billing_address_id AND customer_id = NEW.customer_id;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION
+                'jobs.billing_address_id % does not belong to customer %',
+                NEW.billing_address_id, NEW.customer_id;
+        END IF;
+    END IF;
+    IF NEW.shipping_address_id IS NOT NULL THEN
+        PERFORM 1 FROM public.customer_addresses
+         WHERE id = NEW.shipping_address_id AND customer_id = NEW.customer_id;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION
+                'jobs.shipping_address_id % does not belong to customer %',
+                NEW.shipping_address_id, NEW.customer_id;
+        END IF;
+    END IF;
+    IF NEW.contact_id IS NOT NULL THEN
+        PERFORM 1 FROM public.customer_contacts
+         WHERE id = NEW.contact_id AND customer_id = NEW.customer_id;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION
+                'jobs.contact_id % does not belong to customer %',
+                NEW.contact_id, NEW.customer_id;
+        END IF;
+    END IF;
+    RETURN NEW;
+END $function$;
+
+DROP TRIGGER IF EXISTS enforce_job_address_contact_customer_trg ON public.jobs;
+CREATE TRIGGER enforce_job_address_contact_customer_trg
+    BEFORE INSERT OR UPDATE OF billing_address_id, shipping_address_id, contact_id, customer_id
+    ON public.jobs
+    FOR EACH ROW EXECUTE FUNCTION public.enforce_job_address_contact_customer();

--- a/supabase/schema.staging.sql
+++ b/supabase/schema.staging.sql
@@ -1,6 +1,6 @@
 -- ============================================================
 -- Jigged Manufacturing Data Platform - Database Schema
--- Generated: 2026-06-05T02:07:01Z
+-- Generated: 2026-06-12T19:17:13Z
 -- Schemas: public, storage
 -- ============================================================
 
@@ -239,6 +239,9 @@ CREATE TABLE IF NOT EXISTS "public"."jobs"
     "production_status" text NOT NULL,
     "fulfillment_status" text NOT NULL,
     "customer_po_number" text,
+    "billing_address_id" uuid,
+    "shipping_address_id" uuid,
+    "contact_id" uuid,
     CONSTRAINT "jobs_pkey" PRIMARY KEY (id),
     CONSTRAINT "jobs_company_id_job_number_key" UNIQUE (company_id, job_number),
     CONSTRAINT "jobs_fulfillment_status_check" CHECK ((fulfillment_status = ANY (ARRAY['unshipped'::text, 'partially_shipped'::text, 'fully_shipped'::text]))),
@@ -2109,7 +2112,13 @@ ALTER TABLE "public"."job_parts"
     ADD CONSTRAINT "job_parts_source_quote_line_item_id_fkey" FOREIGN KEY (source_quote_line_item_id) REFERENCES quote_line_items(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."jobs"
+    ADD CONSTRAINT "jobs_billing_address_id_fkey" FOREIGN KEY (billing_address_id) REFERENCES customer_addresses(id) ON DELETE SET NULL;
+
+ALTER TABLE "public"."jobs"
     ADD CONSTRAINT "jobs_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."jobs"
+    ADD CONSTRAINT "jobs_contact_id_fkey" FOREIGN KEY (contact_id) REFERENCES customer_contacts(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."jobs"
     ADD CONSTRAINT "jobs_created_by_fkey" FOREIGN KEY (created_by) REFERENCES auth.users(id);
@@ -2119,6 +2128,9 @@ ALTER TABLE "public"."jobs"
 
 ALTER TABLE "public"."jobs"
     ADD CONSTRAINT "jobs_quote_id_fkey" FOREIGN KEY (quote_id) REFERENCES quotes(id) ON DELETE SET NULL;
+
+ALTER TABLE "public"."jobs"
+    ADD CONSTRAINT "jobs_shipping_address_id_fkey" FOREIGN KEY (shipping_address_id) REFERENCES customer_addresses(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."markup_rates"
     ADD CONSTRAINT "markup_rates_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
@@ -3129,6 +3141,43 @@ BEGIN
     END LOOP;
 
     RETURN v_shipment_id;
+END $function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.enforce_job_address_contact_customer()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    IF NEW.billing_address_id IS NOT NULL THEN
+        PERFORM 1 FROM public.customer_addresses
+         WHERE id = NEW.billing_address_id AND customer_id = NEW.customer_id;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION
+                'jobs.billing_address_id % does not belong to customer %',
+                NEW.billing_address_id, NEW.customer_id;
+        END IF;
+    END IF;
+    IF NEW.shipping_address_id IS NOT NULL THEN
+        PERFORM 1 FROM public.customer_addresses
+         WHERE id = NEW.shipping_address_id AND customer_id = NEW.customer_id;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION
+                'jobs.shipping_address_id % does not belong to customer %',
+                NEW.shipping_address_id, NEW.customer_id;
+        END IF;
+    END IF;
+    IF NEW.contact_id IS NOT NULL THEN
+        PERFORM 1 FROM public.customer_contacts
+         WHERE id = NEW.contact_id AND customer_id = NEW.customer_id;
+        IF NOT FOUND THEN
+            RAISE EXCEPTION
+                'jobs.contact_id % does not belong to customer %',
+                NEW.contact_id, NEW.customer_id;
+        END IF;
+    END IF;
+    RETURN NEW;
 END $function$
 
 ;
@@ -4656,6 +4705,9 @@ CREATE TRIGGER trigger_sync_job_production_status_from_parts_ins AFTER INSERT ON
 
 DROP TRIGGER IF EXISTS "trigger_sync_job_production_status_from_parts_upd" ON "public"."job_parts";
 CREATE TRIGGER trigger_sync_job_production_status_from_parts_upd AFTER UPDATE OF production_status ON public.job_parts FOR EACH ROW WHEN ((old.production_status IS DISTINCT FROM new.production_status)) EXECUTE FUNCTION sync_job_production_status_from_parts();
+
+DROP TRIGGER IF EXISTS "enforce_job_address_contact_customer_trg" ON "public"."jobs";
+CREATE TRIGGER enforce_job_address_contact_customer_trg BEFORE INSERT OR UPDATE OF billing_address_id, shipping_address_id, contact_id, customer_id ON public.jobs FOR EACH ROW EXECUTE FUNCTION enforce_job_address_contact_customer();
 
 DROP TRIGGER IF EXISTS "jobs_updated_at" ON "public"."jobs";
 CREATE TRIGGER jobs_updated_at BEFORE UPDATE ON public.jobs FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/types/database.ts
+++ b/types/database.ts
@@ -946,8 +946,10 @@ export type Database = {
       }
       jobs: {
         Row: {
+          billing_address_id: string | null
           company_id: string
           completed_at: string | null
+          contact_id: string | null
           created_at: string | null
           created_by: string | null
           customer_id: string | null
@@ -959,13 +961,16 @@ export type Database = {
           lead_time_days: number | null
           production_status: string
           quote_id: string | null
+          shipping_address_id: string | null
           started_at: string | null
           status_changed_at: string | null
           updated_at: string | null
         }
         Insert: {
+          billing_address_id?: string | null
           company_id: string
           completed_at?: string | null
+          contact_id?: string | null
           created_at?: string | null
           created_by?: string | null
           customer_id?: string | null
@@ -977,13 +982,16 @@ export type Database = {
           lead_time_days?: number | null
           production_status: string
           quote_id?: string | null
+          shipping_address_id?: string | null
           started_at?: string | null
           status_changed_at?: string | null
           updated_at?: string | null
         }
         Update: {
+          billing_address_id?: string | null
           company_id?: string
           completed_at?: string | null
+          contact_id?: string | null
           created_at?: string | null
           created_by?: string | null
           customer_id?: string | null
@@ -995,16 +1003,31 @@ export type Database = {
           lead_time_days?: number | null
           production_status?: string
           quote_id?: string | null
+          shipping_address_id?: string | null
           started_at?: string | null
           status_changed_at?: string | null
           updated_at?: string | null
         }
         Relationships: [
           {
+            foreignKeyName: "jobs_billing_address_id_fkey"
+            columns: ["billing_address_id"]
+            isOneToOne: false
+            referencedRelation: "customer_addresses"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "jobs_company_id_fkey"
             columns: ["company_id"]
             isOneToOne: false
             referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jobs_contact_id_fkey"
+            columns: ["contact_id"]
+            isOneToOne: false
+            referencedRelation: "customer_contacts"
             referencedColumns: ["id"]
           },
           {
@@ -1019,6 +1042,13 @@ export type Database = {
             columns: ["quote_id"]
             isOneToOne: false
             referencedRelation: "quotes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "jobs_shipping_address_id_fkey"
+            columns: ["shipping_address_id"]
+            isOneToOne: false
+            referencedRelation: "customer_addresses"
             referencedColumns: ["id"]
           },
         ]

--- a/types/job.ts
+++ b/types/job.ts
@@ -62,6 +62,12 @@ export interface Job {
   quote_id: string | null;
   customer_id: string;
   customer_po_number: string | null;
+  // FKs into the customer's address book, copied from the source quote at
+  // conversion and editable on the job. Mirror quotes.{billing,shipping}_address_id
+  // + contact_id; a customer-match trigger enforces they belong to customer_id.
+  billing_address_id: string | null;
+  shipping_address_id: string | null;
+  contact_id: string | null;
   production_status: ProductionStatus;
   fulfillment_status: FulfillmentStatus;
   status_changed_at: string | null;
@@ -195,9 +201,32 @@ export interface JobPartWithRelations extends JobPart {
  * Job with joined relation data — used by the dashboard detail page.
  */
 export interface JobWithRelations extends Job {
+  // Customer + their full address book / contacts, so the job detail page can
+  // both resolve the job's selected billing/shipping/contact for display and
+  // offer the customer's other saved addresses/contacts in the edit dropdowns.
   customers?: {
     id: string;
     name: string;
+    customer_contacts?: Array<{
+      id: string;
+      name: string;
+      role: string;
+      email: string | null;
+      phone: string | null;
+      is_primary: boolean;
+    }>;
+    addresses?: Array<{
+      id: string;
+      address_line1: string | null;
+      address_line2: string | null;
+      city: string | null;
+      state: string | null;
+      postal_code: string | null;
+      country: string | null;
+      default_billing: boolean;
+      default_shipping: boolean;
+      attention_to: string | null;
+    }>;
   } | null;
   quotes?: {
     id: string;

--- a/utils/jobsAccess.ts
+++ b/utils/jobsAccess.ts
@@ -11,6 +11,7 @@ import type { Database } from '@/types/database';
 // `.update(...)` call rejects bare Record<string, unknown> because it
 // can't verify the keys against the table schema; using the generated
 // Update types preserves the column-name check.
+type JobUpdate = Database['public']['Tables']['jobs']['Update'];
 type JobPartUpdate = Database['public']['Tables']['job_parts']['Update'];
 type JobMaterialUpdate = Database['public']['Tables']['job_materials']['Update'];
 type JobOperationUpdate = Database['public']['Tables']['job_operations']['Update'];
@@ -202,7 +203,15 @@ export async function getJobWithRelations(
     .from('jobs')
     .select(`
       *,
-      customers!left(id, name),
+      customers!left(
+        id, name,
+        customer_contacts(id, name, role, email, phone, is_primary),
+        addresses:customer_addresses(
+          id,
+          address_line1, address_line2, city, state, postal_code, country,
+          default_billing, default_shipping, attention_to
+        )
+      ),
       quotes!jobs_quote_id_fkey(id, quote_number),
       job_parts(
         *,
@@ -240,6 +249,54 @@ export async function getJobWithRelations(
   }
 
   return job;
+}
+
+/**
+ * Update a job's billing/shipping address + contact. Each value is an
+ * address/contact id owned by the job's customer, or '' / null to clear it
+ * (translated to NULL). The enforce_job_address_contact_customer trigger
+ * rejects ids that don't belong to the job's customer.
+ */
+export async function updateJobAddressContact(
+  jobId: string,
+  companyId: string,
+  fields: {
+    billing_address_id?: string | null;
+    shipping_address_id?: string | null;
+    contact_id?: string | null;
+  },
+): Promise<Job> {
+  const supabase = getSupabase();
+
+  const toNull = (v: string | null | undefined): string | null | undefined =>
+    v === undefined ? undefined : v === '' ? null : v;
+
+  const patch: JobUpdate = {
+    billing_address_id: toNull(fields.billing_address_id),
+    shipping_address_id: toNull(fields.shipping_address_id),
+    contact_id: toNull(fields.contact_id),
+    updated_at: new Date().toISOString(),
+  };
+
+  const { data, error } = await supabase
+    .from('jobs')
+    .update(patch)
+    .eq('id', jobId)
+    .eq('company_id', companyId)
+    .select('*')
+    .single();
+
+  if (error) {
+    console.error('Error updating job address/contact:', error);
+    throw new Error(
+      friendlyErrorMessage(error, {
+        entity: 'job',
+        fallback: 'Failed to update job billing/shipping details.',
+      }),
+    );
+  }
+
+  return data as Job;
 }
 
 // ============== Job Materials ==============

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -1079,6 +1079,12 @@ export async function convertQuoteToJob(
       due_date: dueDate,
       lead_time_days: promisedLeadTime,
       customer_po_number: customerPoNumber,
+      // Carry the quote's billing/shipping address + contact onto the job so
+      // it has a shippable address of its own. Editable on the job afterwards
+      // (utils/jobsAccess.ts updateJobAddressContact) without touching the quote.
+      billing_address_id: quote.billing_address_id,
+      shipping_address_id: quote.shipping_address_id,
+      contact_id: quote.contact_id,
       created_by: user.id,
     })
     .select('id, job_number')


### PR DESCRIPTION
## Summary

Quotes stored `billing_address_id` / `shipping_address_id` / `contact_id` (frozen at creation), but the `jobs` table had **no** address columns — so conversion dropped them and a job had no shippable address of its own. This adds those to jobs (copied at conversion, editable afterward) and surfaces all the quote's customer detail on both pages.

## Changes

**Schema** (`20260612190922_add_job_address_contact_fks.sql`)
- Add `billing_address_id`, `shipping_address_id`, `contact_id` to `jobs` — FKs into the customer address book, `ON DELETE SET NULL`.
- **Backfill** existing jobs from their source quote (no runtime "if missing, look at the quote" fallback).
- Add `enforce_job_address_contact_customer` trigger mirroring the quote's customer-match guard.

**Conversion** — `convertQuoteToJob` copies the quote's three FKs onto the new job.

**Quote detail page** (#1) — Customer card now shows Contact (name/email/phone), Shipping address, and Billing address, resolving the quote's frozen FKs. Rounds out every field the edit form captures.

**Job detail page** (#2) — new editable **Billing & Shipping** card: read-only by default, Edit reveals dropdowns of the customer's saved addresses/contacts (same UX as the quote form, incl. "billing same as shipping"). Saves via new `updateJobAddressContact` writer.

**Shared** — read-only `AddressDisplay` component; regenerated DB types; re-exported `schema.staging.sql`.

## Design note
Editing a job's address re-points the conversion-copied FK into the customer's address book — it does **not** create a one-off ship-to independent of the customer record (that's what shipments' `one_time_address` is for). Fully-independent job addresses would be a follow-up.

## Testing
- Migration **applied to staging** (linked project = *Jigged Staging*). **Prod push is owned by the human** — push `20260612190922_…` to prod, then re-run `export_schema.py` to refresh `schema.prod.sql`.
- `tsc --noEmit` clean.
- jobsAccess + quotesAccess unit tests green (57 passed; +3 new for `updateJobAddressContact`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)