### PR TITLE
fix(team-invites): surface invite email-send failures honestly

### DIFF
--- a/app/dashboard/[companyId]/team/members/new/page.tsx
+++ b/app/dashboard/[companyId]/team/members/new/page.tsx
@@ -40,6 +40,7 @@ export default function InviteTeamMemberPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -58,6 +59,7 @@ export default function InviteTeamMemberPage() {
     setLoading(true);
     setError(null);
     setSuccess(null);
+    setWarning(null);
 
     try {
       // Get auth session for Edge Function authorization
@@ -92,6 +94,14 @@ export default function InviteTeamMemberPage() {
 
       if (!data.success) {
         throw new Error(data.message || 'Failed to send invitation');
+      }
+
+      // The invitation row can be created even when the email fails to send.
+      // Don't show a green "sent" confirmation in that case — surface a warning
+      // and keep the admin on the page so they can Resend from the team list.
+      if (data.email_sent === false) {
+        setWarning(data.message || 'Invitation created, but the email could not be sent. Use "Resend" on the team page to try again.');
+        return;
       }
 
       setSuccess(data.message || `Invitation sent to ${email}`);
@@ -131,6 +141,12 @@ export default function InviteTeamMemberPage() {
         {error && (
           <Alert severity="error" sx={{ mb: 3 }}>
             {error}
+          </Alert>
+        )}
+
+        {warning && (
+          <Alert severity="warning" sx={{ mb: 3 }}>
+            {warning}
           </Alert>
         )}
 

--- a/supabase/functions/team-invites/index.ts
+++ b/supabase/functions/team-invites/index.ts
@@ -309,15 +309,20 @@ Deno.serve(async (req) => {
         await sendInviteEmail(resendApiKey, email.toLowerCase(), companyName, actionLink);
       } catch (emailErr) {
         console.error('Email sending error:', emailErr);
+        // The invitation row exists, but the email never went out. Report this
+        // honestly via email_sent:false so the UI can warn rather than show
+        // a green "sent" confirmation the admin would trust.
         return jsonResponse({
           success: true,
+          email_sent: false,
           invitation_id: invitation.id,
-          message: `Invitation created but email could not be sent. Use "Resend" to try again.`,
+          message: `Invitation created, but the email could not be sent to ${email}. Use "Resend" on the team page to try again.`,
         });
       }
 
       return jsonResponse({
         success: true,
+        email_sent: true,
         invitation_id: invitation.id,
         message: `Invitation sent to ${email}`,
       });

--- a/types/team.ts
+++ b/types/team.ts
@@ -56,4 +56,10 @@ export interface InviteResponse {
   success: boolean;
   invitation_id: string;
   message: string;
+  /**
+   * Whether the invitation email was actually handed off to the provider (Resend).
+   * `false` means the invitation record was created but the email send failed —
+   * the admin must use "Resend" to try again. Absent on legacy responses.
+   */
+  email_sent?: boolean;
 }


### PR DESCRIPTION
## Problem

Reported live: team invites appeared sent but were never received. Root cause is a silent-success path in the invite flow.

When Resend rejected the email, the `team-invites` Edge Function caught the error and still returned `success: true` with a message. The invite form keys its banner off `data.success`, so it rendered a **green "Invitation sent"** Alert — admins trusted it and the email never went out.

## Fix

Make the email-send outcome explicit end-to-end:

- **Edge Function** ([supabase/functions/team-invites/index.ts](supabase/functions/team-invites/index.ts)) — adds an `email_sent` flag to the create-invite response. On send failure it returns `success: true` (the invitation row genuinely exists) with `email_sent: false`; on success, `email_sent: true`.
- **Invite form** ([app/dashboard/[companyId]/team/members/new/page.tsx](app/dashboard/[companyId]/team/members/new/page.tsx)) — when `email_sent === false`, shows a **warning** Alert instead of the success banner and keeps the admin on the page (no auto-navigate) so they can Resend. The submit button stays enabled for a retry.
- **Type** ([types/team.ts](types/team.ts)) — adds optional `email_sent?: boolean` to `InviteResponse` (optional so legacy responses still type-check).

## Notes / follow-ups (not in this PR)

- The actual Friday delivery failure still needs root-causing in the Resend dashboard + Edge Function logs (likely `jigged.app` domain auth / SPF-DKIM-DMARC, or an invalid `RESEND_API_KEY`). This PR makes such failures *visible*, not impossible.
- Worth rotating `RESEND_API_KEY` if it has ever been shared/committed.

## Testing

Logic-only change across three files; no existing tests reference these symbols. `next build` (Vercel preview) covers type-check/lint. Manual check: trigger a send failure (e.g. invalid Resend key on staging) and confirm the form shows the warning rather than a success banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)