### PR TITLE
chore: gitignore .claude + untrack stray worktree gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,8 @@ api/.coverage
 # mutmut mutation-testing cache (regenerated per run)
 api/.mutmut-cache
 api/mutants/
+
+# Claude Code: local settings + git worktrees (kept out of version control).
+# settings.json is re-included so shared, team-level Claude config can still be committed.
+.claude/*
+!.claude/settings.json


### PR DESCRIPTION
## Why

`.claude/` in this repo holds only **local** config (`settings.local.json`) and **git worktrees** — none of it belongs in version control. One worktree (`.claude/worktrees/feature+parts-page-rearchitecture`) had been accidentally committed as a bare gitlink (mode 160000, no `.gitmodules`), so it showed up dirty in `git status` and got swept into unrelated `git add -A` commits.

## What

- `.gitignore`: ignore `.claude/*`, with `!.claude/settings.json` re-included so shared, team-level Claude config stays committable if it's ever added. (If you'd rather ignore *everything* under `.claude/`, drop the `!` line.)
- `git rm --cached` the stray `.claude/worktrees/feature+parts-page-rearchitecture` gitlink so it's no longer tracked.

`git check-ignore` confirms `.claude/settings.local.json` and `.claude/worktrees/*` are now ignored, so `git add -A` won't grab local worktrees again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
