### PR TITLE
Reframe part Notes tab as Activity with comments

### DIFF
--- a/components/parts/workspace/PartWorkspace.tsx
+++ b/components/parts/workspace/PartWorkspace.tsx
@@ -219,7 +219,7 @@ export default function PartWorkspace({
     if (part?.is_stocked) tabs.push({ slug: 'inventory', label: 'Inventory' });
     tabs.push({ slug: 'usage', label: 'Usage' });
     // Slug stays 'history' so existing ?tab=history deep links keep working.
-    tabs.push({ slug: 'history', label: 'Notes' });
+    tabs.push({ slug: 'history', label: 'Activity' });
     return tabs;
   }, [part?.is_stocked]);
 

--- a/components/parts/workspace/tabs/HistoryTab.tsx
+++ b/components/parts/workspace/tabs/HistoryTab.tsx
@@ -44,17 +44,17 @@ const TXN_VERB: Record<string, string> = {
   adjustment: 'Adjusted to',
 };
 
-/** Which slice of the unified Notes feed is shown. */
-type NotesFilter = 'all' | 'user' | 'pricing' | 'stock';
+/** Which slice of the unified Activity feed is shown. */
+type ActivityFilter = 'all' | 'user' | 'pricing' | 'stock';
 
-const FILTERS: { value: NotesFilter; label: string }[] = [
+const FILTERS: { value: ActivityFilter; label: string }[] = [
   { value: 'all', label: 'All' },
-  { value: 'user', label: 'Notes' },
+  { value: 'user', label: 'Comments' },
   { value: 'pricing', label: 'Pricing' },
   { value: 'stock', label: 'Stock' },
 ];
 
-function matchesFilter(ev: PartActivityEvent, filter: NotesFilter): boolean {
+function matchesFilter(ev: PartActivityEvent, filter: ActivityFilter): boolean {
   switch (filter) {
     case 'all':
       return true;
@@ -68,9 +68,10 @@ function matchesFilter(ev: PartActivityEvent, filter: NotesFilter): boolean {
 }
 
 /**
- * Notes. A single feed mixing manual notes, auto-logged pricing notes, and
+ * Activity. A single feed mixing user comments, auto-logged pricing notes, and
  * stock movements — every entry is typed and filterable. The composer adds
- * 'user' notes; pricing notes are written automatically on a pricing save and
+ * 'user' notes (shown as "comments" in the UI); pricing notes are written
+ * automatically on a pricing save and
  * are not user-deletable (audit trail). Job/quote links were dropped — they're
  * already visible on the Jobs and Quotes pages.
  */
@@ -82,7 +83,7 @@ export default function HistoryTab({ partId, companyId }: HistoryTabProps) {
   const [submitting, setSubmitting] = useState(false);
   const [composerError, setComposerError] = useState<string | null>(null);
   const [refreshTick, setRefreshTick] = useState(0);
-  const [filter, setFilter] = useState<NotesFilter>('all');
+  const [filter, setFilter] = useState<ActivityFilter>('all');
 
   useEffect(() => {
     let cancelled = false;
@@ -94,7 +95,7 @@ export default function HistoryTab({ partId, companyId }: HistoryTabProps) {
         }
       })
       .catch((err) => {
-        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load notes');
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load activity');
       });
     return () => {
       cancelled = true;
@@ -129,7 +130,7 @@ export default function HistoryTab({ partId, companyId }: HistoryTabProps) {
       setBody('');
       setRefreshTick((t) => t + 1);
     } catch (err) {
-      setComposerError(err instanceof Error ? err.message : 'Failed to add note');
+      setComposerError(err instanceof Error ? err.message : 'Failed to add comment');
     } finally {
       setSubmitting(false);
     }
@@ -140,7 +141,7 @@ export default function HistoryTab({ partId, companyId }: HistoryTabProps) {
       await deletePartNote(noteId);
       setRefreshTick((t) => t + 1);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete note');
+      setError(err instanceof Error ? err.message : 'Failed to delete comment');
     }
   };
 
@@ -155,7 +156,7 @@ export default function HistoryTab({ partId, companyId }: HistoryTabProps) {
       <Card elevation={2}>
         <CardContent>
           <Typography variant="h6" sx={{ fontWeight: 600 }}>
-            Notes
+            Comments
           </Typography>
 
           {/* Composer — manual notes only. */}
@@ -165,7 +166,7 @@ export default function HistoryTab({ partId, companyId }: HistoryTabProps) {
             minRows={2}
             value={body}
             onChange={(e) => setBody(e.target.value)}
-            placeholder="Note about this part…"
+            placeholder="Comment on this part…"
             disabled={submitting}
             sx={{ mt: 1.5 }}
           />
@@ -183,7 +184,7 @@ export default function HistoryTab({ partId, companyId }: HistoryTabProps) {
                 submitting ? <CircularProgress size={16} color="inherit" /> : <AddCommentIcon />
               }
             >
-              {submitting ? 'Adding…' : 'Add note'}
+              {submitting ? 'Adding…' : 'Add comment'}
             </Button>
           </Box>
 
@@ -195,7 +196,7 @@ export default function HistoryTab({ partId, companyId }: HistoryTabProps) {
             exclusive
             size="small"
             onChange={(_e, next) => {
-              if (next !== null) setFilter(next as NotesFilter);
+              if (next !== null) setFilter(next as ActivityFilter);
             }}
             aria-label="Filter notes"
             sx={{ mb: 2, flexWrap: 'wrap' }}
@@ -261,7 +262,7 @@ function FeedRow({
         canDelete && ev.kind === 'note' ? (
           <DeleteIconButton
             edge="end"
-            ariaLabel="Delete note"
+            ariaLabel="Delete comment"
             onClick={() => onDelete(ev.note.id)}
           />
         ) : undefined


### PR DESCRIPTION
## Why

The part **Notes** tab (PR #402) had a **Notes** filter chip — a self-referential redundancy (the page name duplicated a filter option).

## What

Fixed at the information-architecture level rather than a chip rename: the tab is really an **Activity** timeline, and a human-written entry is a **comment** — one activity type alongside pricing and stock.

- **Tab:** "Notes" → **"Activity"** (slug stays `history`, so `?tab=history` deep links keep working).
- **Composer card:** "Notes" → **"Comments"**; placeholder → "Comment on this part…"; button → "Add comment"; delete label → "Delete comment".
- **Filter chips:** `All · Comments · Pricing · Stock` (was `… Notes …`) — no more collision with the tab name.
- Error copy + the internal `ActivityFilter` type renamed to match.

**Display-only.** The `part_notes` table, `note_type` column, and the access layer (`getPartActivity`, `addPartPricingNote`) are unchanged — internal names don't track UI vocabulary.

## Verification
- `tsc --noEmit` clean
- `__tests__/standards/interactionStandards.test.ts` 8/8 (new "Comment on this part…" placeholder is instructional → allowed)
- eslint on changed files: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)