### PR TITLE
feat(quotes): payment terms, value+unit lead time, inline address add

### DIFF
--- a/__tests__/components/quotes/QuoteForm.test.tsx
+++ b/__tests__/components/quotes/QuoteForm.test.tsx
@@ -53,8 +53,14 @@ vi.mock('@/utils/quotePricingResolver', () => ({
   })),
 }));
 
-// Modal/autocomplete children — render nothing so the surface stays clean
+// Modal/autocomplete children — render nothing so the surface stays clean.
+// CustomerAddressForm is mocked too: it transitively imports
+// customerAddressesAccess → lib/supabase, which eagerly initializes a browser
+// client and throws without test env. The inline-add flow isn't under test here.
 vi.mock('@/components/customers/CustomerFormModal', () => ({
+  default: () => null,
+}));
+vi.mock('@/components/customers/CustomerAddressForm', () => ({
   default: () => null,
 }));
 vi.mock('@/components/parts/PartAutocomplete', () => ({
@@ -67,7 +73,9 @@ const initialBlank: QuoteFormData = {
   billing_address_id: '',
   shipping_address_id: '',
   parts: [],
-  lead_time_days: '',
+  lead_time_value: '',
+  lead_time_unit: 'business_days',
+  payment_terms: '',
   expiration_date: '',
 };
 
@@ -77,7 +85,9 @@ const initialPopulated: QuoteFormData = {
   billing_address_id: '',
   shipping_address_id: '',
   parts: [{ part_id: 'part-1', order_quantity: 5 }],
-  lead_time_days: '14',
+  lead_time_value: '14',
+  lead_time_unit: 'business_days',
+  payment_terms: '',
   expiration_date: '',
 };
 
@@ -140,7 +150,7 @@ describe('QuoteForm', () => {
     render(
       <QuoteForm
         mode="create"
-        initialData={{ ...initialBlank, customer_id: 'cust-1', lead_time_days: '14' }}
+        initialData={{ ...initialBlank, customer_id: 'cust-1', lead_time_value: '14' }}
       />,
     );
     await waitFor(() => {
@@ -174,7 +184,7 @@ describe('QuoteForm', () => {
     const [companyId, payload] = createQuote.mock.calls[0];
     expect(companyId).toBe('test-company-id'); // from test-utils useParams mock
     expect(payload.customer_id).toBe('cust-1');
-    expect(payload.lead_time_days).toBe('14');
+    expect(payload.lead_time_value).toBe('14');
     expect(payload.parts).toEqual([{ part_id: 'part-1', order_quantity: 5 }]);
 
     await waitFor(() => {

--- a/__tests__/types/quote.test.ts
+++ b/__tests__/types/quote.test.ts
@@ -3,6 +3,8 @@ import {
   calculateMarkupFromUnitPrice,
   calculateTotalPrice,
   quoteToFormData,
+  leadTimeToDays,
+  formatLeadTime,
 } from '@/types/quote';
 import type { QuoteWithRelations } from '@/types/quote';
 
@@ -112,6 +114,48 @@ describe('calculateTotalPrice', () => {
   });
 });
 
+describe('leadTimeToDays', () => {
+  it('passes calendar days through unchanged', () => {
+    expect(leadTimeToDays(10, 'calendar_days')).toBe(10);
+  });
+
+  it('multiplies weeks by 7', () => {
+    expect(leadTimeToDays(6, 'weeks')).toBe(42);
+  });
+
+  it('converts business days to calendar days (7/5, rounded up)', () => {
+    // 10 business days → 14 calendar days
+    expect(leadTimeToDays(10, 'business_days')).toBe(14);
+    // 1 business day → ceil(1.4) = 2
+    expect(leadTimeToDays(1, 'business_days')).toBe(2);
+  });
+
+  it('returns null for null/invalid/negative values', () => {
+    expect(leadTimeToDays(null, 'weeks')).toBeNull();
+    expect(leadTimeToDays(undefined, 'weeks')).toBeNull();
+    expect(leadTimeToDays(NaN, 'weeks')).toBeNull();
+    expect(leadTimeToDays(-1, 'weeks')).toBeNull();
+  });
+});
+
+describe('formatLeadTime', () => {
+  it('formats plural and singular by unit label', () => {
+    expect(formatLeadTime(6, 'weeks')).toBe('6 weeks');
+    expect(formatLeadTime(1, 'weeks')).toBe('1 week');
+    expect(formatLeadTime(10, 'business_days')).toBe('10 business days');
+    expect(formatLeadTime(1, 'business_days')).toBe('1 business day');
+  });
+
+  it('returns null when no value is set', () => {
+    expect(formatLeadTime(null, 'weeks')).toBeNull();
+    expect(formatLeadTime(undefined, null)).toBeNull();
+  });
+
+  it('falls back to the default unit when unit is missing', () => {
+    expect(formatLeadTime(3, null)).toBe('3 business days');
+  });
+});
+
 describe('quoteToFormData', () => {
   function makeQuote(lineItems: QuoteWithRelations['line_items']): QuoteWithRelations {
     return {
@@ -123,6 +167,9 @@ describe('quoteToFormData', () => {
       shipping_address_id: 'addr-1',
       contact_id: 'contact-1',
       lead_time_days: 14,
+      lead_time_value: 14,
+      lead_time_unit: 'calendar_days',
+      payment_terms: 'Net 30',
       expiration_date: '2099-12-31',
       status: 'active',
       status_changed_at: null,

--- a/__tests__/utils/quotePdf.test.ts
+++ b/__tests__/utils/quotePdf.test.ts
@@ -71,6 +71,9 @@ const baseQuote: QuoteWithRelations = {
   shipping_address_id: 'addr-1',
   contact_id: 'contact-1',
   lead_time_days: 14,
+  lead_time_value: 14,
+  lead_time_unit: 'calendar_days',
+  payment_terms: null,
   expiration_date: '2099-12-31',
   status: 'active',
   status_changed_at: null,
@@ -240,6 +243,7 @@ describe('generateQuotePdf', () => {
       ...baseQuote,
       expiration_date: null,
       lead_time_days: null,
+      lead_time_value: null,
     };
 
     await generateQuotePdf(barebonesQuote, baseCompany);

--- a/__tests__/utils/quotesAccess.test.ts
+++ b/__tests__/utils/quotesAccess.test.ts
@@ -382,7 +382,9 @@ describe('quotesAccess utilities', () => {
       billing_address_id: '',
       shipping_address_id: '',
       parts: [{ part_id: 'part-1', order_quantity: 100 }],
-      lead_time_days: '14',
+      lead_time_value: '14',
+      lead_time_unit: 'business_days',
+      payment_terms: '',
       expiration_date: '',
     };
 
@@ -442,16 +444,17 @@ describe('quotesAccess utilities', () => {
       ).rejects.toThrow('Every part needs an order quantity greater than zero.');
     });
 
-    it('rejects lead_time_days > 3650', async () => {
+    it('rejects a lead time that normalizes to > 3650 days', async () => {
+      // 5000 business days → ceil(5000 * 7/5) = 7000 calendar days.
       await expect(
-        createQuote('company-1', { ...baseForm, lead_time_days: '5000' }),
-      ).rejects.toThrow('Lead time must be between 0 and 3,650 days');
+        createQuote('company-1', { ...baseForm, lead_time_value: '5000' }),
+      ).rejects.toThrow('Lead time must be 3,650 days or fewer.');
     });
 
-    it('rejects negative lead_time_days', async () => {
+    it('rejects a negative lead time value', async () => {
       await expect(
-        createQuote('company-1', { ...baseForm, lead_time_days: '-5' }),
-      ).rejects.toThrow('Lead time must be between 0 and 3,650 days');
+        createQuote('company-1', { ...baseForm, lead_time_value: '-5' }),
+      ).rejects.toThrow('Lead time must be a whole number');
     });
   });
 
@@ -462,7 +465,9 @@ describe('quotesAccess utilities', () => {
       billing_address_id: '',
       shipping_address_id: '',
       parts: [{ part_id: 'part-1', order_quantity: 200 }],
-      lead_time_days: '14',
+      lead_time_value: '14',
+      lead_time_unit: 'business_days',
+      payment_terms: '',
       expiration_date: '',
     };
 
@@ -834,7 +839,9 @@ describe('quotesAccess utilities', () => {
       billing_address_id: '',
       shipping_address_id: '',
       parts: [],
-      lead_time_days: '14',
+      lead_time_value: '14',
+      lead_time_unit: 'business_days',
+      payment_terms: '',
       expiration_date: '',
     };
 

--- a/api/tools/schema_context.py
+++ b/api/tools/schema_context.py
@@ -125,7 +125,9 @@ SCHEMA_CONTEXT = """
 - status: TEXT -- one of: 'active', 'expired'
 - status_changed_at: TIMESTAMPTZ
 - converted_at: TIMESTAMPTZ (when accepted/converted to a job)
-- lead_time_days: INTEGER, expiration_date: DATE
+- lead_time_days: INTEGER (normalized calendar days, derived from lead_time_value/unit)
+- lead_time_value: INTEGER, lead_time_unit: TEXT -- business_days | calendar_days | weeks
+- payment_terms: TEXT (e.g. 'Net 30', '2/10 Net 30'), expiration_date: DATE
 - created_by: UUID, created_at: TIMESTAMPTZ, updated_at: TIMESTAMPTZ
 - NOTE: revenue is NOT on quotes anymore. Sum quote_line_items.total_price
   for per-quote revenue.

--- a/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
+++ b/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
@@ -37,6 +37,7 @@ import {
   quoteToFormData,
   isQuoteExpired,
   daysUntilExpiration,
+  formatLeadTime,
 } from '@/types/quote';
 import type { QuoteLineItem, QuoteWithRelations } from '@/types/quote';
 import QuoteStatusChip from '@/components/quotes/QuoteStatusChip';
@@ -305,9 +306,14 @@ export default function QuoteDetailPage() {
                   : `Expires ${formatDate(quote.expiration_date)}`}
               </Typography>
             )}
-            {quote.lead_time_days !== null && (
+            {quote.lead_time_value !== null && (
               <Typography variant="body2" color="text.secondary">
-                Lead time: {quote.lead_time_days} day{quote.lead_time_days === 1 ? '' : 's'}
+                Lead time: {formatLeadTime(quote.lead_time_value, quote.lead_time_unit)}
+              </Typography>
+            )}
+            {quote.payment_terms && (
+              <Typography variant="body2" color="text.secondary">
+                Payment terms: {quote.payment_terms}
               </Typography>
             )}
           </Box>

--- a/components/customers/CustomerAddressForm.tsx
+++ b/components/customers/CustomerAddressForm.tsx
@@ -29,8 +29,12 @@ interface CustomerAddressFormProps {
   customerId: string;
   /** Provided when editing an existing address; omitted for "Add Address". */
   existing?: CustomerAddress;
-  /** Called after the address has been successfully created or updated. */
-  onSaved: () => void;
+  /**
+   * Called after the address has been successfully created or updated, with
+   * the saved row so callers can select it immediately (e.g. the quote form's
+   * inline add). Callers that don't need it can ignore the argument.
+   */
+  onSaved: (saved: CustomerAddress) => void;
   /** Called when the user cancels — returns to the address list. */
   onCancel: () => void;
 }
@@ -90,12 +94,11 @@ export default function CustomerAddressForm({
     setLoading(true);
     setError(null);
     try {
-      if (isEdit && existing) {
-        await updateCustomerAddress(existing.id, customerId, formData);
-      } else {
-        await createCustomerAddress(customerId, formData);
-      }
-      onSaved();
+      const saved =
+        isEdit && existing
+          ? await updateCustomerAddress(existing.id, customerId, formData)
+          : await createCustomerAddress(customerId, formData);
+      onSaved(saved);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save address');
     } finally {

--- a/components/quotes/ConvertToJobModal.tsx
+++ b/components/quotes/ConvertToJobModal.tsx
@@ -18,7 +18,7 @@ import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormLabel from '@mui/material/FormLabel';
 import type { QuoteLineItem, QuoteWithRelations } from '@/types/quote';
-import { isQuoteExpired } from '@/types/quote';
+import { isQuoteExpired, formatLeadTime } from '@/types/quote';
 import { convertQuoteToJob } from '@/utils/quotesAccess';
 import { uploadJobAttachment } from '@/utils/jobAttachmentsAccess';
 import AttachmentUploadField from '@/components/jobs/AttachmentUploadField';
@@ -272,9 +272,7 @@ export default function ConvertToJobModal({
                 Quoted lead time
               </Typography>
               <Typography variant="body1" fontWeight={500}>
-                {quote.lead_time_days !== null
-                  ? `${quote.lead_time_days} day${quote.lead_time_days === 1 ? '' : 's'}`
-                  : 'Not specified'}
+                {formatLeadTime(quote.lead_time_value, quote.lead_time_unit) ?? 'Not specified'}
               </Typography>
             </Box>
             <TextField

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -24,10 +24,12 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
+import Collapse from '@mui/material/Collapse';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 
-import type { QuoteFormData } from '@/types/quote';
+import type { QuoteFormData, LeadTimeUnit } from '@/types/quote';
+import { LEAD_TIME_UNITS, PAYMENT_TERM_PRESETS } from '@/types/quote';
 import {
   createQuote,
   updateQuote,
@@ -45,6 +47,7 @@ import { getTiersWithComputedPrices } from '@/utils/partPricingTiersAccess';
 import { resolveTier } from '@/utils/quotePricingResolver';
 import type { ComputedPartPricingTier } from '@/types/partPricing';
 import CustomerFormModal from '@/components/customers/CustomerFormModal';
+import CustomerAddressForm from '@/components/customers/CustomerAddressForm';
 import PartAutocomplete, { type PartSelectOption } from '@/components/parts/PartAutocomplete';
 import type {
   Customer,
@@ -213,6 +216,11 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   const [error, setError] = useState<string | null>(null);
 
   const [customerModalOpen, setCustomerModalOpen] = useState(false);
+
+  // Which address selector triggered the inline "+ Add new address" form
+  // (null = closed). The new address is created against the current customer
+  // and auto-selected into this field on save.
+  const [addressFormFor, setAddressFormFor] = useState<'shipping' | 'billing' | null>(null);
 
   // Drift state (edit mode only):
   //   - driftByLineId: server-detected drift map for the lines currently
@@ -412,6 +420,34 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
         billing_address_id: prev.shipping_address_id,
       }));
     }
+  };
+
+  /**
+   * A new address was created inline for the current customer. Patch it into
+   * the cached customer row (so the selector lists it) and auto-select it into
+   * the field that opened the form — mirroring billing→shipping when "same as
+   * shipping" is on. Then close the inline form.
+   */
+  const handleAddressCreated = (saved: CustomerAddress) => {
+    const target = addressFormFor;
+    if (formData.customer_id) {
+      setCustomersById((prev) => {
+        const existing = prev.get(formData.customer_id);
+        if (!existing) return prev;
+        const next = new Map(prev);
+        next.set(formData.customer_id, {
+          ...existing,
+          addresses: [...(existing.addresses ?? []), saved],
+        });
+        return next;
+      });
+    }
+    if (target === 'shipping') {
+      handleShippingAddressChange(saved.id);
+    } else if (target === 'billing') {
+      handleFieldChange('billing_address_id', saved.id);
+    }
+    setAddressFormFor(null);
   };
 
   /** Addresses + contacts for the currently-selected customer (or empty). */
@@ -677,7 +713,7 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   const validationError = useMemo<string | null>(() => {
     if (!formData.customer_id) return 'Pick a customer.';
     if (partBlocks.length === 0) return 'Add at least one part to the quote.';
-    const leadRaw = formData.lead_time_days;
+    const leadRaw = formData.lead_time_value;
     const leadNum = Number(leadRaw);
     if (
       leadRaw === '' ||
@@ -685,7 +721,7 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
       leadNum < 0 ||
       !Number.isInteger(leadNum)
     ) {
-      return 'Enter a lead time (whole number of days).';
+      return 'Enter a lead time (whole number).';
     }
     const seenParts = new Set<string>();
     for (const block of partBlocks) {
@@ -879,7 +915,7 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                       value={formData.shipping_address_id}
                       onChange={(e) => {
                         if (e.target.value === ADD_NEW_ADDRESS_ID) {
-                          router.push(customerDetailHref);
+                          setAddressFormFor('shipping');
                           return;
                         }
                         handleShippingAddressChange(e.target.value);
@@ -899,6 +935,15 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                       </MenuItem>
                     </Select>
                   </FormControl>
+                  <Collapse in={addressFormFor === 'shipping'} unmountOnExit>
+                    <Box sx={{ mt: 2, p: 2, borderRadius: 1, bgcolor: 'action.hover' }}>
+                      <CustomerAddressForm
+                        customerId={formData.customer_id}
+                        onSaved={handleAddressCreated}
+                        onCancel={() => setAddressFormFor(null)}
+                      />
+                    </Box>
+                  </Collapse>
                 </Grid>
               </Grid>
 
@@ -927,7 +972,7 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                       value={formData.billing_address_id}
                       onChange={(e) => {
                         if (e.target.value === ADD_NEW_ADDRESS_ID) {
-                          router.push(customerDetailHref);
+                          setAddressFormFor('billing');
                           return;
                         }
                         handleFieldChange('billing_address_id', e.target.value);
@@ -947,6 +992,15 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                       </MenuItem>
                     </Select>
                   </FormControl>
+                  <Collapse in={addressFormFor === 'billing'} unmountOnExit>
+                    <Box sx={{ mt: 2, p: 2, borderRadius: 1, bgcolor: 'action.hover' }}>
+                      <CustomerAddressForm
+                        customerId={formData.customer_id}
+                        onSaved={handleAddressCreated}
+                        onCancel={() => setAddressFormFor(null)}
+                      />
+                    </Box>
+                  </Collapse>
                 </Box>
               )}
             </Box>
@@ -1362,16 +1416,35 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
           </Typography>
           <Grid container spacing={2}>
             <Grid size={{ xs: 12, sm: 6 }}>
-              <TextField
-                label="Lead time (days)"
-                type="number"
-                size="small"
-                fullWidth
-                required
-                value={formData.lead_time_days}
-                onChange={(e) => handleFieldChange('lead_time_days', e.target.value)}
-                inputProps={{ min: 0, step: 1, inputMode: 'numeric' }}
-              />
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <TextField
+                  label="Lead time"
+                  type="number"
+                  size="small"
+                  required
+                  value={formData.lead_time_value}
+                  onChange={(e) => handleFieldChange('lead_time_value', e.target.value)}
+                  inputProps={{ min: 0, step: 1, inputMode: 'numeric' }}
+                  sx={{ width: 120 }}
+                />
+                <FormControl size="small" sx={{ flex: 1 }}>
+                  <InputLabel id="lead-time-unit-label">Unit</InputLabel>
+                  <Select
+                    labelId="lead-time-unit-label"
+                    label="Unit"
+                    value={formData.lead_time_unit}
+                    onChange={(e) =>
+                      handleFieldChange('lead_time_unit', e.target.value as LeadTimeUnit)
+                    }
+                  >
+                    {LEAD_TIME_UNITS.map((u) => (
+                      <MenuItem key={u.value} value={u.value}>
+                        {u.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Box>
             </Grid>
             <Grid size={{ xs: 12, sm: 6 }}>
               <TextField
@@ -1382,6 +1455,25 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                 value={formData.expiration_date}
                 onChange={(e) => handleFieldChange('expiration_date', e.target.value)}
                 InputLabelProps={{ shrink: true }}
+              />
+            </Grid>
+            <Grid size={{ xs: 12 }}>
+              <Autocomplete
+                freeSolo
+                options={PAYMENT_TERM_PRESETS}
+                value={formData.payment_terms || null}
+                // freeSolo emits a string on free entry and on option pick; keep
+                // '' when cleared so the access layer stores NULL.
+                onChange={(_, v) => handleFieldChange('payment_terms', v ?? '')}
+                onInputChange={(_, v) => handleFieldChange('payment_terms', v)}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Payment terms"
+                    size="small"
+                    placeholder="e.g. Net 30, 2/10 Net 30"
+                  />
+                )}
               />
             </Grid>
           </Grid>

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -84,7 +84,10 @@ The quote is now a thin header. Per-part, per-tier pricing lives on `quote_line_
 | quote_number | Text | Auto | Auto-generated: Q-0001, Q-0002, … |
 | legacy_quote_number | Text | No | Original quote number from legacy system (migrated quotes) |
 | customer_id | UUID (FK) | Yes | Link to customer |
-| lead_time_days | Integer | No | Days to deliver; copied to `jobs.lead_time_days` on conversion |
+| lead_time_days | Integer | No | **Normalized** calendar days, derived from `lead_time_value`/`lead_time_unit` on save; copied to `jobs.lead_time_days` on conversion |
+| lead_time_value | Integer | No | Lead time as the user states it (the number; unit in `lead_time_unit`) |
+| lead_time_unit | Text | No | `business_days` \| `calendar_days` \| `weeks` (default `business_days`) |
+| payment_terms | Text | No | Payment terms shown on the quote (preset or custom free text), e.g. `Net 30`, `2/10 Net 30` |
 | expiration_date | Date | No | When the quoted price stops being honored. Defaults to `created_at + 10 days` |
 | status | Text | Yes | `active` or `expired` |
 | status_changed_at | Timestamp | No | When `status` last changed |
@@ -198,8 +201,9 @@ There is **no separate "Pricing tiers" reference section** — the editable quan
 
 ▸ **Terms**
 
-- Lead time (days, required — a whole number)
+- Lead time — a whole-number **value** plus a **unit** dropdown (Business days / Calendar days / Weeks; defaults to business days). Required. Normalized to a calendar-day count (`lead_time_days`) on save so quote→job conversion is unaffected.
 - Expiration date (defaults to today + 10 days)
+- Payment terms — a combobox of common presets (Net 15, Net 30, 2/10 Net 30, Net 45/60/90, Due on Receipt, COD, 50% Deposit / Balance Net 30) that also accepts custom free text (e.g. "Net 30, 1% late charge"). Optional.
 
 **Actions:**
 
@@ -212,7 +216,9 @@ There is **no separate "Pricing tiers" reference section** — the editable quan
 - A part may appear in only one block (its quantities go in that block's rows).
 - Every quantity row must be a whole number > 0; quantities must be unique within a part.
 - Each non-override row must resolve to a priced tier, or use a custom price.
-- Lead time is required: a whole number 0 – 3,650 days.
+- Lead time is required: a whole-number value (with unit) that normalizes to 0 – 3,650 days.
+
+**Inline address add:** the shipping / billing address selectors include a "+ Add new address" option that opens the `CustomerAddressForm` **inline** (in a `Collapse` below the selector) rather than navigating to the customer page. On save the new address is added to the customer and auto-selected into the field that opened it (and mirrored to billing when "billing same as shipping" is on).
 
 ### 3. Quote Detail View
 
@@ -222,7 +228,7 @@ There is **no separate "Pricing tiers" reference section** — the editable quan
 
 - Quote number (large)
 - Status pill (Active / Expired)
-- Created date, created by, expires-in, lead time
+- Created date, created by, expires-in, lead time (formatted with its unit, e.g. "6 weeks"), payment terms (when set)
 
 **Content cards:**
 
@@ -511,7 +517,7 @@ This follows the same pattern as Customers, Parts, and Operations:
 
 - [ ] Form blocks submission until every part block has a part selected and at least one valid quantity row (quantities unique within a part)
 
-- [ ] Quote header is editable (customer, lead time, expiration). Line items are editable via the [Edit policy](#edit-policy-line-item-reconcile-frozen-pricing-drift) below — reconciled on save, prices frozen by default
+- [ ] Quote header is editable (customer, lead time value + unit, payment terms, expiration), and all persist across reload. Line items are editable via the [Edit policy](#edit-policy-line-item-reconcile-frozen-pricing-drift) below — reconciled on save, prices frozen by default
 
 - [ ] List page has no Total column (totals live on the detail page / PDF for firm quotes)
 
@@ -666,7 +672,9 @@ While creating a quote, users can create new entities without leaving the form:
 
 **Quantities:** each block needs at least one quantity row; every quantity must be a whole number > 0 and unique within the part. Each non-override row must resolve to a priced tier (or use a custom price).
 
-**Lead time (days):** required — a whole number 0 – 3,650.
+**Lead time:** required — a whole-number value plus a unit (business days / calendar days / weeks); normalizes to 0 – 3,650 days.
+
+**Payment terms:** optional — preset or custom free text.
 
 **Expiration date:** ISO date (defaults to created + 10 days)
 

--- a/supabase/migrations/20260622003025_add_quote_payment_terms_and_lead_unit.sql
+++ b/supabase/migrations/20260622003025_add_quote_payment_terms_and_lead_unit.sql
@@ -1,0 +1,32 @@
+-- Quote enhancements: payment terms + lead-time units.
+--
+-- 1. payment_terms: free-form/preset payment terms string shown on the quote
+--    (e.g. 'Net 30', '2/10 Net 30', 'Net 30, 1% late charge').
+-- 2. lead_time_value + lead_time_unit: the lead time as the user states it
+--    (e.g. 6 weeks). The existing lead_time_days column is KEPT as the
+--    normalized canonical day count consumed by convertQuoteToJob — the
+--    access layer recomputes it from (value, unit) on every save, so reads
+--    have a single clean shape and never branch on a missing normalization.
+
+ALTER TABLE quotes
+  ADD COLUMN IF NOT EXISTS payment_terms text,
+  ADD COLUMN IF NOT EXISTS lead_time_value integer,
+  ADD COLUMN IF NOT EXISTS lead_time_unit text
+    DEFAULT 'business_days'
+    CHECK (lead_time_unit IN ('business_days', 'calendar_days', 'weeks'));
+
+-- Backfill existing rows: their lead_time_days was always a calendar-day count,
+-- so the value carries over 1:1 with unit 'calendar_days'. Leaving lead_time_days
+-- untouched keeps the conversion path working unchanged.
+UPDATE quotes
+SET lead_time_value = lead_time_days,
+    lead_time_unit = 'calendar_days'
+WHERE lead_time_days IS NOT NULL
+  AND lead_time_value IS NULL;
+
+COMMENT ON COLUMN quotes.payment_terms IS
+  'Payment terms shown on the quote (preset or custom free text), e.g. Net 30, 2/10 Net 30.';
+COMMENT ON COLUMN quotes.lead_time_value IS
+  'Lead time as stated by the user, in the unit given by lead_time_unit. Normalized into lead_time_days on save.';
+COMMENT ON COLUMN quotes.lead_time_unit IS
+  'Unit for lead_time_value: business_days | calendar_days | weeks.';

--- a/types/database.ts
+++ b/types/database.ts
@@ -1940,6 +1940,9 @@ export type Database = {
           expiration_date: string | null
           id: string
           lead_time_days: number | null
+          lead_time_unit: string | null
+          lead_time_value: number | null
+          payment_terms: string | null
           quote_number: string
           shipping_address_id: string | null
           status: string
@@ -1957,6 +1960,9 @@ export type Database = {
           expiration_date?: string | null
           id?: string
           lead_time_days?: number | null
+          lead_time_unit?: string | null
+          lead_time_value?: number | null
+          payment_terms?: string | null
           quote_number: string
           shipping_address_id?: string | null
           status?: string
@@ -1974,6 +1980,9 @@ export type Database = {
           expiration_date?: string | null
           id?: string
           lead_time_days?: number | null
+          lead_time_unit?: string | null
+          lead_time_value?: number | null
+          payment_terms?: string | null
           quote_number?: string
           shipping_address_id?: string | null
           status?: string

--- a/types/quote.ts
+++ b/types/quote.ts
@@ -4,6 +4,86 @@
 export type QuoteStatus = 'active' | 'expired';
 
 /**
+ * Unit the salesperson states a quote's lead time in. Stored on
+ * quotes.lead_time_unit; normalized to a calendar-day count (lead_time_days)
+ * via leadTimeToDays at save time.
+ */
+export type LeadTimeUnit = 'business_days' | 'calendar_days' | 'weeks';
+
+export const LEAD_TIME_UNITS: ReadonlyArray<{ value: LeadTimeUnit; label: string }> = [
+  { value: 'business_days', label: 'Business days' },
+  { value: 'calendar_days', label: 'Calendar days' },
+  { value: 'weeks', label: 'Weeks' },
+];
+
+export const DEFAULT_LEAD_TIME_UNIT: LeadTimeUnit = 'business_days';
+
+/**
+ * Common B2B payment terms offered as presets in the quote form's
+ * combobox. The field is free-solo, so shops can also type custom wording
+ * like 'Net 30, 1% late charge'.
+ */
+export const PAYMENT_TERM_PRESETS: ReadonlyArray<string> = [
+  'Due on Receipt',
+  'Net 15',
+  'Net 30',
+  '2/10 Net 30',
+  'Net 45',
+  'Net 60',
+  'Net 90',
+  'COD',
+  '50% Deposit / Balance Net 30',
+];
+
+/**
+ * Normalize a (value, unit) lead time into a calendar-day count — the single
+ * source of truth for the lead_time_days column the conversion flow reads.
+ *
+ *   - weeks         → value × 7
+ *   - calendar_days → value
+ *   - business_days → ceil(value × 7/5)  (a fixed estimate; we don't have a
+ *                     start date here to skip specific weekends/holidays)
+ *
+ * Returns null for a missing/invalid value so callers can persist NULL.
+ */
+export function leadTimeToDays(
+  value: number | null | undefined,
+  unit: LeadTimeUnit,
+): number | null {
+  if (value === null || value === undefined || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  switch (unit) {
+    case 'weeks':
+      return value * 7;
+    case 'business_days':
+      return Math.ceil((value * 7) / 5);
+    case 'calendar_days':
+    default:
+      return value;
+  }
+}
+
+/**
+ * Human-readable lead time for read-side display, e.g. "6 weeks",
+ * "10 business days". Returns null when no value is set.
+ */
+const LEAD_TIME_NOUNS: Record<LeadTimeUnit, { one: string; many: string }> = {
+  calendar_days: { one: 'day', many: 'days' },
+  business_days: { one: 'business day', many: 'business days' },
+  weeks: { one: 'week', many: 'weeks' },
+};
+
+export function formatLeadTime(
+  value: number | null | undefined,
+  unit: LeadTimeUnit | null | undefined,
+): string | null {
+  if (value === null || value === undefined) return null;
+  const nouns = LEAD_TIME_NOUNS[unit ?? DEFAULT_LEAD_TIME_UNIT] ?? LEAD_TIME_NOUNS.calendar_days;
+  return `${value} ${value === 1 ? nouns.one : nouns.many}`;
+}
+
+/**
  * Quote header record. Part/quantity/pricing lives on quote_line_items.
  *
  * Three relational FKs are set at quote creation from the customer's
@@ -31,7 +111,14 @@ export interface Quote {
   billing_address_id: string | null;
   shipping_address_id: string | null;
   contact_id: string | null;
+  // lead_time_days stays the normalized canonical day count consumed by
+  // convertQuoteToJob; lead_time_value + lead_time_unit are what the user
+  // stated and what the form edits. The access layer recomputes
+  // lead_time_days from (value, unit) on every save.
   lead_time_days: number | null;
+  lead_time_value: number | null;
+  lead_time_unit: LeadTimeUnit | null;
+  payment_terms: string | null;
   expiration_date: string | null;
   status: QuoteStatus;
   status_changed_at: string | null;
@@ -226,7 +313,13 @@ export interface QuoteFormData {
   billing_address_id: string;
   shipping_address_id: string;
   parts: QuoteFormPartBlock[];
-  lead_time_days: string;
+  // Lead time as the user states it. lead_time_value is a working-copy string
+  // (so the input can be empty mid-edit); the access layer normalizes
+  // (value, unit) into the canonical lead_time_days column on save.
+  lead_time_value: string;
+  lead_time_unit: LeadTimeUnit;
+  // Payment terms shown on the quote (preset or custom free text). '' = unset.
+  payment_terms: string;
   expiration_date: string; // ISO date (YYYY-MM-DD)
   status?: QuoteStatus;
 }
@@ -270,7 +363,9 @@ export const EMPTY_QUOTE_FORM: QuoteFormData = {
   billing_address_id: '',
   shipping_address_id: '',
   parts: [],
-  lead_time_days: '',
+  lead_time_value: '',
+  lead_time_unit: DEFAULT_LEAD_TIME_UNIT,
+  payment_terms: '',
   expiration_date: defaultExpirationDate(),
 };
 
@@ -307,7 +402,9 @@ export function quoteToFormData(quote: QuoteWithRelations): QuoteFormData {
             }
           : {}),
       })),
-    lead_time_days: quote.lead_time_days !== null ? String(quote.lead_time_days) : '',
+    lead_time_value: quote.lead_time_value !== null ? String(quote.lead_time_value) : '',
+    lead_time_unit: quote.lead_time_unit ?? DEFAULT_LEAD_TIME_UNIT,
+    payment_terms: quote.payment_terms ?? '',
     expiration_date: quote.expiration_date || defaultExpirationDate(),
     status: quote.status,
   };

--- a/utils/quotePdf.ts
+++ b/utils/quotePdf.ts
@@ -9,7 +9,7 @@ import { jsPDF } from 'jspdf';
 import autoTable, { type RowInput } from 'jspdf-autotable';
 import type { QuoteWithRelations } from '@/types/quote';
 import type { Company } from '@/utils/companyAccess';
-import { isQuoteExpired, daysUntilExpiration } from '@/types/quote';
+import { isQuoteExpired, daysUntilExpiration, formatLeadTime } from '@/types/quote';
 
 const MARGIN = 40;
 
@@ -192,10 +192,12 @@ export async function generateQuotePdf(
       color: expiredOrSoon ? [180, 40, 40] : undefined,
     });
   }
-  if (quote.lead_time_days !== null && quote.lead_time_days !== undefined) {
-    metaRows.push({
-      text: `Lead Time: ${quote.lead_time_days} day${quote.lead_time_days === 1 ? '' : 's'} ARO`,
-    });
+  const leadTimeText = formatLeadTime(quote.lead_time_value, quote.lead_time_unit);
+  if (leadTimeText) {
+    metaRows.push({ text: `Lead Time: ${leadTimeText} ARO` });
+  }
+  if (quote.payment_terms) {
+    metaRows.push({ text: `Payment Terms: ${quote.payment_terms}` });
   }
 
   doc.setFont('helvetica', 'normal');

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -17,7 +17,8 @@ import type {
   QuoteLineItem,
   CompanyMember,
 } from '@/types/quote';
-import { isQuoteExpired } from '@/types/quote';
+import { isQuoteExpired, leadTimeToDays, DEFAULT_LEAD_TIME_UNIT } from '@/types/quote';
+import type { LeadTimeUnit } from '@/types/quote';
 import { calculateRoutingCost } from '@/utils/routingCostCalculation';
 import { getCompanyMembers } from '@/utils/companyAccess';
 import { getTiersWithComputedPrices } from '@/utils/partPricingTiersAccess';
@@ -39,6 +40,35 @@ import type { ComputedPartPricingTier } from '@/types/partPricing';
  */
 function asQuote(row: Record<string, unknown> & { status: string }): Quote {
   return row as unknown as Quote;
+}
+
+/** Trim a form string to a value or NULL (empty/whitespace → NULL). */
+function nullIfBlank(s: string | null | undefined): string | null {
+  return s && s.trim() !== '' ? s.trim() : null;
+}
+
+/**
+ * Resolve the lead-time columns to persist from the form payload. Returns the
+ * raw (value, unit) the user stated plus the normalized calendar-day count
+ * (lead_time_days) that convertQuoteToJob reads. Throws on an out-of-range
+ * value so create/update share one validation path.
+ */
+function normalizeLeadTime(formData: QuoteFormData): {
+  leadTimeValue: number | null;
+  leadTimeUnit: LeadTimeUnit;
+  leadTimeDays: number | null;
+} {
+  const unit: LeadTimeUnit = formData.lead_time_unit ?? DEFAULT_LEAD_TIME_UNIT;
+  const raw = formData.lead_time_value;
+  const value = raw !== '' && raw !== null && raw !== undefined ? Number(raw) : null;
+  if (value !== null && (!Number.isFinite(value) || value < 0 || !Number.isInteger(value))) {
+    throw new Error('Lead time must be a whole number of days/weeks.');
+  }
+  const leadTimeDays = leadTimeToDays(value, unit);
+  if (leadTimeDays !== null && leadTimeDays > 3650) {
+    throw new Error('Lead time must be 3,650 days or fewer.');
+  }
+  return { leadTimeValue: value, leadTimeUnit: unit, leadTimeDays };
 }
 
 /**
@@ -337,12 +367,10 @@ export async function createQuote(
     }
   }
 
-  const leadTimeDays = formData.lead_time_days ? parseInt(formData.lead_time_days, 10) : null;
-  if (leadTimeDays !== null && (isNaN(leadTimeDays) || leadTimeDays < 0 || leadTimeDays > 3650)) {
-    throw new Error('Lead time must be between 0 and 3,650 days');
-  }
+  const { leadTimeValue, leadTimeUnit, leadTimeDays } = normalizeLeadTime(formData);
 
   const expirationDate = formData.expiration_date || null;
+  const paymentTerms = nullIfBlank(formData.payment_terms);
 
   const { data: { user } } = await supabase.auth.getUser();
 
@@ -371,6 +399,9 @@ export async function createQuote(
       billing_address_id: nullIfEmpty(formData.billing_address_id),
       shipping_address_id: nullIfEmpty(formData.shipping_address_id),
       lead_time_days: leadTimeDays,
+      lead_time_value: leadTimeValue,
+      lead_time_unit: leadTimeUnit,
+      payment_terms: paymentTerms,
       expiration_date: expirationDate,
       status: 'active',
       created_by: user?.id ?? null,
@@ -491,10 +522,7 @@ export async function updateQuote(
     }
   }
 
-  const leadTimeDays = formData.lead_time_days ? parseInt(formData.lead_time_days, 10) : null;
-  if (leadTimeDays !== null && (isNaN(leadTimeDays) || leadTimeDays < 0 || leadTimeDays > 3650)) {
-    throw new Error('Lead time must be between 0 and 3,650 days');
-  }
+  const { leadTimeValue, leadTimeUnit, leadTimeDays } = normalizeLeadTime(formData);
 
   // customer_po_number is not on the quote — it lives on jobs and is
   // captured during convertQuoteToJob (migration 20260526). updateQuote
@@ -510,6 +538,9 @@ export async function updateQuote(
       billing_address_id: nullIfEmpty(formData.billing_address_id),
       shipping_address_id: nullIfEmpty(formData.shipping_address_id),
       lead_time_days: leadTimeDays,
+      lead_time_value: leadTimeValue,
+      lead_time_unit: leadTimeUnit,
+      payment_terms: nullIfBlank(formData.payment_terms),
       expiration_date: formData.expiration_date || null,
       updated_at: new Date().toISOString(),
     })


### PR DESCRIPTION
## Summary

Three quote-form enhancements ahead of the pilot:

1. **Payment terms** — new `payment_terms` column + a free-solo combobox of common B2B presets (Net 15/30, 2/10 Net 30, Net 45/60/90, Due on Receipt, COD, 50% Deposit / Balance Net 30) that also accepts custom wording like "Net 30, 1% late charge".
2. **Lead time as value + unit** — new `lead_time_value` + `lead_time_unit` (business days / calendar days / weeks). The existing `lead_time_days` stays the **normalized canonical day count** read by `convertQuoteToJob`; the access layer recomputes it from `(value, unit)` on save via a single `leadTimeToDays` helper, so the read path has one clean shape and the job promise-date snapshot is unchanged. (Industry research showed shops state lead times in days/weeks/months; free text would have broken the job snapshot, so value+unit was chosen.)
3. **Inline address add** — the "+ Add new address" selector options now expand `CustomerAddressForm` inline in a `Collapse` (reusing the existing component) instead of navigating to the customer page, and auto-select the new address on save (mirrored to billing when "same as shipping" is on).

Read-side (quote detail page, convert-to-job modal, quote PDF) shows lead time with its unit (e.g. "6 weeks") and payment terms. Docs (`docs/modules/quotes.md`) + AI schema context updated.

## Migration

`20260622003025_add_quote_payment_terms_and_lead_unit.sql` adds the three columns and backfills existing rows (`lead_time_value = lead_time_days`, `lead_time_unit = 'calendar_days'`).

⚠️ **Before merge:** `types/database.ts` was **hand-bridged** with the new columns so the typed Supabase client compiles. The canonical flow still needs to run:
1. `supabase link --project-ref <staging>` → `supabase db push`
2. `pnpm gen:db-types` (regenerates `types/database.ts` identically)
3. Prod push is owned by the human per CLAUDE.md.

## Testing

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run` on the affected suites (`types/quote`, `utils/quotesAccess`, `utils/quotePdf`, `components/quotes/QuoteForm`) — **109 passing**, including new `leadTimeToDays` / `formatLeadTime` unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)