### PR TITLE
chore(types): regenerate database.ts after quote-terms staging push

### DIFF
--- a/types/database.ts
+++ b/types/database.ts
@@ -10,7 +10,7 @@ export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "14.4"
+    PostgrestVersion: "14.1"
   }
   graphql_public: {
     Tables: {


### PR DESCRIPTION
## Summary

Runs `pnpm gen:db-types` against the linked **staging** project now that the #405 migration (`payment_terms` / `lead_time_value` / `lead_time_unit`) is applied there, replacing the hand-bridged `types/database.ts` from #405 with the canonical generated output.

## Notable

- The quote columns hand-added in #405 were **byte-identical** to the generated output — the `quotes` block doesn't appear in the diff. (Good sign the bridge was correct; bad sign that nothing automated verified it — see #406.)
- The only effective change is `PostgrestVersion` metadata `14.4 → 14.1`, reflecting the linked staging project's PostgREST version.

## Testing

- `pnpm exec tsc --noEmit` — clean (the typed client now validates against the real generated schema, not a hand-edit).

Follow-up to #406 — CI should regenerate these types from committed migrations and `git diff --exit-code` so this step is enforced automatically instead of done by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)