### PR TITLE
feat(work-centers): tab-aware header + internal labor-rate & kind-change guards

### DIFF
--- a/app/dashboard/[companyId]/work-centers/[workCenterId]/edit/page.tsx
+++ b/app/dashboard/[companyId]/work-centers/[workCenterId]/edit/page.tsx
@@ -8,7 +8,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { WorkCenterForm } from '@/components/work-centers';
-import { getWorkCenter } from '@/utils/workCentersAccess';
+import { getWorkCenterWithRelations } from '@/utils/workCentersAccess';
 import { workCenterToFormData, EMPTY_WORK_CENTER_FORM } from '@/types/workCenter';
 import type { WorkCenterFormData } from '@/types/workCenter';
 
@@ -19,18 +19,20 @@ export default function WorkCenterEditPage() {
   const workCenterId = params.workCenterId as string;
 
   const [initialData, setInitialData] = useState<WorkCenterFormData | null>(null);
+  const [routingOperationsCount, setRoutingOperationsCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function fetchWorkCenter() {
       try {
-        const wc = await getWorkCenter(workCenterId);
+        const wc = await getWorkCenterWithRelations(workCenterId);
         if (!wc) {
           setError('Work center not found');
           setInitialData(EMPTY_WORK_CENTER_FORM);
         } else {
           setInitialData(workCenterToFormData(wc));
+          setRoutingOperationsCount(wc.routing_operations_count);
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : 'An error occurred');
@@ -75,6 +77,7 @@ export default function WorkCenterEditPage() {
         mode="edit"
         initialData={initialData}
         workCenterId={workCenterId}
+        routingOperationsCount={routingOperationsCount}
         onSuccess={() =>
           router.push(`/dashboard/${companyId}/work-centers/${workCenterId}`)
         }

--- a/app/dashboard/[companyId]/work-centers/page.tsx
+++ b/app/dashboard/[companyId]/work-centers/page.tsx
@@ -43,6 +43,7 @@ import {
   bulkDeleteWorkCenters,
 } from '@/utils/workCentersAccess';
 import { getAllVendors } from '@/utils/vendorsAccess';
+import { usePageTitle } from '@/components/layout/PageTitleProvider';
 import ExportCsvButton from '@/components/common/ExportCsvButton';
 import type { WorkCenter, WorkCenterKind } from '@/types/workCenter';
 import type { Vendor } from '@/types/vendor';
@@ -68,6 +69,7 @@ export default function WorkCentersPage() {
   const router = useRouter();
   const params = useParams();
   const companyId = params.companyId as string;
+  const { setTitle } = usePageTitle();
 
   const [rows, setRows] = useState<WorkCenterRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -91,6 +93,13 @@ export default function WorkCentersPage() {
     const timer = setTimeout(() => setSearchDebounced(search), 300);
     return () => clearTimeout(timer);
   }, [search]);
+
+  // Reflect the active tab in the global app bar title (cleared on unmount so
+  // other pages fall back to their pathname title).
+  useEffect(() => {
+    setTitle(activeKind === 'internal' ? 'Work Centers — Internal' : 'Work Centers — External');
+    return () => setTitle(null);
+  }, [activeKind, setTitle]);
 
   const fetchRows = useCallback(async () => {
     setLoading(true);

--- a/components/work-centers/WorkCenterForm.tsx
+++ b/components/work-centers/WorkCenterForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
@@ -37,6 +37,12 @@ interface WorkCenterFormProps {
   workCenterId?: string;
   /** Optional: companyId override for modal usage */
   companyId?: string;
+  /**
+   * Number of routing operations referencing this work center (edit mode).
+   * When > 0 the kind toggle is locked: pricing is read live from kind, so
+   * flipping it would break the cost of every operation already using it.
+   */
+  routingOperationsCount?: number;
   /** Optional: Callback when work center is created/updated successfully */
   onSuccess?: (workCenter: WorkCenter) => void;
   /** Optional: Callback when cancel is clicked */
@@ -48,12 +54,18 @@ export default function WorkCenterForm({
   initialData,
   workCenterId,
   companyId: companyIdProp,
+  routingOperationsCount = 0,
   onSuccess,
   onCancel,
 }: WorkCenterFormProps) {
   const router = useRouter();
   const params = useParams();
   const companyId = companyIdProp || (params.companyId as string);
+
+  // Once a work center is used by routing operations, its kind is fixed:
+  // costing reads kind live, so switching internal↔external would orphan the
+  // pricing fields on every referencing operation (see Q1 in the PR).
+  const kindLocked = mode === 'edit' && routingOperationsCount > 0;
 
   const [formData, setFormData] = useState<WorkCenterFormData>(initialData);
   const [loading, setLoading] = useState(false);
@@ -98,10 +110,19 @@ export default function WorkCenterForm({
       errors.vendor_id = 'Vendor is required for external work centers';
     }
 
-    if (formData.kind === 'internal' && formData.labor_rate.trim()) {
-      const rate = parseOptionalNumber(formData.labor_rate);
-      if (rate === null || rate < 0) {
-        errors.labor_rate = 'Labor rate must be a non-negative number';
+    // Labor rate is required for internal work centers: an internal routing
+    // operation with no rate (and no per-op override) cannot be priced — the
+    // cost function raises and the part shows as unpriceable. Requiring it here
+    // stops that bad state at the source. (External WCs price per operation, so
+    // labor_rate stays hidden/empty for them.)
+    if (formData.kind === 'internal') {
+      if (!formData.labor_rate.trim()) {
+        errors.labor_rate = 'Labor rate is required for internal work centers';
+      } else {
+        const rate = parseOptionalNumber(formData.labor_rate);
+        if (rate === null || rate < 0) {
+          errors.labor_rate = 'Labor rate must be a non-negative number';
+        }
       }
     }
 
@@ -219,7 +240,7 @@ export default function WorkCenterForm({
                   value={formData.kind}
                   exclusive
                   onChange={handleKindChange}
-                  disabled={loading}
+                  disabled={loading || kindLocked}
                   fullWidth
                   color="primary"
                   size="medium"
@@ -239,9 +260,13 @@ export default function WorkCenterForm({
                   color="text.secondary"
                   sx={{ mt: 0.5, display: 'block' }}
                 >
-                  {formData.kind === 'internal'
-                    ? 'Runs in your shop. Has a labor rate.'
-                    : 'Performed by an outside vendor.'}
+                  {kindLocked
+                    ? `Locked — used by ${routingOperationsCount} routing operation${
+                        routingOperationsCount === 1 ? '' : 's'
+                      }. Changing the kind would break their pricing.`
+                    : formData.kind === 'internal'
+                      ? 'Runs in your shop. Has a labor rate.'
+                      : 'Performed by an outside vendor.'}
                 </Typography>
               </Box>
             </Grid>
@@ -253,11 +278,12 @@ export default function WorkCenterForm({
               <Grid size={{ xs: 12, sm: 6 }}>
                 <TextField
                   fullWidth
+                  required
                   label="Labor Rate"
                   value={formData.labor_rate}
                   onChange={handleTextChange('labor_rate')}
                   error={!!fieldErrors.labor_rate}
-                  helperText={fieldErrors.labor_rate || 'Optional. Hourly rate in dollars.'}
+                  helperText={fieldErrors.labor_rate || 'Hourly rate in dollars. Required for quoting.'}
                   disabled={loading}
                   type="number"
                   inputProps={{ min: 0, step: '0.01', inputMode: 'decimal' }}


### PR DESCRIPTION
Follow-ups to the Internal/External tab split (#408). Three related changes, all small work-centers form/page tweaks.

## 1. Header reflects the active tab
The list page sets the global app-bar title to **"Work Centers — Internal"** / **"Work Centers — External"** following the active tab, via the existing `PageTitleProvider` override (the same mechanism the part detail page uses to show the part number). Cleared on unmount so other routes fall back to their pathname title. No changes to `Header`/layout needed.

## 2. Labor rate required for internal work centers (create + edit)
**Why:** an internal routing operation with no labor rate (and no per-op override) can't be priced — `compute_part_cost_at_qty` raises and `get_priceable_part_ids` flags the part as unpriceable. The form now blocks saving an internal WC without a rate, stopping that state at the source. External WCs are untouched (they price per operation, so `labor_rate` stays empty for them).

**Scope:** form-level validation only, on create **and** edit. Not a DB constraint — a plain `NOT NULL` is impossible since external WCs legitimately have null `labor_rate`, and a conditional CHECK would break the import-created placeholder rows + the import pipeline (which deliberately creates internal WCs with null rates to be filled in later). Existing null-rate rows and the importer are unaffected.

## 3. Kind toggle locks once a work center is referenced
**Why (the footgun this closes):** costing reads `work_center.kind` *live* (both the TS `routingCostCalculation` path and the SQL cost function) — routing operations don't snapshot pricing. So flipping an in-use WC internal↔external orphans the pricing fields on every referencing operation: an internal op (priced on time × rate) suddenly needs `external_unit_price`, which is null → cost computation raises / the part becomes unpriceable. Silent until someone tries to quote it.

**Fix:** the edit page fetches `routing_operations_count` via the existing `getWorkCenterWithRelations` and passes it to the form. When > 0, the Internal/External toggle is disabled with an inline caption: *"Locked — used by N routing operations. Changing the kind would break their pricing."* Work centers with no operations can still freely change kind (covers the "picked the wrong kind right after creating" case). Inline caption rather than a hover tooltip, since the app targets shop-floor tablets.

Also drops a pre-existing unused `useEffect` import in `WorkCenterForm`.

## Files
- `app/dashboard/[companyId]/work-centers/page.tsx` — tab-aware title.
- `components/work-centers/WorkCenterForm.tsx` — required internal rate + kind lock.
- `app/dashboard/[companyId]/work-centers/[workCenterId]/edit/page.tsx` — wires the operation count.

## Verification
- `tsc --noEmit` — clean.
- `pnpm test --run __tests__/utils/workCentersAccess.test.ts` — 11/11 pass.
- `eslint` on changed files — 0 errors (remaining `set-state-in-effect` warnings are pre-existing patterns; the new title effect mirrors the part page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)