### PR TITLE
Focus new part on add; link job BOM materials to part pages

### DIFF
--- a/components/jobs/JobPartMaterialsCard.tsx
+++ b/components/jobs/JobPartMaterialsCard.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import NextLink from 'next/link';
 import {
   Card,
   CardContent,
@@ -8,6 +10,7 @@ import {
   Typography,
   List,
   ListItem,
+  ListItemButton,
   ListItemText,
   CircularProgress,
 } from '@mui/material';
@@ -27,6 +30,8 @@ interface JobPartMaterialsCardProps {
  * page reflects the current BOM. Quantities are per unit of the part.
  */
 export default function JobPartMaterialsCard({ partId }: JobPartMaterialsCardProps) {
+  const params = useParams();
+  const companyId = params.companyId as string;
   const [lines, setLines] = useState<BomLineWithChildPart[] | null>(null);
 
   useEffect(() => {
@@ -68,12 +73,9 @@ export default function JobPartMaterialsCard({ partId }: JobPartMaterialsCardPro
           </Typography>
         ) : (
           <List dense disablePadding>
-            {lines.map((line, idx) => (
-              <ListItem
-                key={line.id}
-                divider={idx < lines.length - 1}
-                sx={{ alignItems: 'flex-start', py: 1 }}
-              >
+            {lines.map((line, idx) => {
+              const childPartId = line.child_part?.id;
+              const text = (
                 <ListItemText
                   primary={
                     <Typography variant="body2" sx={{ fontWeight: 500 }}>
@@ -86,8 +88,29 @@ export default function JobPartMaterialsCard({ partId }: JobPartMaterialsCardPro
                     </Typography>
                   }
                 />
-              </ListItem>
-            ))}
+              );
+              // Each BOM material is a real part — link the row to its detail
+              // page. Rows without a resolvable child part stay non-clickable.
+              return childPartId ? (
+                <ListItemButton
+                  key={line.id}
+                  component={NextLink}
+                  href={`/dashboard/${companyId}/parts/${childPartId}`}
+                  divider={idx < lines.length - 1}
+                  sx={{ alignItems: 'flex-start', py: 1 }}
+                >
+                  {text}
+                </ListItemButton>
+              ) : (
+                <ListItem
+                  key={line.id}
+                  divider={idx < lines.length - 1}
+                  sx={{ alignItems: 'flex-start', py: 1 }}
+                >
+                  {text}
+                </ListItem>
+              );
+            })}
           </List>
         )}
       </CardContent>

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -195,6 +195,15 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   const [partBlocks, setPartBlocks] = useState<PartBlockState[]>(() =>
     groupPartsIntoBlocks(initialData.parts),
   );
+  // Index of the part block whose part picker should grab focus after it
+  // mounts — set when the user clicks "Add part" so the new (empty) entry
+  // gets focus and scrolls into view. Cleared once consumed so later
+  // re-renders (e.g. removing a block) don't steal focus.
+  const [focusBlockIndex, setFocusBlockIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (focusBlockIndex !== null) setFocusBlockIndex(null);
+  }, [focusBlockIndex]);
 
   const [customers, setCustomers] = useState<CustomerOption[]>([]);
   // Full customer rows (with addresses + contacts) keyed by id so the
@@ -502,6 +511,8 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   const customerDetailHref = `/dashboard/${companyId}/customers/${formData.customer_id}`;
 
   const addPartBlock = () => {
+    // New block lands at the current end, so its index is the current length.
+    setFocusBlockIndex(partBlocks.length);
     setPartBlocks((prev) => [...prev, emptyBlock()]);
   };
 
@@ -1099,6 +1110,7 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                         )
                       }
                       label={`Part ${idx + 1}`}
+                      autoFocus={idx === focusBlockIndex}
                     />
                   </Box>
                   <IconButton


### PR DESCRIPTION
## Summary

Two small shop-floor UX fixes:

1. **Quote form — focus the new part on "Add part".** Clicking _Add part_ now moves focus to the newly added (empty) part picker and scrolls it into view, so the user can immediately start typing. Implemented by tracking the new block's index and passing the existing `PartAutocomplete` `autoFocus` prop to that block (cleared after consumption so later re-renders, e.g. removing a block, don't steal focus).

2. **Job part Materials card — clickable BOM rows.** Each BOM material row in `JobPartMaterialsCard` is now a `ListItemButton` linking to that material's part detail page (`/dashboard/{companyId}/parts/{childPartId}`). BOM `child_part_id` is a real FK into `parts`, so the route is always valid. Rows without a resolvable child part ("Unknown item") stay non-clickable. `companyId` is read from `useParams` (no prop threading).

## Testing

- `pnpm exec tsc --noEmit` — clean.
- `pnpm test --run __tests__/components/quotes/QuoteForm.test.tsx` — 21/21 pass.
- No existing tests reference `JobPartMaterialsCard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)