### PR TITLE
Inventory Locations & QR-Addressable Stock — PR1 (tree, balances, part-detail)

### DIFF
--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -46,26 +46,26 @@ describe('VisualLocationBuilder', () => {
     expect(onCreated).toHaveBeenCalledWith(16);
   });
 
-  it('fine-tunes one branch (remove + add), reflects it, and can start over', async () => {
+  it('customizes per branch from the config, then can start over', async () => {
     const user = userEvent.setup();
     render(<VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={vi.fn()} />);
 
     await user.click(screen.getByText('Cabinet'));
     expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
 
-    // remove one leaf from one branch → non-uniform, count drops, config reflects it
-    await user.click(screen.getAllByRole('button', { name: /^remove left$/i })[0]);
-    expect(await screen.findByRole('button', { name: /create 15 locations/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /start over/i })).toBeInTheDocument(); // customized config
+    // editing is in the config now — enter the per-branch editor
+    await user.click(screen.getByRole('button', { name: /customize individual spots/i }));
+    expect(await screen.findByText('Cabinet 1 › Row 1')).toBeInTheDocument(); // config reflects branches
+    expect(screen.getByRole('button', { name: /^start over$/i })).toBeInTheDocument();
 
-    // add one back to that branch
-    await user.click(screen.getByRole('button', { name: /add to row 1/i }));
-    expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
+    // add one to a single branch → count rises
+    await user.click(screen.getAllByRole('button', { name: /^add$/i })[0]);
+    expect(await screen.findByRole('button', { name: /create 17 locations/i })).toBeInTheDocument();
 
     // start over → confirm → back to the uniform numbers form
-    await user.click(screen.getByRole('button', { name: /start over/i }));
-    const confirms = screen.getAllByRole('button', { name: /start over/i });
-    await user.click(confirms[confirms.length - 1]); // the dialog's confirm
+    await user.click(screen.getByRole('button', { name: /^start over$/i }));
+    const confirms = screen.getAllByRole('button', { name: /^start over$/i });
+    await user.click(confirms[confirms.length - 1]);
     expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
     expect(screen.getAllByText('Call them').length).toBeGreaterThan(0); // uniform controls back
   });

--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * VisualLocationBuilder: the no-AI stepper that turns a picked storage type +
+ * configured divisions into a location tree. Asserts the happy path —
+ * palette → layout → review board → Create calls materializeLocationSpec with
+ * the assembled spec and reports the count. The spec math itself is covered by
+ * locationSpec.test.ts; here we test the wiring.
+ */
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render, screen } from '../../../test-utils';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@/utils/inventoryLocationsAccess', () => ({
+  materializeLocationSpec: vi.fn(async (_co: string, _p: string | null, nodes: { children: unknown[] }[]) => {
+    const count = (function c(ns: { children: unknown[] }[]): number {
+      return ns.reduce((s, n) => s + 1 + c(n.children as { children: unknown[] }[]), 0);
+    })(nodes);
+    return Array.from({ length: count }, (_, i) => ({ id: String(i) }));
+  }),
+}));
+
+import VisualLocationBuilder from '@/components/inventory/locations/builder/VisualLocationBuilder';
+import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('VisualLocationBuilder', () => {
+  it('walks palette → layout → review → create and materializes the spec', async () => {
+    const user = userEvent.setup();
+    const onCreated = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <VisualLocationBuilder open companyId="co1" onClose={onClose} onCreated={onCreated} />,
+    );
+
+    // Step 1 — palette: pick Cabinet (defaults to 1 cabinet × 5 rows × {Left,Right} = 16)
+    await user.click(screen.getByText('Cabinet'));
+
+    // Step 2 — layout: advances and a Review action appears
+    const reviewBtn = await screen.findByRole('button', { name: /review/i });
+    await user.click(reviewBtn);
+
+    // Step 3 — review board shows the top container and a Create button with the count
+    expect(await screen.findByText('Cabinet 1')).toBeInTheDocument();
+    const createBtn = await screen.findByRole('button', { name: /create 16 locations/i });
+    await user.click(createBtn);
+
+    expect(materializeLocationSpec).toHaveBeenCalledTimes(1);
+    const [companyId, parentId, spec] = (materializeLocationSpec as Mock).mock.calls[0];
+    expect(companyId).toBe('co1');
+    expect(parentId).toBeNull();
+    expect(spec[0].name).toBe('Cabinet 1');
+    expect(spec[0].is_qr_anchor).toBe(true); // default QR anchor = top container
+    expect(onCreated).toHaveBeenCalledWith(16);
+  });
+
+  it('lets you prune a tile before creating, lowering the count', async () => {
+    const user = userEvent.setup();
+    render(
+      <VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={vi.fn()} />,
+    );
+
+    await user.click(screen.getByText('Bins')); // flat: 6 bins
+    await user.click(await screen.findByRole('button', { name: /review/i }));
+    expect(await screen.findByRole('button', { name: /create 6 locations/i })).toBeInTheDocument();
+
+    // remove one bin tile
+    await user.click(screen.getByRole('button', { name: /remove bin 1/i }));
+    expect(await screen.findByRole('button', { name: /create 5 locations/i })).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -35,8 +35,11 @@ describe('VisualLocationBuilder', () => {
     // Step 1 — palette: pick Cabinet (defaults to 1 cabinet × 5 rows × {Left,Right} = 16)
     await user.click(screen.getByText('Cabinet'));
 
-    // Step 2 — Build: controls + live board are shown together, Create carries the count
+    // Step 2 — Build: controls + live board together. The WHOLE nesting is
+    // visible without any drill-in click (cabinet → rows → bin leaves).
     expect(await screen.findByText('Cabinet 1')).toBeInTheDocument();
+    expect(screen.getByText('Row 1')).toBeInTheDocument(); // level 2 section
+    expect(screen.getAllByText('Left').length).toBeGreaterThan(0); // level 3 leaf chips
     const createBtn = await screen.findByRole('button', { name: /create 16 locations/i });
     await user.click(createBtn);
 

--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -69,4 +69,17 @@ describe('VisualLocationBuilder', () => {
     expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
     expect(screen.getAllByText('Call them').length).toBeGreaterThan(0); // uniform controls back
   });
+
+  it('duplicates a top-level entry from the customize editor', async () => {
+    const user = userEvent.setup();
+    render(<VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={vi.fn()} />);
+
+    await user.click(screen.getByText('Cabinet')); // 16 nodes
+    await user.click(screen.getByRole('button', { name: /customize individual spots/i }));
+
+    // duplicate the cabinet → a second one like it → 32 nodes
+    await user.click(await screen.findByRole('button', { name: /duplicate cabinet 1/i }));
+    expect(await screen.findByRole('button', { name: /create 32 locations/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /duplicate cabinet 2/i })).toBeInTheDocument();
+  });
 });

--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -24,7 +24,7 @@ import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
 beforeEach(() => vi.clearAllMocks());
 
 describe('VisualLocationBuilder', () => {
-  it('walks palette → layout → review → create and materializes the spec', async () => {
+  it('picks a type, shows the live build step, and creates the materialized spec', async () => {
     const user = userEvent.setup();
     const onCreated = vi.fn();
     const onClose = vi.fn();
@@ -35,11 +35,7 @@ describe('VisualLocationBuilder', () => {
     // Step 1 — palette: pick Cabinet (defaults to 1 cabinet × 5 rows × {Left,Right} = 16)
     await user.click(screen.getByText('Cabinet'));
 
-    // Step 2 — layout: advances and a Review action appears
-    const reviewBtn = await screen.findByRole('button', { name: /review/i });
-    await user.click(reviewBtn);
-
-    // Step 3 — review board shows the top container and a Create button with the count
+    // Step 2 — Build: controls + live board are shown together, Create carries the count
     expect(await screen.findByText('Cabinet 1')).toBeInTheDocument();
     const createBtn = await screen.findByRole('button', { name: /create 16 locations/i });
     await user.click(createBtn);
@@ -53,17 +49,16 @@ describe('VisualLocationBuilder', () => {
     expect(onCreated).toHaveBeenCalledWith(16);
   });
 
-  it('lets you prune a tile before creating, lowering the count', async () => {
+  it('lets you prune a tile in the live preview, lowering the count', async () => {
     const user = userEvent.setup();
     render(
       <VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={vi.fn()} />,
     );
 
-    await user.click(screen.getByText('Bins')); // flat: 6 bins
-    await user.click(await screen.findByRole('button', { name: /review/i }));
+    await user.click(screen.getByText('Bins')); // flat: 6 bins, shown live on the build step
     expect(await screen.findByRole('button', { name: /create 6 locations/i })).toBeInTheDocument();
 
-    // remove one bin tile
+    // remove one bin tile from the preview
     await user.click(screen.getByRole('button', { name: /remove bin 1/i }));
     expect(await screen.findByRole('button', { name: /create 5 locations/i })).toBeInTheDocument();
   });

--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -1,9 +1,7 @@
 /**
- * VisualLocationBuilder: the no-AI stepper that turns a picked storage type +
- * configured divisions into a location tree. Asserts the happy path —
- * palette → layout → review board → Create calls materializeLocationSpec with
- * the assembled spec and reports the count. The spec math itself is covered by
- * locationSpec.test.ts; here we test the wiring.
+ * VisualLocationBuilder: pick a type, see the full nested live preview, fine-tune
+ * individual branches (non-uniform), and create. The spec math + per-branch
+ * edits are covered by locationSpec.test.ts; here we test the wiring.
  */
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { render, screen } from '../../../test-utils';
@@ -24,45 +22,51 @@ import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
 beforeEach(() => vi.clearAllMocks());
 
 describe('VisualLocationBuilder', () => {
-  it('picks a type, shows the live build step, and creates the materialized spec', async () => {
+  it('picks a type, shows the full nested preview, and creates the spec', async () => {
     const user = userEvent.setup();
     const onCreated = vi.fn();
-    const onClose = vi.fn();
-    render(
-      <VisualLocationBuilder open companyId="co1" onClose={onClose} onCreated={onCreated} />,
-    );
+    render(<VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={onCreated} />);
 
-    // Step 1 — palette: pick Cabinet (defaults to 1 cabinet × 5 rows × {Left,Right} = 16)
+    // Cabinet default: 1 cabinet × 5 rows × {Left, Right} = 16
     await user.click(screen.getByText('Cabinet'));
 
-    // Step 2 — Build: controls + live board together. The WHOLE nesting is
-    // visible without any drill-in click (cabinet → rows → bin leaves).
+    // whole nesting visible, no drill-in
     expect(await screen.findByText('Cabinet 1')).toBeInTheDocument();
-    expect(screen.getByText('Row 1')).toBeInTheDocument(); // level 2 section
-    expect(screen.getAllByText('Left').length).toBeGreaterThan(0); // level 3 leaf chips
-    const createBtn = await screen.findByRole('button', { name: /create 16 locations/i });
-    await user.click(createBtn);
+    expect(screen.getByText('Row 1')).toBeInTheDocument();
+    expect(screen.getAllByText('Left').length).toBeGreaterThan(0);
+
+    await user.click(await screen.findByRole('button', { name: /create 16 locations/i }));
 
     expect(materializeLocationSpec).toHaveBeenCalledTimes(1);
     const [companyId, parentId, spec] = (materializeLocationSpec as Mock).mock.calls[0];
     expect(companyId).toBe('co1');
     expect(parentId).toBeNull();
     expect(spec[0].name).toBe('Cabinet 1');
-    expect(spec[0].is_qr_anchor).toBe(true); // default QR anchor = top container
+    expect(spec[0].is_qr_anchor).toBe(true);
     expect(onCreated).toHaveBeenCalledWith(16);
   });
 
-  it('lets you prune a tile in the live preview, lowering the count', async () => {
+  it('fine-tunes one branch (remove + add), reflects it, and can start over', async () => {
     const user = userEvent.setup();
-    render(
-      <VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={vi.fn()} />,
-    );
+    render(<VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={vi.fn()} />);
 
-    await user.click(screen.getByText('Bins')); // flat: 6 bins, shown live on the build step
-    expect(await screen.findByRole('button', { name: /create 6 locations/i })).toBeInTheDocument();
+    await user.click(screen.getByText('Cabinet'));
+    expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
 
-    // remove one bin tile from the preview
-    await user.click(screen.getByRole('button', { name: /remove bin 1/i }));
-    expect(await screen.findByRole('button', { name: /create 5 locations/i })).toBeInTheDocument();
+    // remove one leaf from one branch → non-uniform, count drops, config reflects it
+    await user.click(screen.getAllByRole('button', { name: /^remove left$/i })[0]);
+    expect(await screen.findByRole('button', { name: /create 15 locations/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /start over/i })).toBeInTheDocument(); // customized config
+
+    // add one back to that branch
+    await user.click(screen.getByRole('button', { name: /add to row 1/i }));
+    expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
+
+    // start over → confirm → back to the uniform numbers form
+    await user.click(screen.getByRole('button', { name: /start over/i }));
+    const confirms = screen.getAllByRole('button', { name: /start over/i });
+    await user.click(confirms[confirms.length - 1]); // the dialog's confirm
+    expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
+    expect(screen.getAllByText('Call them').length).toBeGreaterThan(0); // uniform controls back
   });
 });

--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -42,7 +42,6 @@ describe('VisualLocationBuilder', () => {
     expect(companyId).toBe('co1');
     expect(parentId).toBeNull();
     expect(spec[0].name).toBe('Cabinet 1');
-    expect(spec[0].is_qr_anchor).toBe(true);
     expect(onCreated).toHaveBeenCalledWith(16);
   });
 

--- a/__tests__/lib/featureFlags.test.ts
+++ b/__tests__/lib/featureFlags.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isInventoryLocationsEnabled,
+  isShipmentsEnabled,
+  readCompanyFeatures,
+  KNOWN_FEATURES,
+} from '@/lib/featureFlags';
+
+describe('featureFlags: inventory_locations', () => {
+  it('is registered in KNOWN_FEATURES (so /admin/companies renders a toggle)', () => {
+    expect(KNOWN_FEATURES.map((f) => f.key)).toContain('inventory_locations');
+  });
+
+  it('reads settings.features.inventory_locations (boolean or "true")', () => {
+    expect(isInventoryLocationsEnabled({ settings: { features: { inventory_locations: true } } })).toBe(true);
+    expect(isInventoryLocationsEnabled({ settings: { features: { inventory_locations: 'true' } } })).toBe(true);
+    expect(isInventoryLocationsEnabled({ settings: { features: {} } })).toBe(false);
+    expect(isInventoryLocationsEnabled({ settings: {} })).toBe(false);
+    expect(isInventoryLocationsEnabled(null)).toBe(false);
+    expect(isInventoryLocationsEnabled(undefined)).toBe(false);
+  });
+
+  it('defaults OFF and is independent of the shipments flag', () => {
+    const shipmentsOnly = { settings: { features: { shipments: true } } };
+    expect(isInventoryLocationsEnabled(shipmentsOnly)).toBe(false);
+    expect(isShipmentsEnabled(shipmentsOnly)).toBe(true);
+  });
+
+  it('readCompanyFeatures includes the new key', () => {
+    const features = readCompanyFeatures({ settings: { features: { inventory_locations: true } } });
+    expect(features.inventory_locations).toBe(true);
+    expect(features.shipments).toBe(false);
+  });
+});

--- a/__tests__/utils/inventoryLocationsAccess.test.ts
+++ b/__tests__/utils/inventoryLocationsAccess.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Access-layer unit tests (mocked Supabase). These cover the TypeScript logic:
+ * tree assembly, path computation, unit conversion, RPC argument shaping, and
+ * the client-side delete/move guards.
+ *
+ * The DB-enforced invariants the access layer DELEGATES to Postgres —
+ * parts.quantity == SUM(balances), the cross-tenant guard inside each RPC, and
+ * the enable/disable backfill ordering — are not mockable here; they are
+ * validated by the migration applying to staging and by the E2E flow
+ * (scan → deplete → assert balance + rollup + ledger). See the PR description.
+ */
+
+const { state, mockSupabase } = vi.hoisted(() => {
+  const s: { fromQueue: Array<{ data: unknown; error: unknown }>; rpc: { data: unknown; error: unknown } } = {
+    fromQueue: [],
+    rpc: { data: null, error: null },
+  };
+  const makeBuilder = (result: { data: unknown; error: unknown }) => {
+    const b: Record<string, unknown> = {};
+    ['select', 'insert', 'update', 'delete', 'eq', 'neq', 'in', 'gt', 'order', 'limit', 'single', 'maybeSingle'].forEach(
+      (m) => {
+        b[m] = vi.fn(() => b);
+      },
+    );
+    // Thenable: awaiting anywhere in the chain resolves to { data, error }.
+    b.then = (resolve: (v: unknown) => unknown) => resolve(result);
+    return b;
+  };
+  const supabase = {
+    from: vi.fn(() => makeBuilder(s.fromQueue.shift() ?? { data: null, error: null })),
+    rpc: vi.fn(() => s.rpc),
+  };
+  return { state: s, mockSupabase: supabase };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+
+import {
+  buildLocationTree,
+  buildLocationUrl,
+  createLocation,
+  deleteLocation,
+  moveLocation,
+  getBalancesForPart,
+  addStockAtLocation,
+  depleteStockAtLocation,
+  adjustStockAtLocation,
+  transferStock,
+  enableLocationTracking,
+  disableLocationTracking,
+} from '@/utils/inventoryLocationsAccess';
+import type { InventoryLocation } from '@/types/inventoryLocations';
+
+const loc = (over: Partial<InventoryLocation> & { id: string }): InventoryLocation => ({
+  company_id: 'co1',
+  parent_id: null,
+  name: over.id,
+  kind: null,
+  code: null,
+  is_stockable: true,
+  is_qr_anchor: false,
+  sort_order: 0,
+  created_at: '',
+  updated_at: '',
+  ...over,
+});
+
+const queueFrom = (...results: Array<{ data: unknown; error: unknown }>) => {
+  state.fromQueue.push(...results);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.fromQueue = [];
+  state.rpc = { data: null, error: null };
+});
+
+// ---------------------------------------------------------------------------
+describe('buildLocationTree (pure)', () => {
+  it('nests children under parents and assigns depth', () => {
+    const flat = [
+      loc({ id: 'cab', name: 'Cabinet 1' }),
+      loc({ id: 'row3', name: 'Row 3', parent_id: 'cab' }),
+      loc({ id: 'left', name: 'Left', parent_id: 'row3' }),
+      loc({ id: 'cab2', name: 'Cabinet 2' }),
+    ];
+    const tree = buildLocationTree(flat);
+    expect(tree.map((n) => n.id).sort()).toEqual(['cab', 'cab2']);
+    const cab = tree.find((n) => n.id === 'cab')!;
+    expect(cab.depth).toBe(0);
+    expect(cab.children[0].id).toBe('row3');
+    expect(cab.children[0].depth).toBe(1);
+    expect(cab.children[0].children[0].id).toBe('left');
+    expect(cab.children[0].children[0].depth).toBe(2);
+  });
+
+  it('treats a node whose parent is absent as a root', () => {
+    const tree = buildLocationTree([loc({ id: 'orphan', parent_id: 'missing' })]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].id).toBe('orphan');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('buildLocationUrl', () => {
+  it('encodes the location UUID against the operator login route', () => {
+    expect(buildLocationUrl('co1', 'loc-abc')).toContain('/operator/co1/login?location=loc-abc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('createLocation', () => {
+  it('rejects a blank name without querying', async () => {
+    await expect(createLocation('co1', { name: '  ' })).rejects.toThrow(/name is required/i);
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+
+  it('inserts a trimmed, company-scoped row (no parent → no parent check)', async () => {
+    queueFrom({ data: loc({ id: 'new', name: 'Cabinet 1' }), error: null });
+    const created = await createLocation('co1', { name: '  Cabinet 1 ', kind: 'cabinet' });
+    expect(created.id).toBe('new');
+    const builder = mockSupabase.from.mock.results[0].value as Record<string, ReturnType<typeof vi.fn>>;
+    expect(builder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ company_id: 'co1', name: 'Cabinet 1', kind: 'cabinet', parent_id: null }),
+    );
+  });
+
+  it('rejects a parent from another company', async () => {
+    queueFrom({ data: loc({ id: 'p', company_id: 'OTHER' }), error: null });
+    await expect(createLocation('co1', { name: 'X', parent_id: 'p' })).rejects.toThrow(/same company/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('moveLocation', () => {
+  it('rejects moving a node beneath its own descendant (cycle)', async () => {
+    // parent check: getLocation('child') returns same-company node
+    queueFrom({ data: loc({ id: 'child', parent_id: 'node' }), error: null });
+    // getLocations(company) for the ancestor walk: node → child → node
+    queueFrom({
+      data: [loc({ id: 'node' }), loc({ id: 'child', parent_id: 'node' })],
+      error: null,
+    });
+    await expect(moveLocation('node', 'child', 'co1')).rejects.toThrow(/beneath one of its own/i);
+  });
+
+  it('rejects making a node its own parent', async () => {
+    await expect(moveLocation('node', 'node', 'co1')).rejects.toThrow(/its own parent/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('deleteLocation', () => {
+  it('refuses when sub-locations exist', async () => {
+    queueFrom({ data: null, error: null }); // child count query (count read below)
+    queueFrom({ data: null, error: null }); // balance count query
+    // counts come back via the `count` field; emulate by patching the builders:
+    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      select: () => ({ eq: () => ({ count: 2, error: null, then: (r: (v: unknown) => unknown) => r({ count: 2, error: null }) }) }),
+    }));
+    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      select: () => ({ eq: () => ({ count: 0, error: null, then: (r: (v: unknown) => unknown) => r({ count: 0, error: null }) }) }),
+    }));
+    await expect(deleteLocation('node')).rejects.toThrow(/sub-locations/i);
+  });
+
+  it('refuses when stock balances exist', async () => {
+    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      select: () => ({ eq: () => ({ then: (r: (v: unknown) => unknown) => r({ count: 0, error: null }) }) }),
+    }));
+    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      select: () => ({ eq: () => ({ then: (r: (v: unknown) => unknown) => r({ count: 3, error: null }) }) }),
+    }));
+    await expect(deleteLocation('node')).rejects.toThrow(/still holds stock/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('getBalancesForPart', () => {
+  it('joins each balance to its location and computes the full path', async () => {
+    queueFrom({
+      data: [{ company_id: 'co1', location_id: 'left', quantity: 7 }],
+      error: null,
+    });
+    queueFrom({
+      data: [
+        loc({ id: 'cab', name: 'Cabinet 1' }),
+        loc({ id: 'row3', name: 'Row 3', parent_id: 'cab' }),
+        loc({ id: 'left', name: 'Left', parent_id: 'row3' }),
+      ],
+      error: null,
+    });
+    const balances = await getBalancesForPart('part1');
+    expect(balances).toHaveLength(1);
+    expect(balances[0].quantity).toBe(7);
+    expect(balances[0].path).toEqual(['Cabinet 1', 'Row 3', 'Left']);
+  });
+
+  it('returns empty when the part has no balances', async () => {
+    queueFrom({ data: [], error: null });
+    expect(await getBalancesForPart('part1')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('RPC wrappers', () => {
+  // For each: first from() is loadConversionContext (parts row), then rpc().
+  const partCtx = (over: Record<string, unknown> = {}) => ({
+    data: { primary_unit: 'ft', parts_unit_conversions: [], ...over },
+    error: null,
+  });
+
+  it('addStockAtLocation passes through quantity when unit === primary', async () => {
+    queueFrom(partCtx());
+    state.rpc = { data: { location_balance: 12, part_quantity: 12 }, error: null };
+    const res = await addStockAtLocation('part1', 'loc1', 12, 'ft', 'received');
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('add_stock_at_location', {
+      p_part_id: 'part1',
+      p_location_id: 'loc1',
+      p_quantity: 12,
+      p_unit: 'ft',
+      p_converted_quantity: 12,
+      p_notes: 'received',
+    });
+    expect(res.part_quantity).toBe(12);
+  });
+
+  it('addStockAtLocation applies a custom unit conversion to the converted quantity', async () => {
+    queueFrom(partCtx({ parts_unit_conversions: [{ from_unit: 'in', to_primary_factor: 1 / 12 }] }));
+    state.rpc = { data: { location_balance: 2, part_quantity: 2 }, error: null };
+    await addStockAtLocation('part1', 'loc1', 24, 'in');
+    expect(mockSupabase.rpc).toHaveBeenCalledWith(
+      'add_stock_at_location',
+      expect.objectContaining({ p_quantity: 24, p_unit: 'in', p_converted_quantity: 2 }),
+    );
+  });
+
+  it('depleteStockAtLocation forwards graceful flag, job tag, and discrepancy result', async () => {
+    queueFrom(partCtx());
+    state.rpc = { data: { location_balance: 0, part_quantity: 0, has_discrepancy: true, shortfall: 3 }, error: null };
+    const res = await depleteStockAtLocation('part1', 'loc1', 8, 'ft', {
+      graceful: true,
+      jobId: 'job1',
+      jobOperationId: 'op1',
+      operatorId: 'opr1',
+      notes: 'used',
+    });
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('deplete_stock_at_location', {
+      p_part_id: 'part1',
+      p_location_id: 'loc1',
+      p_quantity: 8,
+      p_unit: 'ft',
+      p_converted_quantity: 8,
+      p_graceful: true,
+      p_notes: 'used',
+      p_job_id: 'job1',
+      p_job_operation_id: 'op1',
+      p_operator_id: 'opr1',
+    });
+    expect(res.has_discrepancy).toBe(true);
+    expect(res.shortfall).toBe(3);
+  });
+
+  it('adjustStockAtLocation calls adjust with the new converted quantity', async () => {
+    queueFrom(partCtx());
+    state.rpc = { data: { location_balance: 5, part_quantity: 5 }, error: null };
+    await adjustStockAtLocation('part1', 'loc1', 5, 'ft', 'cycle count');
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('adjust_stock_at_location', {
+      p_part_id: 'part1',
+      p_location_id: 'loc1',
+      p_new_quantity: 5,
+      p_unit: 'ft',
+      p_converted_new_quantity: 5,
+      p_notes: 'cycle count',
+    });
+  });
+
+  it('transferStock calls transfer with from/to and returns the group id', async () => {
+    queueFrom(partCtx());
+    state.rpc = { data: { transfer_group_id: 'grp1', from_balance: 2, to_balance: 5 }, error: null };
+    const res = await transferStock('part1', 'from1', 'to1', 3, 'ft');
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('transfer_stock', {
+      p_part_id: 'part1',
+      p_from_location_id: 'from1',
+      p_to_location_id: 'to1',
+      p_quantity: 3,
+      p_unit: 'ft',
+      p_converted_quantity: 3,
+      p_notes: undefined,
+    });
+    expect(res.transfer_group_id).toBe('grp1');
+  });
+
+  it('enableLocationTracking calls the opt-in RPC with the optional initial location', async () => {
+    state.rpc = { data: { location_id: 'unassigned', part_quantity: 100, tracked: true }, error: null };
+    const res = await enableLocationTracking('part1', 'loc1');
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('enable_location_tracking', {
+      p_part_id: 'part1',
+      p_initial_location_id: 'loc1',
+    });
+    expect(res.tracked).toBe(true);
+  });
+
+  it('disableLocationTracking calls the opt-out RPC', async () => {
+    state.rpc = { data: { part_quantity: 100, tracked: false }, error: null };
+    const res = await disableLocationTracking('part1');
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('disable_location_tracking', { p_part_id: 'part1' });
+    expect(res.tracked).toBe(false);
+  });
+
+  it('propagates an RPC error (e.g. the DB tenancy guard rejecting cross-company ids)', async () => {
+    queueFrom(partCtx());
+    state.rpc = { data: null, error: { message: 'access denied to company X' } };
+    await expect(addStockAtLocation('part1', 'loc1', 1, 'ft')).rejects.toBeDefined();
+  });
+});

--- a/__tests__/utils/inventoryLocationsAccess.test.ts
+++ b/__tests__/utils/inventoryLocationsAccess.test.ts
@@ -156,26 +156,19 @@ describe('moveLocation', () => {
 
 // ---------------------------------------------------------------------------
 describe('deleteLocation', () => {
-  it('refuses when sub-locations exist', async () => {
-    queueFrom({ data: null, error: null }); // child count query (count read below)
-    queueFrom({ data: null, error: null }); // balance count query
-    // counts come back via the `count` field; emulate by patching the builders:
-    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
-      select: () => ({ eq: () => ({ count: 2, error: null, then: (r: (v: unknown) => unknown) => r({ count: 2, error: null }) }) }),
-    }));
-    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
-      select: () => ({ eq: () => ({ count: 0, error: null, then: (r: (v: unknown) => unknown) => r({ count: 0, error: null }) }) }),
-    }));
+  it('calls the delete_location RPC and resolves on success', async () => {
+    state.rpc = { data: null, error: null };
+    await expect(deleteLocation('node')).resolves.toBeUndefined();
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('delete_location', { p_location_id: 'node' });
+  });
+
+  it('maps the RPC sub-locations error to a friendly message', async () => {
+    state.rpc = { data: null, error: { message: 'location has sub-locations' } };
     await expect(deleteLocation('node')).rejects.toThrow(/sub-locations/i);
   });
 
-  it('refuses when stock balances exist', async () => {
-    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
-      select: () => ({ eq: () => ({ then: (r: (v: unknown) => unknown) => r({ count: 0, error: null }) }) }),
-    }));
-    (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
-      select: () => ({ eq: () => ({ then: (r: (v: unknown) => unknown) => r({ count: 3, error: null }) }) }),
-    }));
+  it('maps the RPC stock error to a friendly message', async () => {
+    state.rpc = { data: null, error: { message: 'location still holds stock' } };
     await expect(deleteLocation('node')).rejects.toThrow(/still holds stock/i);
   });
 });

--- a/__tests__/utils/inventoryLocationsAccess.test.ts
+++ b/__tests__/utils/inventoryLocationsAccess.test.ts
@@ -47,6 +47,7 @@ import {
   deleteLocation,
   moveLocation,
   materializeLocationSpec,
+  duplicateLocation,
   getBalancesForPart,
   addStockAtLocation,
   depleteStockAtLocation,
@@ -323,16 +324,12 @@ describe('materializeLocationSpec', () => {
         name: 'Cabinet 1',
         kind: 'cabinet',
         code: 'C01',
-        is_stockable: false,
-        is_qr_anchor: true,
         children: [
           {
             key: '0/0',
             name: 'Row 1',
             kind: 'row',
             code: 'C01-R01',
-            is_stockable: true,
-            is_qr_anchor: false,
             children: [],
           },
         ],
@@ -354,10 +351,41 @@ describe('materializeLocationSpec', () => {
         parent_id: null,
         name: 'Cabinet 1',
         code: 'C01',
-        is_qr_anchor: true,
-        is_stockable: false,
         sort_order: 0,
       }),
+    );
+  });
+});
+
+describe('duplicateLocation', () => {
+  it('deep-copies a subtree as a bumped sibling, codes re-derived, structure only', async () => {
+    // Existing: Cabinet 1 (C01) → Bin 1 (C01-B01)
+    queueFrom({
+      data: [
+        loc({ id: 'cab', name: 'Cabinet 1', kind: 'cabinet', code: 'C01' }),
+        loc({ id: 'b1', name: 'Bin 1', kind: 'bin', parent_id: 'cab', code: 'C01-B01' }),
+      ],
+      error: null,
+    });
+    // materialize → new cabinet insert (parent_id null, no parent check)
+    queueFrom({ data: loc({ id: 'cab2', name: 'Cabinet 2', code: 'C02' }), error: null });
+    // copied bin → assertParentInCompany('cab2') getLocation, then insert
+    queueFrom({ data: loc({ id: 'cab2', company_id: 'co1' }), error: null });
+    queueFrom({ data: loc({ id: 'b2', name: 'Bin 1', parent_id: 'cab2', code: 'C02-B01' }), error: null });
+
+    const created = await duplicateLocation('co1', 'cab');
+
+    expect(created.map((r) => r.id)).toEqual(['cab2', 'b2']);
+    // from() #0 = getLocations; #1 = new cabinet insert. sort_order lands AFTER
+    // the one existing sibling (sort_order 0), so the copy doesn't jump to front.
+    const cabInsert = mockSupabase.from.mock.results[1].value as Record<string, ReturnType<typeof vi.fn>>;
+    expect(cabInsert.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ parent_id: null, name: 'Cabinet 2', code: 'C02', sort_order: 1 }),
+    );
+    // #3 = copied bin insert, code re-derived under the new cabinet
+    const binInsert = mockSupabase.from.mock.results[3].value as Record<string, ReturnType<typeof vi.fn>>;
+    expect(binInsert.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ parent_id: 'cab2', name: 'Bin 1', code: 'C02-B01' }),
     );
   });
 });

--- a/__tests__/utils/inventoryLocationsAccess.test.ts
+++ b/__tests__/utils/inventoryLocationsAccess.test.ts
@@ -162,13 +162,8 @@ describe('deleteLocation', () => {
     expect(mockSupabase.rpc).toHaveBeenCalledWith('delete_location', { p_location_id: 'node' });
   });
 
-  it('maps the RPC sub-locations error to a friendly message', async () => {
-    state.rpc = { data: null, error: { message: 'location has sub-locations' } };
-    await expect(deleteLocation('node')).rejects.toThrow(/sub-locations/i);
-  });
-
-  it('maps the RPC stock error to a friendly message', async () => {
-    state.rpc = { data: null, error: { message: 'location still holds stock' } };
+  it('maps a stocked-subtree error to a friendly message', async () => {
+    state.rpc = { data: null, error: { message: 'location subtree still holds stock' } };
     await expect(deleteLocation('node')).rejects.toThrow(/still holds stock/i);
   });
 });

--- a/__tests__/utils/inventoryLocationsAccess.test.ts
+++ b/__tests__/utils/inventoryLocationsAccess.test.ts
@@ -46,6 +46,7 @@ import {
   createLocation,
   deleteLocation,
   moveLocation,
+  materializeLocationSpec,
   getBalancesForPart,
   addStockAtLocation,
   depleteStockAtLocation,
@@ -310,5 +311,53 @@ describe('RPC wrappers', () => {
     queueFrom(partCtx());
     state.rpc = { data: null, error: { message: 'access denied to company X' } };
     await expect(addStockAtLocation('part1', 'loc1', 1, 'ft')).rejects.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('materializeLocationSpec', () => {
+  it('recursively creates parent-then-child and returns every created row', async () => {
+    const spec = [
+      {
+        key: '0',
+        name: 'Cabinet 1',
+        kind: 'cabinet',
+        code: 'C01',
+        is_stockable: false,
+        is_qr_anchor: true,
+        children: [
+          {
+            key: '0/0',
+            name: 'Row 1',
+            kind: 'row',
+            code: 'C01-R01',
+            is_stockable: true,
+            is_qr_anchor: false,
+            children: [],
+          },
+        ],
+      },
+    ];
+    // createLocation(A): insert (no parent check, parent_id null)
+    queueFrom({ data: loc({ id: 'a', name: 'Cabinet 1', code: 'C01' }), error: null });
+    // createLocation(B): assertParentInCompany('a') -> getLocation, then insert
+    queueFrom({ data: loc({ id: 'a', company_id: 'co1' }), error: null });
+    queueFrom({ data: loc({ id: 'b', name: 'Row 1', parent_id: 'a', code: 'C01-R01' }), error: null });
+
+    const created = await materializeLocationSpec('co1', null, spec);
+
+    expect(created.map((r) => r.id)).toEqual(['a', 'b']);
+    // first from() is the cabinet insert; assert the payload carries the spec fields
+    const cabinetBuilder = mockSupabase.from.mock.results[0].value as Record<string, ReturnType<typeof vi.fn>>;
+    expect(cabinetBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parent_id: null,
+        name: 'Cabinet 1',
+        code: 'C01',
+        is_qr_anchor: true,
+        is_stockable: false,
+        sort_order: 0,
+      }),
+    );
   });
 });

--- a/__tests__/utils/locationLabelPdf.test.ts
+++ b/__tests__/utils/locationLabelPdf.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture jsPDF calls without parsing PDF bytes.
+const pdf = {
+  setFontSize: vi.fn(),
+  setTextColor: vi.fn(),
+  text: vi.fn(),
+  addImage: vi.fn(),
+  addPage: vi.fn(),
+  save: vi.fn(),
+  splitTextToSize: vi.fn((s: string) => [s]),
+  internal: { pageSize: { getWidth: () => 210, getHeight: () => 297 } },
+};
+vi.mock('jspdf', () => ({ jsPDF: function MockJsPdf() { return pdf; } }));
+
+const toDataURL = vi.fn(async () => 'data:image/png;base64,stub');
+vi.mock('qrcode', () => ({ default: { toDataURL: (...a: unknown[]) => toDataURL(...a) } }));
+
+import { generateLocationLabelSheet, buildLocationScanUrl } from '@/utils/locationLabelPdf';
+
+const label = (id: string, path: string[], code: string | null = null) => ({ id, path, code });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  pdf.splitTextToSize.mockImplementation((s: string) => [s]);
+});
+
+describe('buildLocationScanUrl', () => {
+  it('encodes the location UUID against the operator login route', () => {
+    expect(buildLocationScanUrl('http://x', 'co1', 'loc1')).toBe('http://x/operator/co1/login?location=loc1');
+  });
+});
+
+describe('generateLocationLabelSheet', () => {
+  it('renders one QR (level H) and image per label, with the path text', async () => {
+    await generateLocationLabelSheet({
+      companyId: 'co1',
+      baseUrl: 'http://x',
+      labels: [label('a', ['Cabinet 1', 'Row 3', 'Left'], 'CAB1-R3-L'), label('b', ['Cabinet 1', 'Row 3', 'Right'])],
+    });
+
+    expect(toDataURL).toHaveBeenCalledTimes(2);
+    // payload is the UUID deep-link, high error-correction
+    expect(toDataURL).toHaveBeenCalledWith(
+      'http://x/operator/co1/login?location=a',
+      expect.objectContaining({ errorCorrectionLevel: 'H' }),
+    );
+    expect(pdf.addImage).toHaveBeenCalledTimes(2);
+    // the human path is printed on the label
+    expect(pdf.text).toHaveBeenCalledWith(['Cabinet 1  ›  Row 3  ›  Left'], expect.any(Number), expect.any(Number));
+  });
+
+  it('paginates beyond 10 labels per page', async () => {
+    const labels = Array.from({ length: 11 }, (_, i) => label(`n${i}`, [`Bin ${i}`]));
+    await generateLocationLabelSheet({ companyId: 'co1', baseUrl: 'http://x', labels });
+    expect(pdf.addPage).toHaveBeenCalledTimes(1); // 10 on page 1, 11th forces a new page
+  });
+
+  it('continues when a single QR fails to render', async () => {
+    toDataURL.mockRejectedValueOnce(new Error('boom'));
+    await generateLocationLabelSheet({
+      companyId: 'co1',
+      baseUrl: 'http://x',
+      labels: [label('a', ['A']), label('b', ['B'])],
+    });
+    // first label's image is skipped, second still drawn
+    expect(pdf.addImage).toHaveBeenCalledTimes(1);
+    expect(pdf.text).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/utils/locationSpec.test.ts
+++ b/__tests__/utils/locationSpec.test.ts
@@ -5,7 +5,7 @@ import {
   removeSpecNode,
   addChildUnder,
   duplicateNode,
-  applyQrAnchorByDepth,
+  duplicateSubtreeAsSibling,
   generatedCode,
   explicitCode,
 } from '@/utils/locationSpec';
@@ -52,30 +52,14 @@ describe('buildSpecFromLevels', () => {
     expect(left.code).toBe('C01-R03-L');
   });
 
-  it('marks is_stockable ONLY on the deepest level (leaves)', () => {
-    const [cab1] = buildSpecFromLevels(cabinetsRowsSides);
-    expect(cab1.is_stockable).toBe(false); // cabinet
-    expect(cab1.children[0].is_stockable).toBe(false); // row
-    expect(cab1.children[0].children[0].is_stockable).toBe(true); // side (leaf)
-  });
-
-  it('defaults QR anchors to the top container level; honors qrAnchorDepth override', () => {
-    const [cabTop] = buildSpecFromLevels(cabinetsRowsSides);
-    expect(cabTop.is_qr_anchor).toBe(true); // depth 0 default
-    expect(cabTop.children[0].is_qr_anchor).toBe(false);
-
-    const [cabDeep] = buildSpecFromLevels(cabinetsRowsSides, { qrAnchorDepth: 2 });
-    expect(cabDeep.is_qr_anchor).toBe(false);
-    expect(cabDeep.children[0].children[0].is_qr_anchor).toBe(true); // leaves
-  });
-
-  it('a 2-level spec makes the middle level the leaves', () => {
+  it('a 2-level spec nests the second level under the first', () => {
     const roots = buildSpecFromLevels([
       { kind: 'cabinet', count: 1, namePattern: 'Cabinet {n}' },
       { kind: 'shelf', count: 5, namePattern: 'Shelf {n}' },
     ]);
     expect(countSpecNodes(roots)).toBe(6); // 1 + 5
-    expect(roots[0].children[0].is_stockable).toBe(true); // shelves are leaves now
+    expect(roots[0].children).toHaveLength(5);
+    expect(roots[0].children[0].name).toBe('Shelf 1');
   });
 
   it('zero-pads to a uniform width across the level', () => {
@@ -173,10 +157,30 @@ describe('non-uniform editing', () => {
     expect(next[0].children[1].children).toHaveLength(4);
   });
 
-  it('applyQrAnchorByDepth re-stamps anchors to a chosen depth', () => {
-    const roots = applyQrAnchorByDepth(buildSpecFromLevels(cabinetSidesBins), 2);
-    expect(roots[0].is_qr_anchor).toBe(false); // cabinet
-    expect(roots[0].children[0].is_qr_anchor).toBe(false); // side
-    expect(roots[0].children[0].children[0].is_qr_anchor).toBe(true); // bin (depth 2)
+  it('duplicateSubtreeAsSibling names past EXISTING db siblings and re-derives codes', () => {
+    // One DB cabinet "Cabinet 1" (C01) with 2 bins; duplicate it as a sibling.
+    const [root] = buildSpecFromLevels([
+      { kind: 'cabinet', count: 1, namePattern: 'Cabinet {n}' },
+      { kind: 'bin', count: 2, namePattern: 'Bin {n}' },
+    ]);
+    // Existing siblings in the DB are ["Cabinet 1", "Cabinet 2"] (a gap-free run),
+    // so the copy must land on "Cabinet 3" — not collide with the existing 2.
+    const clone = duplicateSubtreeAsSibling(root, null, ['Cabinet 1', 'Cabinet 2']);
+    expect(clone.name).toBe('Cabinet 3');
+    expect(clone.code).toBe('C03');
+    expect(clone.children.map((b) => b.code)).toEqual(['C03-B01', 'C03-B02']);
+    expect(clone.key).not.toBe(root.key); // fresh keys
+  });
+
+  it('duplicateSubtreeAsSibling re-derives nested codes under a parent code', () => {
+    const [root] = buildSpecFromLevels([
+      { kind: 'row', count: 1, namePattern: 'Row {n}' },
+      { kind: 'side', names: ['Left', 'Right'] },
+    ]);
+    // Duplicating "Row 1" under parent "C01" with one existing sibling.
+    const clone = duplicateSubtreeAsSibling(root, 'C01', ['Row 1']);
+    expect(clone.name).toBe('Row 2');
+    expect(clone.code).toBe('C01-R02');
+    expect(clone.children.map((s) => s.code)).toEqual(['C01-R02-L', 'C01-R02-R']);
   });
 });

--- a/__tests__/utils/locationSpec.test.ts
+++ b/__tests__/utils/locationSpec.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSpecFromLevels,
+  countSpecNodes,
+  removeSpecNode,
+  generatedCode,
+  explicitCode,
+} from '@/utils/locationSpec';
+import type { LevelSpec } from '@/types/inventoryLocations';
+
+const cabinetsRowsSides: LevelSpec[] = [
+  { kind: 'cabinet', count: 3, namePattern: 'Cabinet {n}' },
+  { kind: 'row', count: 10, namePattern: 'Row {n}' },
+  { kind: 'side', names: ['Left', 'Right'] },
+];
+
+describe('code helpers (parity with bulkGenerateChildren)', () => {
+  it('generatedCode: parent prefix + kind initial + zero-padded index', () => {
+    expect(generatedCode(null, 'cabinet', 1, 2)).toBe('C01');
+    expect(generatedCode('C01', 'row', 3, 2)).toBe('C01-R03');
+    expect(generatedCode('C01', 'row', 12, 2)).toBe('C01-R12');
+  });
+  it('explicitCode: parent prefix + first-letter uppercase', () => {
+    expect(explicitCode('C01-R03', 'Left')).toBe('C01-R03-L');
+    expect(explicitCode(null, 'Zone')).toBe('Z');
+  });
+});
+
+describe('buildSpecFromLevels', () => {
+  it('builds the full nested forest with the right node count', () => {
+    const roots = buildSpecFromLevels(cabinetsRowsSides);
+    expect(roots).toHaveLength(3);
+    // 3 cabinets + 3*10 rows + 3*10*2 sides = 3 + 30 + 60 = 93
+    expect(countSpecNodes(roots)).toBe(93);
+  });
+
+  it('names, kinds and codes match the manual scheme at every level', () => {
+    const [cab1] = buildSpecFromLevels(cabinetsRowsSides);
+    expect(cab1.name).toBe('Cabinet 1');
+    expect(cab1.kind).toBe('cabinet');
+    expect(cab1.code).toBe('C01');
+
+    const row3 = cab1.children[2];
+    expect(row3.name).toBe('Row 3');
+    expect(row3.code).toBe('C01-R03');
+
+    const left = row3.children[0];
+    expect(left.name).toBe('Left');
+    expect(left.code).toBe('C01-R03-L');
+  });
+
+  it('marks is_stockable ONLY on the deepest level (leaves)', () => {
+    const [cab1] = buildSpecFromLevels(cabinetsRowsSides);
+    expect(cab1.is_stockable).toBe(false); // cabinet
+    expect(cab1.children[0].is_stockable).toBe(false); // row
+    expect(cab1.children[0].children[0].is_stockable).toBe(true); // side (leaf)
+  });
+
+  it('defaults QR anchors to the top container level; honors qrAnchorDepth override', () => {
+    const [cabTop] = buildSpecFromLevels(cabinetsRowsSides);
+    expect(cabTop.is_qr_anchor).toBe(true); // depth 0 default
+    expect(cabTop.children[0].is_qr_anchor).toBe(false);
+
+    const [cabDeep] = buildSpecFromLevels(cabinetsRowsSides, { qrAnchorDepth: 2 });
+    expect(cabDeep.is_qr_anchor).toBe(false);
+    expect(cabDeep.children[0].children[0].is_qr_anchor).toBe(true); // leaves
+  });
+
+  it('a 2-level spec makes the middle level the leaves', () => {
+    const roots = buildSpecFromLevels([
+      { kind: 'cabinet', count: 1, namePattern: 'Cabinet {n}' },
+      { kind: 'shelf', count: 5, namePattern: 'Shelf {n}' },
+    ]);
+    expect(countSpecNodes(roots)).toBe(6); // 1 + 5
+    expect(roots[0].children[0].is_stockable).toBe(true); // shelves are leaves now
+  });
+
+  it('zero-pads to a uniform width across the level', () => {
+    const roots = buildSpecFromLevels([{ kind: 'bin', count: 12, namePattern: 'Bin {n}' }]);
+    expect(roots[0].code).toBe('B01');
+    expect(roots[11].code).toBe('B12');
+  });
+
+  it('keys are deterministic and unique', () => {
+    const roots = buildSpecFromLevels(cabinetsRowsSides);
+    const keys = new Set<string>();
+    const walk = (n: { key: string; children: { key: string; children: never[] }[] }) => {
+      keys.add(n.key);
+      n.children.forEach((c) => walk(c as never));
+    };
+    roots.forEach((r) => walk(r as never));
+    expect(keys.size).toBe(93);
+    expect(roots[0].key).toBe('0');
+    expect(roots[0].children[0].key).toBe('0/0');
+  });
+});
+
+describe('removeSpecNode (prune)', () => {
+  it('removes a node and its subtree by key', () => {
+    const roots = buildSpecFromLevels(cabinetsRowsSides);
+    const row1Key = roots[0].children[0].key; // a row with 2 sides under it
+    const pruned = removeSpecNode(roots, row1Key);
+    // removed 1 row + its 2 sides = 3 fewer
+    expect(countSpecNodes(pruned)).toBe(93 - 3);
+    expect(pruned[0].children.find((c) => c.key === row1Key)).toBeUndefined();
+  });
+});

--- a/__tests__/utils/locationSpec.test.ts
+++ b/__tests__/utils/locationSpec.test.ts
@@ -4,6 +4,7 @@ import {
   countSpecNodes,
   removeSpecNode,
   addChildUnder,
+  duplicateNode,
   applyQrAnchorByDepth,
   generatedCode,
   explicitCode,
@@ -146,6 +147,30 @@ describe('non-uniform editing', () => {
     // Right is the last section → a new section cloned with 4 bins under it
     expect(next[0].children).toHaveLength(3);
     expect(next[0].children[2].children).toHaveLength(4);
+  });
+
+  it('duplicateNode clones a top-level entry as the next sibling (Cabinet 1 → Cabinet 2)', () => {
+    const roots = buildSpecFromLevels([
+      { kind: 'cabinet', count: 1, namePattern: 'Cabinet {n}' },
+      { kind: 'bin', count: 2, namePattern: 'Bin {n}' },
+    ]);
+    const next = duplicateNode(roots, roots[0].key);
+
+    expect(next.map((c) => c.name)).toEqual(['Cabinet 1', 'Cabinet 2']);
+    expect(next[1].code).toBe('C02');
+    expect(next[1].children.map((b) => b.name)).toEqual(['Bin 1', 'Bin 2']);
+    expect(next[1].children[0].code).toBe('C02-B01'); // re-coded under the new cabinet
+    expect(next[1].key).not.toBe(next[0].key); // fresh keys
+    expect(countSpecNodes(next)).toBe(6); // 2 cabinets × (1 + 2)
+  });
+
+  it('duplicateNode works on a nested branch too', () => {
+    const roots = buildSpecFromLevels(cabinetSidesBins); // cabinet → {Left,Right} → 4 bins
+    const left = roots[0].children[0];
+    const next = duplicateNode(roots, left.key);
+    // Left duplicated → a sibling "Left 2" with its 4 bins; Right untouched
+    expect(next[0].children.map((s) => s.name)).toEqual(['Left', 'Left 2', 'Right']);
+    expect(next[0].children[1].children).toHaveLength(4);
   });
 
   it('applyQrAnchorByDepth re-stamps anchors to a chosen depth', () => {

--- a/__tests__/utils/locationSpec.test.ts
+++ b/__tests__/utils/locationSpec.test.ts
@@ -3,6 +3,8 @@ import {
   buildSpecFromLevels,
   countSpecNodes,
   removeSpecNode,
+  addChildUnder,
+  applyQrAnchorByDepth,
   generatedCode,
   explicitCode,
 } from '@/utils/locationSpec';
@@ -103,5 +105,53 @@ describe('removeSpecNode (prune)', () => {
     // removed 1 row + its 2 sides = 3 fewer
     expect(countSpecNodes(pruned)).toBe(93 - 3);
     expect(pruned[0].children.find((c) => c.key === row1Key)).toBeUndefined();
+  });
+});
+
+// Non-uniform editing: Cabinet → {Left, Right} → 4 bins each (uniform start).
+const cabinetSidesBins: LevelSpec[] = [
+  { kind: 'cabinet', count: 1, namePattern: 'Cabinet {n}' },
+  { kind: 'side', names: ['Left', 'Right'] },
+  { kind: 'bin', count: 4, namePattern: 'Bin {n}' },
+];
+
+describe('non-uniform editing', () => {
+  it('removeSpecNode leaves ONE branch shorter (the gap case)', () => {
+    const roots = buildSpecFromLevels(cabinetSidesBins);
+    const [, right] = roots[0].children; // Left, Right
+    const rightBin3 = right.children[2]; // "Bin 3" under Right
+    const next = removeSpecNode(roots, rightBin3.key);
+
+    const [left2, right2] = next[0].children;
+    expect(left2.children.map((b) => b.name)).toEqual(['Bin 1', 'Bin 2', 'Bin 3', 'Bin 4']);
+    expect(right2.children.map((b) => b.name)).toEqual(['Bin 1', 'Bin 2', 'Bin 4']); // gap kept
+    expect(countSpecNodes(next)).toBe(1 + 2 + 4 + 3);
+  });
+
+  it('addChildUnder adds to that branch only, bumping the trailing number', () => {
+    const roots = buildSpecFromLevels(cabinetSidesBins);
+    const left = roots[0].children[0];
+    const next = addChildUnder(roots, left.key);
+
+    const [left2, right2] = next[0].children;
+    expect(left2.children.map((b) => b.name)).toEqual(['Bin 1', 'Bin 2', 'Bin 3', 'Bin 4', 'Bin 5']);
+    expect(left2.children[4].code).toBe('C01-L-B05'); // parent code + kind + padded index
+    expect(right2.children).toHaveLength(4); // untouched
+  });
+
+  it('addChildUnder on a container clones its last section (with its bins)', () => {
+    const roots = buildSpecFromLevels(cabinetSidesBins);
+    const cabinet = roots[0];
+    const next = addChildUnder(roots, cabinet.key);
+    // Right is the last section → a new section cloned with 4 bins under it
+    expect(next[0].children).toHaveLength(3);
+    expect(next[0].children[2].children).toHaveLength(4);
+  });
+
+  it('applyQrAnchorByDepth re-stamps anchors to a chosen depth', () => {
+    const roots = applyQrAnchorByDepth(buildSpecFromLevels(cabinetSidesBins), 2);
+    expect(roots[0].is_qr_anchor).toBe(false); // cabinet
+    expect(roots[0].children[0].is_qr_anchor).toBe(false); // side
+    expect(roots[0].children[0].children[0].is_qr_anchor).toBe(true); // bin (depth 2)
   });
 });

--- a/__tests__/utils/partsAccess.test.ts
+++ b/__tests__/utils/partsAccess.test.ts
@@ -97,6 +97,7 @@ describe('partsAccess utilities', () => {
     reorder_point: null,
     preferred_vendor_id: null,
     legacy_id: null,
+    is_location_tracked: false,
     created_at: '2024-01-01T00:00:00Z',
     updated_at: '2024-01-01T00:00:00Z',
   };
@@ -563,6 +564,7 @@ describe('partsAccess utilities', () => {
         reorder_point: null,
         preferred_vendor_id: null,
         legacy_id: null,
+        is_location_tracked: false,
         created_at: '2024-01-01T00:00:00Z',
         updated_at: '2024-01-01T00:00:00Z',
       };

--- a/app/dashboard/[companyId]/inventory/locations/page.tsx
+++ b/app/dashboard/[companyId]/inventory/locations/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+
+import { usePageTitle } from '@/components/layout/PageTitleProvider';
+import LocationsManager from '@/components/inventory/locations/LocationsManager';
+
+export default function InventoryLocationsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const companyId = params.companyId as string;
+  const { setTitle } = usePageTitle();
+
+  useEffect(() => {
+    setTitle('Inventory Locations');
+    return () => setTitle(null);
+  }, [setTitle]);
+
+  return (
+    <Box>
+      <Button
+        startIcon={<ArrowBackIcon />}
+        onClick={() => router.push(`/dashboard/${companyId}/inventory`)}
+        sx={{ mb: 2 }}
+      >
+        Back to Inventory
+      </Button>
+      <LocationsManager companyId={companyId} />
+    </Box>
+  );
+}

--- a/app/dashboard/[companyId]/inventory/locations/page.tsx
+++ b/app/dashboard/[companyId]/inventory/locations/page.tsx
@@ -4,9 +4,11 @@ import { useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 import { usePageTitle } from '@/components/layout/PageTitleProvider';
+import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 import LocationsManager from '@/components/inventory/locations/LocationsManager';
 
 export default function InventoryLocationsPage() {
@@ -14,11 +16,28 @@ export default function InventoryLocationsPage() {
   const router = useRouter();
   const companyId = params.companyId as string;
   const { setTitle } = usePageTitle();
+  const { features, loading } = useCompanyFeatures();
+  const enabled = features.inventory_locations;
 
   useEffect(() => {
     setTitle('Inventory Locations');
     return () => setTitle(null);
   }, [setTitle]);
+
+  // Feature-flagged: bounce companies that haven't opted in back to Inventory.
+  useEffect(() => {
+    if (!loading && !enabled) {
+      router.replace(`/dashboard/${companyId}/inventory`);
+    }
+  }, [loading, enabled, router, companyId]);
+
+  if (loading || !enabled) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
 
   return (
     <Box>

--- a/app/dashboard/[companyId]/inventory/page.tsx
+++ b/app/dashboard/[companyId]/inventory/page.tsx
@@ -26,6 +26,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import Inventory2Icon from '@mui/icons-material/Inventory2';
 import UploadIcon from '@mui/icons-material/Upload';
 import WarehouseOutlinedIcon from '@mui/icons-material/WarehouseOutlined';
+import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 
 import { AgGridReact } from 'ag-grid-react';
 import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
@@ -69,6 +70,7 @@ export default function InventoryPage() {
   const router = useRouter();
   const params = useParams();
   const companyId = params.companyId as string;
+  const { features } = useCompanyFeatures();
 
   const [rows, setRows] = useState<InventoryRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -390,13 +392,15 @@ export default function InventoryPage() {
 
         <Box sx={{ flex: 1 }} />
 
-        <Button
-          variant="outlined"
-          startIcon={<WarehouseOutlinedIcon />}
-          onClick={() => router.push(`/dashboard/${companyId}/inventory/locations`)}
-        >
-          Locations
-        </Button>
+        {features.inventory_locations && (
+          <Button
+            variant="outlined"
+            startIcon={<WarehouseOutlinedIcon />}
+            onClick={() => router.push(`/dashboard/${companyId}/inventory/locations`)}
+          >
+            Locations
+          </Button>
+        )}
 
         <Button
           variant="outlined"

--- a/app/dashboard/[companyId]/inventory/page.tsx
+++ b/app/dashboard/[companyId]/inventory/page.tsx
@@ -25,6 +25,7 @@ import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import Inventory2Icon from '@mui/icons-material/Inventory2';
 import UploadIcon from '@mui/icons-material/Upload';
+import WarehouseOutlinedIcon from '@mui/icons-material/WarehouseOutlined';
 
 import { AgGridReact } from 'ag-grid-react';
 import { ModuleRegistry, AllCommunityModule } from 'ag-grid-community';
@@ -388,6 +389,14 @@ export default function InventoryPage() {
         )}
 
         <Box sx={{ flex: 1 }} />
+
+        <Button
+          variant="outlined"
+          startIcon={<WarehouseOutlinedIcon />}
+          onClick={() => router.push(`/dashboard/${companyId}/inventory/locations`)}
+        >
+          Locations
+        </Button>
 
         <Button
           variant="outlined"

--- a/components/inventory/locations/BulkGenerateModal.tsx
+++ b/components/inventory/locations/BulkGenerateModal.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Alert from '@mui/material/Alert';
+import Typography from '@mui/material/Typography';
+
+import type { BulkGenerateSpec } from '@/types/inventoryLocations';
+
+interface BulkGenerateModalProps {
+  open: boolean;
+  parentPath: string[];
+  onClose: () => void;
+  onSubmit: (spec: BulkGenerateSpec) => Promise<void>;
+}
+
+/** Bulk-generate repetitive structure, e.g. 10 rows × {Left, Right}. */
+export default function BulkGenerateModal({ open, parentPath, onClose, onSubmit }: BulkGenerateModalProps) {
+  const [count, setCount] = useState('10');
+  const [kind, setKind] = useState('row');
+  const [namePattern, setNamePattern] = useState('Row {n}');
+  const [leaves, setLeaves] = useState('Left, Right');
+  const [leafKind, setLeafKind] = useState('side');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setCount('10');
+    setKind('row');
+    setNamePattern('Row {n}');
+    setLeaves('Left, Right');
+    setLeafKind('side');
+    setError(null);
+  }, [open]);
+
+  const leafList = useMemo(
+    () => leaves.split(',').map((s) => s.trim()).filter(Boolean),
+    [leaves],
+  );
+  const n = Math.max(0, parseInt(count, 10) || 0);
+  const total = n * (leafList.length > 0 ? 1 + leafList.length : 1);
+
+  const handleSubmit = async () => {
+    if (n <= 0) {
+      setError('Count must be at least 1.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await onSubmit({
+        count: n,
+        kind: kind.trim() || undefined,
+        namePattern: namePattern.trim() || '{n}',
+        leaves: leafList.length > 0 ? leafList : undefined,
+        leafKind: leafKind.trim() || undefined,
+      });
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to generate locations.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Bulk-generate sub-locations</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Alert severity="info" sx={{ py: 0 }}>
+            Under <strong>{parentPath.join(' › ') || '(root)'}</strong>
+          </Alert>
+          <TextField
+            label="How many"
+            type="number"
+            value={count}
+            onChange={(e) => setCount(e.target.value)}
+            inputProps={{ min: 1 }}
+            fullWidth
+          />
+          <TextField
+            label="Name pattern"
+            value={namePattern}
+            onChange={(e) => setNamePattern(e.target.value)}
+            helperText="{n} is replaced with the number, e.g. “Row {n}”."
+            fullWidth
+          />
+          <TextField label="Kind" value={kind} onChange={(e) => setKind(e.target.value)} fullWidth />
+          <TextField
+            label="Leaves per node (optional)"
+            value={leaves}
+            onChange={(e) => setLeaves(e.target.value)}
+            helperText="Comma-separated, e.g. “Left, Right”. Leave blank for none."
+            fullWidth
+          />
+          {leafList.length > 0 && (
+            <TextField label="Leaf kind" value={leafKind} onChange={(e) => setLeafKind(e.target.value)} fullWidth />
+          )}
+          <Typography variant="body2" color="text.secondary">
+            Will create <strong>{total}</strong> location{total === 1 ? '' : 's'}
+            {leafList.length > 0
+              ? ` (${n} × ${kind || 'node'} + ${leafList.length} leaves each)`
+              : ''}
+            .
+          </Typography>
+          {error && <Alert severity="error">{error}</Alert>}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={saving || total === 0}>
+          Generate
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/inventory/locations/BulkGenerateModal.tsx
+++ b/components/inventory/locations/BulkGenerateModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -30,15 +30,14 @@ export default function BulkGenerateModal({ open, parentPath, onClose, onSubmit 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!open) return;
+  const handleEnter = () => {
     setCount('10');
     setKind('row');
     setNamePattern('Row {n}');
     setLeaves('Left, Right');
     setLeafKind('side');
     setError(null);
-  }, [open]);
+  };
 
   const leafList = useMemo(
     () => leaves.split(',').map((s) => s.trim()).filter(Boolean),
@@ -71,7 +70,13 @@ export default function BulkGenerateModal({ open, parentPath, onClose, onSubmit 
   };
 
   return (
-    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="xs" fullWidth>
+    <Dialog
+      open={open}
+      onClose={saving ? undefined : onClose}
+      maxWidth="xs"
+      fullWidth
+      TransitionProps={{ onEnter: handleEnter }}
+    >
       <DialogTitle>Bulk-generate sub-locations</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>

--- a/components/inventory/locations/LocationFormModal.tsx
+++ b/components/inventory/locations/LocationFormModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -50,15 +50,16 @@ export default function LocationFormModal({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!open) return;
+  // Reset form when the dialog opens (codebase convention: Dialog onEnter,
+  // not a setState-in-effect).
+  const handleEnter = () => {
     setName(location?.name ?? '');
     setKind(location?.kind ?? null);
     setCode(location?.code ?? '');
     setIsStockable(location?.is_stockable ?? true);
     setIsQrAnchor(location?.is_qr_anchor ?? false);
     setError(null);
-  }, [open, location]);
+  };
 
   const handleSubmit = async () => {
     if (!name.trim()) {
@@ -84,7 +85,13 @@ export default function LocationFormModal({
   };
 
   return (
-    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="xs" fullWidth>
+    <Dialog
+      open={open}
+      onClose={saving ? undefined : onClose}
+      maxWidth="xs"
+      fullWidth
+      TransitionProps={{ onEnter: handleEnter }}
+    >
       <DialogTitle>{location ? 'Edit location' : 'New location'}</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>

--- a/components/inventory/locations/LocationFormModal.tsx
+++ b/components/inventory/locations/LocationFormModal.tsx
@@ -9,8 +9,6 @@ import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import Autocomplete from '@mui/material/Autocomplete';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Switch from '@mui/material/Switch';
 import Alert from '@mui/material/Alert';
 
 import type { InventoryLocation } from '@/types/inventoryLocations';
@@ -21,8 +19,6 @@ export interface LocationFormValues {
   name: string;
   kind: string | null;
   code: string | null;
-  is_stockable: boolean;
-  is_qr_anchor: boolean;
 }
 
 interface LocationFormModalProps {
@@ -45,8 +41,6 @@ export default function LocationFormModal({
   const [name, setName] = useState('');
   const [kind, setKind] = useState<string | null>(null);
   const [code, setCode] = useState('');
-  const [isStockable, setIsStockable] = useState(true);
-  const [isQrAnchor, setIsQrAnchor] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -56,8 +50,6 @@ export default function LocationFormModal({
     setName(location?.name ?? '');
     setKind(location?.kind ?? null);
     setCode(location?.code ?? '');
-    setIsStockable(location?.is_stockable ?? true);
-    setIsQrAnchor(location?.is_qr_anchor ?? false);
     setError(null);
   };
 
@@ -73,8 +65,6 @@ export default function LocationFormModal({
         name: name.trim(),
         kind: kind?.trim() || null,
         code: code.trim() || null,
-        is_stockable: isStockable,
-        is_qr_anchor: isQrAnchor,
       });
       onClose();
     } catch (e) {
@@ -126,14 +116,6 @@ export default function LocationFormModal({
             placeholder="CAB1-R3-L"
             helperText="Printed on the label; the QR itself always encodes the location ID."
             fullWidth
-          />
-          <FormControlLabel
-            control={<Switch checked={isStockable} onChange={(e) => setIsStockable(e.target.checked)} />}
-            label="Can hold stock"
-          />
-          <FormControlLabel
-            control={<Switch checked={isQrAnchor} onChange={(e) => setIsQrAnchor(e.target.checked)} />}
-            label="QR anchor (print a scannable label here)"
           />
           {error && <Alert severity="error">{error}</Alert>}
         </Stack>

--- a/components/inventory/locations/LocationFormModal.tsx
+++ b/components/inventory/locations/LocationFormModal.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Autocomplete from '@mui/material/Autocomplete';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Switch from '@mui/material/Switch';
+import Alert from '@mui/material/Alert';
+
+import type { InventoryLocation } from '@/types/inventoryLocations';
+
+const KIND_SUGGESTIONS = ['cabinet', 'shelf', 'rack', 'row', 'drawer', 'side', 'bin', 'zone', 'aisle'];
+
+export interface LocationFormValues {
+  name: string;
+  kind: string | null;
+  code: string | null;
+  is_stockable: boolean;
+  is_qr_anchor: boolean;
+}
+
+interface LocationFormModalProps {
+  open: boolean;
+  /** Existing location when editing; null when creating. */
+  location: InventoryLocation | null;
+  /** Human path of the parent (for the "Adding under …" hint). */
+  parentPath?: string[];
+  onClose: () => void;
+  onSubmit: (values: LocationFormValues) => Promise<void>;
+}
+
+export default function LocationFormModal({
+  open,
+  location,
+  parentPath,
+  onClose,
+  onSubmit,
+}: LocationFormModalProps) {
+  const [name, setName] = useState('');
+  const [kind, setKind] = useState<string | null>(null);
+  const [code, setCode] = useState('');
+  const [isStockable, setIsStockable] = useState(true);
+  const [isQrAnchor, setIsQrAnchor] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setName(location?.name ?? '');
+    setKind(location?.kind ?? null);
+    setCode(location?.code ?? '');
+    setIsStockable(location?.is_stockable ?? true);
+    setIsQrAnchor(location?.is_qr_anchor ?? false);
+    setError(null);
+  }, [open, location]);
+
+  const handleSubmit = async () => {
+    if (!name.trim()) {
+      setError('Name is required.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await onSubmit({
+        name: name.trim(),
+        kind: kind?.trim() || null,
+        code: code.trim() || null,
+        is_stockable: isStockable,
+        is_qr_anchor: isQrAnchor,
+      });
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save location.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{location ? 'Edit location' : 'New location'}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          {parentPath && parentPath.length > 0 && (
+            <Alert severity="info" sx={{ py: 0 }}>
+              Adding under <strong>{parentPath.join(' › ')}</strong>
+            </Alert>
+          )}
+          <TextField
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Cabinet 1, Row 3, Left…"
+            autoFocus
+            fullWidth
+            required
+          />
+          <Autocomplete
+            freeSolo
+            options={KIND_SUGGESTIONS}
+            value={kind}
+            onChange={(_, v) => setKind(v)}
+            onInputChange={(_, v) => setKind(v)}
+            renderInput={(params) => (
+              <TextField {...params} label="Kind (optional)" placeholder="cabinet, row, bin…" />
+            )}
+          />
+          <TextField
+            label="Code (optional)"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            placeholder="CAB1-R3-L"
+            helperText="Printed on the label; the QR itself always encodes the location ID."
+            fullWidth
+          />
+          <FormControlLabel
+            control={<Switch checked={isStockable} onChange={(e) => setIsStockable(e.target.checked)} />}
+            label="Can hold stock"
+          />
+          <FormControlLabel
+            control={<Switch checked={isQrAnchor} onChange={(e) => setIsQrAnchor(e.target.checked)} />}
+            label="QR anchor (print a scannable label here)"
+          />
+          {error && <Alert severity="error">{error}</Alert>}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={saving}>
+          {location ? 'Save' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/inventory/locations/LocationQRModal.tsx
+++ b/components/inventory/locations/LocationQRModal.tsx
@@ -27,8 +27,8 @@ interface LocationQRModalProps {
   node: InventoryLocation | null;
   /** Full path of `node`, root → node. */
   path: string[];
-  /** Labels for every QR-anchor at/under `node` (incl. node if it is an anchor). */
-  anchorLabels: LocationLabel[];
+  /** Labels for `node` and every descendant (every location is printable). */
+  labels: LocationLabel[];
   onClose: () => void;
 }
 
@@ -38,7 +38,7 @@ export default function LocationQRModal({
   companyName,
   node,
   path,
-  anchorLabels,
+  labels,
   onClose,
 }: LocationQRModalProps) {
   const [busy, setBusy] = useState(false);
@@ -63,7 +63,7 @@ export default function LocationQRModal({
     }
   };
 
-  const subtreeAnchors = anchorLabels.length;
+  const subtreeCount = labels.length;
   const thisLabel: LocationLabel = { id: node.id, path, code: node.code };
 
   return (
@@ -94,12 +94,12 @@ export default function LocationQRModal({
               fullWidth
               variant="contained"
               startIcon={<PictureAsPdfIcon />}
-              onClick={() => download(anchorLabels, `${fileStem}-qr-anchors`)}
-              disabled={busy || subtreeAnchors === 0}
+              onClick={() => download(labels, `${fileStem}-labels`)}
+              disabled={busy || subtreeCount <= 1}
             >
-              {subtreeAnchors > 0
-                ? `Download sheet — ${subtreeAnchors} QR anchor${subtreeAnchors === 1 ? '' : 's'} below`
-                : 'No QR anchors below'}
+              {subtreeCount > 1
+                ? `Download sheet — ${subtreeCount} labels (this + below)`
+                : 'No sub-locations to print'}
             </Button>
           </Box>
           <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>

--- a/components/inventory/locations/LocationQRModal.tsx
+++ b/components/inventory/locations/LocationQRModal.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import { QRCodeCanvas } from 'qrcode.react';
+
+import type { InventoryLocation } from '@/types/inventoryLocations';
+import {
+  generateLocationLabelSheet,
+  buildLocationScanUrl,
+  type LocationLabel,
+} from '@/utils/locationLabelPdf';
+
+interface LocationQRModalProps {
+  open: boolean;
+  companyId: string;
+  companyName?: string;
+  node: InventoryLocation | null;
+  /** Full path of `node`, root → node. */
+  path: string[];
+  /** Labels for every QR-anchor at/under `node` (incl. node if it is an anchor). */
+  anchorLabels: LocationLabel[];
+  onClose: () => void;
+}
+
+export default function LocationQRModal({
+  open,
+  companyId,
+  companyName,
+  node,
+  path,
+  anchorLabels,
+  onClose,
+}: LocationQRModalProps) {
+  const [busy, setBusy] = useState(false);
+  if (!node) return null;
+
+  const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
+  const url = buildLocationScanUrl(baseUrl, companyId, node.id);
+  const fileStem = (node.code || node.name).replace(/\s+/g, '-');
+
+  const download = async (labels: LocationLabel[], stem: string) => {
+    setBusy(true);
+    try {
+      const doc = await generateLocationLabelSheet({
+        companyId,
+        baseUrl,
+        labels,
+        heading: companyName,
+      });
+      doc.save(`${stem}.pdf`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const subtreeAnchors = anchorLabels.length;
+  const thisLabel: LocationLabel = { id: node.id, path, code: node.code };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{path.join(' › ')}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} alignItems="center">
+          <Paper elevation={0} sx={{ p: 2, bgcolor: 'white', borderRadius: 2 }}>
+            <QRCodeCanvas value={url} size={200} level="H" includeMargin bgColor="#ffffff" fgColor="#000000" />
+          </Paper>
+          {node.code && (
+            <Typography variant="body2" color="text.secondary">
+              {node.code}
+            </Typography>
+          )}
+          <Box sx={{ width: '100%' }}>
+            <Button
+              fullWidth
+              variant="outlined"
+              startIcon={<PictureAsPdfIcon />}
+              onClick={() => download([thisLabel], `${fileStem}-label`)}
+              disabled={busy}
+              sx={{ mb: 1 }}
+            >
+              Download this label
+            </Button>
+            <Button
+              fullWidth
+              variant="contained"
+              startIcon={<PictureAsPdfIcon />}
+              onClick={() => download(anchorLabels, `${fileStem}-qr-anchors`)}
+              disabled={busy || subtreeAnchors === 0}
+            >
+              {subtreeAnchors > 0
+                ? `Download sheet — ${subtreeAnchors} QR anchor${subtreeAnchors === 1 ? '' : 's'} below`
+                : 'No QR anchors below'}
+            </Button>
+          </Box>
+          <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>
+            The QR encodes the location ID, so renaming or recoding never breaks a printed label.
+          </Typography>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/inventory/locations/LocationTreeView.tsx
+++ b/components/inventory/locations/LocationTreeView.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Typography from '@mui/material/Typography';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import QrCode2Icon from '@mui/icons-material/QrCode2';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import AddIcon from '@mui/icons-material/Add';
+import AutoAwesomeMotionIcon from '@mui/icons-material/AutoAwesomeMotion';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+
+import type { InventoryLocationNode } from '@/types/inventoryLocations';
+
+export interface LocationTreeCallbacks {
+  onAddChild: (node: InventoryLocationNode) => void;
+  onBulkGenerate: (node: InventoryLocationNode) => void;
+  onPrintQR: (node: InventoryLocationNode) => void;
+  onEdit: (node: InventoryLocationNode) => void;
+  onDelete: (node: InventoryLocationNode) => void;
+}
+
+function LocationRow({ node, cb }: { node: InventoryLocationNode; cb: LocationTreeCallbacks }) {
+  const [expanded, setExpanded] = useState(true);
+  const [menuEl, setMenuEl] = useState<null | HTMLElement>(null);
+  const hasChildren = node.children.length > 0;
+
+  const act = (fn: (n: InventoryLocationNode) => void) => () => {
+    setMenuEl(null);
+    fn(node);
+  };
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          minHeight: 48,
+          pl: node.depth * 3,
+          pr: 1,
+          borderRadius: 1,
+          '&:hover': { bgcolor: 'action.hover' },
+        }}
+      >
+        <IconButton
+          size="small"
+          onClick={() => setExpanded((e) => !e)}
+          sx={{ visibility: hasChildren ? 'visible' : 'hidden' }}
+          aria-label={expanded ? 'Collapse' : 'Expand'}
+        >
+          {expanded ? <KeyboardArrowDownIcon /> : <KeyboardArrowRightIcon />}
+        </IconButton>
+
+        <Typography sx={{ fontWeight: hasChildren ? 600 : 400 }}>{node.name}</Typography>
+
+        {node.code && <Chip size="small" label={node.code} variant="outlined" />}
+        {node.kind && (
+          <Typography variant="caption" color="text.secondary">
+            {node.kind}
+          </Typography>
+        )}
+        {node.is_qr_anchor && <QrCode2Icon fontSize="small" color="action" titleAccess="QR anchor" />}
+
+        <Box sx={{ flex: 1 }} />
+
+        <IconButton size="small" aria-label="Actions" onClick={(e) => setMenuEl(e.currentTarget)}>
+          <MoreVertIcon />
+        </IconButton>
+        <Menu anchorEl={menuEl} open={Boolean(menuEl)} onClose={() => setMenuEl(null)}>
+          <MenuItem onClick={act(cb.onAddChild)}>
+            <ListItemIcon><AddIcon fontSize="small" /></ListItemIcon>
+            <ListItemText>Add sub-location</ListItemText>
+          </MenuItem>
+          <MenuItem onClick={act(cb.onBulkGenerate)}>
+            <ListItemIcon><AutoAwesomeMotionIcon fontSize="small" /></ListItemIcon>
+            <ListItemText>Bulk-generate…</ListItemText>
+          </MenuItem>
+          <MenuItem onClick={act(cb.onPrintQR)}>
+            <ListItemIcon><QrCode2Icon fontSize="small" /></ListItemIcon>
+            <ListItemText>Print QR…</ListItemText>
+          </MenuItem>
+          <MenuItem onClick={act(cb.onEdit)}>
+            <ListItemIcon><EditIcon fontSize="small" /></ListItemIcon>
+            <ListItemText>Edit</ListItemText>
+          </MenuItem>
+          <MenuItem onClick={act(cb.onDelete)}>
+            <ListItemIcon><DeleteOutlineIcon fontSize="small" color="error" /></ListItemIcon>
+            <ListItemText sx={{ color: 'error.main' }}>Delete</ListItemText>
+          </MenuItem>
+        </Menu>
+      </Box>
+
+      {hasChildren && expanded && (
+        <Box>
+          {node.children.map((child) => (
+            <LocationRow key={child.id} node={child} cb={cb} />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export default function LocationTreeView({
+  nodes,
+  callbacks,
+}: {
+  nodes: InventoryLocationNode[];
+  callbacks: LocationTreeCallbacks;
+}) {
+  return (
+    <Box>
+      {nodes.map((node) => (
+        <LocationRow key={node.id} node={node} cb={callbacks} />
+      ))}
+    </Box>
+  );
+}

--- a/components/inventory/locations/LocationTreeView.tsx
+++ b/components/inventory/locations/LocationTreeView.tsx
@@ -15,6 +15,7 @@ import QrCode2Icon from '@mui/icons-material/QrCode2';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import AddIcon from '@mui/icons-material/Add';
 import AutoAwesomeMotionIcon from '@mui/icons-material/AutoAwesomeMotion';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 
@@ -24,6 +25,7 @@ export interface LocationTreeCallbacks {
   onAddChild: (node: InventoryLocationNode) => void;
   onBulkGenerate: (node: InventoryLocationNode) => void;
   onPrintQR: (node: InventoryLocationNode) => void;
+  onDuplicate: (node: InventoryLocationNode) => void;
   onEdit: (node: InventoryLocationNode) => void;
   onDelete: (node: InventoryLocationNode) => void;
 }
@@ -69,35 +71,45 @@ function LocationRow({ node, cb }: { node: InventoryLocationNode; cb: LocationTr
             {node.kind}
           </Typography>
         )}
-        {node.is_qr_anchor && <QrCode2Icon fontSize="small" color="action" titleAccess="QR anchor" />}
 
         <Box sx={{ flex: 1 }} />
 
-        <IconButton size="small" aria-label="Actions" onClick={(e) => setMenuEl(e.currentTarget)}>
-          <MoreVertIcon />
-        </IconButton>
-        <Menu anchorEl={menuEl} open={Boolean(menuEl)} onClose={() => setMenuEl(null)}>
-          <MenuItem onClick={act(cb.onAddChild)}>
-            <ListItemIcon><AddIcon fontSize="small" /></ListItemIcon>
-            <ListItemText>Add sub-location</ListItemText>
-          </MenuItem>
-          <MenuItem onClick={act(cb.onBulkGenerate)}>
-            <ListItemIcon><AutoAwesomeMotionIcon fontSize="small" /></ListItemIcon>
-            <ListItemText>Bulk-generate…</ListItemText>
-          </MenuItem>
-          <MenuItem onClick={act(cb.onPrintQR)}>
-            <ListItemIcon><QrCode2Icon fontSize="small" /></ListItemIcon>
-            <ListItemText>Print QR…</ListItemText>
-          </MenuItem>
-          <MenuItem onClick={act(cb.onEdit)}>
-            <ListItemIcon><EditIcon fontSize="small" /></ListItemIcon>
-            <ListItemText>Edit</ListItemText>
-          </MenuItem>
-          <MenuItem onClick={act(cb.onDelete)}>
-            <ListItemIcon><DeleteOutlineIcon fontSize="small" color="error" /></ListItemIcon>
-            <ListItemText sx={{ color: 'error.main' }}>Delete</ListItemText>
-          </MenuItem>
-        </Menu>
+        {/* The auto-managed system 'Unassigned' bucket has no manual actions —
+            renaming it would split the backfill bucket (the RPC resolves it by
+            name), and it can't be added under, duplicated, printed, or deleted. */}
+        {node.kind !== 'system' && (
+          <>
+            <IconButton size="small" aria-label="Actions" onClick={(e) => setMenuEl(e.currentTarget)}>
+              <MoreVertIcon />
+            </IconButton>
+            <Menu anchorEl={menuEl} open={Boolean(menuEl)} onClose={() => setMenuEl(null)}>
+              <MenuItem onClick={act(cb.onAddChild)}>
+                <ListItemIcon><AddIcon fontSize="small" /></ListItemIcon>
+                <ListItemText>Add sub-location</ListItemText>
+              </MenuItem>
+              <MenuItem onClick={act(cb.onBulkGenerate)}>
+                <ListItemIcon><AutoAwesomeMotionIcon fontSize="small" /></ListItemIcon>
+                <ListItemText>Bulk-generate…</ListItemText>
+              </MenuItem>
+              <MenuItem onClick={act(cb.onPrintQR)}>
+                <ListItemIcon><QrCode2Icon fontSize="small" /></ListItemIcon>
+                <ListItemText>Print QR…</ListItemText>
+              </MenuItem>
+              <MenuItem onClick={act(cb.onDuplicate)}>
+                <ListItemIcon><ContentCopyIcon fontSize="small" /></ListItemIcon>
+                <ListItemText>Duplicate</ListItemText>
+              </MenuItem>
+              <MenuItem onClick={act(cb.onEdit)}>
+                <ListItemIcon><EditIcon fontSize="small" /></ListItemIcon>
+                <ListItemText>Edit</ListItemText>
+              </MenuItem>
+              <MenuItem onClick={act(cb.onDelete)}>
+                <ListItemIcon><DeleteOutlineIcon fontSize="small" color="error" /></ListItemIcon>
+                <ListItemText sx={{ color: 'error.main' }}>Delete</ListItemText>
+              </MenuItem>
+            </Menu>
+          </>
+        )}
       </Box>
 
       {hasChildren && expanded && (

--- a/components/inventory/locations/LocationsManager.tsx
+++ b/components/inventory/locations/LocationsManager.tsx
@@ -29,6 +29,7 @@ import {
   createLocation,
   updateLocation,
   bulkGenerateChildren,
+  duplicateLocation,
   deleteLocation,
 } from '@/utils/inventoryLocationsAccess';
 import { generateLocationLabelSheet, type LocationLabel } from '@/utils/locationLabelPdf';
@@ -51,10 +52,13 @@ function computePath(id: string, byId: Map<string, InventoryLocation>): string[]
   return names;
 }
 
-function collectAnchorLabels(node: InventoryLocationNode, byId: Map<string, InventoryLocation>): LocationLabel[] {
+// Every real location is printable, so a label is collected for the node and
+// every descendant. The auto-managed system 'Unassigned' bucket is virtual (no
+// physical shelf), so it never gets a printed label.
+function collectLabels(node: InventoryLocationNode, byId: Map<string, InventoryLocation>): LocationLabel[] {
   const out: LocationLabel[] = [];
   const walk = (n: InventoryLocationNode) => {
-    if (n.is_qr_anchor) out.push({ id: n.id, path: computePath(n.id, byId), code: n.code });
+    if (n.kind !== 'system') out.push({ id: n.id, path: computePath(n.id, byId), code: n.code });
     n.children.forEach(walk);
   };
   walk(node);
@@ -90,8 +94,8 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
     open: boolean;
     node: InventoryLocation | null;
     path: string[];
-    anchorLabels: LocationLabel[];
-  }>({ open: false, node: null, path: [], anchorLabels: [] });
+    labels: LocationLabel[];
+  }>({ open: false, node: null, path: [], labels: [] });
 
   const [deleteState, setDeleteState] = useState<{ open: boolean; node: InventoryLocationNode | null }>({
     open: false,
@@ -100,7 +104,7 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
 
   const byId = useMemo(() => new Map(locations.map((l) => [l.id, l] as const)), [locations]);
   const tree = useMemo(() => buildLocationTree(locations), [locations]);
-  const allAnchors = useMemo(() => tree.flatMap((n) => collectAnchorLabels(n, byId)), [tree, byId]);
+  const allLabels = useMemo(() => tree.flatMap((n) => collectLabels(n, byId)), [tree, byId]);
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -130,8 +134,17 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
         open: true,
         node,
         path: computePath(node.id, byId),
-        anchorLabels: collectAnchorLabels(node, byId),
+        labels: collectLabels(node, byId),
       }),
+    onDuplicate: async (node: InventoryLocationNode) => {
+      try {
+        const created = await duplicateLocation(companyId, node.id);
+        await reload();
+        setToast(`Duplicated ${node.name} (${created.length} location${created.length === 1 ? '' : 's'}).`);
+      } catch (e) {
+        setToast(e instanceof Error ? e.message : 'Failed to duplicate location.');
+      }
+    },
     onDelete: (node: InventoryLocationNode) => setDeleteState({ open: true, node }),
   };
 
@@ -162,18 +175,18 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
     }
   };
 
-  const printAllAnchors = async () => {
-    if (allAnchors.length === 0) {
-      setToast('No QR anchors yet. Mark a location as a QR anchor first.');
+  const printAllLabels = async () => {
+    if (allLabels.length === 0) {
+      setToast('No locations to print yet.');
       return;
     }
     const doc = await generateLocationLabelSheet({
       companyId,
       baseUrl: window.location.origin,
-      labels: allAnchors,
+      labels: allLabels,
       heading: companyName,
     });
-    doc.save('inventory-qr-anchors.pdf');
+    doc.save('inventory-labels.pdf');
   };
 
   return (
@@ -184,10 +197,10 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
         <Button
           variant="outlined"
           startIcon={<QrCode2Icon />}
-          onClick={printAllAnchors}
-          disabled={loading || allAnchors.length === 0}
+          onClick={printAllLabels}
+          disabled={loading || allLabels.length === 0}
         >
-          Print all QR anchors
+          Print all labels
         </Button>
         <Button
           variant="outlined"
@@ -263,7 +276,7 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
         companyName={companyName}
         node={qrState.node}
         path={qrState.path}
-        anchorLabels={qrState.anchorLabels}
+        labels={qrState.labels}
         onClose={() => setQrState((s) => ({ ...s, open: false }))}
       />
       <VisualLocationBuilder

--- a/components/inventory/locations/LocationsManager.tsx
+++ b/components/inventory/locations/LocationsManager.tsx
@@ -252,8 +252,8 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
         <DialogTitle>Delete location?</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Delete <strong>{deleteState.node?.name}</strong>? This can&apos;t be undone. Locations with
-            sub-locations, stock, or transaction history can&apos;t be deleted.
+            Delete <strong>{deleteState.node?.name}</strong>? This can&apos;t be undone. A location with
+            sub-locations or stock on it can&apos;t be deleted, but past activity is kept in history.
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/components/inventory/locations/LocationsManager.tsx
+++ b/components/inventory/locations/LocationsManager.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CircularProgress from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+import Snackbar from '@mui/material/Snackbar';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import AddIcon from '@mui/icons-material/Add';
+import QrCode2Icon from '@mui/icons-material/QrCode2';
+
+import type {
+  BulkGenerateSpec,
+  InventoryLocation,
+  InventoryLocationNode,
+} from '@/types/inventoryLocations';
+import {
+  getLocations,
+  buildLocationTree,
+  createLocation,
+  updateLocation,
+  bulkGenerateChildren,
+  deleteLocation,
+} from '@/utils/inventoryLocationsAccess';
+import { generateLocationLabelSheet, type LocationLabel } from '@/utils/locationLabelPdf';
+import LocationTreeView from './LocationTreeView';
+import LocationFormModal, { type LocationFormValues } from './LocationFormModal';
+import BulkGenerateModal from './BulkGenerateModal';
+import LocationQRModal from './LocationQRModal';
+
+function computePath(id: string, byId: Map<string, InventoryLocation>): string[] {
+  const names: string[] = [];
+  let cursor: string | null = id;
+  const guard = new Set<string>();
+  while (cursor && byId.has(cursor) && !guard.has(cursor)) {
+    guard.add(cursor);
+    const node: InventoryLocation = byId.get(cursor)!;
+    names.unshift(node.name);
+    cursor = node.parent_id;
+  }
+  return names;
+}
+
+function collectAnchorLabels(node: InventoryLocationNode, byId: Map<string, InventoryLocation>): LocationLabel[] {
+  const out: LocationLabel[] = [];
+  const walk = (n: InventoryLocationNode) => {
+    if (n.is_qr_anchor) out.push({ id: n.id, path: computePath(n.id, byId), code: n.code });
+    n.children.forEach(walk);
+  };
+  walk(node);
+  return out;
+}
+
+interface LocationsManagerProps {
+  companyId: string;
+  companyName?: string;
+}
+
+export default function LocationsManager({ companyId, companyName }: LocationsManagerProps) {
+  const [locations, setLocations] = useState<InventoryLocation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const [formState, setFormState] = useState<{
+    open: boolean;
+    location: InventoryLocation | null;
+    parentId: string | null;
+    parentPath: string[];
+  }>({ open: false, location: null, parentId: null, parentPath: [] });
+
+  const [bulkState, setBulkState] = useState<{ open: boolean; parentId: string; parentPath: string[] }>({
+    open: false,
+    parentId: '',
+    parentPath: [],
+  });
+
+  const [qrState, setQrState] = useState<{
+    open: boolean;
+    node: InventoryLocation | null;
+    path: string[];
+    anchorLabels: LocationLabel[];
+  }>({ open: false, node: null, path: [], anchorLabels: [] });
+
+  const [deleteState, setDeleteState] = useState<{ open: boolean; node: InventoryLocationNode | null }>({
+    open: false,
+    node: null,
+  });
+
+  const byId = useMemo(() => new Map(locations.map((l) => [l.id, l] as const)), [locations]);
+  const tree = useMemo(() => buildLocationTree(locations), [locations]);
+  const allAnchors = useMemo(() => tree.flatMap((n) => collectAnchorLabels(n, byId)), [tree, byId]);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setLocations(await getLocations(companyId));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load locations.');
+    } finally {
+      setLoading(false);
+    }
+  }, [companyId]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const callbacks = {
+    onAddChild: (node: InventoryLocationNode) =>
+      setFormState({ open: true, location: null, parentId: node.id, parentPath: computePath(node.id, byId) }),
+    onEdit: (node: InventoryLocationNode) =>
+      setFormState({ open: true, location: node, parentId: node.parent_id, parentPath: [] }),
+    onBulkGenerate: (node: InventoryLocationNode) =>
+      setBulkState({ open: true, parentId: node.id, parentPath: computePath(node.id, byId) }),
+    onPrintQR: (node: InventoryLocationNode) =>
+      setQrState({
+        open: true,
+        node,
+        path: computePath(node.id, byId),
+        anchorLabels: collectAnchorLabels(node, byId),
+      }),
+    onDelete: (node: InventoryLocationNode) => setDeleteState({ open: true, node }),
+  };
+
+  const submitForm = async (values: LocationFormValues) => {
+    if (formState.location) {
+      await updateLocation(formState.location.id, values);
+    } else {
+      await createLocation(companyId, { ...values, parent_id: formState.parentId });
+    }
+    await reload();
+  };
+
+  const submitBulk = async (spec: BulkGenerateSpec) => {
+    const created = await bulkGenerateChildren(companyId, bulkState.parentId, spec);
+    await reload();
+    setToast(`Created ${created.length} locations.`);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteState.node) return;
+    try {
+      await deleteLocation(deleteState.node.id);
+      setDeleteState({ open: false, node: null });
+      await reload();
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : 'Failed to delete location.');
+      setDeleteState({ open: false, node: null });
+    }
+  };
+
+  const printAllAnchors = async () => {
+    if (allAnchors.length === 0) {
+      setToast('No QR anchors yet. Mark a location as a QR anchor first.');
+      return;
+    }
+    const doc = await generateLocationLabelSheet({
+      companyId,
+      baseUrl: window.location.origin,
+      labels: allAnchors,
+      heading: companyName,
+    });
+    doc.save('inventory-qr-anchors.pdf');
+  };
+
+  return (
+    <Box>
+      {/* Toolbar */}
+      <Box sx={{ display: 'flex', gap: 2, mb: 3, flexWrap: 'wrap', alignItems: 'center' }}>
+        <Box sx={{ flex: 1 }} />
+        <Button
+          variant="outlined"
+          startIcon={<QrCode2Icon />}
+          onClick={printAllAnchors}
+          disabled={loading || allAnchors.length === 0}
+        >
+          Print all QR anchors
+        </Button>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => setFormState({ open: true, location: null, parentId: null, parentPath: [] })}
+        >
+          New top-level location
+        </Button>
+      </Box>
+
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : tree.length === 0 ? (
+        <Card elevation={2}>
+          <CardContent sx={{ textAlign: 'center', py: 6 }}>
+            <Typography color="text.secondary" sx={{ mb: 2 }}>
+              No storage locations yet. Build your shelving, cabinets, and bins here, then print QR
+              labels to scan from the shop floor.
+            </Typography>
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={() => setFormState({ open: true, location: null, parentId: null, parentPath: [] })}
+            >
+              New top-level location
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card elevation={2}>
+          <CardContent>
+            <LocationTreeView nodes={tree} callbacks={callbacks} />
+          </CardContent>
+        </Card>
+      )}
+
+      <LocationFormModal
+        open={formState.open}
+        location={formState.location}
+        parentPath={formState.location ? undefined : formState.parentPath}
+        onClose={() => setFormState((s) => ({ ...s, open: false }))}
+        onSubmit={submitForm}
+      />
+      <BulkGenerateModal
+        open={bulkState.open}
+        parentPath={bulkState.parentPath}
+        onClose={() => setBulkState((s) => ({ ...s, open: false }))}
+        onSubmit={submitBulk}
+      />
+      <LocationQRModal
+        open={qrState.open}
+        companyId={companyId}
+        companyName={companyName}
+        node={qrState.node}
+        path={qrState.path}
+        anchorLabels={qrState.anchorLabels}
+        onClose={() => setQrState((s) => ({ ...s, open: false }))}
+      />
+
+      <Dialog open={deleteState.open} onClose={() => setDeleteState({ open: false, node: null })}>
+        <DialogTitle>Delete location?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Delete <strong>{deleteState.node?.name}</strong>? This can&apos;t be undone. Locations with
+            sub-locations, stock, or transaction history can&apos;t be deleted.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteState({ open: false, node: null })}>Cancel</Button>
+          <Button onClick={confirmDelete} color="error" variant="contained">
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={Boolean(toast)}
+        autoHideDuration={5000}
+        onClose={() => setToast(null)}
+        message={toast}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      />
+    </Box>
+  );
+}

--- a/components/inventory/locations/LocationsManager.tsx
+++ b/components/inventory/locations/LocationsManager.tsx
@@ -16,6 +16,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogActions from '@mui/material/DialogActions';
 import AddIcon from '@mui/icons-material/Add';
 import QrCode2Icon from '@mui/icons-material/QrCode2';
+import AutoAwesomeMosaicOutlinedIcon from '@mui/icons-material/AutoAwesomeMosaicOutlined';
 
 import type {
   BulkGenerateSpec,
@@ -35,6 +36,7 @@ import LocationTreeView from './LocationTreeView';
 import LocationFormModal, { type LocationFormValues } from './LocationFormModal';
 import BulkGenerateModal from './BulkGenerateModal';
 import LocationQRModal from './LocationQRModal';
+import VisualLocationBuilder from './builder/VisualLocationBuilder';
 
 function computePath(id: string, byId: Map<string, InventoryLocation>): string[] {
   const names: string[] = [];
@@ -69,6 +71,7 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
+  const [builderOpen, setBuilderOpen] = useState(false);
 
   const [formState, setFormState] = useState<{
     open: boolean;
@@ -187,11 +190,18 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
           Print all QR anchors
         </Button>
         <Button
-          variant="contained"
+          variant="outlined"
           startIcon={<AddIcon />}
           onClick={() => setFormState({ open: true, location: null, parentId: null, parentPath: [] })}
         >
           New top-level location
+        </Button>
+        <Button
+          variant="contained"
+          startIcon={<AutoAwesomeMosaicOutlinedIcon />}
+          onClick={() => setBuilderOpen(true)}
+        >
+          Build visually
         </Button>
       </Box>
 
@@ -205,16 +215,25 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
         <Card elevation={2}>
           <CardContent sx={{ textAlign: 'center', py: 6 }}>
             <Typography color="text.secondary" sx={{ mb: 2 }}>
-              No storage locations yet. Build your shelving, cabinets, and bins here, then print QR
-              labels to scan from the shop floor.
+              No storage locations yet. Build your cabinets, shelving, and bins visually in a couple of
+              taps, then print QR labels to scan from the shop floor.
             </Typography>
-            <Button
-              variant="contained"
-              startIcon={<AddIcon />}
-              onClick={() => setFormState({ open: true, location: null, parentId: null, parentPath: [] })}
-            >
-              New top-level location
-            </Button>
+            <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center', flexWrap: 'wrap' }}>
+              <Button
+                variant="contained"
+                startIcon={<AutoAwesomeMosaicOutlinedIcon />}
+                onClick={() => setBuilderOpen(true)}
+              >
+                Build visually
+              </Button>
+              <Button
+                variant="text"
+                startIcon={<AddIcon />}
+                onClick={() => setFormState({ open: true, location: null, parentId: null, parentPath: [] })}
+              >
+                Add manually
+              </Button>
+            </Box>
           </CardContent>
         </Card>
       ) : (
@@ -246,6 +265,15 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
         path={qrState.path}
         anchorLabels={qrState.anchorLabels}
         onClose={() => setQrState((s) => ({ ...s, open: false }))}
+      />
+      <VisualLocationBuilder
+        open={builderOpen}
+        companyId={companyId}
+        onClose={() => setBuilderOpen(false)}
+        onCreated={(n) => {
+          void reload();
+          setToast(`Created ${n} location${n === 1 ? '' : 's'}.`);
+        }}
       />
 
       <Dialog open={deleteState.open} onClose={() => setDeleteState({ open: false, node: null })}>

--- a/components/inventory/locations/LocationsManager.tsx
+++ b/components/inventory/locations/LocationsManager.tsx
@@ -252,8 +252,9 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
         <DialogTitle>Delete location?</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Delete <strong>{deleteState.node?.name}</strong>? This can&apos;t be undone. A location with
-            sub-locations or stock on it can&apos;t be deleted, but past activity is kept in history.
+            Delete <strong>{deleteState.node?.name}</strong> and everything empty inside it? This
+            can&apos;t be undone. A location can&apos;t be deleted while it (or something inside it)
+            holds stock, but past activity is kept in history.
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/components/inventory/locations/builder/LevelConfigStep.tsx
+++ b/components/inventory/locations/builder/LevelConfigStep.tsx
@@ -10,16 +10,36 @@ import IconButton from '@mui/material/IconButton';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 
 import type { LevelSpec } from '@/types/inventoryLocations';
 
 const MAX_LEVELS = 4;
 
+const stripPattern = (p?: string) => (p ?? '').replace(/\s*\{n\}\s*/g, ' ').trim();
+const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+/** The friendly word for this level (no "{n}" jargon). */
+function labelOf(level: LevelSpec): string {
+  return level.names ? capitalize(level.kind) : stripPattern(level.namePattern);
+}
+
+/** A live example of the names this level will produce. */
+function exampleOf(level: LevelSpec): string {
+  if (level.names) return level.names.join(', ') || '—';
+  const count = level.count ?? 0;
+  if (count === 0) return 'none';
+  const pattern = level.namePattern || '{n}';
+  const shown = Array.from({ length: Math.min(3, count) }, (_, i) =>
+    pattern.replace('{n}', String(i + 1)),
+  );
+  return shown.join(', ') + (count > 3 ? ', …' : '');
+}
+
 interface LevelConfigStepProps {
   levels: LevelSpec[];
   onChange: (levels: LevelSpec[]) => void;
-  /** Live total node count for the "will create N" hint. */
   total: number;
 }
 
@@ -27,33 +47,46 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
   const update = (i: number, patch: Partial<LevelSpec>) =>
     onChange(levels.map((l, idx) => (idx === i ? { ...l, ...patch } : l)));
 
+  const setLabel = (i: number, label: string) => {
+    const kind = label.trim().toLowerCase() || 'level';
+    if (levels[i].names) update(i, { kind });
+    else update(i, { kind, namePattern: label.trim() ? `${label.trim()} {n}` : '{n}' });
+  };
+
+  const setCount = (i: number, count: number) => update(i, { count: Math.max(0, count) });
+
   const setMode = (i: number, mode: 'count' | 'names') => {
+    const label = labelOf(levels[i]) || 'Bin';
     if (mode === 'names') {
       update(i, { names: levels[i].names ?? ['Left', 'Right'], count: undefined, namePattern: undefined });
     } else {
-      update(i, { count: levels[i].count ?? 4, namePattern: levels[i].namePattern ?? 'Item {n}', names: undefined });
+      update(i, {
+        count: levels[i].count ?? 4,
+        namePattern: `${label} {n}`,
+        names: undefined,
+      });
     }
   };
 
   const removeLevel = (i: number) => onChange(levels.filter((_, idx) => idx !== i));
-  const addLevel = () =>
-    onChange([...levels, { kind: 'bin', count: 2, namePattern: 'Bin {n}' }]);
+  const addLevel = () => onChange([...levels, { kind: 'bin', count: 4, namePattern: 'Bin {n}' }]);
 
   return (
     <Box>
-      <Typography variant="body1" sx={{ mb: 2 }}>
-        How is it divided up? Each level nests inside the one above. The deepest level holds the stock.
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Each level nests inside the one above. The deepest level holds the stock.
       </Typography>
 
       <Stack spacing={2}>
         {levels.map((level, i) => {
           const mode: 'count' | 'names' = level.names ? 'names' : 'count';
+          const deepest = i === levels.length - 1;
           return (
             <Paper key={i} variant="outlined" sx={{ p: 2 }}>
               <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
                 <Typography variant="subtitle2" color="text.secondary" sx={{ flex: 1 }}>
                   Level {i + 1}
-                  {i === levels.length - 1 ? ' · holds stock' : ''}
+                  {deepest ? ' · holds stock' : ''}
                 </Typography>
                 {levels.length > 1 && (
                   <IconButton size="small" aria-label="Remove level" onClick={() => removeLevel(i)}>
@@ -64,42 +97,49 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
 
               <Stack spacing={1.5}>
                 <TextField
-                  label="Kind"
-                  value={level.kind}
-                  onChange={(e) => update(i, { kind: e.target.value })}
+                  label="Call them"
+                  value={labelOf(level)}
+                  onChange={(e) => setLabel(i, e.target.value)}
+                  placeholder="Cabinet, Row, Bin…"
                   size="small"
                   fullWidth
                 />
 
-                <ToggleButtonGroup
-                  exclusive
-                  size="small"
-                  value={mode}
-                  onChange={(_, v) => v && setMode(i, v)}
-                >
-                  <ToggleButton value="count">By count</ToggleButton>
-                  <ToggleButton value="names">By names</ToggleButton>
+                <ToggleButtonGroup exclusive size="small" value={mode} onChange={(_, v) => v && setMode(i, v)}>
+                  <ToggleButton value="count" sx={{ textTransform: 'none' }}>
+                    A set number
+                  </ToggleButton>
+                  <ToggleButton value="names" sx={{ textTransform: 'none' }}>
+                    Specific names
+                  </ToggleButton>
                 </ToggleButtonGroup>
 
                 {mode === 'count' ? (
-                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+                  <Stack direction="row" alignItems="center" spacing={1}>
+                    <Typography variant="body2" color="text.secondary">
+                      How many?
+                    </Typography>
+                    <IconButton
+                      size="small"
+                      aria-label="Fewer"
+                      onClick={() => setCount(i, (level.count ?? 0) - 1)}
+                    >
+                      <RemoveIcon fontSize="small" />
+                    </IconButton>
                     <TextField
-                      label="How many"
-                      type="number"
                       value={level.count ?? 0}
-                      onChange={(e) => update(i, { count: Math.max(0, parseInt(e.target.value, 10) || 0) })}
+                      onChange={(e) => setCount(i, parseInt(e.target.value, 10) || 0)}
+                      type="number"
                       size="small"
-                      inputProps={{ min: 0 }}
-                      sx={{ width: { xs: '100%', sm: 140 } }}
+                      inputProps={{ min: 0, style: { textAlign: 'center', width: 56 } }}
                     />
-                    <TextField
-                      label="Name pattern"
-                      value={level.namePattern ?? '{n}'}
-                      onChange={(e) => update(i, { namePattern: e.target.value })}
-                      helperText="{n} = the number"
+                    <IconButton
                       size="small"
-                      fullWidth
-                    />
+                      aria-label="More"
+                      onClick={() => setCount(i, (level.count ?? 0) + 1)}
+                    >
+                      <AddIcon fontSize="small" />
+                    </IconButton>
                   </Stack>
                 ) : (
                   <TextField
@@ -113,6 +153,10 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
                     fullWidth
                   />
                 )}
+
+                <Typography variant="caption" color="text.secondary">
+                  → {exampleOf(level)}
+                </Typography>
               </Stack>
             </Paper>
           );
@@ -120,16 +164,12 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
       </Stack>
 
       <Stack direction="row" alignItems="center" sx={{ mt: 2 }}>
-        <Button
-          startIcon={<AddIcon />}
-          onClick={addLevel}
-          disabled={levels.length >= MAX_LEVELS}
-        >
+        <Button startIcon={<AddIcon />} onClick={addLevel} disabled={levels.length >= MAX_LEVELS}>
           Add a deeper level
         </Button>
         <Box sx={{ flex: 1 }} />
         <Typography variant="body2" color="text.secondary">
-          Will create <strong>{total}</strong> location{total === 1 ? '' : 's'}
+          <strong>{total}</strong> location{total === 1 ? '' : 's'}
         </Typography>
       </Stack>
     </Box>

--- a/components/inventory/locations/builder/LevelConfigStep.tsx
+++ b/components/inventory/locations/builder/LevelConfigStep.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+
+import type { LevelSpec } from '@/types/inventoryLocations';
+
+const MAX_LEVELS = 4;
+
+interface LevelConfigStepProps {
+  levels: LevelSpec[];
+  onChange: (levels: LevelSpec[]) => void;
+  /** Live total node count for the "will create N" hint. */
+  total: number;
+}
+
+export default function LevelConfigStep({ levels, onChange, total }: LevelConfigStepProps) {
+  const update = (i: number, patch: Partial<LevelSpec>) =>
+    onChange(levels.map((l, idx) => (idx === i ? { ...l, ...patch } : l)));
+
+  const setMode = (i: number, mode: 'count' | 'names') => {
+    if (mode === 'names') {
+      update(i, { names: levels[i].names ?? ['Left', 'Right'], count: undefined, namePattern: undefined });
+    } else {
+      update(i, { count: levels[i].count ?? 4, namePattern: levels[i].namePattern ?? 'Item {n}', names: undefined });
+    }
+  };
+
+  const removeLevel = (i: number) => onChange(levels.filter((_, idx) => idx !== i));
+  const addLevel = () =>
+    onChange([...levels, { kind: 'bin', count: 2, namePattern: 'Bin {n}' }]);
+
+  return (
+    <Box>
+      <Typography variant="body1" sx={{ mb: 2 }}>
+        How is it divided up? Each level nests inside the one above. The deepest level holds the stock.
+      </Typography>
+
+      <Stack spacing={2}>
+        {levels.map((level, i) => {
+          const mode: 'count' | 'names' = level.names ? 'names' : 'count';
+          return (
+            <Paper key={i} variant="outlined" sx={{ p: 2 }}>
+              <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
+                <Typography variant="subtitle2" color="text.secondary" sx={{ flex: 1 }}>
+                  Level {i + 1}
+                  {i === levels.length - 1 ? ' · holds stock' : ''}
+                </Typography>
+                {levels.length > 1 && (
+                  <IconButton size="small" aria-label="Remove level" onClick={() => removeLevel(i)}>
+                    <DeleteOutlineIcon fontSize="small" />
+                  </IconButton>
+                )}
+              </Stack>
+
+              <Stack spacing={1.5}>
+                <TextField
+                  label="Kind"
+                  value={level.kind}
+                  onChange={(e) => update(i, { kind: e.target.value })}
+                  size="small"
+                  fullWidth
+                />
+
+                <ToggleButtonGroup
+                  exclusive
+                  size="small"
+                  value={mode}
+                  onChange={(_, v) => v && setMode(i, v)}
+                >
+                  <ToggleButton value="count">By count</ToggleButton>
+                  <ToggleButton value="names">By names</ToggleButton>
+                </ToggleButtonGroup>
+
+                {mode === 'count' ? (
+                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+                    <TextField
+                      label="How many"
+                      type="number"
+                      value={level.count ?? 0}
+                      onChange={(e) => update(i, { count: Math.max(0, parseInt(e.target.value, 10) || 0) })}
+                      size="small"
+                      inputProps={{ min: 0 }}
+                      sx={{ width: { xs: '100%', sm: 140 } }}
+                    />
+                    <TextField
+                      label="Name pattern"
+                      value={level.namePattern ?? '{n}'}
+                      onChange={(e) => update(i, { namePattern: e.target.value })}
+                      helperText="{n} = the number"
+                      size="small"
+                      fullWidth
+                    />
+                  </Stack>
+                ) : (
+                  <TextField
+                    label="Names"
+                    value={(level.names ?? []).join(', ')}
+                    onChange={(e) =>
+                      update(i, { names: e.target.value.split(',').map((s) => s.trim()).filter(Boolean) })
+                    }
+                    helperText="Comma-separated, e.g. Left, Right"
+                    size="small"
+                    fullWidth
+                  />
+                )}
+              </Stack>
+            </Paper>
+          );
+        })}
+      </Stack>
+
+      <Stack direction="row" alignItems="center" sx={{ mt: 2 }}>
+        <Button
+          startIcon={<AddIcon />}
+          onClick={addLevel}
+          disabled={levels.length >= MAX_LEVELS}
+        >
+          Add a deeper level
+        </Button>
+        <Box sx={{ flex: 1 }} />
+        <Typography variant="body2" color="text.secondary">
+          Will create <strong>{total}</strong> location{total === 1 ? '' : 's'}
+        </Typography>
+      </Stack>
+    </Box>
+  );
+}

--- a/components/inventory/locations/builder/LevelConfigStep.tsx
+++ b/components/inventory/locations/builder/LevelConfigStep.tsx
@@ -16,6 +16,7 @@ import RemoveIcon from '@mui/icons-material/Remove';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import ReplayIcon from '@mui/icons-material/Replay';
 import TuneIcon from '@mui/icons-material/Tune';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
 import type { LevelSpec, LocationSpecNode } from '@/types/inventoryLocations';
 
@@ -63,6 +64,7 @@ interface LevelConfigStepProps {
   onCustomize: () => void;
   onRemove: (key: string) => void;
   onAdd: (parentKey: string) => void;
+  onDuplicate: (key: string) => void;
   onStartOver: () => void;
 }
 
@@ -75,6 +77,7 @@ export default function LevelConfigStep({
   onCustomize,
   onRemove,
   onAdd,
+  onDuplicate,
   onStartOver,
 }: LevelConfigStepProps) {
   // ----- Customized: reflect the real per-branch structure as editable chips ---
@@ -93,6 +96,36 @@ export default function LevelConfigStep({
         >
           Fine-tuning individual spots. Branches can differ now.
         </Alert>
+
+        {/* Top-level entries: duplicate one to make another like it, or remove it. */}
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+            Top-level
+          </Typography>
+          <Stack spacing={0.5}>
+            {tree.map((container) => (
+              <Stack key={container.key} direction="row" alignItems="center" spacing={0.5}>
+                <Typography variant="body2" sx={{ flex: 1, minWidth: 0 }} noWrap>
+                  {container.name}
+                </Typography>
+                <IconButton
+                  size="small"
+                  aria-label={`Duplicate ${container.name}`}
+                  onClick={() => onDuplicate(container.key)}
+                >
+                  <ContentCopyIcon fontSize="small" />
+                </IconButton>
+                <IconButton
+                  size="small"
+                  aria-label={`Remove ${container.name}`}
+                  onClick={() => onRemove(container.key)}
+                >
+                  <DeleteOutlineIcon fontSize="small" />
+                </IconButton>
+              </Stack>
+            ))}
+          </Stack>
+        </Box>
 
         {leafParents.length === 0 ? (
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>

--- a/components/inventory/locations/builder/LevelConfigStep.tsx
+++ b/components/inventory/locations/builder/LevelConfigStep.tsx
@@ -7,43 +7,135 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
+import Chip from '@mui/material/Chip';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Alert from '@mui/material/Alert';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import ReplayIcon from '@mui/icons-material/Replay';
 
-import type { LevelSpec } from '@/types/inventoryLocations';
+import type { LevelSpec, LocationSpecNode } from '@/types/inventoryLocations';
 
 const MAX_LEVELS = 4;
 
 const stripPattern = (p?: string) => (p ?? '').replace(/\s*\{n\}\s*/g, ' ').trim();
 const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
 
-/** The friendly word for this level (no "{n}" jargon). */
 function labelOf(level: LevelSpec): string {
   return level.names ? capitalize(level.kind) : stripPattern(level.namePattern);
 }
 
-/** A live example of the names this level will produce. */
 function exampleOf(level: LevelSpec): string {
   if (level.names) return level.names.join(', ') || '—';
   const count = level.count ?? 0;
   if (count === 0) return 'none';
   const pattern = level.namePattern || '{n}';
-  const shown = Array.from({ length: Math.min(3, count) }, (_, i) =>
-    pattern.replace('{n}', String(i + 1)),
-  );
+  const shown = Array.from({ length: Math.min(3, count) }, (_, i) => pattern.replace('{n}', String(i + 1)));
   return shown.join(', ') + (count > 3 ? ', …' : '');
+}
+
+/** Branches whose children are all leaves — the rows you'd fine-tune per side. */
+function collectLeafParents(
+  nodes: LocationSpecNode[],
+  trail: string[] = [],
+): { node: LocationSpecNode; path: string[] }[] {
+  const out: { node: LocationSpecNode; path: string[] }[] = [];
+  for (const n of nodes) {
+    const path = [...trail, n.name];
+    if (n.children.length > 0 && n.children.every((c) => c.children.length === 0)) {
+      out.push({ node: n, path });
+    } else if (n.children.length > 0) {
+      out.push(...collectLeafParents(n.children, path));
+    }
+  }
+  return out;
 }
 
 interface LevelConfigStepProps {
   levels: LevelSpec[];
   onChange: (levels: LevelSpec[]) => void;
   total: number;
+  customized: boolean;
+  tree: LocationSpecNode[];
+  onRemove: (key: string) => void;
+  onAdd: (parentKey: string) => void;
+  onStartOver: () => void;
 }
 
-export default function LevelConfigStep({ levels, onChange, total }: LevelConfigStepProps) {
+export default function LevelConfigStep({
+  levels,
+  onChange,
+  total,
+  customized,
+  tree,
+  onRemove,
+  onAdd,
+  onStartOver,
+}: LevelConfigStepProps) {
+  // ----- Customized: reflect the real per-branch structure as editable chips ---
+  if (customized) {
+    const leafParents = collectLeafParents(tree);
+    return (
+      <Box>
+        <Alert
+          severity="info"
+          action={
+            <Button color="inherit" size="small" startIcon={<ReplayIcon />} onClick={onStartOver}>
+              Start over
+            </Button>
+          }
+          sx={{ mb: 2 }}
+        >
+          Fine-tuning individual spots. Branches can differ now.
+        </Alert>
+
+        {leafParents.length === 0 ? (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+            {tree.map((n) => (
+              <Chip key={n.key} size="small" label={n.name} onDelete={() => onRemove(n.key)} />
+            ))}
+          </Box>
+        ) : (
+          <Stack spacing={1.5}>
+            {leafParents.map(({ node, path }) => (
+              <Box key={node.key}>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                  {path.join(' › ')}
+                </Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, alignItems: 'center' }}>
+                  {node.children.map((leaf) => (
+                    <Chip
+                      key={leaf.key}
+                      size="small"
+                      label={leaf.name}
+                      color={leaf.is_qr_anchor ? 'info' : 'default'}
+                      variant={leaf.is_qr_anchor ? 'filled' : 'outlined'}
+                      onDelete={() => onRemove(leaf.key)}
+                    />
+                  ))}
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    icon={<AddIcon />}
+                    label="Add"
+                    onClick={() => onAdd(node.key)}
+                  />
+                </Box>
+              </Box>
+            ))}
+          </Stack>
+        )}
+
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 2, textAlign: 'right' }}>
+          <strong>{total}</strong> location{total === 1 ? '' : 's'}
+        </Typography>
+      </Box>
+    );
+  }
+
+  // ----- Uniform: friendly per-level controls ---------------------------------
   const update = (i: number, patch: Partial<LevelSpec>) =>
     onChange(levels.map((l, idx) => (idx === i ? { ...l, ...patch } : l)));
 
@@ -60,11 +152,7 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
     if (mode === 'names') {
       update(i, { names: levels[i].names ?? ['Left', 'Right'], count: undefined, namePattern: undefined });
     } else {
-      update(i, {
-        count: levels[i].count ?? 4,
-        namePattern: `${label} {n}`,
-        names: undefined,
-      });
+      update(i, { count: levels[i].count ?? 4, namePattern: `${label} {n}`, names: undefined });
     }
   };
 
@@ -119,11 +207,7 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
                     <Typography variant="body2" color="text.secondary">
                       How many?
                     </Typography>
-                    <IconButton
-                      size="small"
-                      aria-label="Fewer"
-                      onClick={() => setCount(i, (level.count ?? 0) - 1)}
-                    >
+                    <IconButton size="small" aria-label="Fewer" onClick={() => setCount(i, (level.count ?? 0) - 1)}>
                       <RemoveIcon fontSize="small" />
                     </IconButton>
                     <TextField
@@ -133,11 +217,7 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
                       size="small"
                       inputProps={{ min: 0, style: { textAlign: 'center', width: 56 } }}
                     />
-                    <IconButton
-                      size="small"
-                      aria-label="More"
-                      onClick={() => setCount(i, (level.count ?? 0) + 1)}
-                    >
+                    <IconButton size="small" aria-label="More" onClick={() => setCount(i, (level.count ?? 0) + 1)}>
                       <AddIcon fontSize="small" />
                     </IconButton>
                   </Stack>

--- a/components/inventory/locations/builder/LevelConfigStep.tsx
+++ b/components/inventory/locations/builder/LevelConfigStep.tsx
@@ -15,6 +15,7 @@ import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import ReplayIcon from '@mui/icons-material/Replay';
+import TuneIcon from '@mui/icons-material/Tune';
 
 import type { LevelSpec, LocationSpecNode } from '@/types/inventoryLocations';
 
@@ -59,6 +60,7 @@ interface LevelConfigStepProps {
   total: number;
   customized: boolean;
   tree: LocationSpecNode[];
+  onCustomize: () => void;
   onRemove: (key: string) => void;
   onAdd: (parentKey: string) => void;
   onStartOver: () => void;
@@ -70,6 +72,7 @@ export default function LevelConfigStep({
   total,
   customized,
   tree,
+  onCustomize,
   onRemove,
   onAdd,
   onStartOver,
@@ -252,6 +255,20 @@ export default function LevelConfigStep({
           <strong>{total}</strong> location{total === 1 ? '' : 's'}
         </Typography>
       </Stack>
+
+      <Button
+        fullWidth
+        variant="outlined"
+        startIcon={<TuneIcon />}
+        onClick={onCustomize}
+        disabled={total === 0}
+        sx={{ mt: 2 }}
+      >
+        Customize individual spots
+      </Button>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5, textAlign: 'center' }}>
+        Give specific branches different bins (e.g. a gap, or one extra).
+      </Typography>
     </Box>
   );
 }

--- a/components/inventory/locations/builder/LevelConfigStep.tsx
+++ b/components/inventory/locations/builder/LevelConfigStep.tsx
@@ -146,8 +146,7 @@ export default function LevelConfigStep({
                       key={leaf.key}
                       size="small"
                       label={leaf.name}
-                      color={leaf.is_qr_anchor ? 'info' : 'default'}
-                      variant={leaf.is_qr_anchor ? 'filled' : 'outlined'}
+                      variant="outlined"
                       onDelete={() => onRemove(leaf.key)}
                     />
                   ))}
@@ -198,19 +197,17 @@ export default function LevelConfigStep({
   return (
     <Box>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        Each level nests inside the one above. The deepest level holds the stock.
+        Each level nests inside the one above.
       </Typography>
 
       <Stack spacing={2}>
         {levels.map((level, i) => {
           const mode: 'count' | 'names' = level.names ? 'names' : 'count';
-          const deepest = i === levels.length - 1;
           return (
             <Paper key={i} variant="outlined" sx={{ p: 2 }}>
               <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
                 <Typography variant="subtitle2" color="text.secondary" sx={{ flex: 1 }}>
                   Level {i + 1}
-                  {deepest ? ' · holds stock' : ''}
                 </Typography>
                 {levels.length > 1 && (
                   <IconButton size="small" aria-label="Remove level" onClick={() => removeLevel(i)}>

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -1,142 +1,129 @@
 'use client';
 
-import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
-import Breadcrumbs from '@mui/material/Breadcrumbs';
-import Link from '@mui/material/Link';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CloseIcon from '@mui/icons-material/Close';
 
 import type { LocationSpecNode } from '@/types/inventoryLocations';
 
-function findPath(
-  nodes: LocationSpecNode[],
-  key: string,
-  trail: LocationSpecNode[] = [],
-): LocationSpecNode[] | null {
-  for (const n of nodes) {
-    const here = [...trail, n];
-    if (n.key === key) return here;
-    const found = findPath(n.children, key, here);
-    if (found) return found;
-  }
-  return null;
-}
+// Show the whole structure nested (container → sections → leaves as chips), but
+// summarize big repetitions so it stays scannable rather than becoming a wall
+// of icons (the research's caution for deep/large sets). Nested CARDS, never a
+// deep indented tree.
+const TOP_LIMIT = 30; // top-level containers shown
+const GROUP_LIMIT = 12; // sub-sections shown per container
+const CHIP_LIMIT = 16; // leaf chips shown per section
 
-const CHIP_LIMIT = 10;
+/** Render an array of leaf (or near-leaf) nodes as chips, with prune + a "+N". */
+function LeafChips({ nodes, onPrune }: { nodes: LocationSpecNode[]; onPrune: (k: string) => void }) {
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+      {nodes.slice(0, CHIP_LIMIT).map((n) => (
+        <Chip
+          key={n.key}
+          size="small"
+          variant={n.is_qr_anchor ? 'filled' : 'outlined'}
+          color={n.is_qr_anchor ? 'info' : 'default'}
+          // a 4th level (rare) is summarized as a count instead of nesting deeper
+          label={n.children.length ? `${n.name} · ${n.children.length}` : n.name}
+          onDelete={() => onPrune(n.key)}
+        />
+      ))}
+      {nodes.length > CHIP_LIMIT && <Chip size="small" label={`+${nodes.length - CHIP_LIMIT}`} />}
+    </Box>
+  );
+}
 
 interface LocationBoardPreviewProps {
   nodes: LocationSpecNode[];
   onPrune: (key: string) => void;
 }
 
-/** Live, read-only board of the assembled spec: each container card shows its
- *  contents nested inside (rows/bins as chips). Click a card to drill in; the ×
- *  removes that node (and its subtree). Pure projection of the spec — no drag,
- *  no stored geometry. */
 export default function LocationBoardPreview({ nodes, onPrune }: LocationBoardPreviewProps) {
-  const [focusKey, setFocusKey] = useState<string | null>(null);
-
-  // Stay valid if the focused node was pruned or the layout changed underneath us.
-  const focusPath = focusKey ? findPath(nodes, focusKey) : null;
-  const focusNode = focusPath?.[focusPath.length - 1] ?? null;
-  const displayed = focusNode ? focusNode.children : nodes;
+  if (nodes.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+        Set a count to see your storage take shape.
+      </Typography>
+    );
+  }
 
   return (
-    <Box>
-      <Breadcrumbs sx={{ mb: 1.5 }}>
-        <Link
-          component="button"
-          type="button"
-          underline="hover"
-          color={focusNode ? 'primary' : 'text.primary'}
-          onClick={() => setFocusKey(null)}
-        >
-          All
-        </Link>
-        {(focusPath ?? []).map((n, i, arr) => (
-          <Link
-            key={n.key}
-            component="button"
-            type="button"
-            underline="hover"
-            color={i === arr.length - 1 ? 'text.primary' : 'primary'}
-            onClick={() => setFocusKey(n.key)}
-          >
-            {n.name}
-          </Link>
-        ))}
-      </Breadcrumbs>
-
-      {displayed.length === 0 ? (
-        <Typography variant="body2" color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
-          Set a count above to see your storage take shape.
-        </Typography>
-      ) : (
-        <Box
-          sx={{
-            display: 'grid',
-            gap: 1.5,
-            gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' },
-          }}
-        >
-          {displayed.map((node) => {
-            const children = node.children;
-            const drillable = children.length > 0;
-            return (
-              <Paper
-                key={node.key}
-                variant="outlined"
-                sx={{
-                  p: 1.5,
-                  cursor: drillable ? 'pointer' : 'default',
-                  '&:hover': drillable ? { borderColor: 'primary.main' } : undefined,
-                }}
-                onClick={drillable ? () => setFocusKey(node.key) : undefined}
+    <Box
+      sx={{ display: 'grid', gap: 1.5, gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' } }}
+    >
+      {nodes.slice(0, TOP_LIMIT).map((node) => {
+        const kids = node.children;
+        const kidsHaveKids = kids.length > 0 && kids[0].children.length > 0;
+        return (
+          <Paper key={node.key} variant="outlined" sx={{ p: 1.5 }}>
+            <Stack direction="row" alignItems="center" spacing={0.5}>
+              <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
+                {node.name}
+              </Typography>
+              {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
+              <IconButton
+                size="small"
+                aria-label={`Remove ${node.name}`}
+                onClick={() => onPrune(node.key)}
               >
-                <Stack direction="row" alignItems="center" spacing={0.5}>
-                  <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
-                    {node.name}
-                  </Typography>
-                  {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
-                  <IconButton
-                    size="small"
-                    aria-label={`Remove ${node.name}`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onPrune(node.key);
-                    }}
-                  >
-                    <CloseIcon fontSize="small" />
-                  </IconButton>
-                  {drillable && <ChevronRightIcon fontSize="small" color="action" />}
-                </Stack>
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </Stack>
+            {node.code && (
+              <Typography variant="caption" color="text.secondary">
+                {node.code}
+              </Typography>
+            )}
 
-                {node.code && (
-                  <Typography variant="caption" color="text.secondary">
-                    {node.code}
-                  </Typography>
-                )}
-
-                {drillable && (
-                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
-                    {children.slice(0, CHIP_LIMIT).map((c) => (
-                      <Chip key={c.key} size="small" variant="outlined" label={c.name} />
+            {kids.length > 0 && (
+              <Box sx={{ mt: 1 }}>
+                {kidsHaveKids ? (
+                  <Stack spacing={1}>
+                    {kids.slice(0, GROUP_LIMIT).map((section) => (
+                      <Box key={section.key}>
+                        <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.5 }}>
+                          <Typography
+                            variant="body2"
+                            sx={{ fontWeight: 500, flex: 1, minWidth: 0 }}
+                            noWrap
+                          >
+                            {section.name}
+                          </Typography>
+                          {section.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
+                          <IconButton
+                            size="small"
+                            aria-label={`Remove ${section.name}`}
+                            onClick={() => onPrune(section.key)}
+                          >
+                            <CloseIcon sx={{ fontSize: 16 }} />
+                          </IconButton>
+                        </Stack>
+                        <LeafChips nodes={section.children} onPrune={onPrune} />
+                      </Box>
                     ))}
-                    {children.length > CHIP_LIMIT && (
-                      <Chip size="small" label={`+${children.length - CHIP_LIMIT}`} />
+                    {kids.length > GROUP_LIMIT && (
+                      <Typography variant="caption" color="text.secondary">
+                        +{kids.length - GROUP_LIMIT} more
+                      </Typography>
                     )}
-                  </Box>
+                  </Stack>
+                ) : (
+                  <LeafChips nodes={kids} onPrune={onPrune} />
                 )}
-              </Paper>
-            );
-          })}
-        </Box>
+              </Box>
+            )}
+          </Paper>
+        );
+      })}
+      {nodes.length > TOP_LIMIT && (
+        <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'center' }}>
+          +{nodes.length - TOP_LIMIT} more
+        </Typography>
       )}
     </Box>
   );

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -7,43 +7,159 @@ import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
+import AddIcon from '@mui/icons-material/Add';
 
 import type { LocationSpecNode } from '@/types/inventoryLocations';
 
-// Show the whole structure nested (container → sections → leaves as chips), but
-// summarize big repetitions so it stays scannable rather than becoming a wall
-// of icons (the research's caution for deep/large sets). Nested CARDS, never a
-// deep indented tree.
-const TOP_LIMIT = 30; // top-level containers shown
-const GROUP_LIMIT = 12; // sub-sections shown per container
-const CHIP_LIMIT = 16; // leaf chips shown per section
+// Spatial depiction: containers as cards, sections stacked, leaves as CENTERED
+// cells (3 on a line → middle one centered). Editable: × removes a node, ＋ adds
+// one to that branch. Big/deep sets are summarized so it stays scannable.
+const TOP_LIMIT = 30;
+const GROUP_LIMIT = 14;
+const CELL_LIMIT = 18;
 
-/** Render an array of leaf (or near-leaf) nodes as chips, with prune + a "+N". */
-function LeafChips({ nodes, onPrune }: { nodes: LocationSpecNode[]; onPrune: (k: string) => void }) {
+const cellSx = (qr: boolean) => ({
+  px: 1,
+  py: 0.5,
+  borderRadius: 1,
+  border: 1,
+  borderColor: qr ? 'info.main' : 'divider',
+  color: qr ? 'info.light' : 'text.primary',
+  fontSize: 13,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 0.25,
+  whiteSpace: 'nowrap' as const,
+});
+
+interface Edit {
+  onRemove: (key: string) => void;
+  onAdd: (parentKey: string) => void;
+}
+
+function Cell({ node, onRemove }: { node: LocationSpecNode } & Pick<Edit, 'onRemove'>) {
   return (
-    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-      {nodes.slice(0, CHIP_LIMIT).map((n) => (
-        <Chip
-          key={n.key}
-          size="small"
-          variant={n.is_qr_anchor ? 'filled' : 'outlined'}
-          color={n.is_qr_anchor ? 'info' : 'default'}
-          // a 4th level (rare) is summarized as a count instead of nesting deeper
-          label={n.children.length ? `${n.name} · ${n.children.length}` : n.name}
-          onDelete={() => onPrune(n.key)}
-        />
-      ))}
-      {nodes.length > CHIP_LIMIT && <Chip size="small" label={`+${nodes.length - CHIP_LIMIT}`} />}
+    <Box sx={cellSx(node.is_qr_anchor)}>
+      {node.name}
+      {node.children.length ? ` ·${node.children.length}` : ''}
+      <IconButton
+        size="small"
+        aria-label={`Remove ${node.name}`}
+        onClick={() => onRemove(node.key)}
+        sx={{ p: 0, ml: 0.25 }}
+      >
+        <CloseIcon sx={{ fontSize: 14 }} />
+      </IconButton>
     </Box>
   );
 }
 
-interface LocationBoardPreviewProps {
-  nodes: LocationSpecNode[];
-  onPrune: (key: string) => void;
+function AddButton({ parentKey, label, onAdd }: { parentKey: string; label: string } & Pick<Edit, 'onAdd'>) {
+  return (
+    <IconButton
+      size="small"
+      aria-label={label}
+      onClick={() => onAdd(parentKey)}
+      sx={{ border: 1, borderStyle: 'dashed', borderColor: 'divider', borderRadius: 1 }}
+    >
+      <AddIcon sx={{ fontSize: 16 }} />
+    </IconButton>
+  );
 }
 
-export default function LocationBoardPreview({ nodes, onPrune }: LocationBoardPreviewProps) {
+/** Centered, wrapping row of leaf cells + an Add button for this branch. */
+function CellGroup({
+  nodes,
+  parentKey,
+  addLabel,
+  onRemove,
+  onAdd,
+}: { nodes: LocationSpecNode[]; parentKey?: string; addLabel?: string } & Edit) {
+  const truncated = nodes.length > CELL_LIMIT;
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 0.5, alignItems: 'center' }}>
+      {nodes.slice(0, CELL_LIMIT).map((n) => (
+        <Cell key={n.key} node={n} onRemove={onRemove} />
+      ))}
+      {truncated && <Box sx={{ ...cellSx(false), color: 'text.secondary' }}>+{nodes.length - CELL_LIMIT}</Box>}
+      {parentKey && !truncated && (
+        <AddButton parentKey={parentKey} label={addLabel ?? 'Add one'} onAdd={onAdd} />
+      )}
+    </Box>
+  );
+}
+
+function ContainerCard({ node, onRemove, onAdd }: { node: LocationSpecNode } & Edit) {
+  const kids = node.children;
+  const threeLevel = kids.length > 0 && kids[0].children.length > 0;
+
+  return (
+    <Paper variant="outlined" sx={{ p: 1.5 }}>
+      <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: kids.length ? 1 : 0 }}>
+        <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
+          {node.name}
+        </Typography>
+        {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
+        <IconButton size="small" aria-label={`Remove ${node.name}`} onClick={() => onRemove(node.key)}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Stack>
+
+      {kids.length > 0 &&
+        (threeLevel ? (
+          <Stack spacing={1}>
+            {kids.slice(0, GROUP_LIMIT).map((section) => (
+              <Box key={section.key}>
+                <Stack direction="row" alignItems="center" justifyContent="center" spacing={0.5} sx={{ mb: 0.25 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    {section.name}
+                    {section.is_qr_anchor ? ' · QR' : ''}
+                  </Typography>
+                  <IconButton
+                    size="small"
+                    aria-label={`Remove ${section.name}`}
+                    onClick={() => onRemove(section.key)}
+                    sx={{ p: 0 }}
+                  >
+                    <CloseIcon sx={{ fontSize: 14 }} />
+                  </IconButton>
+                </Stack>
+                <CellGroup
+                  nodes={section.children}
+                  parentKey={section.key}
+                  addLabel={`Add to ${section.name}`}
+                  onRemove={onRemove}
+                  onAdd={onAdd}
+                />
+              </Box>
+            ))}
+            {kids.length > GROUP_LIMIT && (
+              <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>
+                +{kids.length - GROUP_LIMIT} more
+              </Typography>
+            )}
+            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+              <AddButton parentKey={node.key} label={`Add a section to ${node.name}`} onAdd={onAdd} />
+            </Box>
+          </Stack>
+        ) : (
+          <CellGroup
+            nodes={kids}
+            parentKey={node.key}
+            addLabel={`Add to ${node.name}`}
+            onRemove={onRemove}
+            onAdd={onAdd}
+          />
+        ))}
+    </Paper>
+  );
+}
+
+interface LocationBoardPreviewProps extends Edit {
+  nodes: LocationSpecNode[];
+}
+
+export default function LocationBoardPreview({ nodes, onRemove, onAdd }: LocationBoardPreviewProps) {
   if (nodes.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
@@ -52,74 +168,20 @@ export default function LocationBoardPreview({ nodes, onPrune }: LocationBoardPr
     );
   }
 
-  return (
-    <Box
-      sx={{ display: 'grid', gap: 1.5, gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' } }}
-    >
-      {nodes.slice(0, TOP_LIMIT).map((node) => {
-        const kids = node.children;
-        const kidsHaveKids = kids.length > 0 && kids[0].children.length > 0;
-        return (
-          <Paper key={node.key} variant="outlined" sx={{ p: 1.5 }}>
-            <Stack direction="row" alignItems="center" spacing={0.5}>
-              <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
-                {node.name}
-              </Typography>
-              {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
-              <IconButton
-                size="small"
-                aria-label={`Remove ${node.name}`}
-                onClick={() => onPrune(node.key)}
-              >
-                <CloseIcon fontSize="small" />
-              </IconButton>
-            </Stack>
-            {node.code && (
-              <Typography variant="caption" color="text.secondary">
-                {node.code}
-              </Typography>
-            )}
+  // Flat (every top node is a leaf, e.g. loose bins): one centered cluster.
+  if (nodes.every((n) => n.children.length === 0)) {
+    return (
+      <Paper variant="outlined" sx={{ p: 1.5 }}>
+        <CellGroup nodes={nodes} onRemove={onRemove} onAdd={onAdd} />
+      </Paper>
+    );
+  }
 
-            {kids.length > 0 && (
-              <Box sx={{ mt: 1 }}>
-                {kidsHaveKids ? (
-                  <Stack spacing={1}>
-                    {kids.slice(0, GROUP_LIMIT).map((section) => (
-                      <Box key={section.key}>
-                        <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.5 }}>
-                          <Typography
-                            variant="body2"
-                            sx={{ fontWeight: 500, flex: 1, minWidth: 0 }}
-                            noWrap
-                          >
-                            {section.name}
-                          </Typography>
-                          {section.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
-                          <IconButton
-                            size="small"
-                            aria-label={`Remove ${section.name}`}
-                            onClick={() => onPrune(section.key)}
-                          >
-                            <CloseIcon sx={{ fontSize: 16 }} />
-                          </IconButton>
-                        </Stack>
-                        <LeafChips nodes={section.children} onPrune={onPrune} />
-                      </Box>
-                    ))}
-                    {kids.length > GROUP_LIMIT && (
-                      <Typography variant="caption" color="text.secondary">
-                        +{kids.length - GROUP_LIMIT} more
-                      </Typography>
-                    )}
-                  </Stack>
-                ) : (
-                  <LeafChips nodes={kids} onPrune={onPrune} />
-                )}
-              </Box>
-            )}
-          </Paper>
-        );
-      })}
+  return (
+    <Box sx={{ display: 'grid', gap: 1.5, gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' } }}>
+      {nodes.slice(0, TOP_LIMIT).map((node) => (
+        <ContainerCard key={node.key} node={node} onRemove={onRemove} onAdd={onAdd} />
+      ))}
       {nodes.length > TOP_LIMIT && (
         <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'center' }}>
           +{nodes.length - TOP_LIMIT} more

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -1,165 +1,219 @@
 'use client';
 
 import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
-import IconButton from '@mui/material/IconButton';
-import CloseIcon from '@mui/icons-material/Close';
-import AddIcon from '@mui/icons-material/Add';
+import { alpha } from '@mui/material/styles';
 
 import type { LocationSpecNode } from '@/types/inventoryLocations';
 
-// Spatial depiction: containers as cards, sections stacked, leaves as CENTERED
-// cells (3 on a line → middle one centered). Editable: × removes a node, ＋ adds
-// one to that branch. Big/deep sets are summarized so it stays scannable.
-const TOP_LIMIT = 30;
-const GROUP_LIMIT = 14;
-const CELL_LIMIT = 18;
+// READ-ONLY, type-aware depiction (editing lives in the config). Each top
+// container is drawn to resemble its kind; a section's leaves fill the width as
+// evenly-divided compartments (like real cubbies/positions). Big/deep sets are
+// summarized. A 3D diorama is a tracked follow-up.
+const TOP_LIMIT = 24;
+const SECTION_LIMIT = 16;
+const CELL_LIMIT = 20;
+const FILL_MAX = 8; // up to this many leaves fill the width; beyond, wrap centered
 
-const cellSx = (qr: boolean) => ({
-  px: 1,
-  py: 0.5,
-  borderRadius: 1,
-  border: 1,
-  borderColor: qr ? 'info.main' : 'divider',
-  color: qr ? 'info.light' : 'text.primary',
-  fontSize: 13,
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 0.25,
-  whiteSpace: 'nowrap' as const,
-});
+const qrCellBg = (t: { palette: { info: { main: string } } }) => alpha(t.palette.info.main, 0.18);
 
-interface Edit {
-  onRemove: (key: string) => void;
-  onAdd: (parentKey: string) => void;
-}
+/** Leaves spanning the section width as evenly-divided compartments. */
+function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
+  if (nodes.length === 0) return null;
 
-function Cell({ node, onRemove }: { node: LocationSpecNode } & Pick<Edit, 'onRemove'>) {
+  if (nodes.length > FILL_MAX) {
+    // too many to divide evenly — centered wrap so it stays readable
+    return (
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 0.5, mt: 0.5 }}>
+        {nodes.slice(0, CELL_LIMIT).map((n) => (
+          <Box
+            key={n.key}
+            sx={{
+              fontSize: 12,
+              px: 0.75,
+              py: 0.25,
+              border: 1,
+              borderRadius: 0.5,
+              borderColor: n.is_qr_anchor ? 'info.main' : 'divider',
+              bgcolor: n.is_qr_anchor ? qrCellBg : 'transparent',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {n.name}
+            {n.children.length ? ` ·${n.children.length}` : ''}
+          </Box>
+        ))}
+        {nodes.length > CELL_LIMIT && (
+          <Box sx={{ fontSize: 12, color: 'text.secondary', px: 0.5 }}>+{nodes.length - CELL_LIMIT}</Box>
+        )}
+      </Box>
+    );
+  }
+
   return (
-    <Box sx={cellSx(node.is_qr_anchor)}>
-      {node.name}
-      {node.children.length ? ` ·${node.children.length}` : ''}
-      <IconButton
-        size="small"
-        aria-label={`Remove ${node.name}`}
-        onClick={() => onRemove(node.key)}
-        sx={{ p: 0, ml: 0.25 }}
-      >
-        <CloseIcon sx={{ fontSize: 14 }} />
-      </IconButton>
-    </Box>
-  );
-}
-
-function AddButton({ parentKey, label, onAdd }: { parentKey: string; label: string } & Pick<Edit, 'onAdd'>) {
-  return (
-    <IconButton
-      size="small"
-      aria-label={label}
-      onClick={() => onAdd(parentKey)}
-      sx={{ border: 1, borderStyle: 'dashed', borderColor: 'divider', borderRadius: 1 }}
-    >
-      <AddIcon sx={{ fontSize: 16 }} />
-    </IconButton>
-  );
-}
-
-/** Centered, wrapping row of leaf cells + an Add button for this branch. */
-function CellGroup({
-  nodes,
-  parentKey,
-  addLabel,
-  onRemove,
-  onAdd,
-}: { nodes: LocationSpecNode[]; parentKey?: string; addLabel?: string } & Edit) {
-  const truncated = nodes.length > CELL_LIMIT;
-  return (
-    <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 0.5, alignItems: 'center' }}>
-      {nodes.slice(0, CELL_LIMIT).map((n) => (
-        <Cell key={n.key} node={n} onRemove={onRemove} />
+    <Box sx={{ display: 'flex', mt: 0.5, borderRadius: 0.5, overflow: 'hidden' }}>
+      {nodes.map((n, i) => (
+        <Box
+          key={n.key}
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            textAlign: 'center',
+            fontSize: 12,
+            py: 0.4,
+            px: 0.5,
+            borderRight: i < nodes.length - 1 ? '1px solid' : 0,
+            borderColor: 'divider',
+            color: n.is_qr_anchor ? 'info.light' : 'text.primary',
+            bgcolor: n.is_qr_anchor ? qrCellBg : 'transparent',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+          title={n.name}
+        >
+          {n.name}
+          {n.children.length ? ` ·${n.children.length}` : ''}
+        </Box>
       ))}
-      {truncated && <Box sx={{ ...cellSx(false), color: 'text.secondary' }}>+{nodes.length - CELL_LIMIT}</Box>}
-      {parentKey && !truncated && (
-        <AddButton parentKey={parentKey} label={addLabel ?? 'Add one'} onAdd={onAdd} />
-      )}
     </Box>
   );
 }
 
-function ContainerCard({ node, onRemove, onAdd }: { node: LocationSpecNode } & Edit) {
-  const kids = node.children;
-  const threeLevel = kids.length > 0 && kids[0].children.length > 0;
+function SectionLabel({ node }: { node: LocationSpecNode }) {
+  return (
+    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center' }}>
+      {node.name}
+      {node.is_qr_anchor ? ' · QR' : ''}
+    </Typography>
+  );
+}
+
+type Kind = 'cabinet' | 'shelving' | 'rack' | 'drawer' | 'aisle' | 'generic';
+
+function unitKind(kind?: string | null): Kind {
+  const k = (kind ?? '').toLowerCase();
+  if (k.includes('rack')) return 'rack';
+  if (k.includes('drawer')) return 'drawer';
+  if (k.includes('aisle') || k.includes('zone')) return 'aisle';
+  if (k.includes('shelv') || k.includes('shelf')) return 'shelving';
+  if (k.includes('cabinet')) return 'cabinet';
+  return 'generic';
+}
+
+function Section({ node, kind }: { node: LocationSpecNode; kind: Kind }) {
+  const hasLeaves = node.children.length > 0;
+
+  if (kind === 'drawer') {
+    return (
+      <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 1, bgcolor: 'action.hover', py: 0.75, px: 1, textAlign: 'center' }}>
+        <Box sx={{ width: 28, height: 3, bgcolor: 'text.disabled', borderRadius: 2, mx: 'auto', mb: 0.5 }} />
+        <SectionLabel node={node} />
+        {hasLeaves && <Compartments nodes={node.children} />}
+      </Box>
+    );
+  }
+
+  if (kind === 'rack') {
+    // a beam: thick lines top and bottom, positions span the beam
+    return (
+      <Box sx={{ borderTop: '3px solid', borderBottom: '3px solid', borderColor: alpha('#5b8cf0', 0.55), py: 0.5 }}>
+        <SectionLabel node={node} />
+        <Compartments nodes={node.children} />
+      </Box>
+    );
+  }
+
+  if (kind === 'shelving' && !hasLeaves) {
+    // a plank: a solid shelf bar
+    return (
+      <Box sx={{ bgcolor: 'action.hover', borderBottom: '3px solid', borderColor: 'divider', borderRadius: 0.5, py: 0.5, textAlign: 'center' }}>
+        <Typography variant="caption" color="text.primary">
+          {node.name}
+          {node.is_qr_anchor ? ' · QR' : ''}
+        </Typography>
+      </Box>
+    );
+  }
+
+  // cabinet rows / shelving with items / generic bands: a shelf line with compartments
+  return (
+    <Box sx={{ borderBottom: '3px solid', borderColor: 'divider', pb: 0.5 }}>
+      <SectionLabel node={node} />
+      {hasLeaves && <Compartments nodes={node.children} />}
+    </Box>
+  );
+}
+
+function StorageUnit({ node }: { node: LocationSpecNode }) {
+  const kind = unitKind(node.kind);
+  const children = node.children;
+  const allLeaves = children.length > 0 && children.every((c) => c.children.length === 0);
 
   return (
-    <Paper variant="outlined" sx={{ p: 1.5 }}>
-      <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: kids.length ? 1 : 0 }}>
+    <Box
+      sx={{
+        border: 2,
+        borderColor: 'divider',
+        borderLeftWidth: kind === 'rack' ? 6 : 2,
+        borderRightWidth: kind === 'rack' ? 6 : 2,
+        borderLeftColor: kind === 'rack' ? alpha('#5b8cf0', 0.55) : 'divider',
+        borderRightColor: kind === 'rack' ? alpha('#5b8cf0', 0.55) : 'divider',
+        borderRadius: 1,
+        overflow: 'hidden',
+        bgcolor: 'background.paper',
+      }}
+    >
+      <Box sx={{ px: 1.5, py: 0.75, bgcolor: 'action.hover', borderBottom: 1, borderColor: 'divider', display: 'flex', alignItems: 'center', gap: 0.5 }}>
         <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
           {node.name}
         </Typography>
         {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
-        <IconButton size="small" aria-label={`Remove ${node.name}`} onClick={() => onRemove(node.key)}>
-          <CloseIcon fontSize="small" />
-        </IconButton>
-      </Stack>
+        {node.code && (
+          <Typography variant="caption" color="text.secondary">
+            {node.code}
+          </Typography>
+        )}
+      </Box>
 
-      {kids.length > 0 &&
-        (threeLevel ? (
-          <Stack spacing={1}>
-            {kids.slice(0, GROUP_LIMIT).map((section) => (
-              <Box key={section.key}>
-                <Stack direction="row" alignItems="center" justifyContent="center" spacing={0.5} sx={{ mb: 0.25 }}>
-                  <Typography variant="caption" color="text.secondary">
-                    {section.name}
-                    {section.is_qr_anchor ? ' · QR' : ''}
-                  </Typography>
-                  <IconButton
-                    size="small"
-                    aria-label={`Remove ${section.name}`}
-                    onClick={() => onRemove(section.key)}
-                    sx={{ p: 0 }}
-                  >
-                    <CloseIcon sx={{ fontSize: 14 }} />
-                  </IconButton>
+      <Box sx={{ p: 1 }}>
+        {children.length === 0 ? null : allLeaves ? (
+          <Compartments nodes={children} />
+        ) : kind === 'aisle' ? (
+          <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center', flexWrap: 'wrap' }}>
+            {children.slice(0, SECTION_LIMIT).map((bay) => (
+              <Box key={bay.key} sx={{ border: 1, borderColor: 'divider', borderRadius: 1, p: 0.5, minWidth: 56 }}>
+                <SectionLabel node={bay} />
+                <Stack spacing={0.25} sx={{ mt: 0.25 }}>
+                  {bay.children.slice(0, CELL_LIMIT).map((leaf) => (
+                    <Box key={leaf.key} sx={{ fontSize: 12, textAlign: 'center', border: 1, borderColor: leaf.is_qr_anchor ? 'info.main' : 'divider', borderRadius: 0.5, py: 0.25 }}>
+                      {leaf.name}
+                    </Box>
+                  ))}
                 </Stack>
-                <CellGroup
-                  nodes={section.children}
-                  parentKey={section.key}
-                  addLabel={`Add to ${section.name}`}
-                  onRemove={onRemove}
-                  onAdd={onAdd}
-                />
               </Box>
             ))}
-            {kids.length > GROUP_LIMIT && (
+          </Box>
+        ) : (
+          <Stack spacing={kind === 'drawer' ? 0.75 : 1}>
+            {children.slice(0, SECTION_LIMIT).map((section) => (
+              <Section key={section.key} node={section} kind={kind} />
+            ))}
+            {children.length > SECTION_LIMIT && (
               <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>
-                +{kids.length - GROUP_LIMIT} more
+                +{children.length - SECTION_LIMIT} more
               </Typography>
             )}
-            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-              <AddButton parentKey={node.key} label={`Add a section to ${node.name}`} onAdd={onAdd} />
-            </Box>
           </Stack>
-        ) : (
-          <CellGroup
-            nodes={kids}
-            parentKey={node.key}
-            addLabel={`Add to ${node.name}`}
-            onRemove={onRemove}
-            onAdd={onAdd}
-          />
-        ))}
-    </Paper>
+        )}
+      </Box>
+    </Box>
   );
 }
 
-interface LocationBoardPreviewProps extends Edit {
-  nodes: LocationSpecNode[];
-}
-
-export default function LocationBoardPreview({ nodes, onRemove, onAdd }: LocationBoardPreviewProps) {
+export default function LocationBoardPreview({ nodes }: { nodes: LocationSpecNode[] }) {
   if (nodes.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
@@ -168,19 +222,18 @@ export default function LocationBoardPreview({ nodes, onRemove, onAdd }: Locatio
     );
   }
 
-  // Flat (every top node is a leaf, e.g. loose bins): one centered cluster.
   if (nodes.every((n) => n.children.length === 0)) {
     return (
-      <Paper variant="outlined" sx={{ p: 1.5 }}>
-        <CellGroup nodes={nodes} onRemove={onRemove} onAdd={onAdd} />
-      </Paper>
+      <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 1, p: 1.5 }}>
+        <Compartments nodes={nodes} />
+      </Box>
     );
   }
 
   return (
     <Box sx={{ display: 'grid', gap: 1.5, gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' } }}>
       {nodes.slice(0, TOP_LIMIT).map((node) => (
-        <ContainerCard key={node.key} node={node} onRemove={onRemove} onAdd={onAdd} />
+        <StorageUnit key={node.key} node={node} />
       ))}
       {nodes.length > TOP_LIMIT && (
         <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'center' }}>

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -28,24 +28,28 @@ function findPath(
   return null;
 }
 
+const CHIP_LIMIT = 10;
+
 interface LocationBoardPreviewProps {
   nodes: LocationSpecNode[];
   onPrune: (key: string) => void;
 }
 
-/** Step 3: a read-only board of the assembled spec. Click a tile to drill in;
- *  the × removes that tile (and its subtree) before commit. Pure projection of
- *  the spec — no drag, no stored geometry. */
+/** Live, read-only board of the assembled spec: each container card shows its
+ *  contents nested inside (rows/bins as chips). Click a card to drill in; the ×
+ *  removes that node (and its subtree). Pure projection of the spec — no drag,
+ *  no stored geometry. */
 export default function LocationBoardPreview({ nodes, onPrune }: LocationBoardPreviewProps) {
   const [focusKey, setFocusKey] = useState<string | null>(null);
 
+  // Stay valid if the focused node was pruned or the layout changed underneath us.
   const focusPath = focusKey ? findPath(nodes, focusKey) : null;
   const focusNode = focusPath?.[focusPath.length - 1] ?? null;
   const displayed = focusNode ? focusNode.children : nodes;
 
   return (
     <Box>
-      <Breadcrumbs sx={{ mb: 2 }}>
+      <Breadcrumbs sx={{ mb: 1.5 }}>
         <Link
           component="button"
           type="button"
@@ -70,62 +74,65 @@ export default function LocationBoardPreview({ nodes, onPrune }: LocationBoardPr
       </Breadcrumbs>
 
       {displayed.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
-          Nothing here.
+        <Typography variant="body2" color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+          Set a count above to see your storage take shape.
         </Typography>
       ) : (
         <Box
           sx={{
             display: 'grid',
             gap: 1.5,
-            gridTemplateColumns: { xs: 'repeat(2, 1fr)', sm: 'repeat(3, 1fr)', md: 'repeat(4, 1fr)' },
+            gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' },
           }}
         >
           {displayed.map((node) => {
-            const childCount = node.children.length;
-            const drillable = childCount > 0;
+            const children = node.children;
+            const drillable = children.length > 0;
             return (
               <Paper
                 key={node.key}
                 variant="outlined"
                 sx={{
                   p: 1.5,
-                  minHeight: 72,
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
                   cursor: drillable ? 'pointer' : 'default',
                   '&:hover': drillable ? { borderColor: 'primary.main' } : undefined,
                 }}
                 onClick={drillable ? () => setFocusKey(node.key) : undefined}
               >
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Typography noWrap sx={{ fontWeight: 500 }}>
+                <Stack direction="row" alignItems="center" spacing={0.5}>
+                  <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
                     {node.name}
                   </Typography>
-                  <Stack direction="row" spacing={0.5} alignItems="center" sx={{ mt: 0.25 }}>
-                    {node.code && (
-                      <Typography variant="caption" color="text.secondary" noWrap>
-                        {node.code}
-                      </Typography>
+                  {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
+                  <IconButton
+                    size="small"
+                    aria-label={`Remove ${node.name}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onPrune(node.key);
+                    }}
+                  >
+                    <CloseIcon fontSize="small" />
+                  </IconButton>
+                  {drillable && <ChevronRightIcon fontSize="small" color="action" />}
+                </Stack>
+
+                {node.code && (
+                  <Typography variant="caption" color="text.secondary">
+                    {node.code}
+                  </Typography>
+                )}
+
+                {drillable && (
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
+                    {children.slice(0, CHIP_LIMIT).map((c) => (
+                      <Chip key={c.key} size="small" variant="outlined" label={c.name} />
+                    ))}
+                    {children.length > CHIP_LIMIT && (
+                      <Chip size="small" label={`+${children.length - CHIP_LIMIT}`} />
                     )}
-                    {drillable && (
-                      <Chip size="small" variant="outlined" label={`${childCount} inside`} />
-                    )}
-                    {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
-                  </Stack>
-                </Box>
-                <IconButton
-                  size="small"
-                  aria-label={`Remove ${node.name}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onPrune(node.key);
-                  }}
-                >
-                  <CloseIcon fontSize="small" />
-                </IconButton>
-                {drillable && <ChevronRightIcon fontSize="small" color="action" />}
+                  </Box>
+                )}
               </Paper>
             );
           })}

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import Link from '@mui/material/Link';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import CloseIcon from '@mui/icons-material/Close';
+
+import type { LocationSpecNode } from '@/types/inventoryLocations';
+
+function findPath(
+  nodes: LocationSpecNode[],
+  key: string,
+  trail: LocationSpecNode[] = [],
+): LocationSpecNode[] | null {
+  for (const n of nodes) {
+    const here = [...trail, n];
+    if (n.key === key) return here;
+    const found = findPath(n.children, key, here);
+    if (found) return found;
+  }
+  return null;
+}
+
+interface LocationBoardPreviewProps {
+  nodes: LocationSpecNode[];
+  onPrune: (key: string) => void;
+}
+
+/** Step 3: a read-only board of the assembled spec. Click a tile to drill in;
+ *  the × removes that tile (and its subtree) before commit. Pure projection of
+ *  the spec — no drag, no stored geometry. */
+export default function LocationBoardPreview({ nodes, onPrune }: LocationBoardPreviewProps) {
+  const [focusKey, setFocusKey] = useState<string | null>(null);
+
+  const focusPath = focusKey ? findPath(nodes, focusKey) : null;
+  const focusNode = focusPath?.[focusPath.length - 1] ?? null;
+  const displayed = focusNode ? focusNode.children : nodes;
+
+  return (
+    <Box>
+      <Breadcrumbs sx={{ mb: 2 }}>
+        <Link
+          component="button"
+          type="button"
+          underline="hover"
+          color={focusNode ? 'primary' : 'text.primary'}
+          onClick={() => setFocusKey(null)}
+        >
+          All
+        </Link>
+        {(focusPath ?? []).map((n, i, arr) => (
+          <Link
+            key={n.key}
+            component="button"
+            type="button"
+            underline="hover"
+            color={i === arr.length - 1 ? 'text.primary' : 'primary'}
+            onClick={() => setFocusKey(n.key)}
+          >
+            {n.name}
+          </Link>
+        ))}
+      </Breadcrumbs>
+
+      {displayed.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Nothing here.
+        </Typography>
+      ) : (
+        <Box
+          sx={{
+            display: 'grid',
+            gap: 1.5,
+            gridTemplateColumns: { xs: 'repeat(2, 1fr)', sm: 'repeat(3, 1fr)', md: 'repeat(4, 1fr)' },
+          }}
+        >
+          {displayed.map((node) => {
+            const childCount = node.children.length;
+            const drillable = childCount > 0;
+            return (
+              <Paper
+                key={node.key}
+                variant="outlined"
+                sx={{
+                  p: 1.5,
+                  minHeight: 72,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  cursor: drillable ? 'pointer' : 'default',
+                  '&:hover': drillable ? { borderColor: 'primary.main' } : undefined,
+                }}
+                onClick={drillable ? () => setFocusKey(node.key) : undefined}
+              >
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography noWrap sx={{ fontWeight: 500 }}>
+                    {node.name}
+                  </Typography>
+                  <Stack direction="row" spacing={0.5} alignItems="center" sx={{ mt: 0.25 }}>
+                    {node.code && (
+                      <Typography variant="caption" color="text.secondary" noWrap>
+                        {node.code}
+                      </Typography>
+                    )}
+                    {drillable && (
+                      <Chip size="small" variant="outlined" label={`${childCount} inside`} />
+                    )}
+                    {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
+                  </Stack>
+                </Box>
+                <IconButton
+                  size="small"
+                  aria-label={`Remove ${node.name}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onPrune(node.key);
+                  }}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+                {drillable && <ChevronRightIcon fontSize="small" color="action" />}
+              </Paper>
+            );
+          })}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -3,15 +3,15 @@
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import Chip from '@mui/material/Chip';
+import QrCode2Icon from '@mui/icons-material/QrCode2';
 import { alpha } from '@mui/material/styles';
 
 import type { LocationSpecNode } from '@/types/inventoryLocations';
 
 // READ-ONLY, type-aware depiction (editing lives in the config). Each top
 // container is drawn to resemble its kind; a section's leaves fill the width as
-// evenly-divided compartments (like real cubbies/positions). Big/deep sets are
-// summarized. A 3D diorama is a tracked follow-up.
+// evenly-divided compartments. A QR-code icon marks wherever a label would be
+// printed. Big/deep sets are summarized. A 3D diorama is a tracked follow-up.
 const TOP_LIMIT = 24;
 const SECTION_LIMIT = 16;
 const CELL_LIMIT = 20;
@@ -19,18 +19,30 @@ const FILL_MAX = 8; // up to this many leaves fill the width; beyond, wrap cente
 
 const qrCellBg = (t: { palette: { info: { main: string } } }) => alpha(t.palette.info.main, 0.18);
 
+/** A little QR-code glyph marking where a printed label would go. */
+function QrMark({ size = 15 }: { size?: number }) {
+  return (
+    <QrCode2Icon
+      sx={{ fontSize: size, color: 'info.main', verticalAlign: 'middle', flexShrink: 0 }}
+      titleAccess="A QR label prints here"
+    />
+  );
+}
+
 /** Leaves spanning the section width as evenly-divided compartments. */
 function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
   if (nodes.length === 0) return null;
 
   if (nodes.length > FILL_MAX) {
-    // too many to divide evenly — centered wrap so it stays readable
     return (
       <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 0.5, mt: 0.5 }}>
         {nodes.slice(0, CELL_LIMIT).map((n) => (
           <Box
             key={n.key}
             sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 0.25,
               fontSize: 12,
               px: 0.75,
               py: 0.25,
@@ -41,6 +53,7 @@ function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
               whiteSpace: 'nowrap',
             }}
           >
+            {n.is_qr_anchor && <QrMark size={12} />}
             {n.name}
             {n.children.length ? ` ·${n.children.length}` : ''}
           </Box>
@@ -60,7 +73,10 @@ function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
           sx={{
             flex: 1,
             minWidth: 0,
-            textAlign: 'center',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 0.25,
             fontSize: 12,
             py: 0.4,
             px: 0.5,
@@ -70,12 +86,14 @@ function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
             bgcolor: n.is_qr_anchor ? qrCellBg : 'transparent',
             whiteSpace: 'nowrap',
             overflow: 'hidden',
-            textOverflow: 'ellipsis',
           }}
           title={n.name}
         >
-          {n.name}
-          {n.children.length ? ` ·${n.children.length}` : ''}
+          {n.is_qr_anchor && <QrMark size={12} />}
+          <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {n.name}
+            {n.children.length ? ` ·${n.children.length}` : ''}
+          </Box>
         </Box>
       ))}
     </Box>
@@ -84,10 +102,12 @@ function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
 
 function SectionLabel({ node }: { node: LocationSpecNode }) {
   return (
-    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center' }}>
-      {node.name}
-      {node.is_qr_anchor ? ' · QR' : ''}
-    </Typography>
+    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.25 }}>
+      <Typography variant="caption" color="text.secondary">
+        {node.name}
+      </Typography>
+      {node.is_qr_anchor && <QrMark size={13} />}
+    </Box>
   );
 }
 
@@ -117,7 +137,6 @@ function Section({ node, kind }: { node: LocationSpecNode; kind: Kind }) {
   }
 
   if (kind === 'rack') {
-    // a beam: thick lines top and bottom, positions span the beam
     return (
       <Box sx={{ borderTop: '3px solid', borderBottom: '3px solid', borderColor: alpha('#5b8cf0', 0.55), py: 0.5 }}>
         <SectionLabel node={node} />
@@ -127,18 +146,13 @@ function Section({ node, kind }: { node: LocationSpecNode; kind: Kind }) {
   }
 
   if (kind === 'shelving' && !hasLeaves) {
-    // a plank: a solid shelf bar
     return (
-      <Box sx={{ bgcolor: 'action.hover', borderBottom: '3px solid', borderColor: 'divider', borderRadius: 0.5, py: 0.5, textAlign: 'center' }}>
-        <Typography variant="caption" color="text.primary">
-          {node.name}
-          {node.is_qr_anchor ? ' · QR' : ''}
-        </Typography>
+      <Box sx={{ bgcolor: 'action.hover', borderBottom: '3px solid', borderColor: 'divider', borderRadius: 0.5, py: 0.5 }}>
+        <SectionLabel node={node} />
       </Box>
     );
   }
 
-  // cabinet rows / shelving with items / generic bands: a shelf line with compartments
   return (
     <Box sx={{ borderBottom: '3px solid', borderColor: 'divider', pb: 0.5 }}>
       <SectionLabel node={node} />
@@ -170,7 +184,7 @@ function StorageUnit({ node }: { node: LocationSpecNode }) {
         <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
           {node.name}
         </Typography>
-        {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
+        {node.is_qr_anchor && <QrMark size={18} />}
         {node.code && (
           <Typography variant="caption" color="text.secondary">
             {node.code}
@@ -188,7 +202,11 @@ function StorageUnit({ node }: { node: LocationSpecNode }) {
                 <SectionLabel node={bay} />
                 <Stack spacing={0.25} sx={{ mt: 0.25 }}>
                   {bay.children.slice(0, CELL_LIMIT).map((leaf) => (
-                    <Box key={leaf.key} sx={{ fontSize: 12, textAlign: 'center', border: 1, borderColor: leaf.is_qr_anchor ? 'info.main' : 'divider', borderRadius: 0.5, py: 0.25 }}>
+                    <Box
+                      key={leaf.key}
+                      sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.25, fontSize: 12, border: 1, borderColor: leaf.is_qr_anchor ? 'info.main' : 'divider', borderRadius: 0.5, py: 0.25 }}
+                    >
+                      {leaf.is_qr_anchor && <QrMark size={12} />}
                       {leaf.name}
                     </Box>
                   ))}

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -3,31 +3,18 @@
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import QrCode2Icon from '@mui/icons-material/QrCode2';
 import { alpha } from '@mui/material/styles';
 
 import type { LocationSpecNode } from '@/types/inventoryLocations';
 
 // READ-ONLY, type-aware depiction (editing lives in the config). Each top
 // container is drawn to resemble its kind; a section's leaves fill the width as
-// evenly-divided compartments. A QR-code icon marks wherever a label would be
-// printed. Big/deep sets are summarized. A 3D diorama is a tracked follow-up.
+// evenly-divided compartments. Big/deep sets are summarized. A 3D diorama is a
+// tracked follow-up.
 const TOP_LIMIT = 24;
 const SECTION_LIMIT = 16;
 const CELL_LIMIT = 20;
 const FILL_MAX = 8; // up to this many leaves fill the width; beyond, wrap centered
-
-const qrCellBg = (t: { palette: { info: { main: string } } }) => alpha(t.palette.info.main, 0.18);
-
-/** A little QR-code glyph marking where a printed label would go. */
-function QrMark({ size = 15 }: { size?: number }) {
-  return (
-    <QrCode2Icon
-      sx={{ fontSize: size, color: 'info.main', verticalAlign: 'middle', flexShrink: 0 }}
-      titleAccess="A QR label prints here"
-    />
-  );
-}
 
 /** Leaves spanning the section width as evenly-divided compartments. */
 function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
@@ -48,12 +35,10 @@ function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
               py: 0.25,
               border: 1,
               borderRadius: 0.5,
-              borderColor: n.is_qr_anchor ? 'info.main' : 'divider',
-              bgcolor: n.is_qr_anchor ? qrCellBg : 'transparent',
+              borderColor: 'divider',
               whiteSpace: 'nowrap',
             }}
           >
-            {n.is_qr_anchor && <QrMark size={12} />}
             {n.name}
             {n.children.length ? ` ·${n.children.length}` : ''}
           </Box>
@@ -82,14 +67,12 @@ function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
             px: 0.5,
             borderRight: i < nodes.length - 1 ? '1px solid' : 0,
             borderColor: 'divider',
-            color: n.is_qr_anchor ? 'info.light' : 'text.primary',
-            bgcolor: n.is_qr_anchor ? qrCellBg : 'transparent',
+            color: 'text.primary',
             whiteSpace: 'nowrap',
             overflow: 'hidden',
           }}
           title={n.name}
         >
-          {n.is_qr_anchor && <QrMark size={12} />}
           <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
             {n.name}
             {n.children.length ? ` ·${n.children.length}` : ''}
@@ -106,7 +89,6 @@ function SectionLabel({ node }: { node: LocationSpecNode }) {
       <Typography variant="caption" color="text.secondary">
         {node.name}
       </Typography>
-      {node.is_qr_anchor && <QrMark size={13} />}
     </Box>
   );
 }
@@ -184,7 +166,6 @@ function StorageUnit({ node }: { node: LocationSpecNode }) {
         <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
           {node.name}
         </Typography>
-        {node.is_qr_anchor && <QrMark size={18} />}
         {node.code && (
           <Typography variant="caption" color="text.secondary">
             {node.code}
@@ -204,9 +185,8 @@ function StorageUnit({ node }: { node: LocationSpecNode }) {
                   {bay.children.slice(0, CELL_LIMIT).map((leaf) => (
                     <Box
                       key={leaf.key}
-                      sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.25, fontSize: 12, border: 1, borderColor: leaf.is_qr_anchor ? 'info.main' : 'divider', borderRadius: 0.5, py: 0.25 }}
+                      sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.25, fontSize: 12, border: 1, borderColor: 'divider', borderRadius: 0.5, py: 0.25 }}
                     >
-                      {leaf.is_qr_anchor && <QrMark size={12} />}
                       {leaf.name}
                     </Box>
                   ))}

--- a/components/inventory/locations/builder/StorageTypePalette.tsx
+++ b/components/inventory/locations/builder/StorageTypePalette.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
+import Typography from '@mui/material/Typography';
+
+import { STORAGE_TYPES, type StorageType } from './storageTypes';
+
+interface StorageTypePaletteProps {
+  selectedId: string | null;
+  onSelect: (type: StorageType) => void;
+}
+
+/** Step 1: pick a recognizable storage type. Each card = concrete icon + an
+ *  always-visible label (NN/g 5-second rule), tap target well over 48px. */
+export default function StorageTypePalette({ selectedId, onSelect }: StorageTypePaletteProps) {
+  return (
+    <Box>
+      <Typography variant="body1" sx={{ mb: 2 }}>
+        What kind of storage are you setting up?
+      </Typography>
+      <Box
+        sx={{
+          display: 'grid',
+          gap: 2,
+          gridTemplateColumns: { xs: 'repeat(2, 1fr)', sm: 'repeat(3, 1fr)', md: 'repeat(4, 1fr)' },
+        }}
+      >
+        {STORAGE_TYPES.map((type) => {
+          const selected = type.id === selectedId;
+          const Icon = type.Icon;
+          return (
+            <Card
+              key={type.id}
+              elevation={selected ? 4 : 2}
+              sx={{
+                border: 2,
+                borderColor: selected ? 'primary.main' : 'transparent',
+              }}
+            >
+              <CardActionArea
+                onClick={() => onSelect(type)}
+                sx={{
+                  p: 2,
+                  minHeight: 120,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  textAlign: 'center',
+                  gap: 1,
+                }}
+              >
+                <Icon sx={{ fontSize: 40, color: selected ? 'primary.main' : 'text.secondary' }} />
+                <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.2 }}>
+                  {type.label}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {type.description}
+                </Typography>
+              </CardActionArea>
+            </Card>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
 import DialogActions from '@mui/material/DialogActions';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -15,8 +16,14 @@ import MenuItem from '@mui/material/MenuItem';
 import Alert from '@mui/material/Alert';
 import Typography from '@mui/material/Typography';
 
-import type { LevelSpec } from '@/types/inventoryLocations';
-import { buildSpecFromLevels, countSpecNodes, removeSpecNode } from '@/utils/locationSpec';
+import type { LevelSpec, LocationSpecNode } from '@/types/inventoryLocations';
+import {
+  buildSpecFromLevels,
+  countSpecNodes,
+  removeSpecNode,
+  addChildUnder,
+  applyQrAnchorByDepth,
+} from '@/utils/locationSpec';
 import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
 import StorageTypePalette from './StorageTypePalette';
 import LevelConfigStep from './LevelConfigStep';
@@ -49,7 +56,11 @@ export default function VisualLocationBuilder({
   const [selectedTypeId, setSelectedTypeId] = useState<string | null>(null);
   const [levels, setLevels] = useState<LevelSpec[]>([]);
   const [qrAnchorDepth, setQrAnchorDepth] = useState(0);
-  const [prunedKeys, setPrunedKeys] = useState<string[]>([]);
+  // Once a single branch is fine-tuned, the tree is hand-edited directly and no
+  // longer regenerated from `levels` (which becomes the "Start over" template).
+  const [customized, setCustomized] = useState(false);
+  const [editedTree, setEditedTree] = useState<LocationSpecNode[]>([]);
+  const [startOverOpen, setStartOverOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -58,40 +69,55 @@ export default function VisualLocationBuilder({
     setSelectedTypeId(null);
     setLevels([]);
     setQrAnchorDepth(0);
-    setPrunedKeys([]);
+    setCustomized(false);
+    setEditedTree([]);
+    setStartOverOpen(false);
     setCreating(false);
     setError(null);
   };
 
-  const baseSpec = useMemo(
+  const uniformTree = useMemo(
     () => buildSpecFromLevels(levels, { qrAnchorDepth, parentCode }),
     [levels, qrAnchorDepth, parentCode],
   );
-  const spec = useMemo(
-    () => prunedKeys.reduce((s, k) => removeSpecNode(s, k), baseSpec),
-    [baseSpec, prunedKeys],
-  );
-  const total = countSpecNodes(spec);
+  const tree = customized ? editedTree : uniformTree;
+  const total = countSpecNodes(tree);
 
   const pickType = (type: StorageType) => {
     setSelectedTypeId(type.id);
     setLevels(cloneLevels(type.defaultLevels));
     setQrAnchorDepth(0);
-    setPrunedKeys([]);
+    setCustomized(false);
+    setEditedTree([]);
     setActiveStep(1);
   };
 
-  const changeLevels = (next: LevelSpec[]) => {
-    setLevels(next);
-    setPrunedKeys([]); // keys shift with layout; drop stale prunes
-    if (qrAnchorDepth > next.length - 1) setQrAnchorDepth(Math.max(0, next.length - 1));
+  const changeQrDepth = (depth: number) => {
+    setQrAnchorDepth(depth);
+    if (customized) setEditedTree((t) => applyQrAnchorByDepth(t, depth));
+  };
+
+  // Direct manipulation from either the preview or the config chips.
+  const editRemove = (key: string) => {
+    setEditedTree(applyQrAnchorByDepth(removeSpecNode(tree, key), qrAnchorDepth));
+    setCustomized(true);
+  };
+  const editAdd = (parentKey: string) => {
+    setEditedTree(applyQrAnchorByDepth(addChildUnder(tree, parentKey), qrAnchorDepth));
+    setCustomized(true);
+  };
+
+  const confirmStartOver = () => {
+    setCustomized(false);
+    setEditedTree([]);
+    setStartOverOpen(false);
   };
 
   const handleCreate = async () => {
     setCreating(true);
     setError(null);
     try {
-      const created = await materializeLocationSpec(companyId, parentId, spec);
+      const created = await materializeLocationSpec(companyId, parentId, tree);
       onCreated(created.length);
       onClose();
     } catch (e) {
@@ -123,22 +149,23 @@ export default function VisualLocationBuilder({
 
         {activeStep === 1 && (
           <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'flex-start' }}>
-            {/* Controls */}
-            <Box sx={{ flex: '1 1 300px', minWidth: 280 }}>
-              <LevelConfigStep levels={levels} onChange={changeLevels} total={total} />
+            {/* Controls (uniform) or per-branch chips (customized) */}
+            <Box sx={{ flex: '1 1 320px', minWidth: 280 }}>
+              <LevelConfigStep
+                levels={levels}
+                onChange={setLevels}
+                total={total}
+                customized={customized}
+                tree={tree}
+                onRemove={editRemove}
+                onAdd={editAdd}
+                onStartOver={() => setStartOverOpen(true)}
+              />
             </Box>
 
-            {/* Live preview */}
+            {/* Live spatial preview (also editable) */}
             <Box sx={{ flex: '1 1 340px', minWidth: 280 }}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 2,
-                  mb: 1.5,
-                  flexWrap: 'wrap',
-                }}
-              >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1.5, flexWrap: 'wrap' }}>
                 <Typography variant="subtitle2" color="text.secondary" sx={{ flex: 1 }}>
                   Preview
                 </Typography>
@@ -146,7 +173,7 @@ export default function VisualLocationBuilder({
                   select
                   label="QR labels at"
                   value={qrAnchorDepth}
-                  onChange={(e) => setQrAnchorDepth(Number(e.target.value))}
+                  onChange={(e) => changeQrDepth(Number(e.target.value))}
                   size="small"
                   sx={{ minWidth: 160 }}
                 >
@@ -157,10 +184,7 @@ export default function VisualLocationBuilder({
                   ))}
                 </TextField>
               </Box>
-              <LocationBoardPreview
-                nodes={spec}
-                onPrune={(key) => setPrunedKeys((keys) => [...keys, key])}
-              />
+              <LocationBoardPreview nodes={tree} onRemove={editRemove} onAdd={editAdd} />
             </Box>
           </Box>
         )}
@@ -187,6 +211,21 @@ export default function VisualLocationBuilder({
           </>
         )}
       </DialogActions>
+
+      <Dialog open={startOverOpen} onClose={() => setStartOverOpen(false)}>
+        <DialogTitle>Start over?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This clears your individual tweaks and goes back to editing the layout by the numbers.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setStartOverOpen(false)}>Keep editing</Button>
+          <Button onClick={confirmStartOver} color="error" variant="contained">
+            Start over
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Dialog>
   );
 }

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -11,6 +11,7 @@ import Button from '@mui/material/Button';
 import Stepper from '@mui/material/Stepper';
 import Step from '@mui/material/Step';
 import StepLabel from '@mui/material/StepLabel';
+import Divider from '@mui/material/Divider';
 import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
 import Alert from '@mui/material/Alert';
@@ -152,9 +153,16 @@ export default function VisualLocationBuilder({
         {activeStep === 0 && <StorageTypePalette selectedId={selectedTypeId} onSelect={pickType} />}
 
         {activeStep === 1 && (
-          <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'flex-start' }}>
-            {/* Controls (uniform) or per-branch chips (customized) */}
-            <Box sx={{ flex: '1 1 320px', minWidth: 280 }}>
+          <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 3 }}>
+            {/* Configure (the only editor) */}
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{ display: 'block', mb: 1.5, letterSpacing: 1 }}
+              >
+                Configure
+              </Typography>
               <LevelConfigStep
                 levels={levels}
                 onChange={setLevels}
@@ -168,10 +176,13 @@ export default function VisualLocationBuilder({
               />
             </Box>
 
-            {/* Live spatial preview (also editable) */}
-            <Box sx={{ flex: '1 1 340px', minWidth: 280 }}>
+            <Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', md: 'block' } }} />
+            <Divider sx={{ display: { xs: 'block', md: 'none' } }} />
+
+            {/* Read-only type-aware preview */}
+            <Box sx={{ flex: 1, minWidth: 0 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1.5, flexWrap: 'wrap' }}>
-                <Typography variant="subtitle2" color="text.secondary" sx={{ flex: 1 }}>
+                <Typography variant="overline" color="text.secondary" sx={{ flex: 1, letterSpacing: 1 }}>
                   Preview
                 </Typography>
                 <TextField

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -13,7 +13,7 @@ import StepLabel from '@mui/material/StepLabel';
 import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
 import Alert from '@mui/material/Alert';
-import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 
 import type { LevelSpec } from '@/types/inventoryLocations';
 import { buildSpecFromLevels, countSpecNodes, removeSpecNode } from '@/utils/locationSpec';
@@ -23,7 +23,7 @@ import LevelConfigStep from './LevelConfigStep';
 import LocationBoardPreview from './LocationBoardPreview';
 import { cloneLevels, type StorageType } from './storageTypes';
 
-const STEPS = ['Type', 'Layout', 'Review'];
+const STEPS = ['Type', 'Build'];
 
 interface VisualLocationBuilderProps {
   open: boolean;
@@ -105,13 +105,13 @@ export default function VisualLocationBuilder({
     <Dialog
       open={open}
       onClose={creating ? undefined : onClose}
-      maxWidth="md"
+      maxWidth="lg"
       fullWidth
       TransitionProps={{ onEnter: reset }}
     >
       <DialogTitle>Build storage visually</DialogTitle>
-      <DialogContent dividers sx={{ minHeight: 420 }}>
-        <Stepper activeStep={activeStep} sx={{ mb: 3 }}>
+      <DialogContent dividers sx={{ minHeight: 460 }}>
+        <Stepper activeStep={activeStep} sx={{ mb: 3, maxWidth: 360 }}>
           {STEPS.map((label) => (
             <Step key={label}>
               <StepLabel>{label}</StepLabel>
@@ -122,38 +122,46 @@ export default function VisualLocationBuilder({
         {activeStep === 0 && <StorageTypePalette selectedId={selectedTypeId} onSelect={pickType} />}
 
         {activeStep === 1 && (
-          <LevelConfigStep levels={levels} onChange={changeLevels} total={countSpecNodes(baseSpec)} />
-        )}
+          <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+            {/* Controls */}
+            <Box sx={{ flex: '1 1 300px', minWidth: 280 }}>
+              <LevelConfigStep levels={levels} onChange={changeLevels} total={total} />
+            </Box>
 
-        {activeStep === 2 && (
-          <Box>
-            <Stack
-              direction={{ xs: 'column', sm: 'row' }}
-              spacing={2}
-              alignItems={{ sm: 'center' }}
-              sx={{ mb: 2 }}
-            >
-              <TextField
-                select
-                label="Print QR labels at"
-                value={qrAnchorDepth}
-                onChange={(e) => setQrAnchorDepth(Number(e.target.value))}
-                size="small"
-                sx={{ minWidth: 220 }}
-                helperText="Scanning drills down to what's inside"
+            {/* Live preview */}
+            <Box sx={{ flex: '1 1 340px', minWidth: 280 }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 2,
+                  mb: 1.5,
+                  flexWrap: 'wrap',
+                }}
               >
-                {levels.map((l, i) => (
-                  <MenuItem key={i} value={i}>
-                    {capitalize(l.kind)} (level {i + 1})
-                  </MenuItem>
-                ))}
-              </TextField>
-              <Box sx={{ flex: 1 }} />
-            </Stack>
-            <LocationBoardPreview
-              nodes={spec}
-              onPrune={(key) => setPrunedKeys((keys) => [...keys, key])}
-            />
+                <Typography variant="subtitle2" color="text.secondary" sx={{ flex: 1 }}>
+                  Preview
+                </Typography>
+                <TextField
+                  select
+                  label="QR labels at"
+                  value={qrAnchorDepth}
+                  onChange={(e) => setQrAnchorDepth(Number(e.target.value))}
+                  size="small"
+                  sx={{ minWidth: 160 }}
+                >
+                  {levels.map((l, i) => (
+                    <MenuItem key={i} value={i}>
+                      {capitalize(l.kind)}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              </Box>
+              <LocationBoardPreview
+                nodes={spec}
+                onPrune={(key) => setPrunedKeys((keys) => [...keys, key])}
+              />
+            </Box>
           </Box>
         )}
 
@@ -168,20 +176,15 @@ export default function VisualLocationBuilder({
           Cancel
         </Button>
         <Box sx={{ flex: 1 }} />
-        {activeStep > 0 && (
-          <Button onClick={() => setActiveStep((s) => s - 1)} disabled={creating}>
-            Back
-          </Button>
-        )}
         {activeStep === 1 && (
-          <Button variant="contained" onClick={() => setActiveStep(2)} disabled={total === 0}>
-            Review
-          </Button>
-        )}
-        {activeStep === 2 && (
-          <Button variant="contained" onClick={handleCreate} disabled={creating || total === 0}>
-            Create {total} location{total === 1 ? '' : 's'}
-          </Button>
+          <>
+            <Button onClick={() => setActiveStep(0)} disabled={creating}>
+              Back
+            </Button>
+            <Button variant="contained" onClick={handleCreate} disabled={creating || total === 0}>
+              Create {total} location{total === 1 ? '' : 's'}
+            </Button>
+          </>
         )}
       </DialogActions>
     </Dialog>

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -12,8 +12,6 @@ import Stepper from '@mui/material/Stepper';
 import Step from '@mui/material/Step';
 import StepLabel from '@mui/material/StepLabel';
 import Divider from '@mui/material/Divider';
-import TextField from '@mui/material/TextField';
-import MenuItem from '@mui/material/MenuItem';
 import Alert from '@mui/material/Alert';
 import Typography from '@mui/material/Typography';
 
@@ -24,7 +22,6 @@ import {
   removeSpecNode,
   addChildUnder,
   duplicateNode,
-  applyQrAnchorByDepth,
 } from '@/utils/locationSpec';
 import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
 import StorageTypePalette from './StorageTypePalette';
@@ -44,8 +41,6 @@ interface VisualLocationBuilderProps {
   onCreated: (count: number) => void;
 }
 
-const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
-
 export default function VisualLocationBuilder({
   open,
   companyId,
@@ -57,7 +52,6 @@ export default function VisualLocationBuilder({
   const [activeStep, setActiveStep] = useState(0);
   const [selectedTypeId, setSelectedTypeId] = useState<string | null>(null);
   const [levels, setLevels] = useState<LevelSpec[]>([]);
-  const [qrAnchorDepth, setQrAnchorDepth] = useState(0);
   // Once a single branch is fine-tuned, the tree is hand-edited directly and no
   // longer regenerated from `levels` (which becomes the "Start over" template).
   const [customized, setCustomized] = useState(false);
@@ -70,7 +64,6 @@ export default function VisualLocationBuilder({
     setActiveStep(0);
     setSelectedTypeId(null);
     setLevels([]);
-    setQrAnchorDepth(0);
     setCustomized(false);
     setEditedTree([]);
     setStartOverOpen(false);
@@ -79,8 +72,8 @@ export default function VisualLocationBuilder({
   };
 
   const uniformTree = useMemo(
-    () => buildSpecFromLevels(levels, { qrAnchorDepth, parentCode }),
-    [levels, qrAnchorDepth, parentCode],
+    () => buildSpecFromLevels(levels, { parentCode }),
+    [levels, parentCode],
   );
   const tree = customized ? editedTree : uniformTree;
   const total = countSpecNodes(tree);
@@ -88,32 +81,26 @@ export default function VisualLocationBuilder({
   const pickType = (type: StorageType) => {
     setSelectedTypeId(type.id);
     setLevels(cloneLevels(type.defaultLevels));
-    setQrAnchorDepth(0);
     setCustomized(false);
     setEditedTree([]);
     setActiveStep(1);
   };
 
-  const changeQrDepth = (depth: number) => {
-    setQrAnchorDepth(depth);
-    if (customized) setEditedTree((t) => applyQrAnchorByDepth(t, depth));
-  };
-
   // Editing lives in the config; the preview is read-only.
   const enterCustomize = () => {
-    setEditedTree(applyQrAnchorByDepth(tree, qrAnchorDepth));
+    setEditedTree(tree);
     setCustomized(true);
   };
   const editRemove = (key: string) => {
-    setEditedTree(applyQrAnchorByDepth(removeSpecNode(tree, key), qrAnchorDepth));
+    setEditedTree(removeSpecNode(tree, key));
     setCustomized(true);
   };
   const editAdd = (parentKey: string) => {
-    setEditedTree(applyQrAnchorByDepth(addChildUnder(tree, parentKey), qrAnchorDepth));
+    setEditedTree(addChildUnder(tree, parentKey));
     setCustomized(true);
   };
   const editDuplicate = (key: string) => {
-    setEditedTree(applyQrAnchorByDepth(duplicateNode(tree, key), qrAnchorDepth));
+    setEditedTree(duplicateNode(tree, key));
     setCustomized(true);
   };
 
@@ -187,25 +174,13 @@ export default function VisualLocationBuilder({
 
             {/* Read-only type-aware preview */}
             <Box sx={{ flex: 1, minWidth: 0 }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1.5, flexWrap: 'wrap' }}>
-                <Typography variant="overline" color="text.secondary" sx={{ flex: 1, letterSpacing: 1 }}>
-                  Preview
-                </Typography>
-                <TextField
-                  select
-                  label="QR labels at"
-                  value={qrAnchorDepth}
-                  onChange={(e) => changeQrDepth(Number(e.target.value))}
-                  size="small"
-                  sx={{ minWidth: 160 }}
-                >
-                  {levels.map((l, i) => (
-                    <MenuItem key={i} value={i}>
-                      {capitalize(l.kind)}
-                    </MenuItem>
-                  ))}
-                </TextField>
-              </Box>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{ display: 'block', mb: 1.5, letterSpacing: 1 }}
+              >
+                Preview
+              </Typography>
               <LocationBoardPreview nodes={tree} />
             </Box>
           </Box>

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Stepper from '@mui/material/Stepper';
+import Step from '@mui/material/Step';
+import StepLabel from '@mui/material/StepLabel';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Alert from '@mui/material/Alert';
+import Stack from '@mui/material/Stack';
+
+import type { LevelSpec } from '@/types/inventoryLocations';
+import { buildSpecFromLevels, countSpecNodes, removeSpecNode } from '@/utils/locationSpec';
+import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
+import StorageTypePalette from './StorageTypePalette';
+import LevelConfigStep from './LevelConfigStep';
+import LocationBoardPreview from './LocationBoardPreview';
+import { cloneLevels, type StorageType } from './storageTypes';
+
+const STEPS = ['Type', 'Layout', 'Review'];
+
+interface VisualLocationBuilderProps {
+  open: boolean;
+  companyId: string;
+  /** Build under this node (null = top-level). */
+  parentId?: string | null;
+  parentCode?: string | null;
+  onClose: () => void;
+  onCreated: (count: number) => void;
+}
+
+const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+export default function VisualLocationBuilder({
+  open,
+  companyId,
+  parentId = null,
+  parentCode = null,
+  onClose,
+  onCreated,
+}: VisualLocationBuilderProps) {
+  const [activeStep, setActiveStep] = useState(0);
+  const [selectedTypeId, setSelectedTypeId] = useState<string | null>(null);
+  const [levels, setLevels] = useState<LevelSpec[]>([]);
+  const [qrAnchorDepth, setQrAnchorDepth] = useState(0);
+  const [prunedKeys, setPrunedKeys] = useState<string[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setActiveStep(0);
+    setSelectedTypeId(null);
+    setLevels([]);
+    setQrAnchorDepth(0);
+    setPrunedKeys([]);
+    setCreating(false);
+    setError(null);
+  };
+
+  const baseSpec = useMemo(
+    () => buildSpecFromLevels(levels, { qrAnchorDepth, parentCode }),
+    [levels, qrAnchorDepth, parentCode],
+  );
+  const spec = useMemo(
+    () => prunedKeys.reduce((s, k) => removeSpecNode(s, k), baseSpec),
+    [baseSpec, prunedKeys],
+  );
+  const total = countSpecNodes(spec);
+
+  const pickType = (type: StorageType) => {
+    setSelectedTypeId(type.id);
+    setLevels(cloneLevels(type.defaultLevels));
+    setQrAnchorDepth(0);
+    setPrunedKeys([]);
+    setActiveStep(1);
+  };
+
+  const changeLevels = (next: LevelSpec[]) => {
+    setLevels(next);
+    setPrunedKeys([]); // keys shift with layout; drop stale prunes
+    if (qrAnchorDepth > next.length - 1) setQrAnchorDepth(Math.max(0, next.length - 1));
+  };
+
+  const handleCreate = async () => {
+    setCreating(true);
+    setError(null);
+    try {
+      const created = await materializeLocationSpec(companyId, parentId, spec);
+      onCreated(created.length);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create locations.');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={creating ? undefined : onClose}
+      maxWidth="md"
+      fullWidth
+      TransitionProps={{ onEnter: reset }}
+    >
+      <DialogTitle>Build storage visually</DialogTitle>
+      <DialogContent dividers sx={{ minHeight: 420 }}>
+        <Stepper activeStep={activeStep} sx={{ mb: 3 }}>
+          {STEPS.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
+
+        {activeStep === 0 && <StorageTypePalette selectedId={selectedTypeId} onSelect={pickType} />}
+
+        {activeStep === 1 && (
+          <LevelConfigStep levels={levels} onChange={changeLevels} total={countSpecNodes(baseSpec)} />
+        )}
+
+        {activeStep === 2 && (
+          <Box>
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              spacing={2}
+              alignItems={{ sm: 'center' }}
+              sx={{ mb: 2 }}
+            >
+              <TextField
+                select
+                label="Print QR labels at"
+                value={qrAnchorDepth}
+                onChange={(e) => setQrAnchorDepth(Number(e.target.value))}
+                size="small"
+                sx={{ minWidth: 220 }}
+                helperText="Scanning drills down to what's inside"
+              >
+                {levels.map((l, i) => (
+                  <MenuItem key={i} value={i}>
+                    {capitalize(l.kind)} (level {i + 1})
+                  </MenuItem>
+                ))}
+              </TextField>
+              <Box sx={{ flex: 1 }} />
+            </Stack>
+            <LocationBoardPreview
+              nodes={spec}
+              onPrune={(key) => setPrunedKeys((keys) => [...keys, key])}
+            />
+          </Box>
+        )}
+
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={creating}>
+          Cancel
+        </Button>
+        <Box sx={{ flex: 1 }} />
+        {activeStep > 0 && (
+          <Button onClick={() => setActiveStep((s) => s - 1)} disabled={creating}>
+            Back
+          </Button>
+        )}
+        {activeStep === 1 && (
+          <Button variant="contained" onClick={() => setActiveStep(2)} disabled={total === 0}>
+            Review
+          </Button>
+        )}
+        {activeStep === 2 && (
+          <Button variant="contained" onClick={handleCreate} disabled={creating || total === 0}>
+            Create {total} location{total === 1 ? '' : 's'}
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -23,6 +23,7 @@ import {
   countSpecNodes,
   removeSpecNode,
   addChildUnder,
+  duplicateNode,
   applyQrAnchorByDepth,
 } from '@/utils/locationSpec';
 import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
@@ -111,6 +112,10 @@ export default function VisualLocationBuilder({
     setEditedTree(applyQrAnchorByDepth(addChildUnder(tree, parentKey), qrAnchorDepth));
     setCustomized(true);
   };
+  const editDuplicate = (key: string) => {
+    setEditedTree(applyQrAnchorByDepth(duplicateNode(tree, key), qrAnchorDepth));
+    setCustomized(true);
+  };
 
   const confirmStartOver = () => {
     setCustomized(false);
@@ -172,6 +177,7 @@ export default function VisualLocationBuilder({
                 onCustomize={enterCustomize}
                 onRemove={editRemove}
                 onAdd={editAdd}
+                onDuplicate={editDuplicate}
                 onStartOver={() => setStartOverOpen(true)}
               />
             </Box>

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -97,7 +97,11 @@ export default function VisualLocationBuilder({
     if (customized) setEditedTree((t) => applyQrAnchorByDepth(t, depth));
   };
 
-  // Direct manipulation from either the preview or the config chips.
+  // Editing lives in the config; the preview is read-only.
+  const enterCustomize = () => {
+    setEditedTree(applyQrAnchorByDepth(tree, qrAnchorDepth));
+    setCustomized(true);
+  };
   const editRemove = (key: string) => {
     setEditedTree(applyQrAnchorByDepth(removeSpecNode(tree, key), qrAnchorDepth));
     setCustomized(true);
@@ -157,6 +161,7 @@ export default function VisualLocationBuilder({
                 total={total}
                 customized={customized}
                 tree={tree}
+                onCustomize={enterCustomize}
                 onRemove={editRemove}
                 onAdd={editAdd}
                 onStartOver={() => setStartOverOpen(true)}
@@ -184,7 +189,7 @@ export default function VisualLocationBuilder({
                   ))}
                 </TextField>
               </Box>
-              <LocationBoardPreview nodes={tree} onRemove={editRemove} onAdd={editAdd} />
+              <LocationBoardPreview nodes={tree} />
             </Box>
           </Box>
         )}

--- a/components/inventory/locations/builder/storageTypes.tsx
+++ b/components/inventory/locations/builder/storageTypes.tsx
@@ -1,0 +1,99 @@
+/**
+ * The visual builder's storage-type palette. Each type is a recognizable card
+ * (concrete MUI icon + always-visible label, per NN/g) that doubles as a
+ * starter template: picking it seeds a sensible multi-level layout the owner
+ * then tweaks. `kind` values map onto the existing KIND_SUGGESTIONS taxonomy.
+ */
+import type { SvgIconComponent } from '@mui/icons-material';
+import Inventory2Outlined from '@mui/icons-material/Inventory2Outlined';
+import ViewModuleOutlined from '@mui/icons-material/ViewModuleOutlined';
+import DnsOutlined from '@mui/icons-material/DnsOutlined';
+import GridViewOutlined from '@mui/icons-material/GridViewOutlined';
+import TableRowsOutlined from '@mui/icons-material/TableRowsOutlined';
+import AllInboxOutlined from '@mui/icons-material/AllInboxOutlined';
+import ViewColumnOutlined from '@mui/icons-material/ViewColumnOutlined';
+
+import type { LevelSpec } from '@/types/inventoryLocations';
+
+export interface StorageType {
+  id: string;
+  label: string;
+  description: string;
+  Icon: SvgIconComponent;
+  /** Seeded layout (shallow → deep); the deepest level becomes the leaves. */
+  defaultLevels: LevelSpec[];
+}
+
+export const STORAGE_TYPES: StorageType[] = [
+  {
+    id: 'cabinet',
+    label: 'Cabinet',
+    description: 'Rows of bins or drawers',
+    Icon: Inventory2Outlined,
+    defaultLevels: [
+      { kind: 'cabinet', count: 1, namePattern: 'Cabinet {n}' },
+      { kind: 'row', count: 5, namePattern: 'Row {n}' },
+      { kind: 'bin', names: ['Left', 'Right'] },
+    ],
+  },
+  {
+    id: 'shelving',
+    label: 'Shelving unit',
+    description: 'A unit with several shelves',
+    Icon: ViewModuleOutlined,
+    defaultLevels: [
+      { kind: 'shelving', count: 1, namePattern: 'Shelving {n}' },
+      { kind: 'shelf', count: 5, namePattern: 'Shelf {n}' },
+    ],
+  },
+  {
+    id: 'rack',
+    label: 'Pallet rack',
+    description: 'Bays × levels × positions',
+    Icon: DnsOutlined,
+    defaultLevels: [
+      { kind: 'rack', count: 1, namePattern: 'Rack {n}' },
+      { kind: 'level', count: 4, namePattern: 'Level {n}' },
+      { kind: 'position', count: 3, namePattern: 'Pos {n}' },
+    ],
+  },
+  {
+    id: 'drawer-unit',
+    label: 'Drawer unit',
+    description: 'A tower of drawers',
+    Icon: GridViewOutlined,
+    defaultLevels: [
+      { kind: 'drawer unit', count: 1, namePattern: 'Drawer unit {n}' },
+      { kind: 'drawer', count: 6, namePattern: 'Drawer {n}' },
+    ],
+  },
+  {
+    id: 'shelf',
+    label: 'Single shelf',
+    description: 'One stockable shelf',
+    Icon: TableRowsOutlined,
+    defaultLevels: [{ kind: 'shelf', count: 1, namePattern: 'Shelf {n}' }],
+  },
+  {
+    id: 'bins',
+    label: 'Bins',
+    description: 'A set of loose bins',
+    Icon: AllInboxOutlined,
+    defaultLevels: [{ kind: 'bin', count: 6, namePattern: 'Bin {n}' }],
+  },
+  {
+    id: 'aisle',
+    label: 'Aisle / zone',
+    description: 'A broad area to fill in',
+    Icon: ViewColumnOutlined,
+    defaultLevels: [
+      { kind: 'aisle', count: 1, namePattern: 'Aisle {n}' },
+      { kind: 'bay', count: 4, namePattern: 'Bay {n}' },
+    ],
+  },
+];
+
+/** Deep-clone a type's seed levels so edits don't mutate the shared template. */
+export function cloneLevels(levels: LevelSpec[]): LevelSpec[] {
+  return levels.map((l) => ({ ...l, names: l.names ? [...l.names] : undefined }));
+}

--- a/components/inventory/locations/builder/storageTypes.tsx
+++ b/components/inventory/locations/builder/storageTypes.tsx
@@ -54,7 +54,7 @@ export const STORAGE_TYPES: StorageType[] = [
     defaultLevels: [
       { kind: 'rack', count: 1, namePattern: 'Rack {n}' },
       { kind: 'level', count: 4, namePattern: 'Level {n}' },
-      { kind: 'position', count: 3, namePattern: 'Pos {n}' },
+      { kind: 'position', count: 3, namePattern: 'Position {n}' },
     ],
   },
   {

--- a/components/parts/PartLocationActionModal.tsx
+++ b/components/parts/PartLocationActionModal.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Autocomplete from '@mui/material/Autocomplete';
+import Alert from '@mui/material/Alert';
+
+import {
+  addStockAtLocation,
+  depleteStockAtLocation,
+  adjustStockAtLocation,
+  transferStock,
+} from '@/utils/inventoryLocationsAccess';
+
+export type LocationAction = 'add' | 'deplete' | 'adjust' | 'move';
+
+export interface LocationOption {
+  id: string;
+  label: string;
+}
+
+const TITLES: Record<LocationAction, string> = {
+  add: 'Add stock at a location',
+  deplete: 'Remove stock from a location',
+  adjust: 'Set stock at a location (cycle count)',
+  move: 'Move stock between locations',
+};
+
+interface PartLocationActionModalProps {
+  open: boolean;
+  action: LocationAction;
+  partId: string;
+  primaryUnit: string;
+  unitOptions: string[];
+  locations: LocationOption[];
+  onClose: () => void;
+  onDone: () => void | Promise<void>;
+}
+
+export default function PartLocationActionModal({
+  open,
+  action,
+  partId,
+  primaryUnit,
+  unitOptions,
+  locations,
+  onClose,
+  onDone,
+}: PartLocationActionModalProps) {
+  const [location, setLocation] = useState<LocationOption | null>(null);
+  const [toLocation, setToLocation] = useState<LocationOption | null>(null);
+  const [quantity, setQuantity] = useState('');
+  const [unit, setUnit] = useState(primaryUnit);
+  const [notes, setNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleEnter = () => {
+    setLocation(null);
+    setToLocation(null);
+    setQuantity('');
+    setUnit(primaryUnit);
+    setNotes('');
+    setError(null);
+  };
+
+  const isMove = action === 'move';
+  const qtyLabel = action === 'adjust' ? 'New quantity at location' : 'Quantity';
+
+  const handleSubmit = async () => {
+    const qty = parseFloat(quantity);
+    if (!location) {
+      setError(isMove ? 'Choose a source location.' : 'Choose a location.');
+      return;
+    }
+    if (isMove && !toLocation) {
+      setError('Choose a destination location.');
+      return;
+    }
+    if (isMove && toLocation?.id === location.id) {
+      setError('Source and destination must differ.');
+      return;
+    }
+    if (!Number.isFinite(qty) || (action === 'adjust' ? qty < 0 : qty <= 0)) {
+      setError(action === 'adjust' ? 'Quantity cannot be negative.' : 'Quantity must be positive.');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      if (action === 'add') {
+        await addStockAtLocation(partId, location.id, qty, unit, notes || undefined);
+      } else if (action === 'deplete') {
+        await depleteStockAtLocation(partId, location.id, qty, unit, { notes: notes || undefined });
+      } else if (action === 'adjust') {
+        await adjustStockAtLocation(partId, location.id, qty, unit, notes || undefined);
+      } else {
+        await transferStock(partId, location.id, toLocation!.id, qty, unit, notes || undefined);
+      }
+      await onDone();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update stock.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={saving ? undefined : onClose}
+      maxWidth="xs"
+      fullWidth
+      TransitionProps={{ onEnter: handleEnter }}
+    >
+      <DialogTitle>{TITLES[action]}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Autocomplete
+            options={locations}
+            value={location}
+            onChange={(_, v) => setLocation(v)}
+            getOptionLabel={(o) => o.label}
+            isOptionEqualToValue={(o, v) => o.id === v.id}
+            renderInput={(params) => (
+              <TextField {...params} label={isMove ? 'From location' : 'Location'} required />
+            )}
+          />
+          {isMove && (
+            <Autocomplete
+              options={locations}
+              value={toLocation}
+              onChange={(_, v) => setToLocation(v)}
+              getOptionLabel={(o) => o.label}
+              isOptionEqualToValue={(o, v) => o.id === v.id}
+              renderInput={(params) => <TextField {...params} label="To location" required />}
+            />
+          )}
+          <Stack direction="row" spacing={1}>
+            <TextField
+              label={qtyLabel}
+              type="number"
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+              inputProps={{ min: 0, step: 'any' }}
+              fullWidth
+              autoFocus
+            />
+            <TextField
+              select
+              label="Unit"
+              value={unit}
+              onChange={(e) => setUnit(e.target.value)}
+              sx={{ minWidth: 110 }}
+            >
+              {unitOptions.map((u) => (
+                <MenuItem key={u} value={u}>
+                  {u}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Stack>
+          <TextField
+            label="Notes (optional)"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            multiline
+            minRows={2}
+            fullWidth
+          />
+          {error && <Alert severity="error">{error}</Alert>}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={saving}>
+          Confirm
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/parts/PartLocationInventory.tsx
+++ b/components/parts/PartLocationInventory.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
+import TuneIcon from '@mui/icons-material/Tune';
+import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
+import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined';
+
+import type { Part } from '@/types/part';
+import type {
+  InventoryLocation,
+  PartLocationBalanceWithLocation,
+} from '@/types/inventoryLocations';
+import { getBalancesForPart, getLocations, disableLocationTracking } from '@/utils/inventoryLocationsAccess';
+import { getStandardUnitsForUnit } from '@/lib/unitPresets';
+import PartLocationActionModal, {
+  type LocationAction,
+  type LocationOption,
+} from './PartLocationActionModal';
+
+function pathLabel(id: string, byId: Map<string, InventoryLocation>): string {
+  const names: string[] = [];
+  let cursor: string | null = id;
+  const guard = new Set<string>();
+  while (cursor && byId.has(cursor) && !guard.has(cursor)) {
+    guard.add(cursor);
+    const node: InventoryLocation = byId.get(cursor)!;
+    names.unshift(node.name);
+    cursor = node.parent_id;
+  }
+  return names.join(' › ');
+}
+
+interface PartLocationInventoryProps {
+  part: Part;
+  partId: string;
+  companyId: string;
+  /** Refresh the parent part (rollup quantity + history) after a change. */
+  onStockChanged: () => void | Promise<void>;
+}
+
+export default function PartLocationInventory({
+  part,
+  partId,
+  companyId,
+  onStockChanged,
+}: PartLocationInventoryProps) {
+  const [balances, setBalances] = useState<PartLocationBalanceWithLocation[]>([]);
+  const [locations, setLocations] = useState<InventoryLocation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [action, setAction] = useState<LocationAction | null>(null);
+  const [disabling, setDisabling] = useState(false);
+
+  const primaryUnit = part.primary_unit ?? '';
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [b, locs] = await Promise.all([getBalancesForPart(partId), getLocations(companyId)]);
+      setBalances(b);
+      setLocations(locs);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load location balances.');
+    } finally {
+      setLoading(false);
+    }
+  }, [partId, companyId]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const byId = useMemo(() => new Map(locations.map((l) => [l.id, l] as const)), [locations]);
+
+  const locationOptions = useMemo<LocationOption[]>(
+    () =>
+      locations
+        .filter((l) => l.is_stockable)
+        .map((l) => ({ id: l.id, label: pathLabel(l.id, byId) }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [locations, byId],
+  );
+
+  const unitOptions = useMemo(
+    () => Array.from(new Set([primaryUnit, ...getStandardUnitsForUnit(primaryUnit)])).filter(Boolean),
+    [primaryUnit],
+  );
+
+  const handleDisable = async () => {
+    setDisabling(true);
+    try {
+      await disableLocationTracking(partId);
+      await onStockChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to disable tracking.');
+    } finally {
+      setDisabling(false);
+    }
+  };
+
+  const onActionDone = async () => {
+    await reload();
+    await onStockChanged();
+  };
+
+  return (
+    <Box sx={{ textAlign: 'left' }}>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
+        <Chip icon={<LocationOnOutlinedIcon />} label="Location-tracked" color="info" size="small" />
+        <Box sx={{ flex: 1 }} />
+        <Button size="small" color="inherit" onClick={handleDisable} disabled={disabling}>
+          Disable tracking
+        </Button>
+      </Stack>
+
+      <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: 'wrap', gap: 1 }}>
+        <Button variant="contained" color="success" startIcon={<AddIcon />} onClick={() => setAction('add')}>
+          Add
+        </Button>
+        <Button variant="contained" color="error" startIcon={<RemoveIcon />} onClick={() => setAction('deplete')}>
+          Remove
+        </Button>
+        <Button variant="outlined" startIcon={<SwapHorizIcon />} onClick={() => setAction('move')}>
+          Move
+        </Button>
+        <Button variant="outlined" color="info" startIcon={<TuneIcon />} onClick={() => setAction('adjust')}>
+          Adjust
+        </Button>
+      </Stack>
+
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+          <CircularProgress size={28} />
+        </Box>
+      ) : balances.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No stock placed yet. Use Add to place stock at a location.
+        </Typography>
+      ) : (
+        <Stack spacing={1}>
+          {balances.map((b) => (
+            <Paper key={b.location_id} variant="outlined" sx={{ px: 2, py: 1, display: 'flex', alignItems: 'center' }}>
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography noWrap>{b.path.join(' › ') || b.location_name}</Typography>
+                {b.location_code && (
+                  <Typography variant="caption" color="text.secondary">
+                    {b.location_code}
+                  </Typography>
+                )}
+              </Box>
+              <Typography sx={{ fontWeight: 600 }}>
+                {b.quantity.toLocaleString(undefined, { maximumFractionDigits: 4 })} {primaryUnit}
+              </Typography>
+            </Paper>
+          ))}
+        </Stack>
+      )}
+
+      {action && (
+        <PartLocationActionModal
+          open={Boolean(action)}
+          action={action}
+          partId={partId}
+          primaryUnit={primaryUnit}
+          unitOptions={unitOptions}
+          locations={locationOptions}
+          onClose={() => setAction(null)}
+          onDone={onActionDone}
+        />
+      )}
+    </Box>
+  );
+}

--- a/components/parts/PartLocationInventory.tsx
+++ b/components/parts/PartLocationInventory.tsx
@@ -86,7 +86,6 @@ export default function PartLocationInventory({
   const locationOptions = useMemo<LocationOption[]>(
     () =>
       locations
-        .filter((l) => l.is_stockable)
         .map((l) => ({ id: l.id, label: pathLabel(l.id, byId) }))
         .sort((a, b) => a.label.localeCompare(b.label)),
     [locations, byId],

--- a/components/parts/PartTransactionHistoryTable.tsx
+++ b/components/parts/PartTransactionHistoryTable.tsx
@@ -149,6 +149,7 @@ export default function PartTransactionHistoryTable({
               <TableCell sx={{ fontWeight: 600 }}>Type</TableCell>
               <TableCell sx={{ fontWeight: 600 }} align="right">Quantity</TableCell>
               <TableCell sx={{ fontWeight: 600 }}>Related Job</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Location</TableCell>
               <TableCell sx={{ fontWeight: 600 }}>Notes</TableCell>
             </TableRow>
           </TableHead>
@@ -221,6 +222,11 @@ export default function PartTransactionHistoryTable({
                         —
                       </Typography>
                     )}
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2" color="text.secondary">
+                      {transaction.location_name || '—'}
+                    </Typography>
                   </TableCell>
                   <TableCell>
                     {editingId === transaction.id ? (

--- a/components/parts/workspace/PartWorkspace.tsx
+++ b/components/parts/workspace/PartWorkspace.tsx
@@ -380,6 +380,7 @@ export default function PartWorkspace({
           transactionsRefreshKey={transactionsRefreshKey}
           openTxnModal={openTxnModal}
           onConversionsChanged={setUnitConversions}
+          onStockChanged={handleTxnSuccess}
         />
       )}
 

--- a/components/parts/workspace/tabs/InventoryTab.tsx
+++ b/components/parts/workspace/tabs/InventoryTab.tsx
@@ -1,19 +1,24 @@
 'use client';
 
+import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
+import Alert from '@mui/material/Alert';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import TuneIcon from '@mui/icons-material/Tune';
+import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined';
 
 import type { Part, PartUnitConversion } from '@/types/part';
 import type { InventoryTransactionType } from '@/types/partTransaction';
 import PartTransactionHistoryTable from '@/components/parts/PartTransactionHistoryTable';
 import PartUnitConversionsEditor from '@/components/parts/PartUnitConversionsEditor';
+import PartLocationInventory from '@/components/parts/PartLocationInventory';
+import { enableLocationTracking } from '@/utils/inventoryLocationsAccess';
 
 interface InventoryTabProps {
   part: Part;
@@ -22,6 +27,8 @@ interface InventoryTabProps {
   transactionsRefreshKey: number;
   openTxnModal: (type: InventoryTransactionType) => void;
   onConversionsChanged: (next: PartUnitConversion[]) => void;
+  /** Refresh the part (rollup quantity + history) after a location change. */
+  onStockChanged: () => void | Promise<void>;
 }
 
 /**
@@ -37,9 +44,26 @@ export default function InventoryTab({
   transactionsRefreshKey,
   openTxnModal,
   onConversionsChanged,
+  onStockChanged,
 }: InventoryTabProps) {
   const belowReorder =
     part.reorder_point !== null && part.quantity <= part.reorder_point;
+
+  const [enabling, setEnabling] = useState(false);
+  const [enableError, setEnableError] = useState<string | null>(null);
+
+  const handleEnableTracking = async () => {
+    setEnabling(true);
+    setEnableError(null);
+    try {
+      await enableLocationTracking(partId);
+      await onStockChanged();
+    } catch (e) {
+      setEnableError(e instanceof Error ? e.message : 'Failed to enable location tracking.');
+    } finally {
+      setEnabling(false);
+    }
+  };
 
   return (
     <Card elevation={2}>
@@ -66,38 +90,73 @@ export default function InventoryTab({
           />
         )}
 
-        <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', mt: 4, flexWrap: 'wrap' }}>
-          <Button
-            variant="contained"
-            color="success"
-            size="large"
-            startIcon={<AddIcon />}
-            onClick={() => openTxnModal('addition')}
-            disabled={!part.primary_unit}
-          >
-            Add Stock
-          </Button>
-          <Button
-            variant="contained"
-            color="error"
-            size="large"
-            startIcon={<RemoveIcon />}
-            onClick={() => openTxnModal('depletion')}
-            disabled={!part.primary_unit || part.quantity <= 0}
-          >
-            Remove Stock
-          </Button>
-          <Button
-            variant="outlined"
-            color="info"
-            size="large"
-            startIcon={<TuneIcon />}
-            onClick={() => openTxnModal('adjustment')}
-            disabled={!part.primary_unit}
-          >
-            Adjust
-          </Button>
-        </Box>
+        {part.is_location_tracked ? (
+          <Box sx={{ mt: 4 }}>
+            <PartLocationInventory
+              part={part}
+              partId={partId}
+              companyId={companyId}
+              onStockChanged={onStockChanged}
+            />
+          </Box>
+        ) : (
+          <>
+            <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', mt: 4, flexWrap: 'wrap' }}>
+              <Button
+                variant="contained"
+                color="success"
+                size="large"
+                startIcon={<AddIcon />}
+                onClick={() => openTxnModal('addition')}
+                disabled={!part.primary_unit}
+              >
+                Add Stock
+              </Button>
+              <Button
+                variant="contained"
+                color="error"
+                size="large"
+                startIcon={<RemoveIcon />}
+                onClick={() => openTxnModal('depletion')}
+                disabled={!part.primary_unit || part.quantity <= 0}
+              >
+                Remove Stock
+              </Button>
+              <Button
+                variant="outlined"
+                color="info"
+                size="large"
+                startIcon={<TuneIcon />}
+                onClick={() => openTxnModal('adjustment')}
+                disabled={!part.primary_unit}
+              >
+                Adjust
+              </Button>
+            </Box>
+
+            {part.primary_unit && (
+              <Box sx={{ mt: 2 }}>
+                <Button
+                  variant="text"
+                  startIcon={<LocationOnOutlinedIcon />}
+                  onClick={handleEnableTracking}
+                  disabled={enabling}
+                >
+                  Enable location tracking
+                </Button>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                  Track where this part is stored across cabinets and bins. Current stock moves to an
+                  “Unassigned” location you can distribute from.
+                </Typography>
+                {enableError && (
+                  <Alert severity="error" sx={{ mt: 1 }}>
+                    {enableError}
+                  </Alert>
+                )}
+              </Box>
+            )}
+          </>
+        )}
 
         {/* Unit conversions — inline-editable list. */}
         {part.primary_unit && (

--- a/components/parts/workspace/tabs/InventoryTab.tsx
+++ b/components/parts/workspace/tabs/InventoryTab.tsx
@@ -19,6 +19,7 @@ import PartTransactionHistoryTable from '@/components/parts/PartTransactionHisto
 import PartUnitConversionsEditor from '@/components/parts/PartUnitConversionsEditor';
 import PartLocationInventory from '@/components/parts/PartLocationInventory';
 import { enableLocationTracking } from '@/utils/inventoryLocationsAccess';
+import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 
 interface InventoryTabProps {
   part: Part;
@@ -48,6 +49,7 @@ export default function InventoryTab({
 }: InventoryTabProps) {
   const belowReorder =
     part.reorder_point !== null && part.quantity <= part.reorder_point;
+  const { features } = useCompanyFeatures();
 
   const [enabling, setEnabling] = useState(false);
   const [enableError, setEnableError] = useState<string | null>(null);
@@ -134,7 +136,7 @@ export default function InventoryTab({
               </Button>
             </Box>
 
-            {part.primary_unit && (
+            {part.primary_unit && features.inventory_locations && (
               <Box sx={{ mt: 2 }}>
                 <Button
                   variant="text"

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -44,6 +44,12 @@ export const KNOWN_FEATURES: readonly FeatureFlagDescriptor[] = [
     description:
       'Packing-slip generation, shipment history, and dual production / fulfillment status on jobs.',
   },
+  {
+    key: 'inventory_locations',
+    label: 'Inventory Locations',
+    description:
+      'QR-addressable storage locations with per-location stock: the Locations manager + visual builder, per-part location tracking, and bin scanning. The base inventory list is unaffected.',
+  },
 ] as const;
 
 export type KnownFeatureKey = (typeof KNOWN_FEATURES)[number]['key'];
@@ -75,6 +81,12 @@ export function isShipmentsEnabled(
   company: Pick<Company, 'settings'> | null | undefined,
 ): boolean {
   return readFeatureFlag(company, 'shipments');
+}
+
+export function isInventoryLocationsEnabled(
+  company: Pick<Company, 'settings'> | null | undefined,
+): boolean {
+  return readFeatureFlag(company, 'inventory_locations');
 }
 
 /**

--- a/supabase/migrations/20260622022856_inventory_locations_schema.sql
+++ b/supabase/migrations/20260622022856_inventory_locations_schema.sql
@@ -1,0 +1,176 @@
+-- Inventory Locations & QR-Addressable Stock — schema (PR1 of 2)
+--
+-- Adds a hierarchical, company-scoped storage-location tree and per-location
+-- stock balances. For a part opted into location tracking, part_location_stock
+-- becomes the source of truth and parts.quantity becomes a trigger-maintained
+-- rollup (see the sibling triggers migration). This file only lays down tables,
+-- columns, constraints, indexes and RLS; triggers and RPCs follow.
+--
+-- Key invariants enforced here:
+--   * part_location_stock.quantity >= 0 (mirrors parts_quantity_non_negative so a
+--     rollup can never try to write a negative SUM).
+--   * UNIQUE(part_id, location_id): one balance row per part per location.
+--   * part_location_stock is SELECT-only under RLS — every balance mutation must
+--     go through the SECURITY DEFINER RPCs (which also write the ledger), so a
+--     balance change can never exist without a paired inventory_transactions row.
+--   * inventory_transactions.location_id uses ON DELETE RESTRICT (preserve the
+--     audit link) which also lets us treat location_id as immutable on the ledger.
+
+-- ============================================================
+-- 1. TABLES
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS "public"."inventory_locations"
+(
+    "id"            uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id"    uuid NOT NULL,
+    "parent_id"     uuid,                                   -- null = root node
+    "name"          text NOT NULL,                          -- "Left", "Row 3", "Cabinet 1"
+    "kind"          text,                                   -- free: 'cabinet'|'row'|'side'|'shelf'|'bin'|…
+    "code"          text,                                   -- derived/edited flat label code e.g. "CAB1-R3-L"
+    "is_stockable"  boolean NOT NULL DEFAULT true,          -- may hold part balances
+    "is_qr_anchor"  boolean NOT NULL DEFAULT false,         -- has a printed QR / is a scan target
+    "sort_order"    integer NOT NULL DEFAULT 0,
+    "created_at"    timestamp with time zone NOT NULL DEFAULT now(),
+    "updated_at"    timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "inventory_locations_pkey" PRIMARY KEY (id),
+    CONSTRAINT "inventory_locations_company_fkey"
+        FOREIGN KEY (company_id) REFERENCES "public"."companies"(id) ON DELETE CASCADE,
+    CONSTRAINT "inventory_locations_parent_fkey"
+        FOREIGN KEY (parent_id) REFERENCES "public"."inventory_locations"(id) ON DELETE RESTRICT,
+    CONSTRAINT "inventory_locations_name_not_blank" CHECK (length(btrim(name)) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS "public"."part_location_stock"
+(
+    "id"            uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id"    uuid NOT NULL,
+    "part_id"       uuid NOT NULL,
+    "location_id"   uuid NOT NULL,
+    "quantity"      numeric NOT NULL DEFAULT 0,
+    "created_at"    timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "part_location_stock_pkey" PRIMARY KEY (id),
+    CONSTRAINT "part_location_stock_company_fkey"
+        FOREIGN KEY (company_id) REFERENCES "public"."companies"(id) ON DELETE CASCADE,
+    CONSTRAINT "part_location_stock_part_fkey"
+        FOREIGN KEY (part_id) REFERENCES "public"."parts"(id) ON DELETE RESTRICT,
+    CONSTRAINT "part_location_stock_location_fkey"
+        FOREIGN KEY (location_id) REFERENCES "public"."inventory_locations"(id) ON DELETE RESTRICT,
+    CONSTRAINT "part_location_stock_part_location_unique" UNIQUE (part_id, location_id),
+    CONSTRAINT "part_location_stock_quantity_non_negative" CHECK ((quantity >= (0)::numeric))
+);
+
+-- ============================================================
+-- 2. ADDITIVE COLUMNS ON EXISTING TABLES
+-- ============================================================
+
+ALTER TABLE "public"."parts"
+    ADD COLUMN IF NOT EXISTS "is_location_tracked" boolean NOT NULL DEFAULT false;
+
+ALTER TABLE "public"."inventory_transactions"
+    ADD COLUMN IF NOT EXISTS "location_id"       uuid,
+    ADD COLUMN IF NOT EXISTS "transfer_group_id" uuid;          -- pairs the two halves of a move
+
+ALTER TABLE "public"."inventory_transactions"
+    ADD CONSTRAINT "inventory_transactions_location_fkey"
+        FOREIGN KEY (location_id) REFERENCES "public"."inventory_locations"(id) ON DELETE RESTRICT;
+
+-- ============================================================
+-- 3. INDEXES
+-- ============================================================
+
+CREATE INDEX IF NOT EXISTS "inventory_locations_company_parent_idx"
+    ON "public"."inventory_locations" (company_id, parent_id);
+
+-- At most one system "Unassigned" location per company (find-or-create target at opt-in).
+CREATE UNIQUE INDEX IF NOT EXISTS "inventory_locations_one_unassigned_per_company"
+    ON "public"."inventory_locations" (company_id)
+    WHERE (name = 'Unassigned');
+
+CREATE INDEX IF NOT EXISTS "part_location_stock_company_idx"
+    ON "public"."part_location_stock" (company_id);
+CREATE INDEX IF NOT EXISTS "part_location_stock_location_idx"
+    ON "public"."part_location_stock" (location_id);          -- "what's in this location?"
+CREATE INDEX IF NOT EXISTS "part_location_stock_part_idx"
+    ON "public"."part_location_stock" (part_id);              -- rollup SUM(WHERE part_id=…)
+
+CREATE INDEX IF NOT EXISTS "inventory_transactions_location_idx"
+    ON "public"."inventory_transactions" (location_id) WHERE (location_id IS NOT NULL);
+CREATE INDEX IF NOT EXISTS "inventory_transactions_transfer_group_idx"
+    ON "public"."inventory_transactions" (transfer_group_id) WHERE (transfer_group_id IS NOT NULL);
+
+-- ============================================================
+-- 4. ROW LEVEL SECURITY
+-- ============================================================
+
+ALTER TABLE "public"."inventory_locations"   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."part_location_stock"   ENABLE ROW LEVEL SECURITY;
+
+-- inventory_locations: full company-scoped CRUD (tree management is plain client CRUD).
+DROP POLICY IF EXISTS "Users can view inventory_locations" ON "public"."inventory_locations";
+CREATE POLICY "Users can view inventory_locations"
+    ON "public"."inventory_locations" FOR SELECT
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+DROP POLICY IF EXISTS "Users can insert inventory_locations" ON "public"."inventory_locations";
+CREATE POLICY "Users can insert inventory_locations"
+    ON "public"."inventory_locations" FOR INSERT
+    WITH CHECK ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+DROP POLICY IF EXISTS "Users can update inventory_locations" ON "public"."inventory_locations";
+CREATE POLICY "Users can update inventory_locations"
+    ON "public"."inventory_locations" FOR UPDATE
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)))
+    WITH CHECK ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+DROP POLICY IF EXISTS "Users can delete inventory_locations" ON "public"."inventory_locations";
+CREATE POLICY "Users can delete inventory_locations"
+    ON "public"."inventory_locations" FOR DELETE
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+-- part_location_stock: SELECT only. INSERT/UPDATE/DELETE intentionally have NO
+-- policy, so direct client writes are denied by RLS — every balance change must
+-- flow through a SECURITY DEFINER RPC that also writes the ledger.
+DROP POLICY IF EXISTS "Users can view part_location_stock" ON "public"."part_location_stock";
+CREATE POLICY "Users can view part_location_stock"
+    ON "public"."part_location_stock" FOR SELECT
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+-- ============================================================
+-- 5. LEDGER IMMUTABILITY — extend the notes-only update guard
+-- ============================================================
+-- location_id and transfer_group_id join the immutable column set so a move's
+-- group link and the where-it-happened pointer can't be rewritten via the
+-- notes-edit path. Safe alongside the ON DELETE RESTRICT FK: RESTRICT never
+-- updates these rows, so there is no cascade-vs-immutability conflict.
+
+CREATE OR REPLACE FUNCTION public.restrict_transaction_update_to_notes()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    IF OLD.company_id          IS DISTINCT FROM NEW.company_id
+       OR OLD.part_id          IS DISTINCT FROM NEW.part_id
+       OR OLD.item_name        IS DISTINCT FROM NEW.item_name
+       OR OLD.type             IS DISTINCT FROM NEW.type
+       OR OLD.quantity         IS DISTINCT FROM NEW.quantity
+       OR OLD.unit             IS DISTINCT FROM NEW.unit
+       OR OLD.converted_quantity IS DISTINCT FROM NEW.converted_quantity
+       OR OLD.job_id           IS DISTINCT FROM NEW.job_id
+       OR OLD.job_operation_id IS DISTINCT FROM NEW.job_operation_id
+       OR OLD.operator_id      IS DISTINCT FROM NEW.operator_id
+       OR OLD.created_at       IS DISTINCT FROM NEW.created_at
+       OR OLD.created_by       IS DISTINCT FROM NEW.created_by
+       OR OLD.has_discrepancy  IS DISTINCT FROM NEW.has_discrepancy
+       OR OLD.location_id       IS DISTINCT FROM NEW.location_id
+       OR OLD.transfer_group_id IS DISTINCT FROM NEW.transfer_group_id
+    THEN
+        RAISE EXCEPTION 'Only the notes field can be updated on inventory transactions';
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+COMMENT ON TABLE "public"."inventory_locations" IS 'Company-scoped, arbitrary-depth storage-location tree (cabinet › row › side, etc.). is_qr_anchor marks nodes with a printed QR.';
+COMMENT ON TABLE "public"."part_location_stock" IS 'Per-location stock balances; source of truth for location-tracked parts. SELECT-only via RLS — mutated only through SECURITY DEFINER RPCs that also write inventory_transactions.';
+COMMENT ON COLUMN "public"."parts"."is_location_tracked" IS 'When true, parts.quantity is a trigger-maintained rollup of part_location_stock and direct quantity writes are rejected.';

--- a/supabase/migrations/20260622023128_inventory_location_rollup_triggers.sql
+++ b/supabase/migrations/20260622023128_inventory_location_rollup_triggers.sql
@@ -1,0 +1,77 @@
+-- Inventory Locations — rollup + invariant-guard triggers (PR1 of 2)
+--
+-- Establishes the data-at-rest invariant for location-tracked parts:
+--     parts.quantity == COALESCE(SUM(part_location_stock.quantity), 0)
+--
+-- Two triggers cooperate:
+--   1. recompute_part_quantity_from_locations (AFTER on part_location_stock):
+--      whenever a balance row changes, recompute the owning part's rollup from
+--      the authoritative SUM — never from NEW-OLD deltas, so concurrent writers
+--      cannot drift. Only acts on location-tracked parts.
+--   2. enforce_tracked_part_quantity (BEFORE UPDATE on parts): rejects any direct
+--      quantity write on a tracked part that does not equal the current SUM. The
+--      rollup's own write (= exactly that SUM) passes; an arbitrary client write
+--      (e.g. a raw PostgREST PATCH that RLS would otherwise allow) fails. This is
+--      what makes the invariant real rather than enforced only in the access layer.
+
+-- ---- 1. Rollup: balance change -> recompute parts.quantity ----------------
+CREATE OR REPLACE FUNCTION public.recompute_part_quantity_from_locations()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_part_id uuid := COALESCE(NEW.part_id, OLD.part_id);
+    v_tracked boolean;
+BEGIN
+    SELECT is_location_tracked INTO v_tracked FROM public.parts WHERE id = v_part_id;
+
+    IF COALESCE(v_tracked, false) THEN
+        UPDATE public.parts
+           SET quantity = COALESCE(
+                   (SELECT SUM(quantity) FROM public.part_location_stock WHERE part_id = v_part_id),
+                   0),
+               updated_at = now()
+         WHERE id = v_part_id;
+    END IF;
+
+    RETURN NULL; -- AFTER trigger: return value is ignored
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS "trg_recompute_part_quantity" ON "public"."part_location_stock";
+CREATE TRIGGER "trg_recompute_part_quantity"
+    AFTER INSERT OR UPDATE OR DELETE ON "public"."part_location_stock"
+    FOR EACH ROW EXECUTE FUNCTION public.recompute_part_quantity_from_locations();
+
+-- ---- 2. Guard: reject direct parts.quantity writes on tracked parts --------
+CREATE OR REPLACE FUNCTION public.enforce_tracked_part_quantity()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_expected numeric;
+BEGIN
+    IF NEW.is_location_tracked AND NEW.quantity IS DISTINCT FROM OLD.quantity THEN
+        v_expected := COALESCE(
+            (SELECT SUM(quantity) FROM public.part_location_stock WHERE part_id = NEW.id),
+            0);
+
+        IF NEW.quantity IS DISTINCT FROM v_expected THEN
+            RAISE EXCEPTION 'parts.quantity for location-tracked part % is maintained from part_location_stock; direct quantity writes are not allowed (attempted %, expected %)',
+                NEW.id, NEW.quantity, v_expected
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS "trg_enforce_tracked_part_quantity" ON "public"."parts";
+CREATE TRIGGER "trg_enforce_tracked_part_quantity"
+    BEFORE UPDATE ON "public"."parts"
+    FOR EACH ROW EXECUTE FUNCTION public.enforce_tracked_part_quantity();

--- a/supabase/migrations/20260622023407_inventory_location_stock_rpcs.sql
+++ b/supabase/migrations/20260622023407_inventory_location_stock_rpcs.sql
@@ -1,0 +1,430 @@
+-- Inventory Locations — atomic stock-mutation RPCs (PR1 of 2)
+--
+-- Every per-location balance change is paired with an inventory_transactions row
+-- in ONE transaction. All are SECURITY DEFINER (like create_shipment_with_line_items)
+-- so they can write the SELECT-only part_location_stock table; because DEFINER
+-- bypasses RLS, the ONLY tenant boundary is the explicit guard inside each function.
+--
+-- Tenancy guard (load-bearing): we DERIVE the company from the part and verify the
+-- caller's membership AND that every location id resolves to that same company. A
+-- caller cannot pass a part/location from another company — the FKs check existence,
+-- not ownership, and DEFINER skips RLS, so corruption is only prevented by this guard.
+--
+-- Unit handling mirrors the existing partsAccess functions: the client converts to
+-- the part's primary unit and passes p_converted_quantity; the RPC stores the display
+-- (quantity, unit) plus converted_quantity, and operates on balances in primary units.
+
+-- ============================================================
+-- Helper: assert a location belongs to a company (or raise)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.inv_assert_location_in_company(p_location_id uuid, p_company_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+    IF p_location_id IS NULL THEN
+        RAISE EXCEPTION 'location_id is required' USING ERRCODE = 'null_value_not_allowed';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM public.inventory_locations
+         WHERE id = p_location_id AND company_id = p_company_id
+    ) THEN
+        RAISE EXCEPTION 'location % is not in company %', p_location_id, p_company_id
+            USING ERRCODE = 'insufficient_privilege';
+    END IF;
+END;
+$function$;
+
+-- ============================================================
+-- add_stock_at_location
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.add_stock_at_location(
+    p_part_id uuid, p_location_id uuid,
+    p_quantity numeric, p_unit text, p_converted_quantity numeric,
+    p_notes text DEFAULT NULL)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_item_name text; v_tracked boolean;
+    v_new_balance numeric; v_rollup numeric;
+BEGIN
+    IF p_quantity <= 0 OR p_converted_quantity <= 0 THEN
+        RAISE EXCEPTION 'Quantity must be positive' USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT company_id, part_name, is_location_tracked
+      INTO v_company, v_item_name, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF NOT v_tracked THEN
+        RAISE EXCEPTION 'part % is not location-tracked; enable tracking first', p_part_id USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM public.inv_assert_location_in_company(p_location_id, v_company);
+
+    INSERT INTO public.part_location_stock AS pls (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, p_location_id, p_converted_quantity)
+    ON CONFLICT (part_id, location_id)
+        DO UPDATE SET quantity = pls.quantity + EXCLUDED.quantity
+    RETURNING pls.quantity INTO v_new_balance;
+
+    INSERT INTO public.inventory_transactions
+        (company_id, part_id, item_name, type, quantity, unit, converted_quantity,
+         location_id, notes, created_by)
+    VALUES
+        (v_company, p_part_id, v_item_name, 'addition', p_quantity, p_unit, p_converted_quantity,
+         p_location_id, p_notes, auth.uid());
+
+    SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+    RETURN jsonb_build_object('location_balance', v_new_balance, 'part_quantity', v_rollup);
+END;
+$function$;
+
+-- ============================================================
+-- deplete_stock_at_location (graceful clamp under a row lock)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.deplete_stock_at_location(
+    p_part_id uuid, p_location_id uuid,
+    p_quantity numeric, p_unit text, p_converted_quantity numeric,
+    p_graceful boolean DEFAULT false,
+    p_notes text DEFAULT NULL,
+    p_job_id uuid DEFAULT NULL, p_job_operation_id uuid DEFAULT NULL, p_operator_id uuid DEFAULT NULL)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_item_name text; v_primary_unit text; v_tracked boolean;
+    v_current numeric; v_new numeric; v_rollup numeric;
+    v_discrepancy boolean := false; v_shortfall numeric := 0;
+    v_notes text; v_disc_note text;
+BEGIN
+    IF p_quantity <= 0 OR p_converted_quantity <= 0 THEN
+        RAISE EXCEPTION 'Quantity must be positive' USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT company_id, part_name, primary_unit, is_location_tracked
+      INTO v_company, v_item_name, v_primary_unit, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF NOT v_tracked THEN
+        RAISE EXCEPTION 'part % is not location-tracked; enable tracking first', p_part_id USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM public.inv_assert_location_in_company(p_location_id, v_company);
+
+    -- Lock the balance row (treat a missing row as 0 on hand).
+    SELECT quantity INTO v_current
+      FROM public.part_location_stock
+     WHERE part_id = p_part_id AND location_id = p_location_id
+       FOR UPDATE;
+    v_current := COALESCE(v_current, 0);
+
+    v_new := v_current - p_converted_quantity;
+    v_notes := p_notes;
+
+    IF v_new < 0 THEN
+        IF p_graceful THEN
+            v_shortfall := p_converted_quantity - v_current;
+            v_new := 0;
+            v_discrepancy := true;
+            v_disc_note := format(
+                '[DISCREPANCY: Confirmed %s %s, but only %s %s was available. Shortfall: %s %s]',
+                p_converted_quantity, v_primary_unit, v_current, v_primary_unit, v_shortfall, v_primary_unit);
+            v_notes := CASE WHEN v_notes IS NULL OR v_notes = '' THEN v_disc_note
+                            ELSE v_notes || ' ' || v_disc_note END;
+        ELSE
+            RAISE EXCEPTION 'Insufficient stock at location (have %, need %)', v_current, p_converted_quantity
+                USING ERRCODE = 'check_violation';
+        END IF;
+    END IF;
+
+    INSERT INTO public.part_location_stock (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, p_location_id, v_new)
+    ON CONFLICT (part_id, location_id) DO UPDATE SET quantity = EXCLUDED.quantity;
+
+    INSERT INTO public.inventory_transactions
+        (company_id, part_id, item_name, type, quantity, unit, converted_quantity,
+         location_id, job_id, job_operation_id, operator_id, notes, has_discrepancy, created_by)
+    VALUES
+        (v_company, p_part_id, v_item_name, 'depletion', p_quantity, p_unit, p_converted_quantity,
+         p_location_id, p_job_id, p_job_operation_id, p_operator_id, v_notes, v_discrepancy, auth.uid());
+
+    SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+    RETURN jsonb_build_object(
+        'location_balance', v_new, 'part_quantity', v_rollup,
+        'has_discrepancy', v_discrepancy, 'shortfall', v_shortfall);
+END;
+$function$;
+
+-- ============================================================
+-- adjust_stock_at_location (cycle count -> set balance to target)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.adjust_stock_at_location(
+    p_part_id uuid, p_location_id uuid,
+    p_new_quantity numeric, p_unit text, p_converted_new_quantity numeric,
+    p_notes text DEFAULT NULL)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_item_name text; v_primary_unit text; v_tracked boolean;
+    v_current numeric; v_diff numeric; v_rollup numeric; v_notes text;
+BEGIN
+    IF p_converted_new_quantity < 0 THEN
+        RAISE EXCEPTION 'Quantity cannot be negative' USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT company_id, part_name, primary_unit, is_location_tracked
+      INTO v_company, v_item_name, v_primary_unit, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF NOT v_tracked THEN
+        RAISE EXCEPTION 'part % is not location-tracked; enable tracking first', p_part_id USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM public.inv_assert_location_in_company(p_location_id, v_company);
+
+    SELECT quantity INTO v_current
+      FROM public.part_location_stock
+     WHERE part_id = p_part_id AND location_id = p_location_id
+       FOR UPDATE;
+    v_current := COALESCE(v_current, 0);
+    v_diff := p_converted_new_quantity - v_current;
+
+    INSERT INTO public.part_location_stock (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, p_location_id, p_converted_new_quantity)
+    ON CONFLICT (part_id, location_id) DO UPDATE SET quantity = EXCLUDED.quantity;
+
+    v_notes := COALESCE(
+        p_notes,
+        format('Adjusted from %s to %s %s', v_current, p_converted_new_quantity, v_primary_unit));
+
+    INSERT INTO public.inventory_transactions
+        (company_id, part_id, item_name, type, quantity, unit, converted_quantity,
+         location_id, notes, created_by)
+    VALUES
+        (v_company, p_part_id, v_item_name, 'adjustment', abs(v_diff), v_primary_unit, abs(v_diff),
+         p_location_id, v_notes, auth.uid());
+
+    SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+    RETURN jsonb_build_object('location_balance', p_converted_new_quantity, 'part_quantity', v_rollup);
+END;
+$function$;
+
+-- ============================================================
+-- transfer_stock (paired depletion@from + addition@to, one group)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.transfer_stock(
+    p_part_id uuid, p_from_location_id uuid, p_to_location_id uuid,
+    p_quantity numeric, p_unit text, p_converted_quantity numeric,
+    p_notes text DEFAULT NULL)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_item_name text; v_tracked boolean;
+    v_src numeric; v_from_balance numeric; v_to_balance numeric;
+    v_group uuid; v_from_name text; v_to_name text;
+    v_from_notes text; v_to_notes text; v_base text;
+BEGIN
+    IF p_quantity <= 0 OR p_converted_quantity <= 0 THEN
+        RAISE EXCEPTION 'Quantity must be positive' USING ERRCODE = 'check_violation';
+    END IF;
+    IF p_from_location_id = p_to_location_id THEN
+        RAISE EXCEPTION 'Source and destination locations must differ' USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT company_id, part_name, is_location_tracked
+      INTO v_company, v_item_name, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF NOT v_tracked THEN
+        RAISE EXCEPTION 'part % is not location-tracked; enable tracking first', p_part_id USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM public.inv_assert_location_in_company(p_from_location_id, v_company);
+    PERFORM public.inv_assert_location_in_company(p_to_location_id, v_company);
+
+    -- Lock + verify source has enough (hard fail — you can't move stock you lack).
+    SELECT quantity INTO v_src
+      FROM public.part_location_stock
+     WHERE part_id = p_part_id AND location_id = p_from_location_id
+       FOR UPDATE;
+    IF v_src IS NULL OR v_src < p_converted_quantity THEN
+        RAISE EXCEPTION 'Insufficient stock at source location (have %, need %)',
+            COALESCE(v_src, 0), p_converted_quantity USING ERRCODE = 'check_violation';
+    END IF;
+
+    UPDATE public.part_location_stock
+       SET quantity = v_src - p_converted_quantity
+     WHERE part_id = p_part_id AND location_id = p_from_location_id
+    RETURNING quantity INTO v_from_balance;
+
+    INSERT INTO public.part_location_stock AS pls (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, p_to_location_id, p_converted_quantity)
+    ON CONFLICT (part_id, location_id)
+        DO UPDATE SET quantity = pls.quantity + EXCLUDED.quantity
+    RETURNING pls.quantity INTO v_to_balance;
+
+    v_group := gen_random_uuid();
+    SELECT name INTO v_from_name FROM public.inventory_locations WHERE id = p_from_location_id;
+    SELECT name INTO v_to_name   FROM public.inventory_locations WHERE id = p_to_location_id;
+    v_base := COALESCE(NULLIF(p_notes, ''), '');
+
+    v_from_notes := btrim(v_base || ' ' || format('[Transfer to %s]', v_to_name));
+    v_to_notes   := btrim(v_base || ' ' || format('[Transfer from %s]', v_from_name));
+
+    INSERT INTO public.inventory_transactions
+        (company_id, part_id, item_name, type, quantity, unit, converted_quantity,
+         location_id, transfer_group_id, notes, created_by)
+    VALUES
+        (v_company, p_part_id, v_item_name, 'depletion', p_quantity, p_unit, p_converted_quantity,
+         p_from_location_id, v_group, v_from_notes, auth.uid()),
+        (v_company, p_part_id, v_item_name, 'addition', p_quantity, p_unit, p_converted_quantity,
+         p_to_location_id, v_group, v_to_notes, auth.uid());
+
+    RETURN jsonb_build_object(
+        'transfer_group_id', v_group,
+        'from_balance', v_from_balance, 'to_balance', v_to_balance);
+END;
+$function$;
+
+-- ============================================================
+-- enable_location_tracking (atomic opt-in + backfill, no double-count)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.enable_location_tracking(
+    p_part_id uuid, p_initial_location_id uuid DEFAULT NULL)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_qty numeric; v_tracked boolean; v_loc uuid; v_rollup numeric;
+BEGIN
+    SELECT company_id, quantity, is_location_tracked
+      INTO v_company, v_qty, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+
+    -- Idempotent: already tracked -> no-op.
+    IF v_tracked THEN
+        SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+        RETURN jsonb_build_object('part_quantity', v_rollup, 'tracked', true, 'noop', true);
+    END IF;
+
+    -- Resolve the backfill location: caller-chosen, else find-or-create "Unassigned".
+    IF p_initial_location_id IS NOT NULL THEN
+        PERFORM public.inv_assert_location_in_company(p_initial_location_id, v_company);
+        v_loc := p_initial_location_id;
+    ELSE
+        PERFORM pg_advisory_xact_lock(hashtext('inv_unassigned:' || v_company::text));
+        SELECT id INTO v_loc
+          FROM public.inventory_locations
+         WHERE company_id = v_company AND name = 'Unassigned';
+        IF v_loc IS NULL THEN
+            INSERT INTO public.inventory_locations (company_id, name, kind, is_stockable, is_qr_anchor)
+            VALUES (v_company, 'Unassigned', 'system', true, false)
+            RETURNING id INTO v_loc;
+        END IF;
+    END IF;
+
+    -- Flip the flag FIRST (quantity unchanged -> guard skipped), THEN seed the
+    -- backfill balance equal to the pre-existing quantity so the rollup overwrites
+    -- parts.quantity with the same SUM. Never let a standalone value coexist.
+    UPDATE public.parts SET is_location_tracked = true, updated_at = now() WHERE id = p_part_id;
+
+    INSERT INTO public.part_location_stock AS pls (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, v_loc, v_qty)
+    ON CONFLICT (part_id, location_id)
+        DO UPDATE SET quantity = pls.quantity + EXCLUDED.quantity;
+
+    SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+    RETURN jsonb_build_object('location_id', v_loc, 'part_quantity', v_rollup, 'tracked', true);
+END;
+$function$;
+
+-- ============================================================
+-- disable_location_tracking (collapse balances back; exact order)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.disable_location_tracking(p_part_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_tracked boolean; v_total numeric;
+BEGIN
+    SELECT company_id, is_location_tracked
+      INTO v_company, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+
+    IF NOT v_tracked THEN
+        RETURN jsonb_build_object('part_quantity',
+            (SELECT quantity FROM public.parts WHERE id = p_part_id), 'tracked', false, 'noop', true);
+    END IF;
+
+    v_total := COALESCE(
+        (SELECT SUM(quantity) FROM public.part_location_stock WHERE part_id = p_part_id), 0);
+
+    -- Flip the flag FIRST (so the subsequent DELETE's rollup is a no-op) and set
+    -- the collapsed total in the same statement (allowed: tracked is now false).
+    UPDATE public.parts
+       SET is_location_tracked = false, quantity = v_total, updated_at = now()
+     WHERE id = p_part_id;
+
+    DELETE FROM public.part_location_stock WHERE part_id = p_part_id;
+
+    RETURN jsonb_build_object('part_quantity', v_total, 'tracked', false);
+END;
+$function$;
+
+-- ============================================================
+-- GRANTS — callable via supabase.rpc() by the standard roles
+-- ============================================================
+GRANT ALL ON FUNCTION public.inv_assert_location_in_company(uuid, uuid) TO anon, authenticated, service_role;
+GRANT ALL ON FUNCTION public.add_stock_at_location(uuid, uuid, numeric, text, numeric, text) TO anon, authenticated, service_role;
+GRANT ALL ON FUNCTION public.deplete_stock_at_location(uuid, uuid, numeric, text, numeric, boolean, text, uuid, uuid, uuid) TO anon, authenticated, service_role;
+GRANT ALL ON FUNCTION public.adjust_stock_at_location(uuid, uuid, numeric, text, numeric, text) TO anon, authenticated, service_role;
+GRANT ALL ON FUNCTION public.transfer_stock(uuid, uuid, uuid, numeric, text, numeric, text) TO anon, authenticated, service_role;
+GRANT ALL ON FUNCTION public.enable_location_tracking(uuid, uuid) TO anon, authenticated, service_role;
+GRANT ALL ON FUNCTION public.disable_location_tracking(uuid) TO anon, authenticated, service_role;

--- a/supabase/migrations/20260622034847_inventory_location_deletable_with_history.sql
+++ b/supabase/migrations/20260622034847_inventory_location_deletable_with_history.sql
@@ -1,0 +1,156 @@
+-- Make an EMPTY location deletable even after it has activity history.
+--
+-- Real-world case: a shelf is used, everything is later removed, and the shelf
+-- is thrown out — the operator should be able to delete the location entirely.
+-- Previously inventory_transactions.location_id was ON DELETE RESTRICT, so any
+-- location that had ever been transacted could never be deleted.
+--
+-- We preserve the historical reference the same way the ledger already handles
+-- deleted parts: snapshot a human-readable name onto each row (like item_name),
+-- and null the live FK link on delete.
+--
+--   * inventory_transactions.location_name — snapshot of the location's full
+--     path at transaction time (auto-filled by a BEFORE INSERT trigger, so the
+--     stock RPCs need no change). Immutable thereafter.
+--   * location_id FK becomes ON DELETE SET NULL (was RESTRICT) and leaves the
+--     immutable column set, so the SET NULL cascade is allowed on deletion.
+--   * delete_location() RPC allows deletion when a location has no children and
+--     no qty>0 balances, cleaning up any leftover zero-qty balance rows (which
+--     clients can't touch — part_location_stock is SELECT-only).
+
+-- ============================================================
+-- 1. Snapshot column + path helper
+-- ============================================================
+ALTER TABLE "public"."inventory_transactions"
+    ADD COLUMN IF NOT EXISTS "location_name" text;
+
+-- Full path label, root › … › leaf (e.g. "Cabinet 1 › Row 3 › Left").
+CREATE OR REPLACE FUNCTION public.inv_location_path_label(p_location_id uuid)
+ RETURNS text
+ LANGUAGE sql
+ STABLE
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH RECURSIVE chain AS (
+    SELECT id, parent_id, name, 0 AS depth
+      FROM public.inventory_locations WHERE id = p_location_id
+    UNION ALL
+    SELECT l.id, l.parent_id, l.name, c.depth + 1
+      FROM public.inventory_locations l JOIN chain c ON l.id = c.parent_id
+  )
+  SELECT string_agg(name, ' › ' ORDER BY depth DESC) FROM chain;
+$function$;
+
+-- ============================================================
+-- 2. Auto-snapshot location_name on insert (RPCs unchanged)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.snapshot_transaction_location_name()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+    IF NEW.location_id IS NOT NULL AND NEW.location_name IS NULL THEN
+        NEW.location_name := public.inv_location_path_label(NEW.location_id);
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS "trg_snapshot_txn_location" ON "public"."inventory_transactions";
+CREATE TRIGGER "trg_snapshot_txn_location"
+    BEFORE INSERT ON "public"."inventory_transactions"
+    FOR EACH ROW EXECUTE FUNCTION public.snapshot_transaction_location_name();
+
+-- ============================================================
+-- 3. Backfill existing rows (data-at-rest: every located row gets a snapshot)
+--    Runs while location_name is still mutable; only location_name changes, so
+--    the notes-only update guard (still listing location_id) is not tripped.
+-- ============================================================
+UPDATE "public"."inventory_transactions"
+   SET location_name = public.inv_location_path_label(location_id)
+ WHERE location_id IS NOT NULL AND location_name IS NULL;
+
+-- ============================================================
+-- 4. Immutability: location_id leaves the set (so SET NULL on delete is
+--    allowed); location_name joins it (the durable audit snapshot).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.restrict_transaction_update_to_notes()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+    IF OLD.company_id          IS DISTINCT FROM NEW.company_id
+       OR OLD.part_id          IS DISTINCT FROM NEW.part_id
+       OR OLD.item_name        IS DISTINCT FROM NEW.item_name
+       OR OLD.type             IS DISTINCT FROM NEW.type
+       OR OLD.quantity         IS DISTINCT FROM NEW.quantity
+       OR OLD.unit             IS DISTINCT FROM NEW.unit
+       OR OLD.converted_quantity IS DISTINCT FROM NEW.converted_quantity
+       OR OLD.job_id           IS DISTINCT FROM NEW.job_id
+       OR OLD.job_operation_id IS DISTINCT FROM NEW.job_operation_id
+       OR OLD.operator_id      IS DISTINCT FROM NEW.operator_id
+       OR OLD.created_at       IS DISTINCT FROM NEW.created_at
+       OR OLD.created_by       IS DISTINCT FROM NEW.created_by
+       OR OLD.has_discrepancy  IS DISTINCT FROM NEW.has_discrepancy
+       OR OLD.location_name     IS DISTINCT FROM NEW.location_name
+       OR OLD.transfer_group_id IS DISTINCT FROM NEW.transfer_group_id
+    THEN
+        RAISE EXCEPTION 'Only the notes field can be updated on inventory transactions';
+    END IF;
+    RETURN NEW;
+END;
+$function$;
+
+-- ============================================================
+-- 5. FK: RESTRICT -> SET NULL (preserve the row + name snapshot on delete)
+-- ============================================================
+ALTER TABLE "public"."inventory_transactions"
+    DROP CONSTRAINT IF EXISTS "inventory_transactions_location_fkey";
+ALTER TABLE "public"."inventory_transactions"
+    ADD CONSTRAINT "inventory_transactions_location_fkey"
+        FOREIGN KEY (location_id) REFERENCES "public"."inventory_locations"(id) ON DELETE SET NULL;
+
+-- ============================================================
+-- 6. delete_location RPC — empty location deletable regardless of history
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.delete_location(p_location_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid;
+BEGIN
+    SELECT company_id INTO v_company FROM public.inventory_locations WHERE id = p_location_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'location % not found', p_location_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF EXISTS (SELECT 1 FROM public.inventory_locations WHERE parent_id = p_location_id) THEN
+        RAISE EXCEPTION 'location has sub-locations' USING ERRCODE = 'foreign_key_violation';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM public.part_location_stock
+         WHERE location_id = p_location_id AND quantity > 0
+    ) THEN
+        RAISE EXCEPTION 'location still holds stock' USING ERRCODE = 'foreign_key_violation';
+    END IF;
+
+    -- Drop any zero-qty balance rows (clients can't — SELECT-only), then the
+    -- location. Historical ledger rows keep location_name; their location_id is
+    -- nulled by the ON DELETE SET NULL FK.
+    DELETE FROM public.part_location_stock WHERE location_id = p_location_id;
+    DELETE FROM public.inventory_locations WHERE id = p_location_id;
+END;
+$function$;
+
+GRANT ALL ON FUNCTION public.inv_location_path_label(uuid) TO anon, authenticated, service_role;
+GRANT ALL ON FUNCTION public.delete_location(uuid) TO anon, authenticated, service_role;
+
+COMMENT ON COLUMN "public"."inventory_transactions"."location_name" IS 'Snapshot of the location''s full path at transaction time, so deleted locations remain referrable in history (mirrors item_name for deleted parts).';

--- a/supabase/migrations/20260622211715_allow_delete_empty_parent_location.sql
+++ b/supabase/migrations/20260622211715_allow_delete_empty_parent_location.sql
@@ -1,0 +1,86 @@
+-- Allow deleting a location whose ENTIRE subtree is empty.
+--
+-- Previously delete_location refused any location that had children ("delete or
+-- move them first"). A shop owner who built a cabinet of empty rows/bins then
+-- wants to throw the whole cabinet out should be able to. New behavior: a
+-- location is deletable when NO location in its subtree holds qty>0 stock; the
+-- empty subtree (and its leftover zero-qty balance rows) is cascade-deleted.
+-- Refuse only when some descendant still holds stock. Historical ledger rows
+-- keep their location_name snapshot; their location_id is nulled by the FK
+-- (ON DELETE SET NULL).
+
+CREATE OR REPLACE FUNCTION public.delete_location(p_location_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid;
+    v_guard   integer := 0;
+BEGIN
+    SELECT company_id INTO v_company FROM public.inventory_locations WHERE id = p_location_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'location % not found', p_location_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+
+    -- Refuse only if any location in the subtree still holds stock.
+    IF EXISTS (
+        WITH RECURSIVE sub AS (
+            SELECT id FROM public.inventory_locations WHERE id = p_location_id
+            UNION ALL
+            SELECT l.id FROM public.inventory_locations l JOIN sub s ON l.parent_id = s.id
+        )
+        SELECT 1
+          FROM public.part_location_stock pls
+          JOIN sub ON pls.location_id = sub.id
+         WHERE pls.quantity > 0
+    ) THEN
+        RAISE EXCEPTION 'location subtree still holds stock' USING ERRCODE = 'foreign_key_violation';
+    END IF;
+
+    -- Drop leftover zero-qty balance rows across the subtree (clients can't —
+    -- part_location_stock is SELECT-only). part_location_stock.location_id is
+    -- ON DELETE RESTRICT, so these must go before their locations.
+    DELETE FROM public.part_location_stock
+     WHERE location_id IN (
+        WITH RECURSIVE sub AS (
+            SELECT id FROM public.inventory_locations WHERE id = p_location_id
+            UNION ALL
+            SELECT l.id FROM public.inventory_locations l JOIN sub s ON l.parent_id = s.id
+        )
+        SELECT id FROM sub
+     );
+
+    -- Delete the subtree bottom-up. inventory_locations.parent_id is ON DELETE
+    -- RESTRICT, so a parent can't be removed while children exist; repeatedly
+    -- delete the current leaves of the subtree until the target is gone.
+    LOOP
+        v_guard := v_guard + 1;
+        IF v_guard > 1000 THEN
+            RAISE EXCEPTION 'delete_location: subtree too deep or cyclic for %', p_location_id;
+        END IF;
+
+        DELETE FROM public.inventory_locations loc
+         WHERE loc.id IN (
+            WITH RECURSIVE sub AS (
+                SELECT id FROM public.inventory_locations WHERE id = p_location_id
+                UNION ALL
+                SELECT l.id FROM public.inventory_locations l JOIN sub s ON l.parent_id = s.id
+            )
+            SELECT s.id
+              FROM sub s
+             WHERE NOT EXISTS (
+                SELECT 1 FROM public.inventory_locations c WHERE c.parent_id = s.id
+             )
+         );
+
+        EXIT WHEN NOT EXISTS (SELECT 1 FROM public.inventory_locations WHERE id = p_location_id);
+    END LOOP;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.delete_location(uuid) IS 'Delete a location and its empty subtree. Refuses only if some descendant still holds qty>0 stock; cascade-removes empty sub-locations and their zero-qty balance rows bottom-up. Ledger rows keep location_name; location_id is nulled by the FK.';

--- a/types/database.ts
+++ b/types/database.ts
@@ -575,6 +575,7 @@ export type Database = {
           job_id: string | null
           job_operation_id: string | null
           location_id: string | null
+          location_name: string | null
           notes: string | null
           operator_id: string | null
           part_id: string | null
@@ -594,6 +595,7 @@ export type Database = {
           job_id?: string | null
           job_operation_id?: string | null
           location_id?: string | null
+          location_name?: string | null
           notes?: string | null
           operator_id?: string | null
           part_id?: string | null
@@ -613,6 +615,7 @@ export type Database = {
           job_id?: string | null
           job_operation_id?: string | null
           location_id?: string | null
+          location_name?: string | null
           notes?: string | null
           operator_id?: string | null
           part_id?: string | null
@@ -2853,6 +2856,7 @@ export type Database = {
         }
         Returns: string
       }
+      delete_location: { Args: { p_location_id: string }; Returns: undefined }
       deplete_stock_at_location: {
         Args: {
           p_converted_quantity: number
@@ -2922,6 +2926,10 @@ export type Database = {
       inv_assert_location_in_company: {
         Args: { p_company_id: string; p_location_id: string }
         Returns: undefined
+      }
+      inv_location_path_label: {
+        Args: { p_location_id: string }
+        Returns: string
       }
       is_company_admin: { Args: { check_company_id: string }; Returns: boolean }
       is_system_admin: { Args: { check_user_id: string }; Returns: boolean }

--- a/types/database.ts
+++ b/types/database.ts
@@ -506,6 +506,63 @@ export type Database = {
           },
         ]
       }
+      inventory_locations: {
+        Row: {
+          code: string | null
+          company_id: string
+          created_at: string
+          id: string
+          is_qr_anchor: boolean
+          is_stockable: boolean
+          kind: string | null
+          name: string
+          parent_id: string | null
+          sort_order: number
+          updated_at: string
+        }
+        Insert: {
+          code?: string | null
+          company_id: string
+          created_at?: string
+          id?: string
+          is_qr_anchor?: boolean
+          is_stockable?: boolean
+          kind?: string | null
+          name: string
+          parent_id?: string | null
+          sort_order?: number
+          updated_at?: string
+        }
+        Update: {
+          code?: string | null
+          company_id?: string
+          created_at?: string
+          id?: string
+          is_qr_anchor?: boolean
+          is_stockable?: boolean
+          kind?: string | null
+          name?: string
+          parent_id?: string | null
+          sort_order?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "inventory_locations_company_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inventory_locations_parent_fkey"
+            columns: ["parent_id"]
+            isOneToOne: false
+            referencedRelation: "inventory_locations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       inventory_transactions: {
         Row: {
           company_id: string
@@ -517,10 +574,12 @@ export type Database = {
           item_name: string
           job_id: string | null
           job_operation_id: string | null
+          location_id: string | null
           notes: string | null
           operator_id: string | null
           part_id: string | null
           quantity: number
+          transfer_group_id: string | null
           type: string
           unit: string
         }
@@ -534,10 +593,12 @@ export type Database = {
           item_name: string
           job_id?: string | null
           job_operation_id?: string | null
+          location_id?: string | null
           notes?: string | null
           operator_id?: string | null
           part_id?: string | null
           quantity: number
+          transfer_group_id?: string | null
           type: string
           unit: string
         }
@@ -551,10 +612,12 @@ export type Database = {
           item_name?: string
           job_id?: string | null
           job_operation_id?: string | null
+          location_id?: string | null
           notes?: string | null
           operator_id?: string | null
           part_id?: string | null
           quantity?: number
+          transfer_group_id?: string | null
           type?: string
           unit?: string
         }
@@ -578,6 +641,13 @@ export type Database = {
             columns: ["job_operation_id"]
             isOneToOne: false
             referencedRelation: "job_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inventory_transactions_location_fkey"
+            columns: ["location_id"]
+            isOneToOne: false
+            referencedRelation: "inventory_locations"
             referencedColumns: ["id"]
           },
           {
@@ -1245,6 +1315,55 @@ export type Database = {
           },
         ]
       }
+      part_location_stock: {
+        Row: {
+          company_id: string
+          created_at: string
+          id: string
+          location_id: string
+          part_id: string
+          quantity: number
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          id?: string
+          location_id: string
+          part_id: string
+          quantity?: number
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          id?: string
+          location_id?: string
+          part_id?: string
+          quantity?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "part_location_stock_company_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "part_location_stock_location_fkey"
+            columns: ["location_id"]
+            isOneToOne: false
+            referencedRelation: "inventory_locations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "part_location_stock_part_fkey"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       part_notes: {
         Row: {
           author_id: string | null
@@ -1405,6 +1524,7 @@ export type Database = {
           created_at: string
           description: string | null
           id: string
+          is_location_tracked: boolean
           is_stocked: boolean
           legacy_id: string | null
           markup_rate_id: string | null
@@ -1421,6 +1541,7 @@ export type Database = {
           created_at?: string
           description?: string | null
           id?: string
+          is_location_tracked?: boolean
           is_stocked?: boolean
           legacy_id?: string | null
           markup_rate_id?: string | null
@@ -1437,6 +1558,7 @@ export type Database = {
           created_at?: string
           description?: string | null
           id?: string
+          is_location_tracked?: boolean
           is_stocked?: boolean
           legacy_id?: string | null
           markup_rate_id?: string | null
@@ -2656,6 +2778,28 @@ export type Database = {
         Args: { p_invitation_id: string; p_user_id: string }
         Returns: string
       }
+      add_stock_at_location: {
+        Args: {
+          p_converted_quantity: number
+          p_location_id: string
+          p_notes?: string
+          p_part_id: string
+          p_quantity: number
+          p_unit: string
+        }
+        Returns: Json
+      }
+      adjust_stock_at_location: {
+        Args: {
+          p_converted_new_quantity: number
+          p_location_id: string
+          p_new_quantity: number
+          p_notes?: string
+          p_part_id: string
+          p_unit: string
+        }
+        Returns: Json
+      }
       bulk_apply_markup_rate: {
         Args: { p_company_id: string; p_part_ids: string[]; p_rate_id: string }
         Returns: Json
@@ -2709,6 +2853,26 @@ export type Database = {
         }
         Returns: string
       }
+      deplete_stock_at_location: {
+        Args: {
+          p_converted_quantity: number
+          p_graceful?: boolean
+          p_job_id?: string
+          p_job_operation_id?: string
+          p_location_id: string
+          p_notes?: string
+          p_operator_id?: string
+          p_part_id: string
+          p_quantity: number
+          p_unit: string
+        }
+        Returns: Json
+      }
+      disable_location_tracking: { Args: { p_part_id: string }; Returns: Json }
+      enable_location_tracking: {
+        Args: { p_initial_location_id?: string; p_part_id: string }
+        Returns: Json
+      }
       generate_direct_job_number: {
         Args: { company_uuid: string }
         Returns: string
@@ -2755,6 +2919,10 @@ export type Database = {
         }[]
       }
       get_user_company_ids: { Args: never; Returns: string[] }
+      inv_assert_location_in_company: {
+        Args: { p_company_id: string; p_location_id: string }
+        Returns: undefined
+      }
       is_company_admin: { Args: { check_company_id: string }; Returns: boolean }
       is_system_admin: { Args: { check_user_id: string }; Returns: boolean }
       job_last_ship_date: { Args: { p_job_id: string }; Returns: string }
@@ -2787,6 +2955,18 @@ export type Database = {
       sync_demo_access: {
         Args: { p_demo_company_id: string; p_source_company_id: string }
         Returns: undefined
+      }
+      transfer_stock: {
+        Args: {
+          p_converted_quantity: number
+          p_from_location_id: string
+          p_notes?: string
+          p_part_id: string
+          p_quantity: number
+          p_to_location_id: string
+          p_unit: string
+        }
+        Returns: Json
       }
     }
     Enums: {

--- a/types/inventoryLocations.ts
+++ b/types/inventoryLocations.ts
@@ -60,6 +60,38 @@ export interface BulkGenerateSpec {
   leafKind?: string;
 }
 
+/**
+ * One configured division level in the visual builder, e.g. "10 rows named
+ * Row {n}" or "{Left, Right}". Either a generated count+pattern OR explicit
+ * names. Levels are ordered shallow → deep; the deepest level's nodes are the
+ * stockable leaves.
+ */
+export interface LevelSpec {
+  kind: string;
+  /** Generated mode: how many, with `{n}` substitution in namePattern. */
+  count?: number;
+  namePattern?: string;
+  /** Explicit mode: fixed child names (e.g. ['Left', 'Right']). */
+  names?: string[];
+}
+
+/**
+ * In-memory location tree the visual builder assembles entirely client-side,
+ * before any DB write. `materializeLocationSpec` inserts it into
+ * inventory_locations on Create. `key` is a stable client id for board
+ * rendering / prune (NOT the DB id); `code` is precomputed during assembly
+ * (parent-prefixed, zero-padded) to match the manual bulk generator.
+ */
+export interface LocationSpecNode {
+  key: string;
+  name: string;
+  kind: string | null;
+  code: string | null;
+  is_stockable: boolean;
+  is_qr_anchor: boolean;
+  children: LocationSpecNode[];
+}
+
 export interface PartLocationBalance {
   id: string;
   company_id: string;

--- a/types/inventoryLocations.ts
+++ b/types/inventoryLocations.ts
@@ -1,0 +1,129 @@
+/**
+ * Inventory Locations & QR-addressable stock — domain types.
+ *
+ * Mirrors the `inventory_locations` / `part_location_stock` tables and the
+ * jsonb returned by the stock-mutation RPCs (see
+ * supabase/migrations/20260622023407_inventory_location_stock_rpcs.sql).
+ */
+
+export interface InventoryLocation {
+  id: string;
+  company_id: string;
+  parent_id: string | null;
+  name: string;
+  kind: string | null;
+  code: string | null;
+  is_stockable: boolean;
+  is_qr_anchor: boolean;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/** A location with its children resolved, for the tree view. */
+export interface InventoryLocationNode extends InventoryLocation {
+  children: InventoryLocationNode[];
+  depth: number;
+}
+
+export interface CreateLocationInput {
+  parent_id?: string | null;
+  name: string;
+  kind?: string | null;
+  code?: string | null;
+  is_stockable?: boolean;
+  is_qr_anchor?: boolean;
+  sort_order?: number;
+}
+
+export type UpdateLocationInput = Partial<
+  Pick<
+    InventoryLocation,
+    'name' | 'kind' | 'code' | 'is_stockable' | 'is_qr_anchor' | 'sort_order'
+  >
+>;
+
+/**
+ * Spec for the bulk generator, e.g. { count: 10, kind: 'row',
+ * namePattern: 'Row {n}', leaves: ['Left', 'Right'] } → 10 rows each with a
+ * Left and Right leaf.
+ */
+export interface BulkGenerateSpec {
+  count: number;
+  kind?: string;
+  /** `{n}` is replaced with the (zero-padded for code) index. Default `'{n}'`. */
+  namePattern?: string;
+  /** First index. Default 1. */
+  startAt?: number;
+  /** Optional leaf children created under each generated node. */
+  leaves?: string[];
+  leafKind?: string;
+}
+
+export interface PartLocationBalance {
+  id: string;
+  company_id: string;
+  part_id: string;
+  location_id: string;
+  quantity: number;
+  created_at: string;
+}
+
+/** A part's balance at a location, with the location's full path for display. */
+export interface PartLocationBalanceWithLocation {
+  location_id: string;
+  location_name: string;
+  location_code: string | null;
+  /** Full path, root → leaf, e.g. ['Cabinet 1', 'Row 3', 'Left']. */
+  path: string[];
+  quantity: number;
+}
+
+/** A part stored at a given location, for the bin/scan view contents list. */
+export interface LocationContent {
+  part_id: string;
+  part_name: string;
+  primary_unit: string | null;
+  quantity: number;
+}
+
+/** Result of resolving a scanned location id into a renderable view. */
+export interface ResolvedScan {
+  node: InventoryLocation;
+  /** Ancestor path including the node itself, root → node. */
+  path: InventoryLocation[];
+  /** Direct children (for parent → drill-down). */
+  children: InventoryLocation[];
+  /** Parts + quantities at this node (for leaf → actions). */
+  contents: LocationContent[];
+}
+
+// ---- RPC return shapes (jsonb) -------------------------------------------
+
+export interface StockMutationResult {
+  location_balance: number;
+  part_quantity: number;
+  has_discrepancy?: boolean;
+  shortfall?: number;
+}
+
+export interface TransferResult {
+  transfer_group_id: string;
+  from_balance: number;
+  to_balance: number;
+}
+
+export interface TrackingResult {
+  part_quantity: number;
+  tracked: boolean;
+  location_id?: string;
+  noop?: boolean;
+}
+
+export interface DepleteOptions {
+  graceful?: boolean;
+  notes?: string;
+  jobId?: string;
+  jobOperationId?: string;
+  operatorId?: string;
+}

--- a/types/inventoryLocations.ts
+++ b/types/inventoryLocations.ts
@@ -63,8 +63,7 @@ export interface BulkGenerateSpec {
 /**
  * One configured division level in the visual builder, e.g. "10 rows named
  * Row {n}" or "{Left, Right}". Either a generated count+pattern OR explicit
- * names. Levels are ordered shallow → deep; the deepest level's nodes are the
- * stockable leaves.
+ * names. Levels are ordered shallow → deep.
  */
 export interface LevelSpec {
   kind: string;
@@ -80,15 +79,14 @@ export interface LevelSpec {
  * before any DB write. `materializeLocationSpec` inserts it into
  * inventory_locations on Create. `key` is a stable client id for board
  * rendering / prune (NOT the DB id); `code` is precomputed during assembly
- * (parent-prefixed, zero-padded) to match the manual bulk generator.
+ * (parent-prefixed, zero-padded) to match the manual bulk generator. Every
+ * location can hold stock and be printed, so no per-node stockable/QR flags.
  */
 export interface LocationSpecNode {
   key: string;
   name: string;
   kind: string | null;
   code: string | null;
-  is_stockable: boolean;
-  is_qr_anchor: boolean;
   children: LocationSpecNode[];
 }
 

--- a/types/part.ts
+++ b/types/part.ts
@@ -31,6 +31,9 @@ export interface Part {
   // caller did not request the join.
   markup_rate_name?: string | null;
   legacy_id: string | null;
+  // When true, parts.quantity is a trigger-maintained rollup of
+  // part_location_stock and stock is managed per-location (see InventoryTab).
+  is_location_tracked: boolean;
   created_at: string;
   updated_at: string;
   // Optional relation counts (populated by getPartWithRelations)

--- a/types/partTransaction.ts
+++ b/types/partTransaction.ts
@@ -26,6 +26,11 @@ export interface InventoryTransaction {
   operator_id: string | null;
   notes: string | null;
   has_discrepancy: boolean;
+  // Location where this happened (null for non-location-tracked parts). Nulled
+  // if the location is later deleted; location_name keeps the snapshot.
+  location_id: string | null;
+  location_name: string | null;
+  transfer_group_id: string | null;
   created_at: string;
   created_by: string | null;
 }

--- a/utils/inventoryLocationsAccess.ts
+++ b/utils/inventoryLocationsAccess.ts
@@ -1,0 +1,563 @@
+/**
+ * Inventory Locations & QR-addressable stock — access layer.
+ *
+ * Tree CRUD (inventory_locations) is plain company-scoped CRUD via the typed
+ * Supabase client. Balance mutations go through the SECURITY DEFINER RPCs
+ * (add/deplete/adjust/transfer/enable/disable) because part_location_stock is
+ * SELECT-only under RLS and each mutation must be paired atomically with an
+ * inventory_transactions row. Unit conversion mirrors partsAccess: we convert
+ * the caller's (quantity, unit) to the part's primary unit and hand the RPC
+ * both the display values and the converted quantity.
+ */
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { convertToBaseUnit } from '@/lib/unitPresets';
+import type {
+  BulkGenerateSpec,
+  CreateLocationInput,
+  DepleteOptions,
+  InventoryLocation,
+  InventoryLocationNode,
+  LocationContent,
+  PartLocationBalanceWithLocation,
+  ResolvedScan,
+  StockMutationResult,
+  TrackingResult,
+  TransferResult,
+  UpdateLocationInput,
+} from '@/types/inventoryLocations';
+
+const LOCATION_COLUMNS =
+  'id, company_id, parent_id, name, kind, code, is_stockable, is_qr_anchor, sort_order, created_at, updated_at';
+
+// ===========================================================================
+// Tree CRUD
+// ===========================================================================
+
+/** Flat list of every location in a company, ordered for stable tree assembly. */
+export async function getLocations(companyId: string): Promise<InventoryLocation[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('inventory_locations')
+    .select(LOCATION_COLUMNS)
+    .eq('company_id', companyId)
+    .order('sort_order', { ascending: true })
+    .order('name', { ascending: true });
+
+  if (error) {
+    console.error('Error fetching inventory locations:', error);
+    throw error;
+  }
+  return (data ?? []) as InventoryLocation[];
+}
+
+/** Assemble a flat location list into a nested tree (roots first). */
+export function buildLocationTree(locations: InventoryLocation[]): InventoryLocationNode[] {
+  const byId = new Map<string, InventoryLocationNode>();
+  for (const loc of locations) {
+    byId.set(loc.id, { ...loc, children: [], depth: 0 });
+  }
+  const roots: InventoryLocationNode[] = [];
+  for (const node of byId.values()) {
+    if (node.parent_id && byId.has(node.parent_id)) {
+      byId.get(node.parent_id)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+  const assignDepth = (node: InventoryLocationNode, depth: number) => {
+    node.depth = depth;
+    for (const child of node.children) assignDepth(child, depth + 1);
+  };
+  for (const root of roots) assignDepth(root, 0);
+  return roots;
+}
+
+export async function getLocationTree(companyId: string): Promise<InventoryLocationNode[]> {
+  return buildLocationTree(await getLocations(companyId));
+}
+
+export async function getLocation(id: string): Promise<InventoryLocation | null> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('inventory_locations')
+    .select(LOCATION_COLUMNS)
+    .eq('id', id)
+    .maybeSingle();
+  if (error) {
+    console.error('Error fetching inventory location:', error);
+    throw error;
+  }
+  return (data as InventoryLocation | null) ?? null;
+}
+
+/** Assert a parent (if given) belongs to the same company. RLS validates the
+ * written row but not the parent_id it points at, so we check it explicitly. */
+async function assertParentInCompany(
+  parentId: string | null | undefined,
+  companyId: string,
+): Promise<void> {
+  if (!parentId) return;
+  const parent = await getLocation(parentId);
+  if (!parent || parent.company_id !== companyId) {
+    throw new Error('Parent location must belong to the same company.');
+  }
+}
+
+export async function createLocation(
+  companyId: string,
+  input: CreateLocationInput,
+): Promise<InventoryLocation> {
+  if (!input.name?.trim()) throw new Error('Location name is required');
+  await assertParentInCompany(input.parent_id, companyId);
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('inventory_locations')
+    .insert({
+      company_id: companyId,
+      parent_id: input.parent_id ?? null,
+      name: input.name.trim(),
+      kind: input.kind ?? null,
+      code: input.code ?? null,
+      is_stockable: input.is_stockable ?? true,
+      is_qr_anchor: input.is_qr_anchor ?? false,
+      sort_order: input.sort_order ?? 0,
+    })
+    .select(LOCATION_COLUMNS)
+    .single();
+
+  if (error) {
+    console.error('Error creating inventory location:', error);
+    throw error;
+  }
+  return data as InventoryLocation;
+}
+
+export async function updateLocation(
+  id: string,
+  patch: UpdateLocationInput,
+): Promise<InventoryLocation> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('inventory_locations')
+    .update({ ...patch, updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .select(LOCATION_COLUMNS)
+    .single();
+  if (error) {
+    console.error('Error updating inventory location:', error);
+    throw error;
+  }
+  return data as InventoryLocation;
+}
+
+/** Re-parent a node, guarding against same-company violations and cycles
+ * (a node cannot be moved beneath one of its own descendants). */
+export async function moveLocation(
+  id: string,
+  newParentId: string | null,
+  companyId: string,
+): Promise<InventoryLocation> {
+  if (newParentId === id) throw new Error('A location cannot be its own parent.');
+  await assertParentInCompany(newParentId, companyId);
+
+  if (newParentId) {
+    const all = await getLocations(companyId);
+    const byId = new Map(all.map((l) => [l.id, l] as const));
+    let cursor: string | null = newParentId;
+    while (cursor) {
+      if (cursor === id) {
+        throw new Error('Cannot move a location beneath one of its own sub-locations.');
+      }
+      cursor = byId.get(cursor)?.parent_id ?? null;
+    }
+  }
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('inventory_locations')
+    .update({ parent_id: newParentId, updated_at: new Date().toISOString() })
+    .eq('id', id)
+    .select(LOCATION_COLUMNS)
+    .single();
+  if (error) {
+    console.error('Error moving inventory location:', error);
+    throw error;
+  }
+  return data as InventoryLocation;
+}
+
+/**
+ * Delete a location. Refuses when it has children or any stock balances
+ * (part_location_stock is SELECT-only, so the client can't clean those up).
+ * A location with ledger history is blocked by the ON DELETE RESTRICT FK; we
+ * translate that into a friendly message.
+ */
+export async function deleteLocation(id: string): Promise<void> {
+  const supabase = getSupabase();
+
+  const [{ count: childCount }, { count: balanceCount }] = await Promise.all([
+    supabase.from('inventory_locations').select('id', { count: 'exact', head: true }).eq('parent_id', id),
+    supabase.from('part_location_stock').select('id', { count: 'exact', head: true }).eq('location_id', id),
+  ]);
+
+  if ((childCount ?? 0) > 0) {
+    throw new Error('This location has sub-locations. Delete or move them first.');
+  }
+  if ((balanceCount ?? 0) > 0) {
+    throw new Error('This location still holds stock. Move the stock out (or disable tracking) first.');
+  }
+
+  const { error } = await supabase.from('inventory_locations').delete().eq('id', id);
+  if (error) {
+    console.error('Error deleting inventory location:', error);
+    throw new Error(
+      friendlyErrorMessage(error, {
+        entity: 'location',
+        fallback:
+          'Failed to delete location. It may have transaction history, which is preserved for audit.',
+      }),
+    );
+  }
+}
+
+/** Zero-pad a 1-based index to a uniform width (warehouse naming discipline). */
+function pad(n: number, width: number): string {
+  return String(n).padStart(width, '0');
+}
+
+/**
+ * Bulk-generate repetitive structure under a parent — e.g. 10 rows × {Left,
+ * Right}. Names follow `namePattern` ('{n}' → index); codes are zero-padded
+ * for sortability. Created sequentially so leaves can attach to their row.
+ */
+export async function bulkGenerateChildren(
+  companyId: string,
+  parentId: string,
+  spec: BulkGenerateSpec,
+): Promise<InventoryLocation[]> {
+  if (spec.count <= 0) throw new Error('Count must be positive');
+  await assertParentInCompany(parentId, companyId);
+
+  const parent = await getLocation(parentId);
+  const start = spec.startAt ?? 1;
+  const width = Math.max(2, String(start + spec.count - 1).length);
+  const pattern = spec.namePattern ?? '{n}';
+  const created: InventoryLocation[] = [];
+
+  for (let i = 0; i < spec.count; i++) {
+    const idx = start + i;
+    const node = await createLocation(companyId, {
+      parent_id: parentId,
+      name: pattern.replace('{n}', String(idx)),
+      kind: spec.kind ?? null,
+      code: `${parent?.code ? parent.code + '-' : ''}${(spec.kind ?? 'N').charAt(0).toUpperCase()}${pad(idx, width)}`,
+      is_stockable: !spec.leaves || spec.leaves.length === 0,
+      sort_order: idx,
+    });
+    created.push(node);
+
+    for (let j = 0; j < (spec.leaves?.length ?? 0); j++) {
+      const leafName = spec.leaves![j];
+      const leaf = await createLocation(companyId, {
+        parent_id: node.id,
+        name: leafName,
+        kind: spec.leafKind ?? 'side',
+        code: `${node.code ?? ''}-${leafName.charAt(0).toUpperCase()}`,
+        is_stockable: true,
+        sort_order: j,
+      });
+      created.push(leaf);
+    }
+  }
+  return created;
+}
+
+// ===========================================================================
+// Balances & scan resolution (reads)
+// ===========================================================================
+
+function computePathNames(
+  locationId: string,
+  byId: Map<string, InventoryLocation>,
+): string[] {
+  const names: string[] = [];
+  let cursor: string | null = locationId;
+  const guard = new Set<string>();
+  while (cursor && byId.has(cursor) && !guard.has(cursor)) {
+    guard.add(cursor);
+    const node: InventoryLocation = byId.get(cursor)!;
+    names.unshift(node.name);
+    cursor = node.parent_id;
+  }
+  return names;
+}
+
+/** A part's balances across locations, each with its full display path. */
+export async function getBalancesForPart(
+  partId: string,
+): Promise<PartLocationBalanceWithLocation[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('part_location_stock')
+    .select('company_id, location_id, quantity')
+    .eq('part_id', partId);
+  if (error) {
+    console.error('Error fetching part balances:', error);
+    throw error;
+  }
+  const rows = (data ?? []) as Array<{ company_id: string; location_id: string; quantity: number }>;
+  if (rows.length === 0) return [];
+
+  const locations = await getLocations(rows[0].company_id);
+  const byId = new Map(locations.map((l) => [l.id, l] as const));
+
+  return rows
+    .map((r) => {
+      const loc = byId.get(r.location_id);
+      return {
+        location_id: r.location_id,
+        location_name: loc?.name ?? 'Unknown',
+        location_code: loc?.code ?? null,
+        path: computePathNames(r.location_id, byId),
+        quantity: Number(r.quantity),
+      };
+    })
+    .sort((a, b) => a.path.join(' / ').localeCompare(b.path.join(' / ')));
+}
+
+/** Parts (and quantities > 0) stored directly at a location. */
+export async function getLocationContents(locationId: string): Promise<LocationContent[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('part_location_stock')
+    .select('quantity, part:parts!part_location_stock_part_fkey(id, part_name, primary_unit)')
+    .eq('location_id', locationId)
+    .gt('quantity', 0);
+  if (error) {
+    console.error('Error fetching location contents:', error);
+    throw error;
+  }
+
+  type Row = {
+    quantity: number;
+    part:
+      | { id: string; part_name: string; primary_unit: string | null }
+      | Array<{ id: string; part_name: string; primary_unit: string | null }>
+      | null;
+  };
+
+  return ((data ?? []) as Row[])
+    .map((row) => {
+      const part = Array.isArray(row.part) ? row.part[0] : row.part;
+      if (!part) return null;
+      return {
+        part_id: part.id,
+        part_name: part.part_name,
+        primary_unit: part.primary_unit,
+        quantity: Number(row.quantity),
+      } as LocationContent;
+    })
+    .filter((r): r is LocationContent => r !== null)
+    .sort((a, b) => a.part_name.localeCompare(b.part_name));
+}
+
+/** Resolve a scanned location id into node + ancestor path + children +
+ * contents, so the bin view can render drill-down (parent) vs actions (leaf). */
+export async function resolveScan(locationId: string): Promise<ResolvedScan> {
+  const node = await getLocation(locationId);
+  if (!node) throw new Error('Location not found');
+
+  const [locations, contents] = await Promise.all([
+    getLocations(node.company_id),
+    getLocationContents(locationId),
+  ]);
+  const byId = new Map(locations.map((l) => [l.id, l] as const));
+
+  const path: InventoryLocation[] = [];
+  let cursor: string | null = locationId;
+  const guard = new Set<string>();
+  while (cursor && byId.has(cursor) && !guard.has(cursor)) {
+    guard.add(cursor);
+    path.unshift(byId.get(cursor)!);
+    cursor = byId.get(cursor)!.parent_id;
+  }
+
+  const children = locations
+    .filter((l) => l.parent_id === locationId)
+    .sort((a, b) => a.sort_order - b.sort_order || a.name.localeCompare(b.name));
+
+  return { node, path, children, contents };
+}
+
+// ===========================================================================
+// Balance mutations (RPC wrappers — atomic balance + ledger)
+// ===========================================================================
+
+async function loadConversionContext(
+  partId: string,
+): Promise<{ primaryUnit: string; conversions: { from_unit: string; to_primary_factor: number }[] }> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('parts')
+    .select('primary_unit, parts_unit_conversions(from_unit, to_primary_factor)')
+    .eq('id', partId)
+    .single();
+  if (error || !data) throw error || new Error('Part not found');
+  if (!data.primary_unit) {
+    throw new Error('Part has no primary unit; cannot record a stock transaction.');
+  }
+  return {
+    primaryUnit: data.primary_unit,
+    conversions:
+      (data.parts_unit_conversions as Array<{ from_unit: string; to_primary_factor: number }>) ?? [],
+  };
+}
+
+export async function enableLocationTracking(
+  partId: string,
+  initialLocationId?: string,
+): Promise<TrackingResult> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase.rpc('enable_location_tracking', {
+    p_part_id: partId,
+    p_initial_location_id: initialLocationId,
+  });
+  if (error) {
+    console.error('Error enabling location tracking:', error);
+    throw error;
+  }
+  return data as unknown as TrackingResult;
+}
+
+export async function disableLocationTracking(partId: string): Promise<TrackingResult> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase.rpc('disable_location_tracking', { p_part_id: partId });
+  if (error) {
+    console.error('Error disabling location tracking:', error);
+    throw error;
+  }
+  return data as unknown as TrackingResult;
+}
+
+export async function addStockAtLocation(
+  partId: string,
+  locationId: string,
+  quantity: number,
+  unit: string,
+  notes?: string,
+): Promise<StockMutationResult> {
+  const { primaryUnit, conversions } = await loadConversionContext(partId);
+  const converted = convertToBaseUnit(quantity, unit, primaryUnit, conversions);
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase.rpc('add_stock_at_location', {
+    p_part_id: partId,
+    p_location_id: locationId,
+    p_quantity: quantity,
+    p_unit: unit,
+    p_converted_quantity: converted,
+    p_notes: notes,
+  });
+  if (error) {
+    console.error('Error adding stock at location:', error);
+    throw error;
+  }
+  return data as unknown as StockMutationResult;
+}
+
+export async function depleteStockAtLocation(
+  partId: string,
+  locationId: string,
+  quantity: number,
+  unit: string,
+  opts: DepleteOptions = {},
+): Promise<StockMutationResult> {
+  const { primaryUnit, conversions } = await loadConversionContext(partId);
+  const converted = convertToBaseUnit(quantity, unit, primaryUnit, conversions);
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase.rpc('deplete_stock_at_location', {
+    p_part_id: partId,
+    p_location_id: locationId,
+    p_quantity: quantity,
+    p_unit: unit,
+    p_converted_quantity: converted,
+    p_graceful: opts.graceful ?? false,
+    p_notes: opts.notes,
+    p_job_id: opts.jobId,
+    p_job_operation_id: opts.jobOperationId,
+    p_operator_id: opts.operatorId,
+  });
+  if (error) {
+    console.error('Error depleting stock at location:', error);
+    throw error;
+  }
+  return data as unknown as StockMutationResult;
+}
+
+export async function adjustStockAtLocation(
+  partId: string,
+  locationId: string,
+  newQuantity: number,
+  unit: string,
+  notes?: string,
+): Promise<StockMutationResult> {
+  const { primaryUnit, conversions } = await loadConversionContext(partId);
+  const converted = convertToBaseUnit(newQuantity, unit, primaryUnit, conversions);
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase.rpc('adjust_stock_at_location', {
+    p_part_id: partId,
+    p_location_id: locationId,
+    p_new_quantity: newQuantity,
+    p_unit: unit,
+    p_converted_new_quantity: converted,
+    p_notes: notes,
+  });
+  if (error) {
+    console.error('Error adjusting stock at location:', error);
+    throw error;
+  }
+  return data as unknown as StockMutationResult;
+}
+
+export async function transferStock(
+  partId: string,
+  fromLocationId: string,
+  toLocationId: string,
+  quantity: number,
+  unit: string,
+  notes?: string,
+): Promise<TransferResult> {
+  const { primaryUnit, conversions } = await loadConversionContext(partId);
+  const converted = convertToBaseUnit(quantity, unit, primaryUnit, conversions);
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase.rpc('transfer_stock', {
+    p_part_id: partId,
+    p_from_location_id: fromLocationId,
+    p_to_location_id: toLocationId,
+    p_quantity: quantity,
+    p_unit: unit,
+    p_converted_quantity: converted,
+    p_notes: notes,
+  });
+  if (error) {
+    console.error('Error transferring stock:', error);
+    throw error;
+  }
+  return data as unknown as TransferResult;
+}
+
+// ===========================================================================
+// QR
+// ===========================================================================
+
+/** Deep-link a location scan to the operator login, which routes to the bin
+ * view post-login (payload is the UUID, never the human code). */
+export function buildLocationUrl(companyId: string, locationId: string): string {
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  return `${origin}/operator/${companyId}/login?location=${locationId}`;
+}

--- a/utils/inventoryLocationsAccess.ts
+++ b/utils/inventoryLocationsAccess.ts
@@ -10,7 +10,6 @@
  * both the display values and the converted quantity.
  */
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import { convertToBaseUnit } from '@/lib/unitPresets';
 import type {
   BulkGenerateSpec,
@@ -189,36 +188,25 @@ export async function moveLocation(
 }
 
 /**
- * Delete a location. Refuses when it has children or any stock balances
- * (part_location_stock is SELECT-only, so the client can't clean those up).
- * A location with ledger history is blocked by the ON DELETE RESTRICT FK; we
- * translate that into a friendly message.
+ * Delete a location via the delete_location RPC. An EMPTY location is deletable
+ * even after activity history: the RPC refuses only when it has children or
+ * qty>0 balances, cleans up any leftover zero-qty balance rows (SELECT-only for
+ * clients), and lets the ON DELETE SET NULL FK null the link on historical
+ * ledger rows — which keep their location_name snapshot for audit.
  */
 export async function deleteLocation(id: string): Promise<void> {
   const supabase = getSupabase();
-
-  const [{ count: childCount }, { count: balanceCount }] = await Promise.all([
-    supabase.from('inventory_locations').select('id', { count: 'exact', head: true }).eq('parent_id', id),
-    supabase.from('part_location_stock').select('id', { count: 'exact', head: true }).eq('location_id', id),
-  ]);
-
-  if ((childCount ?? 0) > 0) {
-    throw new Error('This location has sub-locations. Delete or move them first.');
-  }
-  if ((balanceCount ?? 0) > 0) {
-    throw new Error('This location still holds stock. Move the stock out (or disable tracking) first.');
-  }
-
-  const { error } = await supabase.from('inventory_locations').delete().eq('id', id);
+  const { error } = await supabase.rpc('delete_location', { p_location_id: id });
   if (error) {
     console.error('Error deleting inventory location:', error);
-    throw new Error(
-      friendlyErrorMessage(error, {
-        entity: 'location',
-        fallback:
-          'Failed to delete location. It may have transaction history, which is preserved for audit.',
-      }),
-    );
+    const msg = error.message ?? '';
+    if (msg.includes('sub-locations')) {
+      throw new Error('This location has sub-locations. Delete or move them first.');
+    }
+    if (msg.includes('still holds stock')) {
+      throw new Error('This location still holds stock. Move it out (or disable tracking) first.');
+    }
+    throw new Error('Failed to delete location.');
   }
 }
 

--- a/utils/inventoryLocationsAccess.ts
+++ b/utils/inventoryLocationsAccess.ts
@@ -11,6 +11,7 @@
  */
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import { convertToBaseUnit } from '@/lib/unitPresets';
+import { generatedCode, explicitCode } from '@/utils/locationSpec';
 import type {
   BulkGenerateSpec,
   CreateLocationInput,
@@ -18,6 +19,7 @@ import type {
   InventoryLocation,
   InventoryLocationNode,
   LocationContent,
+  LocationSpecNode,
   PartLocationBalanceWithLocation,
   ResolvedScan,
   StockMutationResult,
@@ -210,15 +212,11 @@ export async function deleteLocation(id: string): Promise<void> {
   }
 }
 
-/** Zero-pad a 1-based index to a uniform width (warehouse naming discipline). */
-function pad(n: number, width: number): string {
-  return String(n).padStart(width, '0');
-}
-
 /**
  * Bulk-generate repetitive structure under a parent — e.g. 10 rows × {Left,
  * Right}. Names follow `namePattern` ('{n}' → index); codes are zero-padded
- * for sortability. Created sequentially so leaves can attach to their row.
+ * for sortability (shared scheme with the visual builder via locationSpec).
+ * Created sequentially so leaves can attach to their row.
  */
 export async function bulkGenerateChildren(
   companyId: string,
@@ -240,7 +238,7 @@ export async function bulkGenerateChildren(
       parent_id: parentId,
       name: pattern.replace('{n}', String(idx)),
       kind: spec.kind ?? null,
-      code: `${parent?.code ? parent.code + '-' : ''}${(spec.kind ?? 'N').charAt(0).toUpperCase()}${pad(idx, width)}`,
+      code: generatedCode(parent?.code ?? null, spec.kind ?? '', idx, width),
       is_stockable: !spec.leaves || spec.leaves.length === 0,
       sort_order: idx,
     });
@@ -252,11 +250,46 @@ export async function bulkGenerateChildren(
         parent_id: node.id,
         name: leafName,
         kind: spec.leafKind ?? 'side',
-        code: `${node.code ?? ''}-${leafName.charAt(0).toUpperCase()}`,
+        code: explicitCode(node.code, leafName),
         is_stockable: true,
         sort_order: j,
       });
       created.push(leaf);
+    }
+  }
+  return created;
+}
+
+/**
+ * Materialize a LocationSpecNode forest (built client-side by the visual
+ * builder) into inventory_locations. Recursively composes the existing
+ * `createLocation` — parent before children — so all the company/parent
+ * validation and code handling is shared with the manual flow. Names, codes,
+ * is_stockable and is_qr_anchor come straight from the precomputed spec.
+ *
+ * Sequential inserts mirror bulkGenerateChildren; a single multi-row insert is
+ * a cheap future optimization if specs ever get large.
+ */
+export async function materializeLocationSpec(
+  companyId: string,
+  parentId: string | null,
+  nodes: LocationSpecNode[],
+): Promise<InventoryLocation[]> {
+  const created: InventoryLocation[] = [];
+  let sortOrder = 0;
+  for (const node of nodes) {
+    const row = await createLocation(companyId, {
+      parent_id: parentId,
+      name: node.name,
+      kind: node.kind,
+      code: node.code,
+      is_stockable: node.is_stockable,
+      is_qr_anchor: node.is_qr_anchor,
+      sort_order: sortOrder++,
+    });
+    created.push(row);
+    if (node.children.length > 0) {
+      created.push(...(await materializeLocationSpec(companyId, row.id, node.children)));
     }
   }
   return created;

--- a/utils/inventoryLocationsAccess.ts
+++ b/utils/inventoryLocationsAccess.ts
@@ -188,11 +188,11 @@ export async function moveLocation(
 }
 
 /**
- * Delete a location via the delete_location RPC. An EMPTY location is deletable
- * even after activity history: the RPC refuses only when it has children or
- * qty>0 balances, cleans up any leftover zero-qty balance rows (SELECT-only for
- * clients), and lets the ON DELETE SET NULL FK null the link on historical
- * ledger rows — which keep their location_name snapshot for audit.
+ * Delete a location (and its EMPTY subtree) via the delete_location RPC. The RPC
+ * refuses only when some location in the subtree still holds qty>0 stock;
+ * otherwise it cascade-deletes the empty sub-locations and their leftover
+ * zero-qty balance rows (SELECT-only for clients). Historical ledger rows keep
+ * their location_name snapshot; their location_id is nulled by the FK.
  */
 export async function deleteLocation(id: string): Promise<void> {
   const supabase = getSupabase();
@@ -200,11 +200,8 @@ export async function deleteLocation(id: string): Promise<void> {
   if (error) {
     console.error('Error deleting inventory location:', error);
     const msg = error.message ?? '';
-    if (msg.includes('sub-locations')) {
-      throw new Error('This location has sub-locations. Delete or move them first.');
-    }
     if (msg.includes('still holds stock')) {
-      throw new Error('This location still holds stock. Move it out (or disable tracking) first.');
+      throw new Error('This location (or something inside it) still holds stock. Move it out first.');
     }
     throw new Error('Failed to delete location.');
   }

--- a/utils/inventoryLocationsAccess.ts
+++ b/utils/inventoryLocationsAccess.ts
@@ -11,7 +11,7 @@
  */
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import { convertToBaseUnit } from '@/lib/unitPresets';
-import { generatedCode, explicitCode } from '@/utils/locationSpec';
+import { generatedCode, explicitCode, duplicateSubtreeAsSibling } from '@/utils/locationSpec';
 import type {
   BulkGenerateSpec,
   CreateLocationInput,
@@ -239,7 +239,6 @@ export async function bulkGenerateChildren(
       name: pattern.replace('{n}', String(idx)),
       kind: spec.kind ?? null,
       code: generatedCode(parent?.code ?? null, spec.kind ?? '', idx, width),
-      is_stockable: !spec.leaves || spec.leaves.length === 0,
       sort_order: idx,
     });
     created.push(node);
@@ -251,7 +250,6 @@ export async function bulkGenerateChildren(
         name: leafName,
         kind: spec.leafKind ?? 'side',
         code: explicitCode(node.code, leafName),
-        is_stockable: true,
         sort_order: j,
       });
       created.push(leaf);
@@ -264,8 +262,9 @@ export async function bulkGenerateChildren(
  * Materialize a LocationSpecNode forest (built client-side by the visual
  * builder) into inventory_locations. Recursively composes the existing
  * `createLocation` — parent before children — so all the company/parent
- * validation and code handling is shared with the manual flow. Names, codes,
- * is_stockable and is_qr_anchor come straight from the precomputed spec.
+ * validation and code handling is shared with the manual flow. Names and codes
+ * come straight from the precomputed spec; every location is stockable +
+ * printable (createLocation defaults).
  *
  * Sequential inserts mirror bulkGenerateChildren; a single multi-row insert is
  * a cheap future optimization if specs ever get large.
@@ -274,17 +273,16 @@ export async function materializeLocationSpec(
   companyId: string,
   parentId: string | null,
   nodes: LocationSpecNode[],
+  startSortOrder = 0,
 ): Promise<InventoryLocation[]> {
   const created: InventoryLocation[] = [];
-  let sortOrder = 0;
+  let sortOrder = startSortOrder;
   for (const node of nodes) {
     const row = await createLocation(companyId, {
       parent_id: parentId,
       name: node.name,
       kind: node.kind,
       code: node.code,
-      is_stockable: node.is_stockable,
-      is_qr_anchor: node.is_qr_anchor,
       sort_order: sortOrder++,
     });
     created.push(row);
@@ -293,6 +291,49 @@ export async function materializeLocationSpec(
     }
   }
   return created;
+}
+
+/**
+ * Duplicate a location and its entire subtree as a new sibling — structure
+ * only, no stock. The copy's root is named past the existing siblings
+ * (Cabinet 1 → Cabinet 2) and sorted after them; every code is re-derived under
+ * the same parent from the bumped name + kind (the shared builder/bulk-generate
+ * scheme, so a custom edited code is not preserved). Sequential inserts via
+ * materializeLocationSpec.
+ */
+export async function duplicateLocation(
+  companyId: string,
+  locationId: string,
+): Promise<InventoryLocation[]> {
+  const all = await getLocations(companyId);
+  const target = all.find((l) => l.id === locationId);
+  if (!target) throw new Error('Location not found.');
+
+  // getLocations is already ordered by sort_order then name, so children keep
+  // their display order.
+  const childrenOf = (parentId: string | null) => all.filter((l) => l.parent_id === parentId);
+
+  const toSpec = (loc: InventoryLocation): LocationSpecNode => ({
+    key: loc.id, // ignored by materialize; cloneSubtree assigns fresh keys
+    name: loc.name,
+    kind: loc.kind,
+    code: loc.code,
+    children: childrenOf(loc.id).map(toSpec),
+  });
+
+  const parentCode = target.parent_id
+    ? (all.find((l) => l.id === target.parent_id)?.code ?? null)
+    : null;
+  const siblings = childrenOf(target.parent_id);
+  const clone = duplicateSubtreeAsSibling(
+    toSpec(target),
+    parentCode,
+    siblings.map((l) => l.name),
+  );
+  // Sort the copy after the existing siblings (sort_order ASC, name ASC read
+  // order) rather than letting it default to 0 and jump to the front.
+  const nextSortOrder = siblings.reduce((max, s) => Math.max(max, s.sort_order), -1) + 1;
+  return materializeLocationSpec(companyId, target.parent_id, [clone], nextSortOrder);
 }
 
 // ===========================================================================

--- a/utils/locationLabelPdf.ts
+++ b/utils/locationLabelPdf.ts
@@ -1,0 +1,103 @@
+/**
+ * Avery-style QR label sheet for inventory locations.
+ *
+ * Mirrors the batch-QR approach in jobTravelerPdf (QRCode.toDataURL up front,
+ * level 'H' per the QR design decision) and lays the labels out in a grid. Each
+ * label shows the QR (payload = the location UUID deep-link, so relabeling never
+ * breaks it) plus the full human path and code — the physical label must match
+ * the software's naming.
+ */
+import { jsPDF } from 'jspdf';
+import QRCode from 'qrcode';
+
+export interface LocationLabel {
+  id: string;
+  /** Full path, root → node, e.g. ['Cabinet 1', 'Row 3', 'Left']. */
+  path: string[];
+  code: string | null;
+}
+
+export interface LocationLabelSheetOptions {
+  companyId: string;
+  /** Absolute origin the scan URLs resolve against (window.location.origin). */
+  baseUrl: string;
+  labels: LocationLabel[];
+  /** Optional heading printed once at the top of page 1. */
+  heading?: string;
+}
+
+const A4 = { w: 210, h: 297 };
+const MARGIN = 12;
+const COLS = 2;
+const ROWS = 5; // 10 labels per page
+const QR_MM = 34;
+
+export function buildLocationScanUrl(baseUrl: string, companyId: string, locationId: string): string {
+  return `${baseUrl}/operator/${companyId}/login?location=${locationId}`;
+}
+
+export async function generateLocationLabelSheet(
+  opts: LocationLabelSheetOptions,
+): Promise<jsPDF> {
+  const { companyId, baseUrl, labels, heading } = opts;
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+
+  const cellW = (A4.w - 2 * MARGIN) / COLS;
+  const headingH = heading ? 10 : 0;
+  const cellH = (A4.h - 2 * MARGIN - headingH) / ROWS;
+  const perPage = COLS * ROWS;
+
+  // Pre-render every QR as a PNG data URL (level H ≈ 30% damage tolerance).
+  const dataUrls = await Promise.all(
+    labels.map((l) =>
+      QRCode.toDataURL(buildLocationScanUrl(baseUrl, companyId, l.id), {
+        margin: 2,
+        width: 320,
+        errorCorrectionLevel: 'H',
+      }).catch(() => null),
+    ),
+  );
+
+  labels.forEach((label, i) => {
+    const onPage = i % perPage;
+    if (i > 0 && onPage === 0) doc.addPage();
+
+    if (onPage === 0 && heading) {
+      doc.setFontSize(12);
+      doc.setTextColor(80);
+      doc.text(heading, MARGIN, MARGIN);
+    }
+
+    const col = onPage % COLS;
+    const row = Math.floor(onPage / COLS);
+    const x = MARGIN + col * cellW;
+    const y = MARGIN + headingH + row * cellH;
+
+    const dataUrl = dataUrls[i];
+    if (dataUrl) {
+      try {
+        doc.addImage(dataUrl, 'PNG', x, y + (cellH - QR_MM) / 2, QR_MM, QR_MM, undefined, 'FAST');
+      } catch {
+        /* skip image, keep text */
+      }
+    }
+
+    const textX = x + QR_MM + 5;
+    const textW = cellW - QR_MM - 8;
+    let ty = y + cellH / 2 - 4;
+
+    doc.setFontSize(11);
+    doc.setTextColor(0);
+    const pathLines = doc.splitTextToSize(label.path.join('  ›  ') || '(unnamed)', textW);
+    doc.text(pathLines, textX, ty);
+    ty += pathLines.length * 5 + 1;
+
+    if (label.code) {
+      doc.setFontSize(10);
+      doc.setTextColor(90);
+      doc.text(label.code, textX, ty);
+    }
+  });
+
+  return doc;
+}

--- a/utils/locationSpec.ts
+++ b/utils/locationSpec.ts
@@ -3,9 +3,9 @@
  *
  * The builder collects an ordered list of LevelSpecs (level 0 = the top
  * containers, level 1 = their divisions, …) and this module turns them into a
- * LocationSpecNode tree with names, zero-padded sortable codes, is_stockable on
- * the deepest level only, and is_qr_anchor on a chosen level. The code scheme is
- * shared with bulkGenerateChildren so the visual and manual builders agree.
+ * LocationSpecNode tree with names and zero-padded sortable codes. The code
+ * scheme is shared with bulkGenerateChildren so the visual and manual builders
+ * agree. Every location can hold stock and be printed — no per-node flags.
  */
 import type { LevelSpec, LocationSpecNode } from '@/types/inventoryLocations';
 
@@ -34,9 +34,6 @@ export function explicitCode(parentCode: string | null, name: string): string {
 export interface BuildSpecOptions {
   /** Code of the parent the tree will be created under (null = top-level). */
   parentCode?: string | null;
-  /** Which level (0-based) gets printed QR anchors. Default 0 = top containers
-   *  (container-level QR + on-screen drill-down, per the inventory design). */
-  qrAnchorDepth?: number;
 }
 
 /**
@@ -48,9 +45,6 @@ export function buildSpecFromLevels(
   levels: LevelSpec[],
   opts: BuildSpecOptions = {},
 ): LocationSpecNode[] {
-  const deepest = levels.length - 1;
-  const qrDepth = opts.qrAnchorDepth ?? 0;
-
   const buildLevel = (
     depth: number,
     parentCode: string | null,
@@ -58,7 +52,6 @@ export function buildSpecFromLevels(
   ): LocationSpecNode[] => {
     if (depth >= levels.length) return [];
     const level = levels[depth];
-    const isLeafLevel = depth === deepest;
 
     const makeNode = (i: number, name: string, code: string): LocationSpecNode => {
       const key = parentKey ? `${parentKey}/${i}` : `${i}`;
@@ -67,8 +60,6 @@ export function buildSpecFromLevels(
         name,
         kind: level.kind || null,
         code,
-        is_stockable: isLeafLevel,
-        is_qr_anchor: depth === qrDepth,
         children: buildLevel(depth + 1, code, key),
       };
     };
@@ -132,8 +123,6 @@ function cloneSubtree(node: LocationSpecNode, parentCode: string | null, overrid
     name,
     kind: node.kind,
     code,
-    is_stockable: node.is_stockable,
-    is_qr_anchor: node.is_qr_anchor,
     children: node.children.map((c) => cloneSubtree(c, code)),
   };
 }
@@ -181,8 +170,6 @@ export function addChildUnder(tree: LocationSpecNode[], parentKey: string): Loca
         name: 'Item 1',
         kind: 'item',
         code: deriveCodeFor('Item 1', 'item', parent.code),
-        is_stockable: true,
-        is_qr_anchor: false,
         children: [],
       };
     } else {
@@ -191,14 +178,6 @@ export function addChildUnder(tree: LocationSpecNode[], parentKey: string): Loca
     }
     return { ...parent, children: [...parent.children, child] };
   });
-}
-
-/** Re-stamp is_qr_anchor by depth across the whole tree (after the QR-level
- *  selector changes while the tree is hand-edited). */
-export function applyQrAnchorByDepth(nodes: LocationSpecNode[], depth: number): LocationSpecNode[] {
-  const walk = (ns: LocationSpecNode[], d: number): LocationSpecNode[] =>
-    ns.map((n) => ({ ...n, is_qr_anchor: d === depth, children: walk(n.children, d + 1) }));
-  return walk(nodes, 0);
 }
 
 /** Parent's code, inferred from a child's code ("C01-R03" → "C01", "C01" → null). */
@@ -225,4 +204,22 @@ export function duplicateNode(tree: LocationSpecNode[], key: string): LocationSp
     return out;
   };
   return walk(tree);
+}
+
+/**
+ * Duplicate a single (DB-sourced) subtree as a sibling: a bumped name past the
+ * EXISTING sibling names (Cabinet 1 → Cabinet 2), fresh keys, and codes
+ * re-derived under `parentCode`. Used by the Locations manager's Duplicate —
+ * unlike duplicateNode it takes the real sibling names + parent code explicitly
+ * (rather than inferring from an in-memory forest), so it can't collide with
+ * siblings the in-memory tree doesn't know about.
+ */
+export function duplicateSubtreeAsSibling(
+  rootNode: LocationSpecNode,
+  parentCode: string | null,
+  existingSiblingNames: string[],
+): LocationSpecNode {
+  const siblings = existingSiblingNames.map((name) => ({ ...rootNode, name, children: [] }));
+  const name = nextSiblingName(siblings, rootNode);
+  return cloneSubtree(rootNode, parentCode, name);
 }

--- a/utils/locationSpec.ts
+++ b/utils/locationSpec.ts
@@ -107,3 +107,90 @@ export function removeSpecNode(nodes: LocationSpecNode[], key: string): Location
     .filter((n) => n.key !== key)
     .map((n) => ({ ...n, children: removeSpecNode(n.children, key) }));
 }
+
+// ---- Per-branch (non-uniform) hand edits -------------------------------------
+// Once the user fine-tunes a single branch, the tree is edited directly (no
+// longer regenerated from the uniform levels). Keys must stay stable across
+// edits, so added nodes get a fresh counter-based key.
+
+let addSeq = 0;
+const freshKey = () => `e${addSeq++}`;
+
+/** Code for a hand-added/cloned node, reusing the generated/explicit scheme. */
+function deriveCodeFor(name: string, kind: string, parentCode: string | null): string {
+  const m = name.match(/(\d+)\s*$/);
+  if (m) return generatedCode(parentCode, kind, parseInt(m[1], 10), Math.max(2, m[1].length));
+  return explicitCode(parentCode, name);
+}
+
+/** Deep-clone a subtree with fresh keys and codes re-derived under `parentCode`. */
+function cloneSubtree(node: LocationSpecNode, parentCode: string | null, overrideName?: string): LocationSpecNode {
+  const name = overrideName ?? node.name;
+  const code = deriveCodeFor(name, node.kind ?? '', parentCode);
+  return {
+    key: freshKey(),
+    name,
+    kind: node.kind,
+    code,
+    is_stockable: node.is_stockable,
+    is_qr_anchor: node.is_qr_anchor,
+    children: node.children.map((c) => cloneSubtree(c, code)),
+  };
+}
+
+/** Next sibling name: bump the trailing number (Bin 4 → Bin 5), skipping gaps. */
+function nextSiblingName(siblings: LocationSpecNode[], last: LocationSpecNode): string {
+  const base = last.name.replace(/\s*\d+\s*$/, '').trim();
+  let max = 0;
+  for (const s of siblings) {
+    const m = s.name.match(/(\d+)\s*$/);
+    if (m) max = Math.max(max, parseInt(m[1], 10));
+  }
+  const next = (max || siblings.length) + 1;
+  return base ? `${base} ${next}` : `${last.name} ${next}`;
+}
+
+function mapNode(
+  nodes: LocationSpecNode[],
+  key: string,
+  fn: (n: LocationSpecNode) => LocationSpecNode,
+): LocationSpecNode[] {
+  return nodes.map((n) =>
+    n.key === key ? fn(n) : { ...n, children: mapNode(n.children, key, fn) },
+  );
+}
+
+/**
+ * Add one child under `parentKey`, to that branch ONLY (the heart of
+ * non-uniform editing). Clones the parent's last child — so "+ under a section"
+ * adds another bin, and "+ under a container" adds another section *with its
+ * bins*. An empty parent gets a single stockable leaf.
+ */
+export function addChildUnder(tree: LocationSpecNode[], parentKey: string): LocationSpecNode[] {
+  return mapNode(tree, parentKey, (parent) => {
+    let child: LocationSpecNode;
+    if (parent.children.length === 0) {
+      child = {
+        key: freshKey(),
+        name: 'Item 1',
+        kind: 'item',
+        code: deriveCodeFor('Item 1', 'item', parent.code),
+        is_stockable: true,
+        is_qr_anchor: false,
+        children: [],
+      };
+    } else {
+      const last = parent.children[parent.children.length - 1];
+      child = cloneSubtree(last, parent.code, nextSiblingName(parent.children, last));
+    }
+    return { ...parent, children: [...parent.children, child] };
+  });
+}
+
+/** Re-stamp is_qr_anchor by depth across the whole tree (after the QR-level
+ *  selector changes while the tree is hand-edited). */
+export function applyQrAnchorByDepth(nodes: LocationSpecNode[], depth: number): LocationSpecNode[] {
+  const walk = (ns: LocationSpecNode[], d: number): LocationSpecNode[] =>
+    ns.map((n) => ({ ...n, is_qr_anchor: d === depth, children: walk(n.children, d + 1) }));
+  return walk(nodes, 0);
+}

--- a/utils/locationSpec.ts
+++ b/utils/locationSpec.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure (DB-free) assembly of the visual builder's in-memory location tree.
+ *
+ * The builder collects an ordered list of LevelSpecs (level 0 = the top
+ * containers, level 1 = their divisions, …) and this module turns them into a
+ * LocationSpecNode tree with names, zero-padded sortable codes, is_stockable on
+ * the deepest level only, and is_qr_anchor on a chosen level. The code scheme is
+ * shared with bulkGenerateChildren so the visual and manual builders agree.
+ */
+import type { LevelSpec, LocationSpecNode } from '@/types/inventoryLocations';
+
+/** Zero-pad a 1-based index to a uniform width (warehouse naming discipline). */
+export function pad(n: number, width: number): string {
+  return String(n).padStart(width, '0');
+}
+
+/** Code for a generated node, e.g. parent "CAB1" + row 3 → "CAB1-R03". */
+export function generatedCode(
+  parentCode: string | null,
+  kind: string,
+  idx: number,
+  width: number,
+): string {
+  const initial = (kind || 'N').charAt(0).toUpperCase();
+  return `${parentCode ? parentCode + '-' : ''}${initial}${pad(idx, width)}`;
+}
+
+/** Code for an explicitly-named node, e.g. parent "CAB1-R03" + "Left" → "CAB1-R03-L". */
+export function explicitCode(parentCode: string | null, name: string): string {
+  const initial = (name.trim().charAt(0) || 'X').toUpperCase();
+  return `${parentCode ? parentCode + '-' : ''}${initial}`;
+}
+
+export interface BuildSpecOptions {
+  /** Code of the parent the tree will be created under (null = top-level). */
+  parentCode?: string | null;
+  /** Which level (0-based) gets printed QR anchors. Default 0 = top containers
+   *  (container-level QR + on-screen drill-down, per the inventory design). */
+  qrAnchorDepth?: number;
+}
+
+/**
+ * Assemble the LocationSpecNode roots from ordered levels. Deepest level's nodes
+ * are the stockable leaves. Keys are deterministic (path-based) for stable React
+ * keys and prune.
+ */
+export function buildSpecFromLevels(
+  levels: LevelSpec[],
+  opts: BuildSpecOptions = {},
+): LocationSpecNode[] {
+  const deepest = levels.length - 1;
+  const qrDepth = opts.qrAnchorDepth ?? 0;
+
+  const buildLevel = (
+    depth: number,
+    parentCode: string | null,
+    parentKey: string,
+  ): LocationSpecNode[] => {
+    if (depth >= levels.length) return [];
+    const level = levels[depth];
+    const isLeafLevel = depth === deepest;
+
+    const makeNode = (i: number, name: string, code: string): LocationSpecNode => {
+      const key = parentKey ? `${parentKey}/${i}` : `${i}`;
+      return {
+        key,
+        name,
+        kind: level.kind || null,
+        code,
+        is_stockable: isLeafLevel,
+        is_qr_anchor: depth === qrDepth,
+        children: buildLevel(depth + 1, code, key),
+      };
+    };
+
+    if (level.names && level.names.length > 0) {
+      return level.names
+        .map((n) => n.trim())
+        .filter(Boolean)
+        .map((nm, i) => makeNode(i, nm, explicitCode(parentCode, nm)));
+    }
+
+    const count = Math.max(0, level.count ?? 0);
+    const width = Math.max(2, String(count).length);
+    const pattern = level.namePattern || '{n}';
+    const nodes: LocationSpecNode[] = [];
+    for (let i = 0; i < count; i++) {
+      const idx = i + 1;
+      nodes.push(
+        makeNode(i, pattern.replace('{n}', String(idx)), generatedCode(parentCode, level.kind, idx, width)),
+      );
+    }
+    return nodes;
+  };
+
+  return buildLevel(0, opts.parentCode ?? null, '');
+}
+
+/** Total node count across the spec forest (for the live "will create N" count). */
+export function countSpecNodes(nodes: LocationSpecNode[]): number {
+  return nodes.reduce((sum, n) => sum + 1 + countSpecNodes(n.children), 0);
+}
+
+/** Remove a node (and its subtree) by key — used by the prune step. */
+export function removeSpecNode(nodes: LocationSpecNode[], key: string): LocationSpecNode[] {
+  return nodes
+    .filter((n) => n.key !== key)
+    .map((n) => ({ ...n, children: removeSpecNode(n.children, key) }));
+}

--- a/utils/locationSpec.ts
+++ b/utils/locationSpec.ts
@@ -138,15 +138,21 @@ function cloneSubtree(node: LocationSpecNode, parentCode: string | null, overrid
   };
 }
 
-/** Next sibling name: bump the trailing number (Bin 4 → Bin 5), skipping gaps. */
+/** Next sibling name for a clone: bump past the highest number sharing the same
+ *  base (Bin 4 → Bin 5, keeping a gap), or count the same-base siblings when
+ *  they're unnumbered (Left among [Left, Right] → Left 2). */
 function nextSiblingName(siblings: LocationSpecNode[], last: LocationSpecNode): string {
   const base = last.name.replace(/\s*\d+\s*$/, '').trim();
-  let max = 0;
+  let maxNum = 0;
+  let sameBase = 0;
   for (const s of siblings) {
-    const m = s.name.match(/(\d+)\s*$/);
-    if (m) max = Math.max(max, parseInt(m[1], 10));
+    if (s.name.replace(/\s*\d+\s*$/, '').trim() === base) {
+      sameBase += 1;
+      const m = s.name.match(/(\d+)\s*$/);
+      if (m) maxNum = Math.max(maxNum, parseInt(m[1], 10));
+    }
   }
-  const next = (max || siblings.length) + 1;
+  const next = (maxNum > 0 ? maxNum : sameBase) + 1;
   return base ? `${base} ${next}` : `${last.name} ${next}`;
 }
 
@@ -193,4 +199,30 @@ export function applyQrAnchorByDepth(nodes: LocationSpecNode[], depth: number): 
   const walk = (ns: LocationSpecNode[], d: number): LocationSpecNode[] =>
     ns.map((n) => ({ ...n, is_qr_anchor: d === depth, children: walk(n.children, d + 1) }));
   return walk(nodes, 0);
+}
+
+/** Parent's code, inferred from a child's code ("C01-R03" → "C01", "C01" → null). */
+function parentCodeOf(code: string | null): string | null {
+  if (!code) return null;
+  const i = code.lastIndexOf('-');
+  return i >= 0 ? code.slice(0, i) : null;
+}
+
+/**
+ * Duplicate a node (and its subtree) as the NEXT sibling — fresh keys, a bumped
+ * name (Cabinet 1 → Cabinet 2), and re-derived codes under the same parent.
+ * Works at any level, including top-level entries.
+ */
+export function duplicateNode(tree: LocationSpecNode[], key: string): LocationSpecNode[] {
+  const walk = (nodes: LocationSpecNode[]): LocationSpecNode[] => {
+    const out: LocationSpecNode[] = [];
+    for (const n of nodes) {
+      out.push({ ...n, children: walk(n.children) });
+      if (n.key === key) {
+        out.push(cloneSubtree(n, parentCodeOf(n.code), nextSiblingName(nodes, n)));
+      }
+    }
+    return out;
+  };
+  return walk(tree);
 }

--- a/utils/partsAccess.ts
+++ b/utils/partsAccess.ts
@@ -24,7 +24,7 @@ import {
 import { convertToBaseUnit } from '@/lib/unitPresets';
 
 const PART_COLUMNS =
-  'id, company_id, part_name, description, source, is_stocked, primary_unit, quantity, reorder_point, preferred_vendor_id, markup_rate_id, legacy_id, created_at, updated_at';
+  'id, company_id, part_name, description, source, is_stocked, primary_unit, quantity, reorder_point, preferred_vendor_id, markup_rate_id, legacy_id, is_location_tracked, created_at, updated_at';
 
 interface PartRow {
   id: string;
@@ -39,6 +39,7 @@ interface PartRow {
   preferred_vendor_id: string | null;
   markup_rate_id: string | null;
   legacy_id: string | null;
+  is_location_tracked: boolean;
   created_at: string;
   updated_at: string;
   routings?: Array<{ id: string }> | { id: string } | null;
@@ -60,6 +61,7 @@ function rowToPart(row: PartRow): Part {
     preferred_vendor_id: row.preferred_vendor_id,
     markup_rate_id: row.markup_rate_id,
     legacy_id: row.legacy_id,
+    is_location_tracked: row.is_location_tracked ?? false,
     created_at: row.created_at,
     updated_at: row.updated_at,
     routing: routingRecord


### PR DESCRIPTION
PR1 of 2 for QR-addressable storage locations (plan: `enchanted-beaming-wind` → resurfaced as `can-you-pull-up-deep-comet`). Adds a hierarchical location tree, per-location stock balances, and the dashboard/part-detail UI. **PR2** will add the operator scan flow + job tie-in.

## What's here
- **Schema** (3 migrations, applied to **staging**): `inventory_locations` (company-scoped, arbitrary-depth tree, `is_qr_anchor`), `part_location_stock` (per-location balances, **SELECT-only** under RLS), `parts.is_location_tracked`, `inventory_transactions.location_id` + `transfer_group_id`.
- **Source-of-truth rollup**: for tracked parts, `parts.quantity` is a trigger-maintained `COALESCE(SUM(balances),0)`. Opt-in **backfills** existing stock into an "Unassigned" location so the invariant holds immediately (no runtime fallback).
- **6 RPCs** (SECURITY DEFINER, atomic balance + ledger, modeled on `create_shipment_with_line_items`): `add` / `deplete` (graceful clamp under `FOR UPDATE`) / `adjust` / `transfer_stock` (paired rows, shared `transfer_group_id` — **bin-to-bin moves are in v1**) / `enable` / `disable_location_tracking`.
- **Locations Manager** (`/inventory/locations`): tree CRUD, bulk-generate (e.g. 10 rows × {Left, Right}), and **QR label printing** (UUID payload, level-H, Avery-style sheet).
- **Part Inventory tab**: enable/disable tracking, balances-by-location list, per-location Add/Remove/Move/Adjust.

## Integrity & multi-tenancy (hardened per an independent review)
- **Cross-tenant safety**: each RPC **derives** the company from the part and verifies the caller's membership *and* that every location id resolves to the same company — caller membership alone is insufficient (DEFINER bypasses RLS; FKs check existence, not ownership).
- **Invariant is DB-enforced**: a `BEFORE UPDATE` trigger rejects any direct `parts.quantity` write on a tracked part that ≠ `SUM(balances)` — so a raw PostgREST `PATCH` can't break it, not just the access layer.
- **Ordered un-track** + `COALESCE` so collapsing balances never yields `NULL`; `transfer_group_id`/`location_id` added to the ledger's notes-only immutable guard.

## Verification
- **Live staging smoke tests, fully rolled back** (`BEGIN … ROLLBACK`, 0 rows persisted): rollup on insert/update/delete, the invariant guard, no-double-count opt-in, ordered disable-collapse; and via authenticated RPCs — enable+backfill, add+ledger, graceful over-deplete (clamp + discrepancy), transfer pairing (rollup unchanged), and a real **cross-tenant rejection**.
- `tsc --noEmit` clean; **full Vitest suite green (661)**; 24 new unit tests (access layer + label PDF); lint consistent with baseline.

## Notes for the reviewer / merge
- Migrations are on **staging only**. Per repo policy, the **prod `supabase db push` is human-owned** — please run it on merge, then `python scripts/export_schema.py` + `pnpm gen:db-types`.
- Acceptance A1–A7 from the plan are covered by the smoke tests; an E2E seed extension lands with PR2's operator flow.
- Follow-ups from the plan (doc commit to `docs/modules/inventory-locations.md`, the 3 §5 citation fixes, correcting the stale `docs/modules/inventory.md`) are tracked for the docs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)