### PR TITLE
Visual Storage Builder — no-AI onboarding accelerator for inventory locations

### DIFF
--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -46,26 +46,26 @@ describe('VisualLocationBuilder', () => {
     expect(onCreated).toHaveBeenCalledWith(16);
   });
 
-  it('fine-tunes one branch (remove + add), reflects it, and can start over', async () => {
+  it('customizes per branch from the config, then can start over', async () => {
     const user = userEvent.setup();
     render(<VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={vi.fn()} />);
 
     await user.click(screen.getByText('Cabinet'));
     expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
 
-    // remove one leaf from one branch → non-uniform, count drops, config reflects it
-    await user.click(screen.getAllByRole('button', { name: /^remove left$/i })[0]);
-    expect(await screen.findByRole('button', { name: /create 15 locations/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /start over/i })).toBeInTheDocument(); // customized config
+    // editing is in the config now — enter the per-branch editor
+    await user.click(screen.getByRole('button', { name: /customize individual spots/i }));
+    expect(await screen.findByText('Cabinet 1 › Row 1')).toBeInTheDocument(); // config reflects branches
+    expect(screen.getByRole('button', { name: /^start over$/i })).toBeInTheDocument();
 
-    // add one back to that branch
-    await user.click(screen.getByRole('button', { name: /add to row 1/i }));
-    expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
+    // add one to a single branch → count rises
+    await user.click(screen.getAllByRole('button', { name: /^add$/i })[0]);
+    expect(await screen.findByRole('button', { name: /create 17 locations/i })).toBeInTheDocument();
 
     // start over → confirm → back to the uniform numbers form
-    await user.click(screen.getByRole('button', { name: /start over/i }));
-    const confirms = screen.getAllByRole('button', { name: /start over/i });
-    await user.click(confirms[confirms.length - 1]); // the dialog's confirm
+    await user.click(screen.getByRole('button', { name: /^start over$/i }));
+    const confirms = screen.getAllByRole('button', { name: /^start over$/i });
+    await user.click(confirms[confirms.length - 1]);
     expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
     expect(screen.getAllByText('Call them').length).toBeGreaterThan(0); // uniform controls back
   });

--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * VisualLocationBuilder: the no-AI stepper that turns a picked storage type +
+ * configured divisions into a location tree. Asserts the happy path —
+ * palette → layout → review board → Create calls materializeLocationSpec with
+ * the assembled spec and reports the count. The spec math itself is covered by
+ * locationSpec.test.ts; here we test the wiring.
+ */
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render, screen } from '../../../test-utils';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@/utils/inventoryLocationsAccess', () => ({
+  materializeLocationSpec: vi.fn(async (_co: string, _p: string | null, nodes: { children: unknown[] }[]) => {
+    const count = (function c(ns: { children: unknown[] }[]): number {
+      return ns.reduce((s, n) => s + 1 + c(n.children as { children: unknown[] }[]), 0);
+    })(nodes);
+    return Array.from({ length: count }, (_, i) => ({ id: String(i) }));
+  }),
+}));
+
+import VisualLocationBuilder from '@/components/inventory/locations/builder/VisualLocationBuilder';
+import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('VisualLocationBuilder', () => {
+  it('walks palette → layout → review → create and materializes the spec', async () => {
+    const user = userEvent.setup();
+    const onCreated = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <VisualLocationBuilder open companyId="co1" onClose={onClose} onCreated={onCreated} />,
+    );
+
+    // Step 1 — palette: pick Cabinet (defaults to 1 cabinet × 5 rows × {Left,Right} = 16)
+    await user.click(screen.getByText('Cabinet'));
+
+    // Step 2 — layout: advances and a Review action appears
+    const reviewBtn = await screen.findByRole('button', { name: /review/i });
+    await user.click(reviewBtn);
+
+    // Step 3 — review board shows the top container and a Create button with the count
+    expect(await screen.findByText('Cabinet 1')).toBeInTheDocument();
+    const createBtn = await screen.findByRole('button', { name: /create 16 locations/i });
+    await user.click(createBtn);
+
+    expect(materializeLocationSpec).toHaveBeenCalledTimes(1);
+    const [companyId, parentId, spec] = (materializeLocationSpec as Mock).mock.calls[0];
+    expect(companyId).toBe('co1');
+    expect(parentId).toBeNull();
+    expect(spec[0].name).toBe('Cabinet 1');
+    expect(spec[0].is_qr_anchor).toBe(true); // default QR anchor = top container
+    expect(onCreated).toHaveBeenCalledWith(16);
+  });
+
+  it('lets you prune a tile before creating, lowering the count', async () => {
+    const user = userEvent.setup();
+    render(
+      <VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={vi.fn()} />,
+    );
+
+    await user.click(screen.getByText('Bins')); // flat: 6 bins
+    await user.click(await screen.findByRole('button', { name: /review/i }));
+    expect(await screen.findByRole('button', { name: /create 6 locations/i })).toBeInTheDocument();
+
+    // remove one bin tile
+    await user.click(screen.getByRole('button', { name: /remove bin 1/i }));
+    expect(await screen.findByRole('button', { name: /create 5 locations/i })).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -35,8 +35,11 @@ describe('VisualLocationBuilder', () => {
     // Step 1 — palette: pick Cabinet (defaults to 1 cabinet × 5 rows × {Left,Right} = 16)
     await user.click(screen.getByText('Cabinet'));
 
-    // Step 2 — Build: controls + live board are shown together, Create carries the count
+    // Step 2 — Build: controls + live board together. The WHOLE nesting is
+    // visible without any drill-in click (cabinet → rows → bin leaves).
     expect(await screen.findByText('Cabinet 1')).toBeInTheDocument();
+    expect(screen.getByText('Row 1')).toBeInTheDocument(); // level 2 section
+    expect(screen.getAllByText('Left').length).toBeGreaterThan(0); // level 3 leaf chips
     const createBtn = await screen.findByRole('button', { name: /create 16 locations/i });
     await user.click(createBtn);
 

--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -69,4 +69,17 @@ describe('VisualLocationBuilder', () => {
     expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
     expect(screen.getAllByText('Call them').length).toBeGreaterThan(0); // uniform controls back
   });
+
+  it('duplicates a top-level entry from the customize editor', async () => {
+    const user = userEvent.setup();
+    render(<VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={vi.fn()} />);
+
+    await user.click(screen.getByText('Cabinet')); // 16 nodes
+    await user.click(screen.getByRole('button', { name: /customize individual spots/i }));
+
+    // duplicate the cabinet → a second one like it → 32 nodes
+    await user.click(await screen.findByRole('button', { name: /duplicate cabinet 1/i }));
+    expect(await screen.findByRole('button', { name: /create 32 locations/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /duplicate cabinet 2/i })).toBeInTheDocument();
+  });
 });

--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -24,7 +24,7 @@ import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
 beforeEach(() => vi.clearAllMocks());
 
 describe('VisualLocationBuilder', () => {
-  it('walks palette → layout → review → create and materializes the spec', async () => {
+  it('picks a type, shows the live build step, and creates the materialized spec', async () => {
     const user = userEvent.setup();
     const onCreated = vi.fn();
     const onClose = vi.fn();
@@ -35,11 +35,7 @@ describe('VisualLocationBuilder', () => {
     // Step 1 — palette: pick Cabinet (defaults to 1 cabinet × 5 rows × {Left,Right} = 16)
     await user.click(screen.getByText('Cabinet'));
 
-    // Step 2 — layout: advances and a Review action appears
-    const reviewBtn = await screen.findByRole('button', { name: /review/i });
-    await user.click(reviewBtn);
-
-    // Step 3 — review board shows the top container and a Create button with the count
+    // Step 2 — Build: controls + live board are shown together, Create carries the count
     expect(await screen.findByText('Cabinet 1')).toBeInTheDocument();
     const createBtn = await screen.findByRole('button', { name: /create 16 locations/i });
     await user.click(createBtn);
@@ -53,17 +49,16 @@ describe('VisualLocationBuilder', () => {
     expect(onCreated).toHaveBeenCalledWith(16);
   });
 
-  it('lets you prune a tile before creating, lowering the count', async () => {
+  it('lets you prune a tile in the live preview, lowering the count', async () => {
     const user = userEvent.setup();
     render(
       <VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={vi.fn()} />,
     );
 
-    await user.click(screen.getByText('Bins')); // flat: 6 bins
-    await user.click(await screen.findByRole('button', { name: /review/i }));
+    await user.click(screen.getByText('Bins')); // flat: 6 bins, shown live on the build step
     expect(await screen.findByRole('button', { name: /create 6 locations/i })).toBeInTheDocument();
 
-    // remove one bin tile
+    // remove one bin tile from the preview
     await user.click(screen.getByRole('button', { name: /remove bin 1/i }));
     expect(await screen.findByRole('button', { name: /create 5 locations/i })).toBeInTheDocument();
   });

--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -1,9 +1,7 @@
 /**
- * VisualLocationBuilder: the no-AI stepper that turns a picked storage type +
- * configured divisions into a location tree. Asserts the happy path —
- * palette → layout → review board → Create calls materializeLocationSpec with
- * the assembled spec and reports the count. The spec math itself is covered by
- * locationSpec.test.ts; here we test the wiring.
+ * VisualLocationBuilder: pick a type, see the full nested live preview, fine-tune
+ * individual branches (non-uniform), and create. The spec math + per-branch
+ * edits are covered by locationSpec.test.ts; here we test the wiring.
  */
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { render, screen } from '../../../test-utils';
@@ -24,45 +22,51 @@ import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
 beforeEach(() => vi.clearAllMocks());
 
 describe('VisualLocationBuilder', () => {
-  it('picks a type, shows the live build step, and creates the materialized spec', async () => {
+  it('picks a type, shows the full nested preview, and creates the spec', async () => {
     const user = userEvent.setup();
     const onCreated = vi.fn();
-    const onClose = vi.fn();
-    render(
-      <VisualLocationBuilder open companyId="co1" onClose={onClose} onCreated={onCreated} />,
-    );
+    render(<VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={onCreated} />);
 
-    // Step 1 — palette: pick Cabinet (defaults to 1 cabinet × 5 rows × {Left,Right} = 16)
+    // Cabinet default: 1 cabinet × 5 rows × {Left, Right} = 16
     await user.click(screen.getByText('Cabinet'));
 
-    // Step 2 — Build: controls + live board together. The WHOLE nesting is
-    // visible without any drill-in click (cabinet → rows → bin leaves).
+    // whole nesting visible, no drill-in
     expect(await screen.findByText('Cabinet 1')).toBeInTheDocument();
-    expect(screen.getByText('Row 1')).toBeInTheDocument(); // level 2 section
-    expect(screen.getAllByText('Left').length).toBeGreaterThan(0); // level 3 leaf chips
-    const createBtn = await screen.findByRole('button', { name: /create 16 locations/i });
-    await user.click(createBtn);
+    expect(screen.getByText('Row 1')).toBeInTheDocument();
+    expect(screen.getAllByText('Left').length).toBeGreaterThan(0);
+
+    await user.click(await screen.findByRole('button', { name: /create 16 locations/i }));
 
     expect(materializeLocationSpec).toHaveBeenCalledTimes(1);
     const [companyId, parentId, spec] = (materializeLocationSpec as Mock).mock.calls[0];
     expect(companyId).toBe('co1');
     expect(parentId).toBeNull();
     expect(spec[0].name).toBe('Cabinet 1');
-    expect(spec[0].is_qr_anchor).toBe(true); // default QR anchor = top container
+    expect(spec[0].is_qr_anchor).toBe(true);
     expect(onCreated).toHaveBeenCalledWith(16);
   });
 
-  it('lets you prune a tile in the live preview, lowering the count', async () => {
+  it('fine-tunes one branch (remove + add), reflects it, and can start over', async () => {
     const user = userEvent.setup();
-    render(
-      <VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={vi.fn()} />,
-    );
+    render(<VisualLocationBuilder open companyId="co1" onClose={vi.fn()} onCreated={vi.fn()} />);
 
-    await user.click(screen.getByText('Bins')); // flat: 6 bins, shown live on the build step
-    expect(await screen.findByRole('button', { name: /create 6 locations/i })).toBeInTheDocument();
+    await user.click(screen.getByText('Cabinet'));
+    expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
 
-    // remove one bin tile from the preview
-    await user.click(screen.getByRole('button', { name: /remove bin 1/i }));
-    expect(await screen.findByRole('button', { name: /create 5 locations/i })).toBeInTheDocument();
+    // remove one leaf from one branch → non-uniform, count drops, config reflects it
+    await user.click(screen.getAllByRole('button', { name: /^remove left$/i })[0]);
+    expect(await screen.findByRole('button', { name: /create 15 locations/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /start over/i })).toBeInTheDocument(); // customized config
+
+    // add one back to that branch
+    await user.click(screen.getByRole('button', { name: /add to row 1/i }));
+    expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
+
+    // start over → confirm → back to the uniform numbers form
+    await user.click(screen.getByRole('button', { name: /start over/i }));
+    const confirms = screen.getAllByRole('button', { name: /start over/i });
+    await user.click(confirms[confirms.length - 1]); // the dialog's confirm
+    expect(await screen.findByRole('button', { name: /create 16 locations/i })).toBeInTheDocument();
+    expect(screen.getAllByText('Call them').length).toBeGreaterThan(0); // uniform controls back
   });
 });

--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -42,7 +42,6 @@ describe('VisualLocationBuilder', () => {
     expect(companyId).toBe('co1');
     expect(parentId).toBeNull();
     expect(spec[0].name).toBe('Cabinet 1');
-    expect(spec[0].is_qr_anchor).toBe(true);
     expect(onCreated).toHaveBeenCalledWith(16);
   });
 

--- a/__tests__/utils/inventoryLocationsAccess.test.ts
+++ b/__tests__/utils/inventoryLocationsAccess.test.ts
@@ -47,6 +47,7 @@ import {
   deleteLocation,
   moveLocation,
   materializeLocationSpec,
+  duplicateLocation,
   getBalancesForPart,
   addStockAtLocation,
   depleteStockAtLocation,
@@ -323,16 +324,12 @@ describe('materializeLocationSpec', () => {
         name: 'Cabinet 1',
         kind: 'cabinet',
         code: 'C01',
-        is_stockable: false,
-        is_qr_anchor: true,
         children: [
           {
             key: '0/0',
             name: 'Row 1',
             kind: 'row',
             code: 'C01-R01',
-            is_stockable: true,
-            is_qr_anchor: false,
             children: [],
           },
         ],
@@ -354,10 +351,41 @@ describe('materializeLocationSpec', () => {
         parent_id: null,
         name: 'Cabinet 1',
         code: 'C01',
-        is_qr_anchor: true,
-        is_stockable: false,
         sort_order: 0,
       }),
+    );
+  });
+});
+
+describe('duplicateLocation', () => {
+  it('deep-copies a subtree as a bumped sibling, codes re-derived, structure only', async () => {
+    // Existing: Cabinet 1 (C01) → Bin 1 (C01-B01)
+    queueFrom({
+      data: [
+        loc({ id: 'cab', name: 'Cabinet 1', kind: 'cabinet', code: 'C01' }),
+        loc({ id: 'b1', name: 'Bin 1', kind: 'bin', parent_id: 'cab', code: 'C01-B01' }),
+      ],
+      error: null,
+    });
+    // materialize → new cabinet insert (parent_id null, no parent check)
+    queueFrom({ data: loc({ id: 'cab2', name: 'Cabinet 2', code: 'C02' }), error: null });
+    // copied bin → assertParentInCompany('cab2') getLocation, then insert
+    queueFrom({ data: loc({ id: 'cab2', company_id: 'co1' }), error: null });
+    queueFrom({ data: loc({ id: 'b2', name: 'Bin 1', parent_id: 'cab2', code: 'C02-B01' }), error: null });
+
+    const created = await duplicateLocation('co1', 'cab');
+
+    expect(created.map((r) => r.id)).toEqual(['cab2', 'b2']);
+    // from() #0 = getLocations; #1 = new cabinet insert. sort_order lands AFTER
+    // the one existing sibling (sort_order 0), so the copy doesn't jump to front.
+    const cabInsert = mockSupabase.from.mock.results[1].value as Record<string, ReturnType<typeof vi.fn>>;
+    expect(cabInsert.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ parent_id: null, name: 'Cabinet 2', code: 'C02', sort_order: 1 }),
+    );
+    // #3 = copied bin insert, code re-derived under the new cabinet
+    const binInsert = mockSupabase.from.mock.results[3].value as Record<string, ReturnType<typeof vi.fn>>;
+    expect(binInsert.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ parent_id: 'cab2', name: 'Bin 1', code: 'C02-B01' }),
     );
   });
 });

--- a/__tests__/utils/inventoryLocationsAccess.test.ts
+++ b/__tests__/utils/inventoryLocationsAccess.test.ts
@@ -46,6 +46,7 @@ import {
   createLocation,
   deleteLocation,
   moveLocation,
+  materializeLocationSpec,
   getBalancesForPart,
   addStockAtLocation,
   depleteStockAtLocation,
@@ -310,5 +311,53 @@ describe('RPC wrappers', () => {
     queueFrom(partCtx());
     state.rpc = { data: null, error: { message: 'access denied to company X' } };
     await expect(addStockAtLocation('part1', 'loc1', 1, 'ft')).rejects.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('materializeLocationSpec', () => {
+  it('recursively creates parent-then-child and returns every created row', async () => {
+    const spec = [
+      {
+        key: '0',
+        name: 'Cabinet 1',
+        kind: 'cabinet',
+        code: 'C01',
+        is_stockable: false,
+        is_qr_anchor: true,
+        children: [
+          {
+            key: '0/0',
+            name: 'Row 1',
+            kind: 'row',
+            code: 'C01-R01',
+            is_stockable: true,
+            is_qr_anchor: false,
+            children: [],
+          },
+        ],
+      },
+    ];
+    // createLocation(A): insert (no parent check, parent_id null)
+    queueFrom({ data: loc({ id: 'a', name: 'Cabinet 1', code: 'C01' }), error: null });
+    // createLocation(B): assertParentInCompany('a') -> getLocation, then insert
+    queueFrom({ data: loc({ id: 'a', company_id: 'co1' }), error: null });
+    queueFrom({ data: loc({ id: 'b', name: 'Row 1', parent_id: 'a', code: 'C01-R01' }), error: null });
+
+    const created = await materializeLocationSpec('co1', null, spec);
+
+    expect(created.map((r) => r.id)).toEqual(['a', 'b']);
+    // first from() is the cabinet insert; assert the payload carries the spec fields
+    const cabinetBuilder = mockSupabase.from.mock.results[0].value as Record<string, ReturnType<typeof vi.fn>>;
+    expect(cabinetBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parent_id: null,
+        name: 'Cabinet 1',
+        code: 'C01',
+        is_qr_anchor: true,
+        is_stockable: false,
+        sort_order: 0,
+      }),
+    );
   });
 });

--- a/__tests__/utils/locationSpec.test.ts
+++ b/__tests__/utils/locationSpec.test.ts
@@ -5,7 +5,7 @@ import {
   removeSpecNode,
   addChildUnder,
   duplicateNode,
-  applyQrAnchorByDepth,
+  duplicateSubtreeAsSibling,
   generatedCode,
   explicitCode,
 } from '@/utils/locationSpec';
@@ -52,30 +52,14 @@ describe('buildSpecFromLevels', () => {
     expect(left.code).toBe('C01-R03-L');
   });
 
-  it('marks is_stockable ONLY on the deepest level (leaves)', () => {
-    const [cab1] = buildSpecFromLevels(cabinetsRowsSides);
-    expect(cab1.is_stockable).toBe(false); // cabinet
-    expect(cab1.children[0].is_stockable).toBe(false); // row
-    expect(cab1.children[0].children[0].is_stockable).toBe(true); // side (leaf)
-  });
-
-  it('defaults QR anchors to the top container level; honors qrAnchorDepth override', () => {
-    const [cabTop] = buildSpecFromLevels(cabinetsRowsSides);
-    expect(cabTop.is_qr_anchor).toBe(true); // depth 0 default
-    expect(cabTop.children[0].is_qr_anchor).toBe(false);
-
-    const [cabDeep] = buildSpecFromLevels(cabinetsRowsSides, { qrAnchorDepth: 2 });
-    expect(cabDeep.is_qr_anchor).toBe(false);
-    expect(cabDeep.children[0].children[0].is_qr_anchor).toBe(true); // leaves
-  });
-
-  it('a 2-level spec makes the middle level the leaves', () => {
+  it('a 2-level spec nests the second level under the first', () => {
     const roots = buildSpecFromLevels([
       { kind: 'cabinet', count: 1, namePattern: 'Cabinet {n}' },
       { kind: 'shelf', count: 5, namePattern: 'Shelf {n}' },
     ]);
     expect(countSpecNodes(roots)).toBe(6); // 1 + 5
-    expect(roots[0].children[0].is_stockable).toBe(true); // shelves are leaves now
+    expect(roots[0].children).toHaveLength(5);
+    expect(roots[0].children[0].name).toBe('Shelf 1');
   });
 
   it('zero-pads to a uniform width across the level', () => {
@@ -173,10 +157,30 @@ describe('non-uniform editing', () => {
     expect(next[0].children[1].children).toHaveLength(4);
   });
 
-  it('applyQrAnchorByDepth re-stamps anchors to a chosen depth', () => {
-    const roots = applyQrAnchorByDepth(buildSpecFromLevels(cabinetSidesBins), 2);
-    expect(roots[0].is_qr_anchor).toBe(false); // cabinet
-    expect(roots[0].children[0].is_qr_anchor).toBe(false); // side
-    expect(roots[0].children[0].children[0].is_qr_anchor).toBe(true); // bin (depth 2)
+  it('duplicateSubtreeAsSibling names past EXISTING db siblings and re-derives codes', () => {
+    // One DB cabinet "Cabinet 1" (C01) with 2 bins; duplicate it as a sibling.
+    const [root] = buildSpecFromLevels([
+      { kind: 'cabinet', count: 1, namePattern: 'Cabinet {n}' },
+      { kind: 'bin', count: 2, namePattern: 'Bin {n}' },
+    ]);
+    // Existing siblings in the DB are ["Cabinet 1", "Cabinet 2"] (a gap-free run),
+    // so the copy must land on "Cabinet 3" — not collide with the existing 2.
+    const clone = duplicateSubtreeAsSibling(root, null, ['Cabinet 1', 'Cabinet 2']);
+    expect(clone.name).toBe('Cabinet 3');
+    expect(clone.code).toBe('C03');
+    expect(clone.children.map((b) => b.code)).toEqual(['C03-B01', 'C03-B02']);
+    expect(clone.key).not.toBe(root.key); // fresh keys
+  });
+
+  it('duplicateSubtreeAsSibling re-derives nested codes under a parent code', () => {
+    const [root] = buildSpecFromLevels([
+      { kind: 'row', count: 1, namePattern: 'Row {n}' },
+      { kind: 'side', names: ['Left', 'Right'] },
+    ]);
+    // Duplicating "Row 1" under parent "C01" with one existing sibling.
+    const clone = duplicateSubtreeAsSibling(root, 'C01', ['Row 1']);
+    expect(clone.name).toBe('Row 2');
+    expect(clone.code).toBe('C01-R02');
+    expect(clone.children.map((s) => s.code)).toEqual(['C01-R02-L', 'C01-R02-R']);
   });
 });

--- a/__tests__/utils/locationSpec.test.ts
+++ b/__tests__/utils/locationSpec.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSpecFromLevels,
+  countSpecNodes,
+  removeSpecNode,
+  generatedCode,
+  explicitCode,
+} from '@/utils/locationSpec';
+import type { LevelSpec } from '@/types/inventoryLocations';
+
+const cabinetsRowsSides: LevelSpec[] = [
+  { kind: 'cabinet', count: 3, namePattern: 'Cabinet {n}' },
+  { kind: 'row', count: 10, namePattern: 'Row {n}' },
+  { kind: 'side', names: ['Left', 'Right'] },
+];
+
+describe('code helpers (parity with bulkGenerateChildren)', () => {
+  it('generatedCode: parent prefix + kind initial + zero-padded index', () => {
+    expect(generatedCode(null, 'cabinet', 1, 2)).toBe('C01');
+    expect(generatedCode('C01', 'row', 3, 2)).toBe('C01-R03');
+    expect(generatedCode('C01', 'row', 12, 2)).toBe('C01-R12');
+  });
+  it('explicitCode: parent prefix + first-letter uppercase', () => {
+    expect(explicitCode('C01-R03', 'Left')).toBe('C01-R03-L');
+    expect(explicitCode(null, 'Zone')).toBe('Z');
+  });
+});
+
+describe('buildSpecFromLevels', () => {
+  it('builds the full nested forest with the right node count', () => {
+    const roots = buildSpecFromLevels(cabinetsRowsSides);
+    expect(roots).toHaveLength(3);
+    // 3 cabinets + 3*10 rows + 3*10*2 sides = 3 + 30 + 60 = 93
+    expect(countSpecNodes(roots)).toBe(93);
+  });
+
+  it('names, kinds and codes match the manual scheme at every level', () => {
+    const [cab1] = buildSpecFromLevels(cabinetsRowsSides);
+    expect(cab1.name).toBe('Cabinet 1');
+    expect(cab1.kind).toBe('cabinet');
+    expect(cab1.code).toBe('C01');
+
+    const row3 = cab1.children[2];
+    expect(row3.name).toBe('Row 3');
+    expect(row3.code).toBe('C01-R03');
+
+    const left = row3.children[0];
+    expect(left.name).toBe('Left');
+    expect(left.code).toBe('C01-R03-L');
+  });
+
+  it('marks is_stockable ONLY on the deepest level (leaves)', () => {
+    const [cab1] = buildSpecFromLevels(cabinetsRowsSides);
+    expect(cab1.is_stockable).toBe(false); // cabinet
+    expect(cab1.children[0].is_stockable).toBe(false); // row
+    expect(cab1.children[0].children[0].is_stockable).toBe(true); // side (leaf)
+  });
+
+  it('defaults QR anchors to the top container level; honors qrAnchorDepth override', () => {
+    const [cabTop] = buildSpecFromLevels(cabinetsRowsSides);
+    expect(cabTop.is_qr_anchor).toBe(true); // depth 0 default
+    expect(cabTop.children[0].is_qr_anchor).toBe(false);
+
+    const [cabDeep] = buildSpecFromLevels(cabinetsRowsSides, { qrAnchorDepth: 2 });
+    expect(cabDeep.is_qr_anchor).toBe(false);
+    expect(cabDeep.children[0].children[0].is_qr_anchor).toBe(true); // leaves
+  });
+
+  it('a 2-level spec makes the middle level the leaves', () => {
+    const roots = buildSpecFromLevels([
+      { kind: 'cabinet', count: 1, namePattern: 'Cabinet {n}' },
+      { kind: 'shelf', count: 5, namePattern: 'Shelf {n}' },
+    ]);
+    expect(countSpecNodes(roots)).toBe(6); // 1 + 5
+    expect(roots[0].children[0].is_stockable).toBe(true); // shelves are leaves now
+  });
+
+  it('zero-pads to a uniform width across the level', () => {
+    const roots = buildSpecFromLevels([{ kind: 'bin', count: 12, namePattern: 'Bin {n}' }]);
+    expect(roots[0].code).toBe('B01');
+    expect(roots[11].code).toBe('B12');
+  });
+
+  it('keys are deterministic and unique', () => {
+    const roots = buildSpecFromLevels(cabinetsRowsSides);
+    const keys = new Set<string>();
+    const walk = (n: { key: string; children: { key: string; children: never[] }[] }) => {
+      keys.add(n.key);
+      n.children.forEach((c) => walk(c as never));
+    };
+    roots.forEach((r) => walk(r as never));
+    expect(keys.size).toBe(93);
+    expect(roots[0].key).toBe('0');
+    expect(roots[0].children[0].key).toBe('0/0');
+  });
+});
+
+describe('removeSpecNode (prune)', () => {
+  it('removes a node and its subtree by key', () => {
+    const roots = buildSpecFromLevels(cabinetsRowsSides);
+    const row1Key = roots[0].children[0].key; // a row with 2 sides under it
+    const pruned = removeSpecNode(roots, row1Key);
+    // removed 1 row + its 2 sides = 3 fewer
+    expect(countSpecNodes(pruned)).toBe(93 - 3);
+    expect(pruned[0].children.find((c) => c.key === row1Key)).toBeUndefined();
+  });
+});

--- a/__tests__/utils/locationSpec.test.ts
+++ b/__tests__/utils/locationSpec.test.ts
@@ -4,6 +4,7 @@ import {
   countSpecNodes,
   removeSpecNode,
   addChildUnder,
+  duplicateNode,
   applyQrAnchorByDepth,
   generatedCode,
   explicitCode,
@@ -146,6 +147,30 @@ describe('non-uniform editing', () => {
     // Right is the last section → a new section cloned with 4 bins under it
     expect(next[0].children).toHaveLength(3);
     expect(next[0].children[2].children).toHaveLength(4);
+  });
+
+  it('duplicateNode clones a top-level entry as the next sibling (Cabinet 1 → Cabinet 2)', () => {
+    const roots = buildSpecFromLevels([
+      { kind: 'cabinet', count: 1, namePattern: 'Cabinet {n}' },
+      { kind: 'bin', count: 2, namePattern: 'Bin {n}' },
+    ]);
+    const next = duplicateNode(roots, roots[0].key);
+
+    expect(next.map((c) => c.name)).toEqual(['Cabinet 1', 'Cabinet 2']);
+    expect(next[1].code).toBe('C02');
+    expect(next[1].children.map((b) => b.name)).toEqual(['Bin 1', 'Bin 2']);
+    expect(next[1].children[0].code).toBe('C02-B01'); // re-coded under the new cabinet
+    expect(next[1].key).not.toBe(next[0].key); // fresh keys
+    expect(countSpecNodes(next)).toBe(6); // 2 cabinets × (1 + 2)
+  });
+
+  it('duplicateNode works on a nested branch too', () => {
+    const roots = buildSpecFromLevels(cabinetSidesBins); // cabinet → {Left,Right} → 4 bins
+    const left = roots[0].children[0];
+    const next = duplicateNode(roots, left.key);
+    // Left duplicated → a sibling "Left 2" with its 4 bins; Right untouched
+    expect(next[0].children.map((s) => s.name)).toEqual(['Left', 'Left 2', 'Right']);
+    expect(next[0].children[1].children).toHaveLength(4);
   });
 
   it('applyQrAnchorByDepth re-stamps anchors to a chosen depth', () => {

--- a/__tests__/utils/locationSpec.test.ts
+++ b/__tests__/utils/locationSpec.test.ts
@@ -3,6 +3,8 @@ import {
   buildSpecFromLevels,
   countSpecNodes,
   removeSpecNode,
+  addChildUnder,
+  applyQrAnchorByDepth,
   generatedCode,
   explicitCode,
 } from '@/utils/locationSpec';
@@ -103,5 +105,53 @@ describe('removeSpecNode (prune)', () => {
     // removed 1 row + its 2 sides = 3 fewer
     expect(countSpecNodes(pruned)).toBe(93 - 3);
     expect(pruned[0].children.find((c) => c.key === row1Key)).toBeUndefined();
+  });
+});
+
+// Non-uniform editing: Cabinet → {Left, Right} → 4 bins each (uniform start).
+const cabinetSidesBins: LevelSpec[] = [
+  { kind: 'cabinet', count: 1, namePattern: 'Cabinet {n}' },
+  { kind: 'side', names: ['Left', 'Right'] },
+  { kind: 'bin', count: 4, namePattern: 'Bin {n}' },
+];
+
+describe('non-uniform editing', () => {
+  it('removeSpecNode leaves ONE branch shorter (the gap case)', () => {
+    const roots = buildSpecFromLevels(cabinetSidesBins);
+    const [, right] = roots[0].children; // Left, Right
+    const rightBin3 = right.children[2]; // "Bin 3" under Right
+    const next = removeSpecNode(roots, rightBin3.key);
+
+    const [left2, right2] = next[0].children;
+    expect(left2.children.map((b) => b.name)).toEqual(['Bin 1', 'Bin 2', 'Bin 3', 'Bin 4']);
+    expect(right2.children.map((b) => b.name)).toEqual(['Bin 1', 'Bin 2', 'Bin 4']); // gap kept
+    expect(countSpecNodes(next)).toBe(1 + 2 + 4 + 3);
+  });
+
+  it('addChildUnder adds to that branch only, bumping the trailing number', () => {
+    const roots = buildSpecFromLevels(cabinetSidesBins);
+    const left = roots[0].children[0];
+    const next = addChildUnder(roots, left.key);
+
+    const [left2, right2] = next[0].children;
+    expect(left2.children.map((b) => b.name)).toEqual(['Bin 1', 'Bin 2', 'Bin 3', 'Bin 4', 'Bin 5']);
+    expect(left2.children[4].code).toBe('C01-L-B05'); // parent code + kind + padded index
+    expect(right2.children).toHaveLength(4); // untouched
+  });
+
+  it('addChildUnder on a container clones its last section (with its bins)', () => {
+    const roots = buildSpecFromLevels(cabinetSidesBins);
+    const cabinet = roots[0];
+    const next = addChildUnder(roots, cabinet.key);
+    // Right is the last section → a new section cloned with 4 bins under it
+    expect(next[0].children).toHaveLength(3);
+    expect(next[0].children[2].children).toHaveLength(4);
+  });
+
+  it('applyQrAnchorByDepth re-stamps anchors to a chosen depth', () => {
+    const roots = applyQrAnchorByDepth(buildSpecFromLevels(cabinetSidesBins), 2);
+    expect(roots[0].is_qr_anchor).toBe(false); // cabinet
+    expect(roots[0].children[0].is_qr_anchor).toBe(false); // side
+    expect(roots[0].children[0].children[0].is_qr_anchor).toBe(true); // bin (depth 2)
   });
 });

--- a/components/inventory/locations/LocationFormModal.tsx
+++ b/components/inventory/locations/LocationFormModal.tsx
@@ -9,8 +9,6 @@ import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import Autocomplete from '@mui/material/Autocomplete';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Switch from '@mui/material/Switch';
 import Alert from '@mui/material/Alert';
 
 import type { InventoryLocation } from '@/types/inventoryLocations';
@@ -21,8 +19,6 @@ export interface LocationFormValues {
   name: string;
   kind: string | null;
   code: string | null;
-  is_stockable: boolean;
-  is_qr_anchor: boolean;
 }
 
 interface LocationFormModalProps {
@@ -45,8 +41,6 @@ export default function LocationFormModal({
   const [name, setName] = useState('');
   const [kind, setKind] = useState<string | null>(null);
   const [code, setCode] = useState('');
-  const [isStockable, setIsStockable] = useState(true);
-  const [isQrAnchor, setIsQrAnchor] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -56,8 +50,6 @@ export default function LocationFormModal({
     setName(location?.name ?? '');
     setKind(location?.kind ?? null);
     setCode(location?.code ?? '');
-    setIsStockable(location?.is_stockable ?? true);
-    setIsQrAnchor(location?.is_qr_anchor ?? false);
     setError(null);
   };
 
@@ -73,8 +65,6 @@ export default function LocationFormModal({
         name: name.trim(),
         kind: kind?.trim() || null,
         code: code.trim() || null,
-        is_stockable: isStockable,
-        is_qr_anchor: isQrAnchor,
       });
       onClose();
     } catch (e) {
@@ -126,14 +116,6 @@ export default function LocationFormModal({
             placeholder="CAB1-R3-L"
             helperText="Printed on the label; the QR itself always encodes the location ID."
             fullWidth
-          />
-          <FormControlLabel
-            control={<Switch checked={isStockable} onChange={(e) => setIsStockable(e.target.checked)} />}
-            label="Can hold stock"
-          />
-          <FormControlLabel
-            control={<Switch checked={isQrAnchor} onChange={(e) => setIsQrAnchor(e.target.checked)} />}
-            label="QR anchor (print a scannable label here)"
           />
           {error && <Alert severity="error">{error}</Alert>}
         </Stack>

--- a/components/inventory/locations/LocationQRModal.tsx
+++ b/components/inventory/locations/LocationQRModal.tsx
@@ -27,8 +27,8 @@ interface LocationQRModalProps {
   node: InventoryLocation | null;
   /** Full path of `node`, root → node. */
   path: string[];
-  /** Labels for every QR-anchor at/under `node` (incl. node if it is an anchor). */
-  anchorLabels: LocationLabel[];
+  /** Labels for `node` and every descendant (every location is printable). */
+  labels: LocationLabel[];
   onClose: () => void;
 }
 
@@ -38,7 +38,7 @@ export default function LocationQRModal({
   companyName,
   node,
   path,
-  anchorLabels,
+  labels,
   onClose,
 }: LocationQRModalProps) {
   const [busy, setBusy] = useState(false);
@@ -63,7 +63,7 @@ export default function LocationQRModal({
     }
   };
 
-  const subtreeAnchors = anchorLabels.length;
+  const subtreeCount = labels.length;
   const thisLabel: LocationLabel = { id: node.id, path, code: node.code };
 
   return (
@@ -94,12 +94,12 @@ export default function LocationQRModal({
               fullWidth
               variant="contained"
               startIcon={<PictureAsPdfIcon />}
-              onClick={() => download(anchorLabels, `${fileStem}-qr-anchors`)}
-              disabled={busy || subtreeAnchors === 0}
+              onClick={() => download(labels, `${fileStem}-labels`)}
+              disabled={busy || subtreeCount <= 1}
             >
-              {subtreeAnchors > 0
-                ? `Download sheet — ${subtreeAnchors} QR anchor${subtreeAnchors === 1 ? '' : 's'} below`
-                : 'No QR anchors below'}
+              {subtreeCount > 1
+                ? `Download sheet — ${subtreeCount} labels (this + below)`
+                : 'No sub-locations to print'}
             </Button>
           </Box>
           <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>

--- a/components/inventory/locations/LocationTreeView.tsx
+++ b/components/inventory/locations/LocationTreeView.tsx
@@ -15,6 +15,7 @@ import QrCode2Icon from '@mui/icons-material/QrCode2';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import AddIcon from '@mui/icons-material/Add';
 import AutoAwesomeMotionIcon from '@mui/icons-material/AutoAwesomeMotion';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 
@@ -24,6 +25,7 @@ export interface LocationTreeCallbacks {
   onAddChild: (node: InventoryLocationNode) => void;
   onBulkGenerate: (node: InventoryLocationNode) => void;
   onPrintQR: (node: InventoryLocationNode) => void;
+  onDuplicate: (node: InventoryLocationNode) => void;
   onEdit: (node: InventoryLocationNode) => void;
   onDelete: (node: InventoryLocationNode) => void;
 }
@@ -69,35 +71,45 @@ function LocationRow({ node, cb }: { node: InventoryLocationNode; cb: LocationTr
             {node.kind}
           </Typography>
         )}
-        {node.is_qr_anchor && <QrCode2Icon fontSize="small" color="action" titleAccess="QR anchor" />}
 
         <Box sx={{ flex: 1 }} />
 
-        <IconButton size="small" aria-label="Actions" onClick={(e) => setMenuEl(e.currentTarget)}>
-          <MoreVertIcon />
-        </IconButton>
-        <Menu anchorEl={menuEl} open={Boolean(menuEl)} onClose={() => setMenuEl(null)}>
-          <MenuItem onClick={act(cb.onAddChild)}>
-            <ListItemIcon><AddIcon fontSize="small" /></ListItemIcon>
-            <ListItemText>Add sub-location</ListItemText>
-          </MenuItem>
-          <MenuItem onClick={act(cb.onBulkGenerate)}>
-            <ListItemIcon><AutoAwesomeMotionIcon fontSize="small" /></ListItemIcon>
-            <ListItemText>Bulk-generate…</ListItemText>
-          </MenuItem>
-          <MenuItem onClick={act(cb.onPrintQR)}>
-            <ListItemIcon><QrCode2Icon fontSize="small" /></ListItemIcon>
-            <ListItemText>Print QR…</ListItemText>
-          </MenuItem>
-          <MenuItem onClick={act(cb.onEdit)}>
-            <ListItemIcon><EditIcon fontSize="small" /></ListItemIcon>
-            <ListItemText>Edit</ListItemText>
-          </MenuItem>
-          <MenuItem onClick={act(cb.onDelete)}>
-            <ListItemIcon><DeleteOutlineIcon fontSize="small" color="error" /></ListItemIcon>
-            <ListItemText sx={{ color: 'error.main' }}>Delete</ListItemText>
-          </MenuItem>
-        </Menu>
+        {/* The auto-managed system 'Unassigned' bucket has no manual actions —
+            renaming it would split the backfill bucket (the RPC resolves it by
+            name), and it can't be added under, duplicated, printed, or deleted. */}
+        {node.kind !== 'system' && (
+          <>
+            <IconButton size="small" aria-label="Actions" onClick={(e) => setMenuEl(e.currentTarget)}>
+              <MoreVertIcon />
+            </IconButton>
+            <Menu anchorEl={menuEl} open={Boolean(menuEl)} onClose={() => setMenuEl(null)}>
+              <MenuItem onClick={act(cb.onAddChild)}>
+                <ListItemIcon><AddIcon fontSize="small" /></ListItemIcon>
+                <ListItemText>Add sub-location</ListItemText>
+              </MenuItem>
+              <MenuItem onClick={act(cb.onBulkGenerate)}>
+                <ListItemIcon><AutoAwesomeMotionIcon fontSize="small" /></ListItemIcon>
+                <ListItemText>Bulk-generate…</ListItemText>
+              </MenuItem>
+              <MenuItem onClick={act(cb.onPrintQR)}>
+                <ListItemIcon><QrCode2Icon fontSize="small" /></ListItemIcon>
+                <ListItemText>Print QR…</ListItemText>
+              </MenuItem>
+              <MenuItem onClick={act(cb.onDuplicate)}>
+                <ListItemIcon><ContentCopyIcon fontSize="small" /></ListItemIcon>
+                <ListItemText>Duplicate</ListItemText>
+              </MenuItem>
+              <MenuItem onClick={act(cb.onEdit)}>
+                <ListItemIcon><EditIcon fontSize="small" /></ListItemIcon>
+                <ListItemText>Edit</ListItemText>
+              </MenuItem>
+              <MenuItem onClick={act(cb.onDelete)}>
+                <ListItemIcon><DeleteOutlineIcon fontSize="small" color="error" /></ListItemIcon>
+                <ListItemText sx={{ color: 'error.main' }}>Delete</ListItemText>
+              </MenuItem>
+            </Menu>
+          </>
+        )}
       </Box>
 
       {hasChildren && expanded && (

--- a/components/inventory/locations/LocationsManager.tsx
+++ b/components/inventory/locations/LocationsManager.tsx
@@ -29,6 +29,7 @@ import {
   createLocation,
   updateLocation,
   bulkGenerateChildren,
+  duplicateLocation,
   deleteLocation,
 } from '@/utils/inventoryLocationsAccess';
 import { generateLocationLabelSheet, type LocationLabel } from '@/utils/locationLabelPdf';
@@ -51,10 +52,13 @@ function computePath(id: string, byId: Map<string, InventoryLocation>): string[]
   return names;
 }
 
-function collectAnchorLabels(node: InventoryLocationNode, byId: Map<string, InventoryLocation>): LocationLabel[] {
+// Every real location is printable, so a label is collected for the node and
+// every descendant. The auto-managed system 'Unassigned' bucket is virtual (no
+// physical shelf), so it never gets a printed label.
+function collectLabels(node: InventoryLocationNode, byId: Map<string, InventoryLocation>): LocationLabel[] {
   const out: LocationLabel[] = [];
   const walk = (n: InventoryLocationNode) => {
-    if (n.is_qr_anchor) out.push({ id: n.id, path: computePath(n.id, byId), code: n.code });
+    if (n.kind !== 'system') out.push({ id: n.id, path: computePath(n.id, byId), code: n.code });
     n.children.forEach(walk);
   };
   walk(node);
@@ -90,8 +94,8 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
     open: boolean;
     node: InventoryLocation | null;
     path: string[];
-    anchorLabels: LocationLabel[];
-  }>({ open: false, node: null, path: [], anchorLabels: [] });
+    labels: LocationLabel[];
+  }>({ open: false, node: null, path: [], labels: [] });
 
   const [deleteState, setDeleteState] = useState<{ open: boolean; node: InventoryLocationNode | null }>({
     open: false,
@@ -100,7 +104,7 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
 
   const byId = useMemo(() => new Map(locations.map((l) => [l.id, l] as const)), [locations]);
   const tree = useMemo(() => buildLocationTree(locations), [locations]);
-  const allAnchors = useMemo(() => tree.flatMap((n) => collectAnchorLabels(n, byId)), [tree, byId]);
+  const allLabels = useMemo(() => tree.flatMap((n) => collectLabels(n, byId)), [tree, byId]);
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -130,8 +134,17 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
         open: true,
         node,
         path: computePath(node.id, byId),
-        anchorLabels: collectAnchorLabels(node, byId),
+        labels: collectLabels(node, byId),
       }),
+    onDuplicate: async (node: InventoryLocationNode) => {
+      try {
+        const created = await duplicateLocation(companyId, node.id);
+        await reload();
+        setToast(`Duplicated ${node.name} (${created.length} location${created.length === 1 ? '' : 's'}).`);
+      } catch (e) {
+        setToast(e instanceof Error ? e.message : 'Failed to duplicate location.');
+      }
+    },
     onDelete: (node: InventoryLocationNode) => setDeleteState({ open: true, node }),
   };
 
@@ -162,18 +175,18 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
     }
   };
 
-  const printAllAnchors = async () => {
-    if (allAnchors.length === 0) {
-      setToast('No QR anchors yet. Mark a location as a QR anchor first.');
+  const printAllLabels = async () => {
+    if (allLabels.length === 0) {
+      setToast('No locations to print yet.');
       return;
     }
     const doc = await generateLocationLabelSheet({
       companyId,
       baseUrl: window.location.origin,
-      labels: allAnchors,
+      labels: allLabels,
       heading: companyName,
     });
-    doc.save('inventory-qr-anchors.pdf');
+    doc.save('inventory-labels.pdf');
   };
 
   return (
@@ -184,10 +197,10 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
         <Button
           variant="outlined"
           startIcon={<QrCode2Icon />}
-          onClick={printAllAnchors}
-          disabled={loading || allAnchors.length === 0}
+          onClick={printAllLabels}
+          disabled={loading || allLabels.length === 0}
         >
-          Print all QR anchors
+          Print all labels
         </Button>
         <Button
           variant="outlined"
@@ -263,7 +276,7 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
         companyName={companyName}
         node={qrState.node}
         path={qrState.path}
-        anchorLabels={qrState.anchorLabels}
+        labels={qrState.labels}
         onClose={() => setQrState((s) => ({ ...s, open: false }))}
       />
       <VisualLocationBuilder

--- a/components/inventory/locations/LocationsManager.tsx
+++ b/components/inventory/locations/LocationsManager.tsx
@@ -16,6 +16,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogActions from '@mui/material/DialogActions';
 import AddIcon from '@mui/icons-material/Add';
 import QrCode2Icon from '@mui/icons-material/QrCode2';
+import AutoAwesomeMosaicOutlinedIcon from '@mui/icons-material/AutoAwesomeMosaicOutlined';
 
 import type {
   BulkGenerateSpec,
@@ -35,6 +36,7 @@ import LocationTreeView from './LocationTreeView';
 import LocationFormModal, { type LocationFormValues } from './LocationFormModal';
 import BulkGenerateModal from './BulkGenerateModal';
 import LocationQRModal from './LocationQRModal';
+import VisualLocationBuilder from './builder/VisualLocationBuilder';
 
 function computePath(id: string, byId: Map<string, InventoryLocation>): string[] {
   const names: string[] = [];
@@ -69,6 +71,7 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
+  const [builderOpen, setBuilderOpen] = useState(false);
 
   const [formState, setFormState] = useState<{
     open: boolean;
@@ -187,11 +190,18 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
           Print all QR anchors
         </Button>
         <Button
-          variant="contained"
+          variant="outlined"
           startIcon={<AddIcon />}
           onClick={() => setFormState({ open: true, location: null, parentId: null, parentPath: [] })}
         >
           New top-level location
+        </Button>
+        <Button
+          variant="contained"
+          startIcon={<AutoAwesomeMosaicOutlinedIcon />}
+          onClick={() => setBuilderOpen(true)}
+        >
+          Build visually
         </Button>
       </Box>
 
@@ -205,16 +215,25 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
         <Card elevation={2}>
           <CardContent sx={{ textAlign: 'center', py: 6 }}>
             <Typography color="text.secondary" sx={{ mb: 2 }}>
-              No storage locations yet. Build your shelving, cabinets, and bins here, then print QR
-              labels to scan from the shop floor.
+              No storage locations yet. Build your cabinets, shelving, and bins visually in a couple of
+              taps, then print QR labels to scan from the shop floor.
             </Typography>
-            <Button
-              variant="contained"
-              startIcon={<AddIcon />}
-              onClick={() => setFormState({ open: true, location: null, parentId: null, parentPath: [] })}
-            >
-              New top-level location
-            </Button>
+            <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center', flexWrap: 'wrap' }}>
+              <Button
+                variant="contained"
+                startIcon={<AutoAwesomeMosaicOutlinedIcon />}
+                onClick={() => setBuilderOpen(true)}
+              >
+                Build visually
+              </Button>
+              <Button
+                variant="text"
+                startIcon={<AddIcon />}
+                onClick={() => setFormState({ open: true, location: null, parentId: null, parentPath: [] })}
+              >
+                Add manually
+              </Button>
+            </Box>
           </CardContent>
         </Card>
       ) : (
@@ -246,6 +265,15 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
         path={qrState.path}
         anchorLabels={qrState.anchorLabels}
         onClose={() => setQrState((s) => ({ ...s, open: false }))}
+      />
+      <VisualLocationBuilder
+        open={builderOpen}
+        companyId={companyId}
+        onClose={() => setBuilderOpen(false)}
+        onCreated={(n) => {
+          void reload();
+          setToast(`Created ${n} location${n === 1 ? '' : 's'}.`);
+        }}
       />
 
       <Dialog open={deleteState.open} onClose={() => setDeleteState({ open: false, node: null })}>

--- a/components/inventory/locations/builder/LevelConfigStep.tsx
+++ b/components/inventory/locations/builder/LevelConfigStep.tsx
@@ -10,16 +10,36 @@ import IconButton from '@mui/material/IconButton';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 
 import type { LevelSpec } from '@/types/inventoryLocations';
 
 const MAX_LEVELS = 4;
 
+const stripPattern = (p?: string) => (p ?? '').replace(/\s*\{n\}\s*/g, ' ').trim();
+const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+/** The friendly word for this level (no "{n}" jargon). */
+function labelOf(level: LevelSpec): string {
+  return level.names ? capitalize(level.kind) : stripPattern(level.namePattern);
+}
+
+/** A live example of the names this level will produce. */
+function exampleOf(level: LevelSpec): string {
+  if (level.names) return level.names.join(', ') || '—';
+  const count = level.count ?? 0;
+  if (count === 0) return 'none';
+  const pattern = level.namePattern || '{n}';
+  const shown = Array.from({ length: Math.min(3, count) }, (_, i) =>
+    pattern.replace('{n}', String(i + 1)),
+  );
+  return shown.join(', ') + (count > 3 ? ', …' : '');
+}
+
 interface LevelConfigStepProps {
   levels: LevelSpec[];
   onChange: (levels: LevelSpec[]) => void;
-  /** Live total node count for the "will create N" hint. */
   total: number;
 }
 
@@ -27,33 +47,46 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
   const update = (i: number, patch: Partial<LevelSpec>) =>
     onChange(levels.map((l, idx) => (idx === i ? { ...l, ...patch } : l)));
 
+  const setLabel = (i: number, label: string) => {
+    const kind = label.trim().toLowerCase() || 'level';
+    if (levels[i].names) update(i, { kind });
+    else update(i, { kind, namePattern: label.trim() ? `${label.trim()} {n}` : '{n}' });
+  };
+
+  const setCount = (i: number, count: number) => update(i, { count: Math.max(0, count) });
+
   const setMode = (i: number, mode: 'count' | 'names') => {
+    const label = labelOf(levels[i]) || 'Bin';
     if (mode === 'names') {
       update(i, { names: levels[i].names ?? ['Left', 'Right'], count: undefined, namePattern: undefined });
     } else {
-      update(i, { count: levels[i].count ?? 4, namePattern: levels[i].namePattern ?? 'Item {n}', names: undefined });
+      update(i, {
+        count: levels[i].count ?? 4,
+        namePattern: `${label} {n}`,
+        names: undefined,
+      });
     }
   };
 
   const removeLevel = (i: number) => onChange(levels.filter((_, idx) => idx !== i));
-  const addLevel = () =>
-    onChange([...levels, { kind: 'bin', count: 2, namePattern: 'Bin {n}' }]);
+  const addLevel = () => onChange([...levels, { kind: 'bin', count: 4, namePattern: 'Bin {n}' }]);
 
   return (
     <Box>
-      <Typography variant="body1" sx={{ mb: 2 }}>
-        How is it divided up? Each level nests inside the one above. The deepest level holds the stock.
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Each level nests inside the one above. The deepest level holds the stock.
       </Typography>
 
       <Stack spacing={2}>
         {levels.map((level, i) => {
           const mode: 'count' | 'names' = level.names ? 'names' : 'count';
+          const deepest = i === levels.length - 1;
           return (
             <Paper key={i} variant="outlined" sx={{ p: 2 }}>
               <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
                 <Typography variant="subtitle2" color="text.secondary" sx={{ flex: 1 }}>
                   Level {i + 1}
-                  {i === levels.length - 1 ? ' · holds stock' : ''}
+                  {deepest ? ' · holds stock' : ''}
                 </Typography>
                 {levels.length > 1 && (
                   <IconButton size="small" aria-label="Remove level" onClick={() => removeLevel(i)}>
@@ -64,42 +97,49 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
 
               <Stack spacing={1.5}>
                 <TextField
-                  label="Kind"
-                  value={level.kind}
-                  onChange={(e) => update(i, { kind: e.target.value })}
+                  label="Call them"
+                  value={labelOf(level)}
+                  onChange={(e) => setLabel(i, e.target.value)}
+                  placeholder="Cabinet, Row, Bin…"
                   size="small"
                   fullWidth
                 />
 
-                <ToggleButtonGroup
-                  exclusive
-                  size="small"
-                  value={mode}
-                  onChange={(_, v) => v && setMode(i, v)}
-                >
-                  <ToggleButton value="count">By count</ToggleButton>
-                  <ToggleButton value="names">By names</ToggleButton>
+                <ToggleButtonGroup exclusive size="small" value={mode} onChange={(_, v) => v && setMode(i, v)}>
+                  <ToggleButton value="count" sx={{ textTransform: 'none' }}>
+                    A set number
+                  </ToggleButton>
+                  <ToggleButton value="names" sx={{ textTransform: 'none' }}>
+                    Specific names
+                  </ToggleButton>
                 </ToggleButtonGroup>
 
                 {mode === 'count' ? (
-                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+                  <Stack direction="row" alignItems="center" spacing={1}>
+                    <Typography variant="body2" color="text.secondary">
+                      How many?
+                    </Typography>
+                    <IconButton
+                      size="small"
+                      aria-label="Fewer"
+                      onClick={() => setCount(i, (level.count ?? 0) - 1)}
+                    >
+                      <RemoveIcon fontSize="small" />
+                    </IconButton>
                     <TextField
-                      label="How many"
-                      type="number"
                       value={level.count ?? 0}
-                      onChange={(e) => update(i, { count: Math.max(0, parseInt(e.target.value, 10) || 0) })}
+                      onChange={(e) => setCount(i, parseInt(e.target.value, 10) || 0)}
+                      type="number"
                       size="small"
-                      inputProps={{ min: 0 }}
-                      sx={{ width: { xs: '100%', sm: 140 } }}
+                      inputProps={{ min: 0, style: { textAlign: 'center', width: 56 } }}
                     />
-                    <TextField
-                      label="Name pattern"
-                      value={level.namePattern ?? '{n}'}
-                      onChange={(e) => update(i, { namePattern: e.target.value })}
-                      helperText="{n} = the number"
+                    <IconButton
                       size="small"
-                      fullWidth
-                    />
+                      aria-label="More"
+                      onClick={() => setCount(i, (level.count ?? 0) + 1)}
+                    >
+                      <AddIcon fontSize="small" />
+                    </IconButton>
                   </Stack>
                 ) : (
                   <TextField
@@ -113,6 +153,10 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
                     fullWidth
                   />
                 )}
+
+                <Typography variant="caption" color="text.secondary">
+                  → {exampleOf(level)}
+                </Typography>
               </Stack>
             </Paper>
           );
@@ -120,16 +164,12 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
       </Stack>
 
       <Stack direction="row" alignItems="center" sx={{ mt: 2 }}>
-        <Button
-          startIcon={<AddIcon />}
-          onClick={addLevel}
-          disabled={levels.length >= MAX_LEVELS}
-        >
+        <Button startIcon={<AddIcon />} onClick={addLevel} disabled={levels.length >= MAX_LEVELS}>
           Add a deeper level
         </Button>
         <Box sx={{ flex: 1 }} />
         <Typography variant="body2" color="text.secondary">
-          Will create <strong>{total}</strong> location{total === 1 ? '' : 's'}
+          <strong>{total}</strong> location{total === 1 ? '' : 's'}
         </Typography>
       </Stack>
     </Box>

--- a/components/inventory/locations/builder/LevelConfigStep.tsx
+++ b/components/inventory/locations/builder/LevelConfigStep.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+
+import type { LevelSpec } from '@/types/inventoryLocations';
+
+const MAX_LEVELS = 4;
+
+interface LevelConfigStepProps {
+  levels: LevelSpec[];
+  onChange: (levels: LevelSpec[]) => void;
+  /** Live total node count for the "will create N" hint. */
+  total: number;
+}
+
+export default function LevelConfigStep({ levels, onChange, total }: LevelConfigStepProps) {
+  const update = (i: number, patch: Partial<LevelSpec>) =>
+    onChange(levels.map((l, idx) => (idx === i ? { ...l, ...patch } : l)));
+
+  const setMode = (i: number, mode: 'count' | 'names') => {
+    if (mode === 'names') {
+      update(i, { names: levels[i].names ?? ['Left', 'Right'], count: undefined, namePattern: undefined });
+    } else {
+      update(i, { count: levels[i].count ?? 4, namePattern: levels[i].namePattern ?? 'Item {n}', names: undefined });
+    }
+  };
+
+  const removeLevel = (i: number) => onChange(levels.filter((_, idx) => idx !== i));
+  const addLevel = () =>
+    onChange([...levels, { kind: 'bin', count: 2, namePattern: 'Bin {n}' }]);
+
+  return (
+    <Box>
+      <Typography variant="body1" sx={{ mb: 2 }}>
+        How is it divided up? Each level nests inside the one above. The deepest level holds the stock.
+      </Typography>
+
+      <Stack spacing={2}>
+        {levels.map((level, i) => {
+          const mode: 'count' | 'names' = level.names ? 'names' : 'count';
+          return (
+            <Paper key={i} variant="outlined" sx={{ p: 2 }}>
+              <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
+                <Typography variant="subtitle2" color="text.secondary" sx={{ flex: 1 }}>
+                  Level {i + 1}
+                  {i === levels.length - 1 ? ' · holds stock' : ''}
+                </Typography>
+                {levels.length > 1 && (
+                  <IconButton size="small" aria-label="Remove level" onClick={() => removeLevel(i)}>
+                    <DeleteOutlineIcon fontSize="small" />
+                  </IconButton>
+                )}
+              </Stack>
+
+              <Stack spacing={1.5}>
+                <TextField
+                  label="Kind"
+                  value={level.kind}
+                  onChange={(e) => update(i, { kind: e.target.value })}
+                  size="small"
+                  fullWidth
+                />
+
+                <ToggleButtonGroup
+                  exclusive
+                  size="small"
+                  value={mode}
+                  onChange={(_, v) => v && setMode(i, v)}
+                >
+                  <ToggleButton value="count">By count</ToggleButton>
+                  <ToggleButton value="names">By names</ToggleButton>
+                </ToggleButtonGroup>
+
+                {mode === 'count' ? (
+                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5}>
+                    <TextField
+                      label="How many"
+                      type="number"
+                      value={level.count ?? 0}
+                      onChange={(e) => update(i, { count: Math.max(0, parseInt(e.target.value, 10) || 0) })}
+                      size="small"
+                      inputProps={{ min: 0 }}
+                      sx={{ width: { xs: '100%', sm: 140 } }}
+                    />
+                    <TextField
+                      label="Name pattern"
+                      value={level.namePattern ?? '{n}'}
+                      onChange={(e) => update(i, { namePattern: e.target.value })}
+                      helperText="{n} = the number"
+                      size="small"
+                      fullWidth
+                    />
+                  </Stack>
+                ) : (
+                  <TextField
+                    label="Names"
+                    value={(level.names ?? []).join(', ')}
+                    onChange={(e) =>
+                      update(i, { names: e.target.value.split(',').map((s) => s.trim()).filter(Boolean) })
+                    }
+                    helperText="Comma-separated, e.g. Left, Right"
+                    size="small"
+                    fullWidth
+                  />
+                )}
+              </Stack>
+            </Paper>
+          );
+        })}
+      </Stack>
+
+      <Stack direction="row" alignItems="center" sx={{ mt: 2 }}>
+        <Button
+          startIcon={<AddIcon />}
+          onClick={addLevel}
+          disabled={levels.length >= MAX_LEVELS}
+        >
+          Add a deeper level
+        </Button>
+        <Box sx={{ flex: 1 }} />
+        <Typography variant="body2" color="text.secondary">
+          Will create <strong>{total}</strong> location{total === 1 ? '' : 's'}
+        </Typography>
+      </Stack>
+    </Box>
+  );
+}

--- a/components/inventory/locations/builder/LevelConfigStep.tsx
+++ b/components/inventory/locations/builder/LevelConfigStep.tsx
@@ -16,6 +16,7 @@ import RemoveIcon from '@mui/icons-material/Remove';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import ReplayIcon from '@mui/icons-material/Replay';
 import TuneIcon from '@mui/icons-material/Tune';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
 import type { LevelSpec, LocationSpecNode } from '@/types/inventoryLocations';
 
@@ -63,6 +64,7 @@ interface LevelConfigStepProps {
   onCustomize: () => void;
   onRemove: (key: string) => void;
   onAdd: (parentKey: string) => void;
+  onDuplicate: (key: string) => void;
   onStartOver: () => void;
 }
 
@@ -75,6 +77,7 @@ export default function LevelConfigStep({
   onCustomize,
   onRemove,
   onAdd,
+  onDuplicate,
   onStartOver,
 }: LevelConfigStepProps) {
   // ----- Customized: reflect the real per-branch structure as editable chips ---
@@ -93,6 +96,36 @@ export default function LevelConfigStep({
         >
           Fine-tuning individual spots. Branches can differ now.
         </Alert>
+
+        {/* Top-level entries: duplicate one to make another like it, or remove it. */}
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+            Top-level
+          </Typography>
+          <Stack spacing={0.5}>
+            {tree.map((container) => (
+              <Stack key={container.key} direction="row" alignItems="center" spacing={0.5}>
+                <Typography variant="body2" sx={{ flex: 1, minWidth: 0 }} noWrap>
+                  {container.name}
+                </Typography>
+                <IconButton
+                  size="small"
+                  aria-label={`Duplicate ${container.name}`}
+                  onClick={() => onDuplicate(container.key)}
+                >
+                  <ContentCopyIcon fontSize="small" />
+                </IconButton>
+                <IconButton
+                  size="small"
+                  aria-label={`Remove ${container.name}`}
+                  onClick={() => onRemove(container.key)}
+                >
+                  <DeleteOutlineIcon fontSize="small" />
+                </IconButton>
+              </Stack>
+            ))}
+          </Stack>
+        </Box>
 
         {leafParents.length === 0 ? (
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>

--- a/components/inventory/locations/builder/LevelConfigStep.tsx
+++ b/components/inventory/locations/builder/LevelConfigStep.tsx
@@ -7,43 +7,135 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
+import Chip from '@mui/material/Chip';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Alert from '@mui/material/Alert';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import ReplayIcon from '@mui/icons-material/Replay';
 
-import type { LevelSpec } from '@/types/inventoryLocations';
+import type { LevelSpec, LocationSpecNode } from '@/types/inventoryLocations';
 
 const MAX_LEVELS = 4;
 
 const stripPattern = (p?: string) => (p ?? '').replace(/\s*\{n\}\s*/g, ' ').trim();
 const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
 
-/** The friendly word for this level (no "{n}" jargon). */
 function labelOf(level: LevelSpec): string {
   return level.names ? capitalize(level.kind) : stripPattern(level.namePattern);
 }
 
-/** A live example of the names this level will produce. */
 function exampleOf(level: LevelSpec): string {
   if (level.names) return level.names.join(', ') || '—';
   const count = level.count ?? 0;
   if (count === 0) return 'none';
   const pattern = level.namePattern || '{n}';
-  const shown = Array.from({ length: Math.min(3, count) }, (_, i) =>
-    pattern.replace('{n}', String(i + 1)),
-  );
+  const shown = Array.from({ length: Math.min(3, count) }, (_, i) => pattern.replace('{n}', String(i + 1)));
   return shown.join(', ') + (count > 3 ? ', …' : '');
+}
+
+/** Branches whose children are all leaves — the rows you'd fine-tune per side. */
+function collectLeafParents(
+  nodes: LocationSpecNode[],
+  trail: string[] = [],
+): { node: LocationSpecNode; path: string[] }[] {
+  const out: { node: LocationSpecNode; path: string[] }[] = [];
+  for (const n of nodes) {
+    const path = [...trail, n.name];
+    if (n.children.length > 0 && n.children.every((c) => c.children.length === 0)) {
+      out.push({ node: n, path });
+    } else if (n.children.length > 0) {
+      out.push(...collectLeafParents(n.children, path));
+    }
+  }
+  return out;
 }
 
 interface LevelConfigStepProps {
   levels: LevelSpec[];
   onChange: (levels: LevelSpec[]) => void;
   total: number;
+  customized: boolean;
+  tree: LocationSpecNode[];
+  onRemove: (key: string) => void;
+  onAdd: (parentKey: string) => void;
+  onStartOver: () => void;
 }
 
-export default function LevelConfigStep({ levels, onChange, total }: LevelConfigStepProps) {
+export default function LevelConfigStep({
+  levels,
+  onChange,
+  total,
+  customized,
+  tree,
+  onRemove,
+  onAdd,
+  onStartOver,
+}: LevelConfigStepProps) {
+  // ----- Customized: reflect the real per-branch structure as editable chips ---
+  if (customized) {
+    const leafParents = collectLeafParents(tree);
+    return (
+      <Box>
+        <Alert
+          severity="info"
+          action={
+            <Button color="inherit" size="small" startIcon={<ReplayIcon />} onClick={onStartOver}>
+              Start over
+            </Button>
+          }
+          sx={{ mb: 2 }}
+        >
+          Fine-tuning individual spots. Branches can differ now.
+        </Alert>
+
+        {leafParents.length === 0 ? (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+            {tree.map((n) => (
+              <Chip key={n.key} size="small" label={n.name} onDelete={() => onRemove(n.key)} />
+            ))}
+          </Box>
+        ) : (
+          <Stack spacing={1.5}>
+            {leafParents.map(({ node, path }) => (
+              <Box key={node.key}>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+                  {path.join(' › ')}
+                </Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, alignItems: 'center' }}>
+                  {node.children.map((leaf) => (
+                    <Chip
+                      key={leaf.key}
+                      size="small"
+                      label={leaf.name}
+                      color={leaf.is_qr_anchor ? 'info' : 'default'}
+                      variant={leaf.is_qr_anchor ? 'filled' : 'outlined'}
+                      onDelete={() => onRemove(leaf.key)}
+                    />
+                  ))}
+                  <Chip
+                    size="small"
+                    variant="outlined"
+                    icon={<AddIcon />}
+                    label="Add"
+                    onClick={() => onAdd(node.key)}
+                  />
+                </Box>
+              </Box>
+            ))}
+          </Stack>
+        )}
+
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 2, textAlign: 'right' }}>
+          <strong>{total}</strong> location{total === 1 ? '' : 's'}
+        </Typography>
+      </Box>
+    );
+  }
+
+  // ----- Uniform: friendly per-level controls ---------------------------------
   const update = (i: number, patch: Partial<LevelSpec>) =>
     onChange(levels.map((l, idx) => (idx === i ? { ...l, ...patch } : l)));
 
@@ -60,11 +152,7 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
     if (mode === 'names') {
       update(i, { names: levels[i].names ?? ['Left', 'Right'], count: undefined, namePattern: undefined });
     } else {
-      update(i, {
-        count: levels[i].count ?? 4,
-        namePattern: `${label} {n}`,
-        names: undefined,
-      });
+      update(i, { count: levels[i].count ?? 4, namePattern: `${label} {n}`, names: undefined });
     }
   };
 
@@ -119,11 +207,7 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
                     <Typography variant="body2" color="text.secondary">
                       How many?
                     </Typography>
-                    <IconButton
-                      size="small"
-                      aria-label="Fewer"
-                      onClick={() => setCount(i, (level.count ?? 0) - 1)}
-                    >
+                    <IconButton size="small" aria-label="Fewer" onClick={() => setCount(i, (level.count ?? 0) - 1)}>
                       <RemoveIcon fontSize="small" />
                     </IconButton>
                     <TextField
@@ -133,11 +217,7 @@ export default function LevelConfigStep({ levels, onChange, total }: LevelConfig
                       size="small"
                       inputProps={{ min: 0, style: { textAlign: 'center', width: 56 } }}
                     />
-                    <IconButton
-                      size="small"
-                      aria-label="More"
-                      onClick={() => setCount(i, (level.count ?? 0) + 1)}
-                    >
+                    <IconButton size="small" aria-label="More" onClick={() => setCount(i, (level.count ?? 0) + 1)}>
                       <AddIcon fontSize="small" />
                     </IconButton>
                   </Stack>

--- a/components/inventory/locations/builder/LevelConfigStep.tsx
+++ b/components/inventory/locations/builder/LevelConfigStep.tsx
@@ -15,6 +15,7 @@ import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import ReplayIcon from '@mui/icons-material/Replay';
+import TuneIcon from '@mui/icons-material/Tune';
 
 import type { LevelSpec, LocationSpecNode } from '@/types/inventoryLocations';
 
@@ -59,6 +60,7 @@ interface LevelConfigStepProps {
   total: number;
   customized: boolean;
   tree: LocationSpecNode[];
+  onCustomize: () => void;
   onRemove: (key: string) => void;
   onAdd: (parentKey: string) => void;
   onStartOver: () => void;
@@ -70,6 +72,7 @@ export default function LevelConfigStep({
   total,
   customized,
   tree,
+  onCustomize,
   onRemove,
   onAdd,
   onStartOver,
@@ -252,6 +255,20 @@ export default function LevelConfigStep({
           <strong>{total}</strong> location{total === 1 ? '' : 's'}
         </Typography>
       </Stack>
+
+      <Button
+        fullWidth
+        variant="outlined"
+        startIcon={<TuneIcon />}
+        onClick={onCustomize}
+        disabled={total === 0}
+        sx={{ mt: 2 }}
+      >
+        Customize individual spots
+      </Button>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5, textAlign: 'center' }}>
+        Give specific branches different bins (e.g. a gap, or one extra).
+      </Typography>
     </Box>
   );
 }

--- a/components/inventory/locations/builder/LevelConfigStep.tsx
+++ b/components/inventory/locations/builder/LevelConfigStep.tsx
@@ -146,8 +146,7 @@ export default function LevelConfigStep({
                       key={leaf.key}
                       size="small"
                       label={leaf.name}
-                      color={leaf.is_qr_anchor ? 'info' : 'default'}
-                      variant={leaf.is_qr_anchor ? 'filled' : 'outlined'}
+                      variant="outlined"
                       onDelete={() => onRemove(leaf.key)}
                     />
                   ))}
@@ -198,19 +197,17 @@ export default function LevelConfigStep({
   return (
     <Box>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        Each level nests inside the one above. The deepest level holds the stock.
+        Each level nests inside the one above.
       </Typography>
 
       <Stack spacing={2}>
         {levels.map((level, i) => {
           const mode: 'count' | 'names' = level.names ? 'names' : 'count';
-          const deepest = i === levels.length - 1;
           return (
             <Paper key={i} variant="outlined" sx={{ p: 2 }}>
               <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
                 <Typography variant="subtitle2" color="text.secondary" sx={{ flex: 1 }}>
                   Level {i + 1}
-                  {deepest ? ' · holds stock' : ''}
                 </Typography>
                 {levels.length > 1 && (
                   <IconButton size="small" aria-label="Remove level" onClick={() => removeLevel(i)}>

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -1,142 +1,129 @@
 'use client';
 
-import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
-import Breadcrumbs from '@mui/material/Breadcrumbs';
-import Link from '@mui/material/Link';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CloseIcon from '@mui/icons-material/Close';
 
 import type { LocationSpecNode } from '@/types/inventoryLocations';
 
-function findPath(
-  nodes: LocationSpecNode[],
-  key: string,
-  trail: LocationSpecNode[] = [],
-): LocationSpecNode[] | null {
-  for (const n of nodes) {
-    const here = [...trail, n];
-    if (n.key === key) return here;
-    const found = findPath(n.children, key, here);
-    if (found) return found;
-  }
-  return null;
-}
+// Show the whole structure nested (container → sections → leaves as chips), but
+// summarize big repetitions so it stays scannable rather than becoming a wall
+// of icons (the research's caution for deep/large sets). Nested CARDS, never a
+// deep indented tree.
+const TOP_LIMIT = 30; // top-level containers shown
+const GROUP_LIMIT = 12; // sub-sections shown per container
+const CHIP_LIMIT = 16; // leaf chips shown per section
 
-const CHIP_LIMIT = 10;
+/** Render an array of leaf (or near-leaf) nodes as chips, with prune + a "+N". */
+function LeafChips({ nodes, onPrune }: { nodes: LocationSpecNode[]; onPrune: (k: string) => void }) {
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+      {nodes.slice(0, CHIP_LIMIT).map((n) => (
+        <Chip
+          key={n.key}
+          size="small"
+          variant={n.is_qr_anchor ? 'filled' : 'outlined'}
+          color={n.is_qr_anchor ? 'info' : 'default'}
+          // a 4th level (rare) is summarized as a count instead of nesting deeper
+          label={n.children.length ? `${n.name} · ${n.children.length}` : n.name}
+          onDelete={() => onPrune(n.key)}
+        />
+      ))}
+      {nodes.length > CHIP_LIMIT && <Chip size="small" label={`+${nodes.length - CHIP_LIMIT}`} />}
+    </Box>
+  );
+}
 
 interface LocationBoardPreviewProps {
   nodes: LocationSpecNode[];
   onPrune: (key: string) => void;
 }
 
-/** Live, read-only board of the assembled spec: each container card shows its
- *  contents nested inside (rows/bins as chips). Click a card to drill in; the ×
- *  removes that node (and its subtree). Pure projection of the spec — no drag,
- *  no stored geometry. */
 export default function LocationBoardPreview({ nodes, onPrune }: LocationBoardPreviewProps) {
-  const [focusKey, setFocusKey] = useState<string | null>(null);
-
-  // Stay valid if the focused node was pruned or the layout changed underneath us.
-  const focusPath = focusKey ? findPath(nodes, focusKey) : null;
-  const focusNode = focusPath?.[focusPath.length - 1] ?? null;
-  const displayed = focusNode ? focusNode.children : nodes;
+  if (nodes.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+        Set a count to see your storage take shape.
+      </Typography>
+    );
+  }
 
   return (
-    <Box>
-      <Breadcrumbs sx={{ mb: 1.5 }}>
-        <Link
-          component="button"
-          type="button"
-          underline="hover"
-          color={focusNode ? 'primary' : 'text.primary'}
-          onClick={() => setFocusKey(null)}
-        >
-          All
-        </Link>
-        {(focusPath ?? []).map((n, i, arr) => (
-          <Link
-            key={n.key}
-            component="button"
-            type="button"
-            underline="hover"
-            color={i === arr.length - 1 ? 'text.primary' : 'primary'}
-            onClick={() => setFocusKey(n.key)}
-          >
-            {n.name}
-          </Link>
-        ))}
-      </Breadcrumbs>
-
-      {displayed.length === 0 ? (
-        <Typography variant="body2" color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
-          Set a count above to see your storage take shape.
-        </Typography>
-      ) : (
-        <Box
-          sx={{
-            display: 'grid',
-            gap: 1.5,
-            gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' },
-          }}
-        >
-          {displayed.map((node) => {
-            const children = node.children;
-            const drillable = children.length > 0;
-            return (
-              <Paper
-                key={node.key}
-                variant="outlined"
-                sx={{
-                  p: 1.5,
-                  cursor: drillable ? 'pointer' : 'default',
-                  '&:hover': drillable ? { borderColor: 'primary.main' } : undefined,
-                }}
-                onClick={drillable ? () => setFocusKey(node.key) : undefined}
+    <Box
+      sx={{ display: 'grid', gap: 1.5, gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' } }}
+    >
+      {nodes.slice(0, TOP_LIMIT).map((node) => {
+        const kids = node.children;
+        const kidsHaveKids = kids.length > 0 && kids[0].children.length > 0;
+        return (
+          <Paper key={node.key} variant="outlined" sx={{ p: 1.5 }}>
+            <Stack direction="row" alignItems="center" spacing={0.5}>
+              <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
+                {node.name}
+              </Typography>
+              {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
+              <IconButton
+                size="small"
+                aria-label={`Remove ${node.name}`}
+                onClick={() => onPrune(node.key)}
               >
-                <Stack direction="row" alignItems="center" spacing={0.5}>
-                  <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
-                    {node.name}
-                  </Typography>
-                  {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
-                  <IconButton
-                    size="small"
-                    aria-label={`Remove ${node.name}`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onPrune(node.key);
-                    }}
-                  >
-                    <CloseIcon fontSize="small" />
-                  </IconButton>
-                  {drillable && <ChevronRightIcon fontSize="small" color="action" />}
-                </Stack>
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </Stack>
+            {node.code && (
+              <Typography variant="caption" color="text.secondary">
+                {node.code}
+              </Typography>
+            )}
 
-                {node.code && (
-                  <Typography variant="caption" color="text.secondary">
-                    {node.code}
-                  </Typography>
-                )}
-
-                {drillable && (
-                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
-                    {children.slice(0, CHIP_LIMIT).map((c) => (
-                      <Chip key={c.key} size="small" variant="outlined" label={c.name} />
+            {kids.length > 0 && (
+              <Box sx={{ mt: 1 }}>
+                {kidsHaveKids ? (
+                  <Stack spacing={1}>
+                    {kids.slice(0, GROUP_LIMIT).map((section) => (
+                      <Box key={section.key}>
+                        <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.5 }}>
+                          <Typography
+                            variant="body2"
+                            sx={{ fontWeight: 500, flex: 1, minWidth: 0 }}
+                            noWrap
+                          >
+                            {section.name}
+                          </Typography>
+                          {section.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
+                          <IconButton
+                            size="small"
+                            aria-label={`Remove ${section.name}`}
+                            onClick={() => onPrune(section.key)}
+                          >
+                            <CloseIcon sx={{ fontSize: 16 }} />
+                          </IconButton>
+                        </Stack>
+                        <LeafChips nodes={section.children} onPrune={onPrune} />
+                      </Box>
                     ))}
-                    {children.length > CHIP_LIMIT && (
-                      <Chip size="small" label={`+${children.length - CHIP_LIMIT}`} />
+                    {kids.length > GROUP_LIMIT && (
+                      <Typography variant="caption" color="text.secondary">
+                        +{kids.length - GROUP_LIMIT} more
+                      </Typography>
                     )}
-                  </Box>
+                  </Stack>
+                ) : (
+                  <LeafChips nodes={kids} onPrune={onPrune} />
                 )}
-              </Paper>
-            );
-          })}
-        </Box>
+              </Box>
+            )}
+          </Paper>
+        );
+      })}
+      {nodes.length > TOP_LIMIT && (
+        <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'center' }}>
+          +{nodes.length - TOP_LIMIT} more
+        </Typography>
       )}
     </Box>
   );

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -7,43 +7,159 @@ import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
+import AddIcon from '@mui/icons-material/Add';
 
 import type { LocationSpecNode } from '@/types/inventoryLocations';
 
-// Show the whole structure nested (container → sections → leaves as chips), but
-// summarize big repetitions so it stays scannable rather than becoming a wall
-// of icons (the research's caution for deep/large sets). Nested CARDS, never a
-// deep indented tree.
-const TOP_LIMIT = 30; // top-level containers shown
-const GROUP_LIMIT = 12; // sub-sections shown per container
-const CHIP_LIMIT = 16; // leaf chips shown per section
+// Spatial depiction: containers as cards, sections stacked, leaves as CENTERED
+// cells (3 on a line → middle one centered). Editable: × removes a node, ＋ adds
+// one to that branch. Big/deep sets are summarized so it stays scannable.
+const TOP_LIMIT = 30;
+const GROUP_LIMIT = 14;
+const CELL_LIMIT = 18;
 
-/** Render an array of leaf (or near-leaf) nodes as chips, with prune + a "+N". */
-function LeafChips({ nodes, onPrune }: { nodes: LocationSpecNode[]; onPrune: (k: string) => void }) {
+const cellSx = (qr: boolean) => ({
+  px: 1,
+  py: 0.5,
+  borderRadius: 1,
+  border: 1,
+  borderColor: qr ? 'info.main' : 'divider',
+  color: qr ? 'info.light' : 'text.primary',
+  fontSize: 13,
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 0.25,
+  whiteSpace: 'nowrap' as const,
+});
+
+interface Edit {
+  onRemove: (key: string) => void;
+  onAdd: (parentKey: string) => void;
+}
+
+function Cell({ node, onRemove }: { node: LocationSpecNode } & Pick<Edit, 'onRemove'>) {
   return (
-    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-      {nodes.slice(0, CHIP_LIMIT).map((n) => (
-        <Chip
-          key={n.key}
-          size="small"
-          variant={n.is_qr_anchor ? 'filled' : 'outlined'}
-          color={n.is_qr_anchor ? 'info' : 'default'}
-          // a 4th level (rare) is summarized as a count instead of nesting deeper
-          label={n.children.length ? `${n.name} · ${n.children.length}` : n.name}
-          onDelete={() => onPrune(n.key)}
-        />
-      ))}
-      {nodes.length > CHIP_LIMIT && <Chip size="small" label={`+${nodes.length - CHIP_LIMIT}`} />}
+    <Box sx={cellSx(node.is_qr_anchor)}>
+      {node.name}
+      {node.children.length ? ` ·${node.children.length}` : ''}
+      <IconButton
+        size="small"
+        aria-label={`Remove ${node.name}`}
+        onClick={() => onRemove(node.key)}
+        sx={{ p: 0, ml: 0.25 }}
+      >
+        <CloseIcon sx={{ fontSize: 14 }} />
+      </IconButton>
     </Box>
   );
 }
 
-interface LocationBoardPreviewProps {
-  nodes: LocationSpecNode[];
-  onPrune: (key: string) => void;
+function AddButton({ parentKey, label, onAdd }: { parentKey: string; label: string } & Pick<Edit, 'onAdd'>) {
+  return (
+    <IconButton
+      size="small"
+      aria-label={label}
+      onClick={() => onAdd(parentKey)}
+      sx={{ border: 1, borderStyle: 'dashed', borderColor: 'divider', borderRadius: 1 }}
+    >
+      <AddIcon sx={{ fontSize: 16 }} />
+    </IconButton>
+  );
 }
 
-export default function LocationBoardPreview({ nodes, onPrune }: LocationBoardPreviewProps) {
+/** Centered, wrapping row of leaf cells + an Add button for this branch. */
+function CellGroup({
+  nodes,
+  parentKey,
+  addLabel,
+  onRemove,
+  onAdd,
+}: { nodes: LocationSpecNode[]; parentKey?: string; addLabel?: string } & Edit) {
+  const truncated = nodes.length > CELL_LIMIT;
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 0.5, alignItems: 'center' }}>
+      {nodes.slice(0, CELL_LIMIT).map((n) => (
+        <Cell key={n.key} node={n} onRemove={onRemove} />
+      ))}
+      {truncated && <Box sx={{ ...cellSx(false), color: 'text.secondary' }}>+{nodes.length - CELL_LIMIT}</Box>}
+      {parentKey && !truncated && (
+        <AddButton parentKey={parentKey} label={addLabel ?? 'Add one'} onAdd={onAdd} />
+      )}
+    </Box>
+  );
+}
+
+function ContainerCard({ node, onRemove, onAdd }: { node: LocationSpecNode } & Edit) {
+  const kids = node.children;
+  const threeLevel = kids.length > 0 && kids[0].children.length > 0;
+
+  return (
+    <Paper variant="outlined" sx={{ p: 1.5 }}>
+      <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: kids.length ? 1 : 0 }}>
+        <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
+          {node.name}
+        </Typography>
+        {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
+        <IconButton size="small" aria-label={`Remove ${node.name}`} onClick={() => onRemove(node.key)}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Stack>
+
+      {kids.length > 0 &&
+        (threeLevel ? (
+          <Stack spacing={1}>
+            {kids.slice(0, GROUP_LIMIT).map((section) => (
+              <Box key={section.key}>
+                <Stack direction="row" alignItems="center" justifyContent="center" spacing={0.5} sx={{ mb: 0.25 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    {section.name}
+                    {section.is_qr_anchor ? ' · QR' : ''}
+                  </Typography>
+                  <IconButton
+                    size="small"
+                    aria-label={`Remove ${section.name}`}
+                    onClick={() => onRemove(section.key)}
+                    sx={{ p: 0 }}
+                  >
+                    <CloseIcon sx={{ fontSize: 14 }} />
+                  </IconButton>
+                </Stack>
+                <CellGroup
+                  nodes={section.children}
+                  parentKey={section.key}
+                  addLabel={`Add to ${section.name}`}
+                  onRemove={onRemove}
+                  onAdd={onAdd}
+                />
+              </Box>
+            ))}
+            {kids.length > GROUP_LIMIT && (
+              <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>
+                +{kids.length - GROUP_LIMIT} more
+              </Typography>
+            )}
+            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+              <AddButton parentKey={node.key} label={`Add a section to ${node.name}`} onAdd={onAdd} />
+            </Box>
+          </Stack>
+        ) : (
+          <CellGroup
+            nodes={kids}
+            parentKey={node.key}
+            addLabel={`Add to ${node.name}`}
+            onRemove={onRemove}
+            onAdd={onAdd}
+          />
+        ))}
+    </Paper>
+  );
+}
+
+interface LocationBoardPreviewProps extends Edit {
+  nodes: LocationSpecNode[];
+}
+
+export default function LocationBoardPreview({ nodes, onRemove, onAdd }: LocationBoardPreviewProps) {
   if (nodes.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
@@ -52,74 +168,20 @@ export default function LocationBoardPreview({ nodes, onPrune }: LocationBoardPr
     );
   }
 
-  return (
-    <Box
-      sx={{ display: 'grid', gap: 1.5, gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' } }}
-    >
-      {nodes.slice(0, TOP_LIMIT).map((node) => {
-        const kids = node.children;
-        const kidsHaveKids = kids.length > 0 && kids[0].children.length > 0;
-        return (
-          <Paper key={node.key} variant="outlined" sx={{ p: 1.5 }}>
-            <Stack direction="row" alignItems="center" spacing={0.5}>
-              <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
-                {node.name}
-              </Typography>
-              {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
-              <IconButton
-                size="small"
-                aria-label={`Remove ${node.name}`}
-                onClick={() => onPrune(node.key)}
-              >
-                <CloseIcon fontSize="small" />
-              </IconButton>
-            </Stack>
-            {node.code && (
-              <Typography variant="caption" color="text.secondary">
-                {node.code}
-              </Typography>
-            )}
+  // Flat (every top node is a leaf, e.g. loose bins): one centered cluster.
+  if (nodes.every((n) => n.children.length === 0)) {
+    return (
+      <Paper variant="outlined" sx={{ p: 1.5 }}>
+        <CellGroup nodes={nodes} onRemove={onRemove} onAdd={onAdd} />
+      </Paper>
+    );
+  }
 
-            {kids.length > 0 && (
-              <Box sx={{ mt: 1 }}>
-                {kidsHaveKids ? (
-                  <Stack spacing={1}>
-                    {kids.slice(0, GROUP_LIMIT).map((section) => (
-                      <Box key={section.key}>
-                        <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.5 }}>
-                          <Typography
-                            variant="body2"
-                            sx={{ fontWeight: 500, flex: 1, minWidth: 0 }}
-                            noWrap
-                          >
-                            {section.name}
-                          </Typography>
-                          {section.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
-                          <IconButton
-                            size="small"
-                            aria-label={`Remove ${section.name}`}
-                            onClick={() => onPrune(section.key)}
-                          >
-                            <CloseIcon sx={{ fontSize: 16 }} />
-                          </IconButton>
-                        </Stack>
-                        <LeafChips nodes={section.children} onPrune={onPrune} />
-                      </Box>
-                    ))}
-                    {kids.length > GROUP_LIMIT && (
-                      <Typography variant="caption" color="text.secondary">
-                        +{kids.length - GROUP_LIMIT} more
-                      </Typography>
-                    )}
-                  </Stack>
-                ) : (
-                  <LeafChips nodes={kids} onPrune={onPrune} />
-                )}
-              </Box>
-            )}
-          </Paper>
-        );
-      })}
+  return (
+    <Box sx={{ display: 'grid', gap: 1.5, gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' } }}>
+      {nodes.slice(0, TOP_LIMIT).map((node) => (
+        <ContainerCard key={node.key} node={node} onRemove={onRemove} onAdd={onAdd} />
+      ))}
       {nodes.length > TOP_LIMIT && (
         <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'center' }}>
           +{nodes.length - TOP_LIMIT} more

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -1,165 +1,219 @@
 'use client';
 
 import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
-import IconButton from '@mui/material/IconButton';
-import CloseIcon from '@mui/icons-material/Close';
-import AddIcon from '@mui/icons-material/Add';
+import { alpha } from '@mui/material/styles';
 
 import type { LocationSpecNode } from '@/types/inventoryLocations';
 
-// Spatial depiction: containers as cards, sections stacked, leaves as CENTERED
-// cells (3 on a line → middle one centered). Editable: × removes a node, ＋ adds
-// one to that branch. Big/deep sets are summarized so it stays scannable.
-const TOP_LIMIT = 30;
-const GROUP_LIMIT = 14;
-const CELL_LIMIT = 18;
+// READ-ONLY, type-aware depiction (editing lives in the config). Each top
+// container is drawn to resemble its kind; a section's leaves fill the width as
+// evenly-divided compartments (like real cubbies/positions). Big/deep sets are
+// summarized. A 3D diorama is a tracked follow-up.
+const TOP_LIMIT = 24;
+const SECTION_LIMIT = 16;
+const CELL_LIMIT = 20;
+const FILL_MAX = 8; // up to this many leaves fill the width; beyond, wrap centered
 
-const cellSx = (qr: boolean) => ({
-  px: 1,
-  py: 0.5,
-  borderRadius: 1,
-  border: 1,
-  borderColor: qr ? 'info.main' : 'divider',
-  color: qr ? 'info.light' : 'text.primary',
-  fontSize: 13,
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 0.25,
-  whiteSpace: 'nowrap' as const,
-});
+const qrCellBg = (t: { palette: { info: { main: string } } }) => alpha(t.palette.info.main, 0.18);
 
-interface Edit {
-  onRemove: (key: string) => void;
-  onAdd: (parentKey: string) => void;
-}
+/** Leaves spanning the section width as evenly-divided compartments. */
+function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
+  if (nodes.length === 0) return null;
 
-function Cell({ node, onRemove }: { node: LocationSpecNode } & Pick<Edit, 'onRemove'>) {
+  if (nodes.length > FILL_MAX) {
+    // too many to divide evenly — centered wrap so it stays readable
+    return (
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 0.5, mt: 0.5 }}>
+        {nodes.slice(0, CELL_LIMIT).map((n) => (
+          <Box
+            key={n.key}
+            sx={{
+              fontSize: 12,
+              px: 0.75,
+              py: 0.25,
+              border: 1,
+              borderRadius: 0.5,
+              borderColor: n.is_qr_anchor ? 'info.main' : 'divider',
+              bgcolor: n.is_qr_anchor ? qrCellBg : 'transparent',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {n.name}
+            {n.children.length ? ` ·${n.children.length}` : ''}
+          </Box>
+        ))}
+        {nodes.length > CELL_LIMIT && (
+          <Box sx={{ fontSize: 12, color: 'text.secondary', px: 0.5 }}>+{nodes.length - CELL_LIMIT}</Box>
+        )}
+      </Box>
+    );
+  }
+
   return (
-    <Box sx={cellSx(node.is_qr_anchor)}>
-      {node.name}
-      {node.children.length ? ` ·${node.children.length}` : ''}
-      <IconButton
-        size="small"
-        aria-label={`Remove ${node.name}`}
-        onClick={() => onRemove(node.key)}
-        sx={{ p: 0, ml: 0.25 }}
-      >
-        <CloseIcon sx={{ fontSize: 14 }} />
-      </IconButton>
-    </Box>
-  );
-}
-
-function AddButton({ parentKey, label, onAdd }: { parentKey: string; label: string } & Pick<Edit, 'onAdd'>) {
-  return (
-    <IconButton
-      size="small"
-      aria-label={label}
-      onClick={() => onAdd(parentKey)}
-      sx={{ border: 1, borderStyle: 'dashed', borderColor: 'divider', borderRadius: 1 }}
-    >
-      <AddIcon sx={{ fontSize: 16 }} />
-    </IconButton>
-  );
-}
-
-/** Centered, wrapping row of leaf cells + an Add button for this branch. */
-function CellGroup({
-  nodes,
-  parentKey,
-  addLabel,
-  onRemove,
-  onAdd,
-}: { nodes: LocationSpecNode[]; parentKey?: string; addLabel?: string } & Edit) {
-  const truncated = nodes.length > CELL_LIMIT;
-  return (
-    <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 0.5, alignItems: 'center' }}>
-      {nodes.slice(0, CELL_LIMIT).map((n) => (
-        <Cell key={n.key} node={n} onRemove={onRemove} />
+    <Box sx={{ display: 'flex', mt: 0.5, borderRadius: 0.5, overflow: 'hidden' }}>
+      {nodes.map((n, i) => (
+        <Box
+          key={n.key}
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            textAlign: 'center',
+            fontSize: 12,
+            py: 0.4,
+            px: 0.5,
+            borderRight: i < nodes.length - 1 ? '1px solid' : 0,
+            borderColor: 'divider',
+            color: n.is_qr_anchor ? 'info.light' : 'text.primary',
+            bgcolor: n.is_qr_anchor ? qrCellBg : 'transparent',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+          title={n.name}
+        >
+          {n.name}
+          {n.children.length ? ` ·${n.children.length}` : ''}
+        </Box>
       ))}
-      {truncated && <Box sx={{ ...cellSx(false), color: 'text.secondary' }}>+{nodes.length - CELL_LIMIT}</Box>}
-      {parentKey && !truncated && (
-        <AddButton parentKey={parentKey} label={addLabel ?? 'Add one'} onAdd={onAdd} />
-      )}
     </Box>
   );
 }
 
-function ContainerCard({ node, onRemove, onAdd }: { node: LocationSpecNode } & Edit) {
-  const kids = node.children;
-  const threeLevel = kids.length > 0 && kids[0].children.length > 0;
+function SectionLabel({ node }: { node: LocationSpecNode }) {
+  return (
+    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center' }}>
+      {node.name}
+      {node.is_qr_anchor ? ' · QR' : ''}
+    </Typography>
+  );
+}
+
+type Kind = 'cabinet' | 'shelving' | 'rack' | 'drawer' | 'aisle' | 'generic';
+
+function unitKind(kind?: string | null): Kind {
+  const k = (kind ?? '').toLowerCase();
+  if (k.includes('rack')) return 'rack';
+  if (k.includes('drawer')) return 'drawer';
+  if (k.includes('aisle') || k.includes('zone')) return 'aisle';
+  if (k.includes('shelv') || k.includes('shelf')) return 'shelving';
+  if (k.includes('cabinet')) return 'cabinet';
+  return 'generic';
+}
+
+function Section({ node, kind }: { node: LocationSpecNode; kind: Kind }) {
+  const hasLeaves = node.children.length > 0;
+
+  if (kind === 'drawer') {
+    return (
+      <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 1, bgcolor: 'action.hover', py: 0.75, px: 1, textAlign: 'center' }}>
+        <Box sx={{ width: 28, height: 3, bgcolor: 'text.disabled', borderRadius: 2, mx: 'auto', mb: 0.5 }} />
+        <SectionLabel node={node} />
+        {hasLeaves && <Compartments nodes={node.children} />}
+      </Box>
+    );
+  }
+
+  if (kind === 'rack') {
+    // a beam: thick lines top and bottom, positions span the beam
+    return (
+      <Box sx={{ borderTop: '3px solid', borderBottom: '3px solid', borderColor: alpha('#5b8cf0', 0.55), py: 0.5 }}>
+        <SectionLabel node={node} />
+        <Compartments nodes={node.children} />
+      </Box>
+    );
+  }
+
+  if (kind === 'shelving' && !hasLeaves) {
+    // a plank: a solid shelf bar
+    return (
+      <Box sx={{ bgcolor: 'action.hover', borderBottom: '3px solid', borderColor: 'divider', borderRadius: 0.5, py: 0.5, textAlign: 'center' }}>
+        <Typography variant="caption" color="text.primary">
+          {node.name}
+          {node.is_qr_anchor ? ' · QR' : ''}
+        </Typography>
+      </Box>
+    );
+  }
+
+  // cabinet rows / shelving with items / generic bands: a shelf line with compartments
+  return (
+    <Box sx={{ borderBottom: '3px solid', borderColor: 'divider', pb: 0.5 }}>
+      <SectionLabel node={node} />
+      {hasLeaves && <Compartments nodes={node.children} />}
+    </Box>
+  );
+}
+
+function StorageUnit({ node }: { node: LocationSpecNode }) {
+  const kind = unitKind(node.kind);
+  const children = node.children;
+  const allLeaves = children.length > 0 && children.every((c) => c.children.length === 0);
 
   return (
-    <Paper variant="outlined" sx={{ p: 1.5 }}>
-      <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: kids.length ? 1 : 0 }}>
+    <Box
+      sx={{
+        border: 2,
+        borderColor: 'divider',
+        borderLeftWidth: kind === 'rack' ? 6 : 2,
+        borderRightWidth: kind === 'rack' ? 6 : 2,
+        borderLeftColor: kind === 'rack' ? alpha('#5b8cf0', 0.55) : 'divider',
+        borderRightColor: kind === 'rack' ? alpha('#5b8cf0', 0.55) : 'divider',
+        borderRadius: 1,
+        overflow: 'hidden',
+        bgcolor: 'background.paper',
+      }}
+    >
+      <Box sx={{ px: 1.5, py: 0.75, bgcolor: 'action.hover', borderBottom: 1, borderColor: 'divider', display: 'flex', alignItems: 'center', gap: 0.5 }}>
         <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
           {node.name}
         </Typography>
         {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
-        <IconButton size="small" aria-label={`Remove ${node.name}`} onClick={() => onRemove(node.key)}>
-          <CloseIcon fontSize="small" />
-        </IconButton>
-      </Stack>
+        {node.code && (
+          <Typography variant="caption" color="text.secondary">
+            {node.code}
+          </Typography>
+        )}
+      </Box>
 
-      {kids.length > 0 &&
-        (threeLevel ? (
-          <Stack spacing={1}>
-            {kids.slice(0, GROUP_LIMIT).map((section) => (
-              <Box key={section.key}>
-                <Stack direction="row" alignItems="center" justifyContent="center" spacing={0.5} sx={{ mb: 0.25 }}>
-                  <Typography variant="caption" color="text.secondary">
-                    {section.name}
-                    {section.is_qr_anchor ? ' · QR' : ''}
-                  </Typography>
-                  <IconButton
-                    size="small"
-                    aria-label={`Remove ${section.name}`}
-                    onClick={() => onRemove(section.key)}
-                    sx={{ p: 0 }}
-                  >
-                    <CloseIcon sx={{ fontSize: 14 }} />
-                  </IconButton>
+      <Box sx={{ p: 1 }}>
+        {children.length === 0 ? null : allLeaves ? (
+          <Compartments nodes={children} />
+        ) : kind === 'aisle' ? (
+          <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center', flexWrap: 'wrap' }}>
+            {children.slice(0, SECTION_LIMIT).map((bay) => (
+              <Box key={bay.key} sx={{ border: 1, borderColor: 'divider', borderRadius: 1, p: 0.5, minWidth: 56 }}>
+                <SectionLabel node={bay} />
+                <Stack spacing={0.25} sx={{ mt: 0.25 }}>
+                  {bay.children.slice(0, CELL_LIMIT).map((leaf) => (
+                    <Box key={leaf.key} sx={{ fontSize: 12, textAlign: 'center', border: 1, borderColor: leaf.is_qr_anchor ? 'info.main' : 'divider', borderRadius: 0.5, py: 0.25 }}>
+                      {leaf.name}
+                    </Box>
+                  ))}
                 </Stack>
-                <CellGroup
-                  nodes={section.children}
-                  parentKey={section.key}
-                  addLabel={`Add to ${section.name}`}
-                  onRemove={onRemove}
-                  onAdd={onAdd}
-                />
               </Box>
             ))}
-            {kids.length > GROUP_LIMIT && (
+          </Box>
+        ) : (
+          <Stack spacing={kind === 'drawer' ? 0.75 : 1}>
+            {children.slice(0, SECTION_LIMIT).map((section) => (
+              <Section key={section.key} node={section} kind={kind} />
+            ))}
+            {children.length > SECTION_LIMIT && (
               <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>
-                +{kids.length - GROUP_LIMIT} more
+                +{children.length - SECTION_LIMIT} more
               </Typography>
             )}
-            <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-              <AddButton parentKey={node.key} label={`Add a section to ${node.name}`} onAdd={onAdd} />
-            </Box>
           </Stack>
-        ) : (
-          <CellGroup
-            nodes={kids}
-            parentKey={node.key}
-            addLabel={`Add to ${node.name}`}
-            onRemove={onRemove}
-            onAdd={onAdd}
-          />
-        ))}
-    </Paper>
+        )}
+      </Box>
+    </Box>
   );
 }
 
-interface LocationBoardPreviewProps extends Edit {
-  nodes: LocationSpecNode[];
-}
-
-export default function LocationBoardPreview({ nodes, onRemove, onAdd }: LocationBoardPreviewProps) {
+export default function LocationBoardPreview({ nodes }: { nodes: LocationSpecNode[] }) {
   if (nodes.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
@@ -168,19 +222,18 @@ export default function LocationBoardPreview({ nodes, onRemove, onAdd }: Locatio
     );
   }
 
-  // Flat (every top node is a leaf, e.g. loose bins): one centered cluster.
   if (nodes.every((n) => n.children.length === 0)) {
     return (
-      <Paper variant="outlined" sx={{ p: 1.5 }}>
-        <CellGroup nodes={nodes} onRemove={onRemove} onAdd={onAdd} />
-      </Paper>
+      <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 1, p: 1.5 }}>
+        <Compartments nodes={nodes} />
+      </Box>
     );
   }
 
   return (
     <Box sx={{ display: 'grid', gap: 1.5, gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' } }}>
       {nodes.slice(0, TOP_LIMIT).map((node) => (
-        <ContainerCard key={node.key} node={node} onRemove={onRemove} onAdd={onAdd} />
+        <StorageUnit key={node.key} node={node} />
       ))}
       {nodes.length > TOP_LIMIT && (
         <Typography variant="caption" color="text.secondary" sx={{ alignSelf: 'center' }}>

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -28,24 +28,28 @@ function findPath(
   return null;
 }
 
+const CHIP_LIMIT = 10;
+
 interface LocationBoardPreviewProps {
   nodes: LocationSpecNode[];
   onPrune: (key: string) => void;
 }
 
-/** Step 3: a read-only board of the assembled spec. Click a tile to drill in;
- *  the × removes that tile (and its subtree) before commit. Pure projection of
- *  the spec — no drag, no stored geometry. */
+/** Live, read-only board of the assembled spec: each container card shows its
+ *  contents nested inside (rows/bins as chips). Click a card to drill in; the ×
+ *  removes that node (and its subtree). Pure projection of the spec — no drag,
+ *  no stored geometry. */
 export default function LocationBoardPreview({ nodes, onPrune }: LocationBoardPreviewProps) {
   const [focusKey, setFocusKey] = useState<string | null>(null);
 
+  // Stay valid if the focused node was pruned or the layout changed underneath us.
   const focusPath = focusKey ? findPath(nodes, focusKey) : null;
   const focusNode = focusPath?.[focusPath.length - 1] ?? null;
   const displayed = focusNode ? focusNode.children : nodes;
 
   return (
     <Box>
-      <Breadcrumbs sx={{ mb: 2 }}>
+      <Breadcrumbs sx={{ mb: 1.5 }}>
         <Link
           component="button"
           type="button"
@@ -70,62 +74,65 @@ export default function LocationBoardPreview({ nodes, onPrune }: LocationBoardPr
       </Breadcrumbs>
 
       {displayed.length === 0 ? (
-        <Typography variant="body2" color="text.secondary">
-          Nothing here.
+        <Typography variant="body2" color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
+          Set a count above to see your storage take shape.
         </Typography>
       ) : (
         <Box
           sx={{
             display: 'grid',
             gap: 1.5,
-            gridTemplateColumns: { xs: 'repeat(2, 1fr)', sm: 'repeat(3, 1fr)', md: 'repeat(4, 1fr)' },
+            gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)' },
           }}
         >
           {displayed.map((node) => {
-            const childCount = node.children.length;
-            const drillable = childCount > 0;
+            const children = node.children;
+            const drillable = children.length > 0;
             return (
               <Paper
                 key={node.key}
                 variant="outlined"
                 sx={{
                   p: 1.5,
-                  minHeight: 72,
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 1,
                   cursor: drillable ? 'pointer' : 'default',
                   '&:hover': drillable ? { borderColor: 'primary.main' } : undefined,
                 }}
                 onClick={drillable ? () => setFocusKey(node.key) : undefined}
               >
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Typography noWrap sx={{ fontWeight: 500 }}>
+                <Stack direction="row" alignItems="center" spacing={0.5}>
+                  <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
                     {node.name}
                   </Typography>
-                  <Stack direction="row" spacing={0.5} alignItems="center" sx={{ mt: 0.25 }}>
-                    {node.code && (
-                      <Typography variant="caption" color="text.secondary" noWrap>
-                        {node.code}
-                      </Typography>
+                  {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
+                  <IconButton
+                    size="small"
+                    aria-label={`Remove ${node.name}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onPrune(node.key);
+                    }}
+                  >
+                    <CloseIcon fontSize="small" />
+                  </IconButton>
+                  {drillable && <ChevronRightIcon fontSize="small" color="action" />}
+                </Stack>
+
+                {node.code && (
+                  <Typography variant="caption" color="text.secondary">
+                    {node.code}
+                  </Typography>
+                )}
+
+                {drillable && (
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
+                    {children.slice(0, CHIP_LIMIT).map((c) => (
+                      <Chip key={c.key} size="small" variant="outlined" label={c.name} />
+                    ))}
+                    {children.length > CHIP_LIMIT && (
+                      <Chip size="small" label={`+${children.length - CHIP_LIMIT}`} />
                     )}
-                    {drillable && (
-                      <Chip size="small" variant="outlined" label={`${childCount} inside`} />
-                    )}
-                    {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
-                  </Stack>
-                </Box>
-                <IconButton
-                  size="small"
-                  aria-label={`Remove ${node.name}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onPrune(node.key);
-                  }}
-                >
-                  <CloseIcon fontSize="small" />
-                </IconButton>
-                {drillable && <ChevronRightIcon fontSize="small" color="action" />}
+                  </Box>
+                )}
               </Paper>
             );
           })}

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import Link from '@mui/material/Link';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import CloseIcon from '@mui/icons-material/Close';
+
+import type { LocationSpecNode } from '@/types/inventoryLocations';
+
+function findPath(
+  nodes: LocationSpecNode[],
+  key: string,
+  trail: LocationSpecNode[] = [],
+): LocationSpecNode[] | null {
+  for (const n of nodes) {
+    const here = [...trail, n];
+    if (n.key === key) return here;
+    const found = findPath(n.children, key, here);
+    if (found) return found;
+  }
+  return null;
+}
+
+interface LocationBoardPreviewProps {
+  nodes: LocationSpecNode[];
+  onPrune: (key: string) => void;
+}
+
+/** Step 3: a read-only board of the assembled spec. Click a tile to drill in;
+ *  the × removes that tile (and its subtree) before commit. Pure projection of
+ *  the spec — no drag, no stored geometry. */
+export default function LocationBoardPreview({ nodes, onPrune }: LocationBoardPreviewProps) {
+  const [focusKey, setFocusKey] = useState<string | null>(null);
+
+  const focusPath = focusKey ? findPath(nodes, focusKey) : null;
+  const focusNode = focusPath?.[focusPath.length - 1] ?? null;
+  const displayed = focusNode ? focusNode.children : nodes;
+
+  return (
+    <Box>
+      <Breadcrumbs sx={{ mb: 2 }}>
+        <Link
+          component="button"
+          type="button"
+          underline="hover"
+          color={focusNode ? 'primary' : 'text.primary'}
+          onClick={() => setFocusKey(null)}
+        >
+          All
+        </Link>
+        {(focusPath ?? []).map((n, i, arr) => (
+          <Link
+            key={n.key}
+            component="button"
+            type="button"
+            underline="hover"
+            color={i === arr.length - 1 ? 'text.primary' : 'primary'}
+            onClick={() => setFocusKey(n.key)}
+          >
+            {n.name}
+          </Link>
+        ))}
+      </Breadcrumbs>
+
+      {displayed.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Nothing here.
+        </Typography>
+      ) : (
+        <Box
+          sx={{
+            display: 'grid',
+            gap: 1.5,
+            gridTemplateColumns: { xs: 'repeat(2, 1fr)', sm: 'repeat(3, 1fr)', md: 'repeat(4, 1fr)' },
+          }}
+        >
+          {displayed.map((node) => {
+            const childCount = node.children.length;
+            const drillable = childCount > 0;
+            return (
+              <Paper
+                key={node.key}
+                variant="outlined"
+                sx={{
+                  p: 1.5,
+                  minHeight: 72,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  cursor: drillable ? 'pointer' : 'default',
+                  '&:hover': drillable ? { borderColor: 'primary.main' } : undefined,
+                }}
+                onClick={drillable ? () => setFocusKey(node.key) : undefined}
+              >
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography noWrap sx={{ fontWeight: 500 }}>
+                    {node.name}
+                  </Typography>
+                  <Stack direction="row" spacing={0.5} alignItems="center" sx={{ mt: 0.25 }}>
+                    {node.code && (
+                      <Typography variant="caption" color="text.secondary" noWrap>
+                        {node.code}
+                      </Typography>
+                    )}
+                    {drillable && (
+                      <Chip size="small" variant="outlined" label={`${childCount} inside`} />
+                    )}
+                    {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
+                  </Stack>
+                </Box>
+                <IconButton
+                  size="small"
+                  aria-label={`Remove ${node.name}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onPrune(node.key);
+                  }}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+                {drillable && <ChevronRightIcon fontSize="small" color="action" />}
+              </Paper>
+            );
+          })}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -3,15 +3,15 @@
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import Chip from '@mui/material/Chip';
+import QrCode2Icon from '@mui/icons-material/QrCode2';
 import { alpha } from '@mui/material/styles';
 
 import type { LocationSpecNode } from '@/types/inventoryLocations';
 
 // READ-ONLY, type-aware depiction (editing lives in the config). Each top
 // container is drawn to resemble its kind; a section's leaves fill the width as
-// evenly-divided compartments (like real cubbies/positions). Big/deep sets are
-// summarized. A 3D diorama is a tracked follow-up.
+// evenly-divided compartments. A QR-code icon marks wherever a label would be
+// printed. Big/deep sets are summarized. A 3D diorama is a tracked follow-up.
 const TOP_LIMIT = 24;
 const SECTION_LIMIT = 16;
 const CELL_LIMIT = 20;
@@ -19,18 +19,30 @@ const FILL_MAX = 8; // up to this many leaves fill the width; beyond, wrap cente
 
 const qrCellBg = (t: { palette: { info: { main: string } } }) => alpha(t.palette.info.main, 0.18);
 
+/** A little QR-code glyph marking where a printed label would go. */
+function QrMark({ size = 15 }: { size?: number }) {
+  return (
+    <QrCode2Icon
+      sx={{ fontSize: size, color: 'info.main', verticalAlign: 'middle', flexShrink: 0 }}
+      titleAccess="A QR label prints here"
+    />
+  );
+}
+
 /** Leaves spanning the section width as evenly-divided compartments. */
 function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
   if (nodes.length === 0) return null;
 
   if (nodes.length > FILL_MAX) {
-    // too many to divide evenly — centered wrap so it stays readable
     return (
       <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 0.5, mt: 0.5 }}>
         {nodes.slice(0, CELL_LIMIT).map((n) => (
           <Box
             key={n.key}
             sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 0.25,
               fontSize: 12,
               px: 0.75,
               py: 0.25,
@@ -41,6 +53,7 @@ function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
               whiteSpace: 'nowrap',
             }}
           >
+            {n.is_qr_anchor && <QrMark size={12} />}
             {n.name}
             {n.children.length ? ` ·${n.children.length}` : ''}
           </Box>
@@ -60,7 +73,10 @@ function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
           sx={{
             flex: 1,
             minWidth: 0,
-            textAlign: 'center',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 0.25,
             fontSize: 12,
             py: 0.4,
             px: 0.5,
@@ -70,12 +86,14 @@ function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
             bgcolor: n.is_qr_anchor ? qrCellBg : 'transparent',
             whiteSpace: 'nowrap',
             overflow: 'hidden',
-            textOverflow: 'ellipsis',
           }}
           title={n.name}
         >
-          {n.name}
-          {n.children.length ? ` ·${n.children.length}` : ''}
+          {n.is_qr_anchor && <QrMark size={12} />}
+          <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {n.name}
+            {n.children.length ? ` ·${n.children.length}` : ''}
+          </Box>
         </Box>
       ))}
     </Box>
@@ -84,10 +102,12 @@ function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
 
 function SectionLabel({ node }: { node: LocationSpecNode }) {
   return (
-    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', textAlign: 'center' }}>
-      {node.name}
-      {node.is_qr_anchor ? ' · QR' : ''}
-    </Typography>
+    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.25 }}>
+      <Typography variant="caption" color="text.secondary">
+        {node.name}
+      </Typography>
+      {node.is_qr_anchor && <QrMark size={13} />}
+    </Box>
   );
 }
 
@@ -117,7 +137,6 @@ function Section({ node, kind }: { node: LocationSpecNode; kind: Kind }) {
   }
 
   if (kind === 'rack') {
-    // a beam: thick lines top and bottom, positions span the beam
     return (
       <Box sx={{ borderTop: '3px solid', borderBottom: '3px solid', borderColor: alpha('#5b8cf0', 0.55), py: 0.5 }}>
         <SectionLabel node={node} />
@@ -127,18 +146,13 @@ function Section({ node, kind }: { node: LocationSpecNode; kind: Kind }) {
   }
 
   if (kind === 'shelving' && !hasLeaves) {
-    // a plank: a solid shelf bar
     return (
-      <Box sx={{ bgcolor: 'action.hover', borderBottom: '3px solid', borderColor: 'divider', borderRadius: 0.5, py: 0.5, textAlign: 'center' }}>
-        <Typography variant="caption" color="text.primary">
-          {node.name}
-          {node.is_qr_anchor ? ' · QR' : ''}
-        </Typography>
+      <Box sx={{ bgcolor: 'action.hover', borderBottom: '3px solid', borderColor: 'divider', borderRadius: 0.5, py: 0.5 }}>
+        <SectionLabel node={node} />
       </Box>
     );
   }
 
-  // cabinet rows / shelving with items / generic bands: a shelf line with compartments
   return (
     <Box sx={{ borderBottom: '3px solid', borderColor: 'divider', pb: 0.5 }}>
       <SectionLabel node={node} />
@@ -170,7 +184,7 @@ function StorageUnit({ node }: { node: LocationSpecNode }) {
         <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
           {node.name}
         </Typography>
-        {node.is_qr_anchor && <Chip size="small" color="info" label="QR" />}
+        {node.is_qr_anchor && <QrMark size={18} />}
         {node.code && (
           <Typography variant="caption" color="text.secondary">
             {node.code}
@@ -188,7 +202,11 @@ function StorageUnit({ node }: { node: LocationSpecNode }) {
                 <SectionLabel node={bay} />
                 <Stack spacing={0.25} sx={{ mt: 0.25 }}>
                   {bay.children.slice(0, CELL_LIMIT).map((leaf) => (
-                    <Box key={leaf.key} sx={{ fontSize: 12, textAlign: 'center', border: 1, borderColor: leaf.is_qr_anchor ? 'info.main' : 'divider', borderRadius: 0.5, py: 0.25 }}>
+                    <Box
+                      key={leaf.key}
+                      sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.25, fontSize: 12, border: 1, borderColor: leaf.is_qr_anchor ? 'info.main' : 'divider', borderRadius: 0.5, py: 0.25 }}
+                    >
+                      {leaf.is_qr_anchor && <QrMark size={12} />}
                       {leaf.name}
                     </Box>
                   ))}

--- a/components/inventory/locations/builder/LocationBoardPreview.tsx
+++ b/components/inventory/locations/builder/LocationBoardPreview.tsx
@@ -3,31 +3,18 @@
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import QrCode2Icon from '@mui/icons-material/QrCode2';
 import { alpha } from '@mui/material/styles';
 
 import type { LocationSpecNode } from '@/types/inventoryLocations';
 
 // READ-ONLY, type-aware depiction (editing lives in the config). Each top
 // container is drawn to resemble its kind; a section's leaves fill the width as
-// evenly-divided compartments. A QR-code icon marks wherever a label would be
-// printed. Big/deep sets are summarized. A 3D diorama is a tracked follow-up.
+// evenly-divided compartments. Big/deep sets are summarized. A 3D diorama is a
+// tracked follow-up.
 const TOP_LIMIT = 24;
 const SECTION_LIMIT = 16;
 const CELL_LIMIT = 20;
 const FILL_MAX = 8; // up to this many leaves fill the width; beyond, wrap centered
-
-const qrCellBg = (t: { palette: { info: { main: string } } }) => alpha(t.palette.info.main, 0.18);
-
-/** A little QR-code glyph marking where a printed label would go. */
-function QrMark({ size = 15 }: { size?: number }) {
-  return (
-    <QrCode2Icon
-      sx={{ fontSize: size, color: 'info.main', verticalAlign: 'middle', flexShrink: 0 }}
-      titleAccess="A QR label prints here"
-    />
-  );
-}
 
 /** Leaves spanning the section width as evenly-divided compartments. */
 function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
@@ -48,12 +35,10 @@ function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
               py: 0.25,
               border: 1,
               borderRadius: 0.5,
-              borderColor: n.is_qr_anchor ? 'info.main' : 'divider',
-              bgcolor: n.is_qr_anchor ? qrCellBg : 'transparent',
+              borderColor: 'divider',
               whiteSpace: 'nowrap',
             }}
           >
-            {n.is_qr_anchor && <QrMark size={12} />}
             {n.name}
             {n.children.length ? ` ·${n.children.length}` : ''}
           </Box>
@@ -82,14 +67,12 @@ function Compartments({ nodes }: { nodes: LocationSpecNode[] }) {
             px: 0.5,
             borderRight: i < nodes.length - 1 ? '1px solid' : 0,
             borderColor: 'divider',
-            color: n.is_qr_anchor ? 'info.light' : 'text.primary',
-            bgcolor: n.is_qr_anchor ? qrCellBg : 'transparent',
+            color: 'text.primary',
             whiteSpace: 'nowrap',
             overflow: 'hidden',
           }}
           title={n.name}
         >
-          {n.is_qr_anchor && <QrMark size={12} />}
           <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
             {n.name}
             {n.children.length ? ` ·${n.children.length}` : ''}
@@ -106,7 +89,6 @@ function SectionLabel({ node }: { node: LocationSpecNode }) {
       <Typography variant="caption" color="text.secondary">
         {node.name}
       </Typography>
-      {node.is_qr_anchor && <QrMark size={13} />}
     </Box>
   );
 }
@@ -184,7 +166,6 @@ function StorageUnit({ node }: { node: LocationSpecNode }) {
         <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }} noWrap>
           {node.name}
         </Typography>
-        {node.is_qr_anchor && <QrMark size={18} />}
         {node.code && (
           <Typography variant="caption" color="text.secondary">
             {node.code}
@@ -204,9 +185,8 @@ function StorageUnit({ node }: { node: LocationSpecNode }) {
                   {bay.children.slice(0, CELL_LIMIT).map((leaf) => (
                     <Box
                       key={leaf.key}
-                      sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.25, fontSize: 12, border: 1, borderColor: leaf.is_qr_anchor ? 'info.main' : 'divider', borderRadius: 0.5, py: 0.25 }}
+                      sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.25, fontSize: 12, border: 1, borderColor: 'divider', borderRadius: 0.5, py: 0.25 }}
                     >
-                      {leaf.is_qr_anchor && <QrMark size={12} />}
                       {leaf.name}
                     </Box>
                   ))}

--- a/components/inventory/locations/builder/StorageTypePalette.tsx
+++ b/components/inventory/locations/builder/StorageTypePalette.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
+import Typography from '@mui/material/Typography';
+
+import { STORAGE_TYPES, type StorageType } from './storageTypes';
+
+interface StorageTypePaletteProps {
+  selectedId: string | null;
+  onSelect: (type: StorageType) => void;
+}
+
+/** Step 1: pick a recognizable storage type. Each card = concrete icon + an
+ *  always-visible label (NN/g 5-second rule), tap target well over 48px. */
+export default function StorageTypePalette({ selectedId, onSelect }: StorageTypePaletteProps) {
+  return (
+    <Box>
+      <Typography variant="body1" sx={{ mb: 2 }}>
+        What kind of storage are you setting up?
+      </Typography>
+      <Box
+        sx={{
+          display: 'grid',
+          gap: 2,
+          gridTemplateColumns: { xs: 'repeat(2, 1fr)', sm: 'repeat(3, 1fr)', md: 'repeat(4, 1fr)' },
+        }}
+      >
+        {STORAGE_TYPES.map((type) => {
+          const selected = type.id === selectedId;
+          const Icon = type.Icon;
+          return (
+            <Card
+              key={type.id}
+              elevation={selected ? 4 : 2}
+              sx={{
+                border: 2,
+                borderColor: selected ? 'primary.main' : 'transparent',
+              }}
+            >
+              <CardActionArea
+                onClick={() => onSelect(type)}
+                sx={{
+                  p: 2,
+                  minHeight: 120,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  textAlign: 'center',
+                  gap: 1,
+                }}
+              >
+                <Icon sx={{ fontSize: 40, color: selected ? 'primary.main' : 'text.secondary' }} />
+                <Typography variant="subtitle1" sx={{ fontWeight: 600, lineHeight: 1.2 }}>
+                  {type.label}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {type.description}
+                </Typography>
+              </CardActionArea>
+            </Card>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
 import DialogActions from '@mui/material/DialogActions';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -15,8 +16,14 @@ import MenuItem from '@mui/material/MenuItem';
 import Alert from '@mui/material/Alert';
 import Typography from '@mui/material/Typography';
 
-import type { LevelSpec } from '@/types/inventoryLocations';
-import { buildSpecFromLevels, countSpecNodes, removeSpecNode } from '@/utils/locationSpec';
+import type { LevelSpec, LocationSpecNode } from '@/types/inventoryLocations';
+import {
+  buildSpecFromLevels,
+  countSpecNodes,
+  removeSpecNode,
+  addChildUnder,
+  applyQrAnchorByDepth,
+} from '@/utils/locationSpec';
 import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
 import StorageTypePalette from './StorageTypePalette';
 import LevelConfigStep from './LevelConfigStep';
@@ -49,7 +56,11 @@ export default function VisualLocationBuilder({
   const [selectedTypeId, setSelectedTypeId] = useState<string | null>(null);
   const [levels, setLevels] = useState<LevelSpec[]>([]);
   const [qrAnchorDepth, setQrAnchorDepth] = useState(0);
-  const [prunedKeys, setPrunedKeys] = useState<string[]>([]);
+  // Once a single branch is fine-tuned, the tree is hand-edited directly and no
+  // longer regenerated from `levels` (which becomes the "Start over" template).
+  const [customized, setCustomized] = useState(false);
+  const [editedTree, setEditedTree] = useState<LocationSpecNode[]>([]);
+  const [startOverOpen, setStartOverOpen] = useState(false);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -58,40 +69,55 @@ export default function VisualLocationBuilder({
     setSelectedTypeId(null);
     setLevels([]);
     setQrAnchorDepth(0);
-    setPrunedKeys([]);
+    setCustomized(false);
+    setEditedTree([]);
+    setStartOverOpen(false);
     setCreating(false);
     setError(null);
   };
 
-  const baseSpec = useMemo(
+  const uniformTree = useMemo(
     () => buildSpecFromLevels(levels, { qrAnchorDepth, parentCode }),
     [levels, qrAnchorDepth, parentCode],
   );
-  const spec = useMemo(
-    () => prunedKeys.reduce((s, k) => removeSpecNode(s, k), baseSpec),
-    [baseSpec, prunedKeys],
-  );
-  const total = countSpecNodes(spec);
+  const tree = customized ? editedTree : uniformTree;
+  const total = countSpecNodes(tree);
 
   const pickType = (type: StorageType) => {
     setSelectedTypeId(type.id);
     setLevels(cloneLevels(type.defaultLevels));
     setQrAnchorDepth(0);
-    setPrunedKeys([]);
+    setCustomized(false);
+    setEditedTree([]);
     setActiveStep(1);
   };
 
-  const changeLevels = (next: LevelSpec[]) => {
-    setLevels(next);
-    setPrunedKeys([]); // keys shift with layout; drop stale prunes
-    if (qrAnchorDepth > next.length - 1) setQrAnchorDepth(Math.max(0, next.length - 1));
+  const changeQrDepth = (depth: number) => {
+    setQrAnchorDepth(depth);
+    if (customized) setEditedTree((t) => applyQrAnchorByDepth(t, depth));
+  };
+
+  // Direct manipulation from either the preview or the config chips.
+  const editRemove = (key: string) => {
+    setEditedTree(applyQrAnchorByDepth(removeSpecNode(tree, key), qrAnchorDepth));
+    setCustomized(true);
+  };
+  const editAdd = (parentKey: string) => {
+    setEditedTree(applyQrAnchorByDepth(addChildUnder(tree, parentKey), qrAnchorDepth));
+    setCustomized(true);
+  };
+
+  const confirmStartOver = () => {
+    setCustomized(false);
+    setEditedTree([]);
+    setStartOverOpen(false);
   };
 
   const handleCreate = async () => {
     setCreating(true);
     setError(null);
     try {
-      const created = await materializeLocationSpec(companyId, parentId, spec);
+      const created = await materializeLocationSpec(companyId, parentId, tree);
       onCreated(created.length);
       onClose();
     } catch (e) {
@@ -123,22 +149,23 @@ export default function VisualLocationBuilder({
 
         {activeStep === 1 && (
           <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'flex-start' }}>
-            {/* Controls */}
-            <Box sx={{ flex: '1 1 300px', minWidth: 280 }}>
-              <LevelConfigStep levels={levels} onChange={changeLevels} total={total} />
+            {/* Controls (uniform) or per-branch chips (customized) */}
+            <Box sx={{ flex: '1 1 320px', minWidth: 280 }}>
+              <LevelConfigStep
+                levels={levels}
+                onChange={setLevels}
+                total={total}
+                customized={customized}
+                tree={tree}
+                onRemove={editRemove}
+                onAdd={editAdd}
+                onStartOver={() => setStartOverOpen(true)}
+              />
             </Box>
 
-            {/* Live preview */}
+            {/* Live spatial preview (also editable) */}
             <Box sx={{ flex: '1 1 340px', minWidth: 280 }}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 2,
-                  mb: 1.5,
-                  flexWrap: 'wrap',
-                }}
-              >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1.5, flexWrap: 'wrap' }}>
                 <Typography variant="subtitle2" color="text.secondary" sx={{ flex: 1 }}>
                   Preview
                 </Typography>
@@ -146,7 +173,7 @@ export default function VisualLocationBuilder({
                   select
                   label="QR labels at"
                   value={qrAnchorDepth}
-                  onChange={(e) => setQrAnchorDepth(Number(e.target.value))}
+                  onChange={(e) => changeQrDepth(Number(e.target.value))}
                   size="small"
                   sx={{ minWidth: 160 }}
                 >
@@ -157,10 +184,7 @@ export default function VisualLocationBuilder({
                   ))}
                 </TextField>
               </Box>
-              <LocationBoardPreview
-                nodes={spec}
-                onPrune={(key) => setPrunedKeys((keys) => [...keys, key])}
-              />
+              <LocationBoardPreview nodes={tree} onRemove={editRemove} onAdd={editAdd} />
             </Box>
           </Box>
         )}
@@ -187,6 +211,21 @@ export default function VisualLocationBuilder({
           </>
         )}
       </DialogActions>
+
+      <Dialog open={startOverOpen} onClose={() => setStartOverOpen(false)}>
+        <DialogTitle>Start over?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This clears your individual tweaks and goes back to editing the layout by the numbers.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setStartOverOpen(false)}>Keep editing</Button>
+          <Button onClick={confirmStartOver} color="error" variant="contained">
+            Start over
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Dialog>
   );
 }

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -11,6 +11,7 @@ import Button from '@mui/material/Button';
 import Stepper from '@mui/material/Stepper';
 import Step from '@mui/material/Step';
 import StepLabel from '@mui/material/StepLabel';
+import Divider from '@mui/material/Divider';
 import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
 import Alert from '@mui/material/Alert';
@@ -152,9 +153,16 @@ export default function VisualLocationBuilder({
         {activeStep === 0 && <StorageTypePalette selectedId={selectedTypeId} onSelect={pickType} />}
 
         {activeStep === 1 && (
-          <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'flex-start' }}>
-            {/* Controls (uniform) or per-branch chips (customized) */}
-            <Box sx={{ flex: '1 1 320px', minWidth: 280 }}>
+          <Box sx={{ display: 'flex', flexDirection: { xs: 'column', md: 'row' }, gap: 3 }}>
+            {/* Configure (the only editor) */}
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{ display: 'block', mb: 1.5, letterSpacing: 1 }}
+              >
+                Configure
+              </Typography>
               <LevelConfigStep
                 levels={levels}
                 onChange={setLevels}
@@ -168,10 +176,13 @@ export default function VisualLocationBuilder({
               />
             </Box>
 
-            {/* Live spatial preview (also editable) */}
-            <Box sx={{ flex: '1 1 340px', minWidth: 280 }}>
+            <Divider orientation="vertical" flexItem sx={{ display: { xs: 'none', md: 'block' } }} />
+            <Divider sx={{ display: { xs: 'block', md: 'none' } }} />
+
+            {/* Read-only type-aware preview */}
+            <Box sx={{ flex: 1, minWidth: 0 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1.5, flexWrap: 'wrap' }}>
-                <Typography variant="subtitle2" color="text.secondary" sx={{ flex: 1 }}>
+                <Typography variant="overline" color="text.secondary" sx={{ flex: 1, letterSpacing: 1 }}>
                   Preview
                 </Typography>
                 <TextField

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -13,7 +13,7 @@ import StepLabel from '@mui/material/StepLabel';
 import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
 import Alert from '@mui/material/Alert';
-import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 
 import type { LevelSpec } from '@/types/inventoryLocations';
 import { buildSpecFromLevels, countSpecNodes, removeSpecNode } from '@/utils/locationSpec';
@@ -23,7 +23,7 @@ import LevelConfigStep from './LevelConfigStep';
 import LocationBoardPreview from './LocationBoardPreview';
 import { cloneLevels, type StorageType } from './storageTypes';
 
-const STEPS = ['Type', 'Layout', 'Review'];
+const STEPS = ['Type', 'Build'];
 
 interface VisualLocationBuilderProps {
   open: boolean;
@@ -105,13 +105,13 @@ export default function VisualLocationBuilder({
     <Dialog
       open={open}
       onClose={creating ? undefined : onClose}
-      maxWidth="md"
+      maxWidth="lg"
       fullWidth
       TransitionProps={{ onEnter: reset }}
     >
       <DialogTitle>Build storage visually</DialogTitle>
-      <DialogContent dividers sx={{ minHeight: 420 }}>
-        <Stepper activeStep={activeStep} sx={{ mb: 3 }}>
+      <DialogContent dividers sx={{ minHeight: 460 }}>
+        <Stepper activeStep={activeStep} sx={{ mb: 3, maxWidth: 360 }}>
           {STEPS.map((label) => (
             <Step key={label}>
               <StepLabel>{label}</StepLabel>
@@ -122,38 +122,46 @@ export default function VisualLocationBuilder({
         {activeStep === 0 && <StorageTypePalette selectedId={selectedTypeId} onSelect={pickType} />}
 
         {activeStep === 1 && (
-          <LevelConfigStep levels={levels} onChange={changeLevels} total={countSpecNodes(baseSpec)} />
-        )}
+          <Box sx={{ display: 'flex', gap: 3, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+            {/* Controls */}
+            <Box sx={{ flex: '1 1 300px', minWidth: 280 }}>
+              <LevelConfigStep levels={levels} onChange={changeLevels} total={total} />
+            </Box>
 
-        {activeStep === 2 && (
-          <Box>
-            <Stack
-              direction={{ xs: 'column', sm: 'row' }}
-              spacing={2}
-              alignItems={{ sm: 'center' }}
-              sx={{ mb: 2 }}
-            >
-              <TextField
-                select
-                label="Print QR labels at"
-                value={qrAnchorDepth}
-                onChange={(e) => setQrAnchorDepth(Number(e.target.value))}
-                size="small"
-                sx={{ minWidth: 220 }}
-                helperText="Scanning drills down to what's inside"
+            {/* Live preview */}
+            <Box sx={{ flex: '1 1 340px', minWidth: 280 }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 2,
+                  mb: 1.5,
+                  flexWrap: 'wrap',
+                }}
               >
-                {levels.map((l, i) => (
-                  <MenuItem key={i} value={i}>
-                    {capitalize(l.kind)} (level {i + 1})
-                  </MenuItem>
-                ))}
-              </TextField>
-              <Box sx={{ flex: 1 }} />
-            </Stack>
-            <LocationBoardPreview
-              nodes={spec}
-              onPrune={(key) => setPrunedKeys((keys) => [...keys, key])}
-            />
+                <Typography variant="subtitle2" color="text.secondary" sx={{ flex: 1 }}>
+                  Preview
+                </Typography>
+                <TextField
+                  select
+                  label="QR labels at"
+                  value={qrAnchorDepth}
+                  onChange={(e) => setQrAnchorDepth(Number(e.target.value))}
+                  size="small"
+                  sx={{ minWidth: 160 }}
+                >
+                  {levels.map((l, i) => (
+                    <MenuItem key={i} value={i}>
+                      {capitalize(l.kind)}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              </Box>
+              <LocationBoardPreview
+                nodes={spec}
+                onPrune={(key) => setPrunedKeys((keys) => [...keys, key])}
+              />
+            </Box>
           </Box>
         )}
 
@@ -168,20 +176,15 @@ export default function VisualLocationBuilder({
           Cancel
         </Button>
         <Box sx={{ flex: 1 }} />
-        {activeStep > 0 && (
-          <Button onClick={() => setActiveStep((s) => s - 1)} disabled={creating}>
-            Back
-          </Button>
-        )}
         {activeStep === 1 && (
-          <Button variant="contained" onClick={() => setActiveStep(2)} disabled={total === 0}>
-            Review
-          </Button>
-        )}
-        {activeStep === 2 && (
-          <Button variant="contained" onClick={handleCreate} disabled={creating || total === 0}>
-            Create {total} location{total === 1 ? '' : 's'}
-          </Button>
+          <>
+            <Button onClick={() => setActiveStep(0)} disabled={creating}>
+              Back
+            </Button>
+            <Button variant="contained" onClick={handleCreate} disabled={creating || total === 0}>
+              Create {total} location{total === 1 ? '' : 's'}
+            </Button>
+          </>
         )}
       </DialogActions>
     </Dialog>

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -12,8 +12,6 @@ import Stepper from '@mui/material/Stepper';
 import Step from '@mui/material/Step';
 import StepLabel from '@mui/material/StepLabel';
 import Divider from '@mui/material/Divider';
-import TextField from '@mui/material/TextField';
-import MenuItem from '@mui/material/MenuItem';
 import Alert from '@mui/material/Alert';
 import Typography from '@mui/material/Typography';
 
@@ -24,7 +22,6 @@ import {
   removeSpecNode,
   addChildUnder,
   duplicateNode,
-  applyQrAnchorByDepth,
 } from '@/utils/locationSpec';
 import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
 import StorageTypePalette from './StorageTypePalette';
@@ -44,8 +41,6 @@ interface VisualLocationBuilderProps {
   onCreated: (count: number) => void;
 }
 
-const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
-
 export default function VisualLocationBuilder({
   open,
   companyId,
@@ -57,7 +52,6 @@ export default function VisualLocationBuilder({
   const [activeStep, setActiveStep] = useState(0);
   const [selectedTypeId, setSelectedTypeId] = useState<string | null>(null);
   const [levels, setLevels] = useState<LevelSpec[]>([]);
-  const [qrAnchorDepth, setQrAnchorDepth] = useState(0);
   // Once a single branch is fine-tuned, the tree is hand-edited directly and no
   // longer regenerated from `levels` (which becomes the "Start over" template).
   const [customized, setCustomized] = useState(false);
@@ -70,7 +64,6 @@ export default function VisualLocationBuilder({
     setActiveStep(0);
     setSelectedTypeId(null);
     setLevels([]);
-    setQrAnchorDepth(0);
     setCustomized(false);
     setEditedTree([]);
     setStartOverOpen(false);
@@ -79,8 +72,8 @@ export default function VisualLocationBuilder({
   };
 
   const uniformTree = useMemo(
-    () => buildSpecFromLevels(levels, { qrAnchorDepth, parentCode }),
-    [levels, qrAnchorDepth, parentCode],
+    () => buildSpecFromLevels(levels, { parentCode }),
+    [levels, parentCode],
   );
   const tree = customized ? editedTree : uniformTree;
   const total = countSpecNodes(tree);
@@ -88,32 +81,26 @@ export default function VisualLocationBuilder({
   const pickType = (type: StorageType) => {
     setSelectedTypeId(type.id);
     setLevels(cloneLevels(type.defaultLevels));
-    setQrAnchorDepth(0);
     setCustomized(false);
     setEditedTree([]);
     setActiveStep(1);
   };
 
-  const changeQrDepth = (depth: number) => {
-    setQrAnchorDepth(depth);
-    if (customized) setEditedTree((t) => applyQrAnchorByDepth(t, depth));
-  };
-
   // Editing lives in the config; the preview is read-only.
   const enterCustomize = () => {
-    setEditedTree(applyQrAnchorByDepth(tree, qrAnchorDepth));
+    setEditedTree(tree);
     setCustomized(true);
   };
   const editRemove = (key: string) => {
-    setEditedTree(applyQrAnchorByDepth(removeSpecNode(tree, key), qrAnchorDepth));
+    setEditedTree(removeSpecNode(tree, key));
     setCustomized(true);
   };
   const editAdd = (parentKey: string) => {
-    setEditedTree(applyQrAnchorByDepth(addChildUnder(tree, parentKey), qrAnchorDepth));
+    setEditedTree(addChildUnder(tree, parentKey));
     setCustomized(true);
   };
   const editDuplicate = (key: string) => {
-    setEditedTree(applyQrAnchorByDepth(duplicateNode(tree, key), qrAnchorDepth));
+    setEditedTree(duplicateNode(tree, key));
     setCustomized(true);
   };
 
@@ -187,25 +174,13 @@ export default function VisualLocationBuilder({
 
             {/* Read-only type-aware preview */}
             <Box sx={{ flex: 1, minWidth: 0 }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1.5, flexWrap: 'wrap' }}>
-                <Typography variant="overline" color="text.secondary" sx={{ flex: 1, letterSpacing: 1 }}>
-                  Preview
-                </Typography>
-                <TextField
-                  select
-                  label="QR labels at"
-                  value={qrAnchorDepth}
-                  onChange={(e) => changeQrDepth(Number(e.target.value))}
-                  size="small"
-                  sx={{ minWidth: 160 }}
-                >
-                  {levels.map((l, i) => (
-                    <MenuItem key={i} value={i}>
-                      {capitalize(l.kind)}
-                    </MenuItem>
-                  ))}
-                </TextField>
-              </Box>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{ display: 'block', mb: 1.5, letterSpacing: 1 }}
+              >
+                Preview
+              </Typography>
               <LocationBoardPreview nodes={tree} />
             </Box>
           </Box>

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Stepper from '@mui/material/Stepper';
+import Step from '@mui/material/Step';
+import StepLabel from '@mui/material/StepLabel';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Alert from '@mui/material/Alert';
+import Stack from '@mui/material/Stack';
+
+import type { LevelSpec } from '@/types/inventoryLocations';
+import { buildSpecFromLevels, countSpecNodes, removeSpecNode } from '@/utils/locationSpec';
+import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
+import StorageTypePalette from './StorageTypePalette';
+import LevelConfigStep from './LevelConfigStep';
+import LocationBoardPreview from './LocationBoardPreview';
+import { cloneLevels, type StorageType } from './storageTypes';
+
+const STEPS = ['Type', 'Layout', 'Review'];
+
+interface VisualLocationBuilderProps {
+  open: boolean;
+  companyId: string;
+  /** Build under this node (null = top-level). */
+  parentId?: string | null;
+  parentCode?: string | null;
+  onClose: () => void;
+  onCreated: (count: number) => void;
+}
+
+const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+export default function VisualLocationBuilder({
+  open,
+  companyId,
+  parentId = null,
+  parentCode = null,
+  onClose,
+  onCreated,
+}: VisualLocationBuilderProps) {
+  const [activeStep, setActiveStep] = useState(0);
+  const [selectedTypeId, setSelectedTypeId] = useState<string | null>(null);
+  const [levels, setLevels] = useState<LevelSpec[]>([]);
+  const [qrAnchorDepth, setQrAnchorDepth] = useState(0);
+  const [prunedKeys, setPrunedKeys] = useState<string[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setActiveStep(0);
+    setSelectedTypeId(null);
+    setLevels([]);
+    setQrAnchorDepth(0);
+    setPrunedKeys([]);
+    setCreating(false);
+    setError(null);
+  };
+
+  const baseSpec = useMemo(
+    () => buildSpecFromLevels(levels, { qrAnchorDepth, parentCode }),
+    [levels, qrAnchorDepth, parentCode],
+  );
+  const spec = useMemo(
+    () => prunedKeys.reduce((s, k) => removeSpecNode(s, k), baseSpec),
+    [baseSpec, prunedKeys],
+  );
+  const total = countSpecNodes(spec);
+
+  const pickType = (type: StorageType) => {
+    setSelectedTypeId(type.id);
+    setLevels(cloneLevels(type.defaultLevels));
+    setQrAnchorDepth(0);
+    setPrunedKeys([]);
+    setActiveStep(1);
+  };
+
+  const changeLevels = (next: LevelSpec[]) => {
+    setLevels(next);
+    setPrunedKeys([]); // keys shift with layout; drop stale prunes
+    if (qrAnchorDepth > next.length - 1) setQrAnchorDepth(Math.max(0, next.length - 1));
+  };
+
+  const handleCreate = async () => {
+    setCreating(true);
+    setError(null);
+    try {
+      const created = await materializeLocationSpec(companyId, parentId, spec);
+      onCreated(created.length);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create locations.');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={creating ? undefined : onClose}
+      maxWidth="md"
+      fullWidth
+      TransitionProps={{ onEnter: reset }}
+    >
+      <DialogTitle>Build storage visually</DialogTitle>
+      <DialogContent dividers sx={{ minHeight: 420 }}>
+        <Stepper activeStep={activeStep} sx={{ mb: 3 }}>
+          {STEPS.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
+
+        {activeStep === 0 && <StorageTypePalette selectedId={selectedTypeId} onSelect={pickType} />}
+
+        {activeStep === 1 && (
+          <LevelConfigStep levels={levels} onChange={changeLevels} total={countSpecNodes(baseSpec)} />
+        )}
+
+        {activeStep === 2 && (
+          <Box>
+            <Stack
+              direction={{ xs: 'column', sm: 'row' }}
+              spacing={2}
+              alignItems={{ sm: 'center' }}
+              sx={{ mb: 2 }}
+            >
+              <TextField
+                select
+                label="Print QR labels at"
+                value={qrAnchorDepth}
+                onChange={(e) => setQrAnchorDepth(Number(e.target.value))}
+                size="small"
+                sx={{ minWidth: 220 }}
+                helperText="Scanning drills down to what's inside"
+              >
+                {levels.map((l, i) => (
+                  <MenuItem key={i} value={i}>
+                    {capitalize(l.kind)} (level {i + 1})
+                  </MenuItem>
+                ))}
+              </TextField>
+              <Box sx={{ flex: 1 }} />
+            </Stack>
+            <LocationBoardPreview
+              nodes={spec}
+              onPrune={(key) => setPrunedKeys((keys) => [...keys, key])}
+            />
+          </Box>
+        )}
+
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={creating}>
+          Cancel
+        </Button>
+        <Box sx={{ flex: 1 }} />
+        {activeStep > 0 && (
+          <Button onClick={() => setActiveStep((s) => s - 1)} disabled={creating}>
+            Back
+          </Button>
+        )}
+        {activeStep === 1 && (
+          <Button variant="contained" onClick={() => setActiveStep(2)} disabled={total === 0}>
+            Review
+          </Button>
+        )}
+        {activeStep === 2 && (
+          <Button variant="contained" onClick={handleCreate} disabled={creating || total === 0}>
+            Create {total} location{total === 1 ? '' : 's'}
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -23,6 +23,7 @@ import {
   countSpecNodes,
   removeSpecNode,
   addChildUnder,
+  duplicateNode,
   applyQrAnchorByDepth,
 } from '@/utils/locationSpec';
 import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
@@ -111,6 +112,10 @@ export default function VisualLocationBuilder({
     setEditedTree(applyQrAnchorByDepth(addChildUnder(tree, parentKey), qrAnchorDepth));
     setCustomized(true);
   };
+  const editDuplicate = (key: string) => {
+    setEditedTree(applyQrAnchorByDepth(duplicateNode(tree, key), qrAnchorDepth));
+    setCustomized(true);
+  };
 
   const confirmStartOver = () => {
     setCustomized(false);
@@ -172,6 +177,7 @@ export default function VisualLocationBuilder({
                 onCustomize={enterCustomize}
                 onRemove={editRemove}
                 onAdd={editAdd}
+                onDuplicate={editDuplicate}
                 onStartOver={() => setStartOverOpen(true)}
               />
             </Box>

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -97,7 +97,11 @@ export default function VisualLocationBuilder({
     if (customized) setEditedTree((t) => applyQrAnchorByDepth(t, depth));
   };
 
-  // Direct manipulation from either the preview or the config chips.
+  // Editing lives in the config; the preview is read-only.
+  const enterCustomize = () => {
+    setEditedTree(applyQrAnchorByDepth(tree, qrAnchorDepth));
+    setCustomized(true);
+  };
   const editRemove = (key: string) => {
     setEditedTree(applyQrAnchorByDepth(removeSpecNode(tree, key), qrAnchorDepth));
     setCustomized(true);
@@ -157,6 +161,7 @@ export default function VisualLocationBuilder({
                 total={total}
                 customized={customized}
                 tree={tree}
+                onCustomize={enterCustomize}
                 onRemove={editRemove}
                 onAdd={editAdd}
                 onStartOver={() => setStartOverOpen(true)}
@@ -184,7 +189,7 @@ export default function VisualLocationBuilder({
                   ))}
                 </TextField>
               </Box>
-              <LocationBoardPreview nodes={tree} onRemove={editRemove} onAdd={editAdd} />
+              <LocationBoardPreview nodes={tree} />
             </Box>
           </Box>
         )}

--- a/components/inventory/locations/builder/storageTypes.tsx
+++ b/components/inventory/locations/builder/storageTypes.tsx
@@ -1,0 +1,99 @@
+/**
+ * The visual builder's storage-type palette. Each type is a recognizable card
+ * (concrete MUI icon + always-visible label, per NN/g) that doubles as a
+ * starter template: picking it seeds a sensible multi-level layout the owner
+ * then tweaks. `kind` values map onto the existing KIND_SUGGESTIONS taxonomy.
+ */
+import type { SvgIconComponent } from '@mui/icons-material';
+import Inventory2Outlined from '@mui/icons-material/Inventory2Outlined';
+import ViewModuleOutlined from '@mui/icons-material/ViewModuleOutlined';
+import DnsOutlined from '@mui/icons-material/DnsOutlined';
+import GridViewOutlined from '@mui/icons-material/GridViewOutlined';
+import TableRowsOutlined from '@mui/icons-material/TableRowsOutlined';
+import AllInboxOutlined from '@mui/icons-material/AllInboxOutlined';
+import ViewColumnOutlined from '@mui/icons-material/ViewColumnOutlined';
+
+import type { LevelSpec } from '@/types/inventoryLocations';
+
+export interface StorageType {
+  id: string;
+  label: string;
+  description: string;
+  Icon: SvgIconComponent;
+  /** Seeded layout (shallow → deep); the deepest level becomes the leaves. */
+  defaultLevels: LevelSpec[];
+}
+
+export const STORAGE_TYPES: StorageType[] = [
+  {
+    id: 'cabinet',
+    label: 'Cabinet',
+    description: 'Rows of bins or drawers',
+    Icon: Inventory2Outlined,
+    defaultLevels: [
+      { kind: 'cabinet', count: 1, namePattern: 'Cabinet {n}' },
+      { kind: 'row', count: 5, namePattern: 'Row {n}' },
+      { kind: 'bin', names: ['Left', 'Right'] },
+    ],
+  },
+  {
+    id: 'shelving',
+    label: 'Shelving unit',
+    description: 'A unit with several shelves',
+    Icon: ViewModuleOutlined,
+    defaultLevels: [
+      { kind: 'shelving', count: 1, namePattern: 'Shelving {n}' },
+      { kind: 'shelf', count: 5, namePattern: 'Shelf {n}' },
+    ],
+  },
+  {
+    id: 'rack',
+    label: 'Pallet rack',
+    description: 'Bays × levels × positions',
+    Icon: DnsOutlined,
+    defaultLevels: [
+      { kind: 'rack', count: 1, namePattern: 'Rack {n}' },
+      { kind: 'level', count: 4, namePattern: 'Level {n}' },
+      { kind: 'position', count: 3, namePattern: 'Pos {n}' },
+    ],
+  },
+  {
+    id: 'drawer-unit',
+    label: 'Drawer unit',
+    description: 'A tower of drawers',
+    Icon: GridViewOutlined,
+    defaultLevels: [
+      { kind: 'drawer unit', count: 1, namePattern: 'Drawer unit {n}' },
+      { kind: 'drawer', count: 6, namePattern: 'Drawer {n}' },
+    ],
+  },
+  {
+    id: 'shelf',
+    label: 'Single shelf',
+    description: 'One stockable shelf',
+    Icon: TableRowsOutlined,
+    defaultLevels: [{ kind: 'shelf', count: 1, namePattern: 'Shelf {n}' }],
+  },
+  {
+    id: 'bins',
+    label: 'Bins',
+    description: 'A set of loose bins',
+    Icon: AllInboxOutlined,
+    defaultLevels: [{ kind: 'bin', count: 6, namePattern: 'Bin {n}' }],
+  },
+  {
+    id: 'aisle',
+    label: 'Aisle / zone',
+    description: 'A broad area to fill in',
+    Icon: ViewColumnOutlined,
+    defaultLevels: [
+      { kind: 'aisle', count: 1, namePattern: 'Aisle {n}' },
+      { kind: 'bay', count: 4, namePattern: 'Bay {n}' },
+    ],
+  },
+];
+
+/** Deep-clone a type's seed levels so edits don't mutate the shared template. */
+export function cloneLevels(levels: LevelSpec[]): LevelSpec[] {
+  return levels.map((l) => ({ ...l, names: l.names ? [...l.names] : undefined }));
+}

--- a/components/inventory/locations/builder/storageTypes.tsx
+++ b/components/inventory/locations/builder/storageTypes.tsx
@@ -54,7 +54,7 @@ export const STORAGE_TYPES: StorageType[] = [
     defaultLevels: [
       { kind: 'rack', count: 1, namePattern: 'Rack {n}' },
       { kind: 'level', count: 4, namePattern: 'Level {n}' },
-      { kind: 'position', count: 3, namePattern: 'Pos {n}' },
+      { kind: 'position', count: 3, namePattern: 'Position {n}' },
     ],
   },
   {

--- a/components/parts/PartLocationInventory.tsx
+++ b/components/parts/PartLocationInventory.tsx
@@ -86,7 +86,6 @@ export default function PartLocationInventory({
   const locationOptions = useMemo<LocationOption[]>(
     () =>
       locations
-        .filter((l) => l.is_stockable)
         .map((l) => ({ id: l.id, label: pathLabel(l.id, byId) }))
         .sort((a, b) => a.label.localeCompare(b.label)),
     [locations, byId],

--- a/types/inventoryLocations.ts
+++ b/types/inventoryLocations.ts
@@ -60,6 +60,38 @@ export interface BulkGenerateSpec {
   leafKind?: string;
 }
 
+/**
+ * One configured division level in the visual builder, e.g. "10 rows named
+ * Row {n}" or "{Left, Right}". Either a generated count+pattern OR explicit
+ * names. Levels are ordered shallow → deep; the deepest level's nodes are the
+ * stockable leaves.
+ */
+export interface LevelSpec {
+  kind: string;
+  /** Generated mode: how many, with `{n}` substitution in namePattern. */
+  count?: number;
+  namePattern?: string;
+  /** Explicit mode: fixed child names (e.g. ['Left', 'Right']). */
+  names?: string[];
+}
+
+/**
+ * In-memory location tree the visual builder assembles entirely client-side,
+ * before any DB write. `materializeLocationSpec` inserts it into
+ * inventory_locations on Create. `key` is a stable client id for board
+ * rendering / prune (NOT the DB id); `code` is precomputed during assembly
+ * (parent-prefixed, zero-padded) to match the manual bulk generator.
+ */
+export interface LocationSpecNode {
+  key: string;
+  name: string;
+  kind: string | null;
+  code: string | null;
+  is_stockable: boolean;
+  is_qr_anchor: boolean;
+  children: LocationSpecNode[];
+}
+
 export interface PartLocationBalance {
   id: string;
   company_id: string;

--- a/types/inventoryLocations.ts
+++ b/types/inventoryLocations.ts
@@ -63,8 +63,7 @@ export interface BulkGenerateSpec {
 /**
  * One configured division level in the visual builder, e.g. "10 rows named
  * Row {n}" or "{Left, Right}". Either a generated count+pattern OR explicit
- * names. Levels are ordered shallow → deep; the deepest level's nodes are the
- * stockable leaves.
+ * names. Levels are ordered shallow → deep.
  */
 export interface LevelSpec {
   kind: string;
@@ -80,15 +79,14 @@ export interface LevelSpec {
  * before any DB write. `materializeLocationSpec` inserts it into
  * inventory_locations on Create. `key` is a stable client id for board
  * rendering / prune (NOT the DB id); `code` is precomputed during assembly
- * (parent-prefixed, zero-padded) to match the manual bulk generator.
+ * (parent-prefixed, zero-padded) to match the manual bulk generator. Every
+ * location can hold stock and be printed, so no per-node stockable/QR flags.
  */
 export interface LocationSpecNode {
   key: string;
   name: string;
   kind: string | null;
   code: string | null;
-  is_stockable: boolean;
-  is_qr_anchor: boolean;
   children: LocationSpecNode[];
 }
 

--- a/utils/inventoryLocationsAccess.ts
+++ b/utils/inventoryLocationsAccess.ts
@@ -11,6 +11,7 @@
  */
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import { convertToBaseUnit } from '@/lib/unitPresets';
+import { generatedCode, explicitCode } from '@/utils/locationSpec';
 import type {
   BulkGenerateSpec,
   CreateLocationInput,
@@ -18,6 +19,7 @@ import type {
   InventoryLocation,
   InventoryLocationNode,
   LocationContent,
+  LocationSpecNode,
   PartLocationBalanceWithLocation,
   ResolvedScan,
   StockMutationResult,
@@ -210,15 +212,11 @@ export async function deleteLocation(id: string): Promise<void> {
   }
 }
 
-/** Zero-pad a 1-based index to a uniform width (warehouse naming discipline). */
-function pad(n: number, width: number): string {
-  return String(n).padStart(width, '0');
-}
-
 /**
  * Bulk-generate repetitive structure under a parent — e.g. 10 rows × {Left,
  * Right}. Names follow `namePattern` ('{n}' → index); codes are zero-padded
- * for sortability. Created sequentially so leaves can attach to their row.
+ * for sortability (shared scheme with the visual builder via locationSpec).
+ * Created sequentially so leaves can attach to their row.
  */
 export async function bulkGenerateChildren(
   companyId: string,
@@ -240,7 +238,7 @@ export async function bulkGenerateChildren(
       parent_id: parentId,
       name: pattern.replace('{n}', String(idx)),
       kind: spec.kind ?? null,
-      code: `${parent?.code ? parent.code + '-' : ''}${(spec.kind ?? 'N').charAt(0).toUpperCase()}${pad(idx, width)}`,
+      code: generatedCode(parent?.code ?? null, spec.kind ?? '', idx, width),
       is_stockable: !spec.leaves || spec.leaves.length === 0,
       sort_order: idx,
     });
@@ -252,11 +250,46 @@ export async function bulkGenerateChildren(
         parent_id: node.id,
         name: leafName,
         kind: spec.leafKind ?? 'side',
-        code: `${node.code ?? ''}-${leafName.charAt(0).toUpperCase()}`,
+        code: explicitCode(node.code, leafName),
         is_stockable: true,
         sort_order: j,
       });
       created.push(leaf);
+    }
+  }
+  return created;
+}
+
+/**
+ * Materialize a LocationSpecNode forest (built client-side by the visual
+ * builder) into inventory_locations. Recursively composes the existing
+ * `createLocation` — parent before children — so all the company/parent
+ * validation and code handling is shared with the manual flow. Names, codes,
+ * is_stockable and is_qr_anchor come straight from the precomputed spec.
+ *
+ * Sequential inserts mirror bulkGenerateChildren; a single multi-row insert is
+ * a cheap future optimization if specs ever get large.
+ */
+export async function materializeLocationSpec(
+  companyId: string,
+  parentId: string | null,
+  nodes: LocationSpecNode[],
+): Promise<InventoryLocation[]> {
+  const created: InventoryLocation[] = [];
+  let sortOrder = 0;
+  for (const node of nodes) {
+    const row = await createLocation(companyId, {
+      parent_id: parentId,
+      name: node.name,
+      kind: node.kind,
+      code: node.code,
+      is_stockable: node.is_stockable,
+      is_qr_anchor: node.is_qr_anchor,
+      sort_order: sortOrder++,
+    });
+    created.push(row);
+    if (node.children.length > 0) {
+      created.push(...(await materializeLocationSpec(companyId, row.id, node.children)));
     }
   }
   return created;

--- a/utils/inventoryLocationsAccess.ts
+++ b/utils/inventoryLocationsAccess.ts
@@ -11,7 +11,7 @@
  */
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import { convertToBaseUnit } from '@/lib/unitPresets';
-import { generatedCode, explicitCode } from '@/utils/locationSpec';
+import { generatedCode, explicitCode, duplicateSubtreeAsSibling } from '@/utils/locationSpec';
 import type {
   BulkGenerateSpec,
   CreateLocationInput,
@@ -239,7 +239,6 @@ export async function bulkGenerateChildren(
       name: pattern.replace('{n}', String(idx)),
       kind: spec.kind ?? null,
       code: generatedCode(parent?.code ?? null, spec.kind ?? '', idx, width),
-      is_stockable: !spec.leaves || spec.leaves.length === 0,
       sort_order: idx,
     });
     created.push(node);
@@ -251,7 +250,6 @@ export async function bulkGenerateChildren(
         name: leafName,
         kind: spec.leafKind ?? 'side',
         code: explicitCode(node.code, leafName),
-        is_stockable: true,
         sort_order: j,
       });
       created.push(leaf);
@@ -264,8 +262,9 @@ export async function bulkGenerateChildren(
  * Materialize a LocationSpecNode forest (built client-side by the visual
  * builder) into inventory_locations. Recursively composes the existing
  * `createLocation` — parent before children — so all the company/parent
- * validation and code handling is shared with the manual flow. Names, codes,
- * is_stockable and is_qr_anchor come straight from the precomputed spec.
+ * validation and code handling is shared with the manual flow. Names and codes
+ * come straight from the precomputed spec; every location is stockable +
+ * printable (createLocation defaults).
  *
  * Sequential inserts mirror bulkGenerateChildren; a single multi-row insert is
  * a cheap future optimization if specs ever get large.
@@ -274,17 +273,16 @@ export async function materializeLocationSpec(
   companyId: string,
   parentId: string | null,
   nodes: LocationSpecNode[],
+  startSortOrder = 0,
 ): Promise<InventoryLocation[]> {
   const created: InventoryLocation[] = [];
-  let sortOrder = 0;
+  let sortOrder = startSortOrder;
   for (const node of nodes) {
     const row = await createLocation(companyId, {
       parent_id: parentId,
       name: node.name,
       kind: node.kind,
       code: node.code,
-      is_stockable: node.is_stockable,
-      is_qr_anchor: node.is_qr_anchor,
       sort_order: sortOrder++,
     });
     created.push(row);
@@ -293,6 +291,49 @@ export async function materializeLocationSpec(
     }
   }
   return created;
+}
+
+/**
+ * Duplicate a location and its entire subtree as a new sibling — structure
+ * only, no stock. The copy's root is named past the existing siblings
+ * (Cabinet 1 → Cabinet 2) and sorted after them; every code is re-derived under
+ * the same parent from the bumped name + kind (the shared builder/bulk-generate
+ * scheme, so a custom edited code is not preserved). Sequential inserts via
+ * materializeLocationSpec.
+ */
+export async function duplicateLocation(
+  companyId: string,
+  locationId: string,
+): Promise<InventoryLocation[]> {
+  const all = await getLocations(companyId);
+  const target = all.find((l) => l.id === locationId);
+  if (!target) throw new Error('Location not found.');
+
+  // getLocations is already ordered by sort_order then name, so children keep
+  // their display order.
+  const childrenOf = (parentId: string | null) => all.filter((l) => l.parent_id === parentId);
+
+  const toSpec = (loc: InventoryLocation): LocationSpecNode => ({
+    key: loc.id, // ignored by materialize; cloneSubtree assigns fresh keys
+    name: loc.name,
+    kind: loc.kind,
+    code: loc.code,
+    children: childrenOf(loc.id).map(toSpec),
+  });
+
+  const parentCode = target.parent_id
+    ? (all.find((l) => l.id === target.parent_id)?.code ?? null)
+    : null;
+  const siblings = childrenOf(target.parent_id);
+  const clone = duplicateSubtreeAsSibling(
+    toSpec(target),
+    parentCode,
+    siblings.map((l) => l.name),
+  );
+  // Sort the copy after the existing siblings (sort_order ASC, name ASC read
+  // order) rather than letting it default to 0 and jump to the front.
+  const nextSortOrder = siblings.reduce((max, s) => Math.max(max, s.sort_order), -1) + 1;
+  return materializeLocationSpec(companyId, target.parent_id, [clone], nextSortOrder);
 }
 
 // ===========================================================================

--- a/utils/locationSpec.ts
+++ b/utils/locationSpec.ts
@@ -3,9 +3,9 @@
  *
  * The builder collects an ordered list of LevelSpecs (level 0 = the top
  * containers, level 1 = their divisions, …) and this module turns them into a
- * LocationSpecNode tree with names, zero-padded sortable codes, is_stockable on
- * the deepest level only, and is_qr_anchor on a chosen level. The code scheme is
- * shared with bulkGenerateChildren so the visual and manual builders agree.
+ * LocationSpecNode tree with names and zero-padded sortable codes. The code
+ * scheme is shared with bulkGenerateChildren so the visual and manual builders
+ * agree. Every location can hold stock and be printed — no per-node flags.
  */
 import type { LevelSpec, LocationSpecNode } from '@/types/inventoryLocations';
 
@@ -34,9 +34,6 @@ export function explicitCode(parentCode: string | null, name: string): string {
 export interface BuildSpecOptions {
   /** Code of the parent the tree will be created under (null = top-level). */
   parentCode?: string | null;
-  /** Which level (0-based) gets printed QR anchors. Default 0 = top containers
-   *  (container-level QR + on-screen drill-down, per the inventory design). */
-  qrAnchorDepth?: number;
 }
 
 /**
@@ -48,9 +45,6 @@ export function buildSpecFromLevels(
   levels: LevelSpec[],
   opts: BuildSpecOptions = {},
 ): LocationSpecNode[] {
-  const deepest = levels.length - 1;
-  const qrDepth = opts.qrAnchorDepth ?? 0;
-
   const buildLevel = (
     depth: number,
     parentCode: string | null,
@@ -58,7 +52,6 @@ export function buildSpecFromLevels(
   ): LocationSpecNode[] => {
     if (depth >= levels.length) return [];
     const level = levels[depth];
-    const isLeafLevel = depth === deepest;
 
     const makeNode = (i: number, name: string, code: string): LocationSpecNode => {
       const key = parentKey ? `${parentKey}/${i}` : `${i}`;
@@ -67,8 +60,6 @@ export function buildSpecFromLevels(
         name,
         kind: level.kind || null,
         code,
-        is_stockable: isLeafLevel,
-        is_qr_anchor: depth === qrDepth,
         children: buildLevel(depth + 1, code, key),
       };
     };
@@ -132,8 +123,6 @@ function cloneSubtree(node: LocationSpecNode, parentCode: string | null, overrid
     name,
     kind: node.kind,
     code,
-    is_stockable: node.is_stockable,
-    is_qr_anchor: node.is_qr_anchor,
     children: node.children.map((c) => cloneSubtree(c, code)),
   };
 }
@@ -181,8 +170,6 @@ export function addChildUnder(tree: LocationSpecNode[], parentKey: string): Loca
         name: 'Item 1',
         kind: 'item',
         code: deriveCodeFor('Item 1', 'item', parent.code),
-        is_stockable: true,
-        is_qr_anchor: false,
         children: [],
       };
     } else {
@@ -191,14 +178,6 @@ export function addChildUnder(tree: LocationSpecNode[], parentKey: string): Loca
     }
     return { ...parent, children: [...parent.children, child] };
   });
-}
-
-/** Re-stamp is_qr_anchor by depth across the whole tree (after the QR-level
- *  selector changes while the tree is hand-edited). */
-export function applyQrAnchorByDepth(nodes: LocationSpecNode[], depth: number): LocationSpecNode[] {
-  const walk = (ns: LocationSpecNode[], d: number): LocationSpecNode[] =>
-    ns.map((n) => ({ ...n, is_qr_anchor: d === depth, children: walk(n.children, d + 1) }));
-  return walk(nodes, 0);
 }
 
 /** Parent's code, inferred from a child's code ("C01-R03" → "C01", "C01" → null). */
@@ -225,4 +204,22 @@ export function duplicateNode(tree: LocationSpecNode[], key: string): LocationSp
     return out;
   };
   return walk(tree);
+}
+
+/**
+ * Duplicate a single (DB-sourced) subtree as a sibling: a bumped name past the
+ * EXISTING sibling names (Cabinet 1 → Cabinet 2), fresh keys, and codes
+ * re-derived under `parentCode`. Used by the Locations manager's Duplicate —
+ * unlike duplicateNode it takes the real sibling names + parent code explicitly
+ * (rather than inferring from an in-memory forest), so it can't collide with
+ * siblings the in-memory tree doesn't know about.
+ */
+export function duplicateSubtreeAsSibling(
+  rootNode: LocationSpecNode,
+  parentCode: string | null,
+  existingSiblingNames: string[],
+): LocationSpecNode {
+  const siblings = existingSiblingNames.map((name) => ({ ...rootNode, name, children: [] }));
+  const name = nextSiblingName(siblings, rootNode);
+  return cloneSubtree(rootNode, parentCode, name);
 }

--- a/utils/locationSpec.ts
+++ b/utils/locationSpec.ts
@@ -107,3 +107,90 @@ export function removeSpecNode(nodes: LocationSpecNode[], key: string): Location
     .filter((n) => n.key !== key)
     .map((n) => ({ ...n, children: removeSpecNode(n.children, key) }));
 }
+
+// ---- Per-branch (non-uniform) hand edits -------------------------------------
+// Once the user fine-tunes a single branch, the tree is edited directly (no
+// longer regenerated from the uniform levels). Keys must stay stable across
+// edits, so added nodes get a fresh counter-based key.
+
+let addSeq = 0;
+const freshKey = () => `e${addSeq++}`;
+
+/** Code for a hand-added/cloned node, reusing the generated/explicit scheme. */
+function deriveCodeFor(name: string, kind: string, parentCode: string | null): string {
+  const m = name.match(/(\d+)\s*$/);
+  if (m) return generatedCode(parentCode, kind, parseInt(m[1], 10), Math.max(2, m[1].length));
+  return explicitCode(parentCode, name);
+}
+
+/** Deep-clone a subtree with fresh keys and codes re-derived under `parentCode`. */
+function cloneSubtree(node: LocationSpecNode, parentCode: string | null, overrideName?: string): LocationSpecNode {
+  const name = overrideName ?? node.name;
+  const code = deriveCodeFor(name, node.kind ?? '', parentCode);
+  return {
+    key: freshKey(),
+    name,
+    kind: node.kind,
+    code,
+    is_stockable: node.is_stockable,
+    is_qr_anchor: node.is_qr_anchor,
+    children: node.children.map((c) => cloneSubtree(c, code)),
+  };
+}
+
+/** Next sibling name: bump the trailing number (Bin 4 → Bin 5), skipping gaps. */
+function nextSiblingName(siblings: LocationSpecNode[], last: LocationSpecNode): string {
+  const base = last.name.replace(/\s*\d+\s*$/, '').trim();
+  let max = 0;
+  for (const s of siblings) {
+    const m = s.name.match(/(\d+)\s*$/);
+    if (m) max = Math.max(max, parseInt(m[1], 10));
+  }
+  const next = (max || siblings.length) + 1;
+  return base ? `${base} ${next}` : `${last.name} ${next}`;
+}
+
+function mapNode(
+  nodes: LocationSpecNode[],
+  key: string,
+  fn: (n: LocationSpecNode) => LocationSpecNode,
+): LocationSpecNode[] {
+  return nodes.map((n) =>
+    n.key === key ? fn(n) : { ...n, children: mapNode(n.children, key, fn) },
+  );
+}
+
+/**
+ * Add one child under `parentKey`, to that branch ONLY (the heart of
+ * non-uniform editing). Clones the parent's last child — so "+ under a section"
+ * adds another bin, and "+ under a container" adds another section *with its
+ * bins*. An empty parent gets a single stockable leaf.
+ */
+export function addChildUnder(tree: LocationSpecNode[], parentKey: string): LocationSpecNode[] {
+  return mapNode(tree, parentKey, (parent) => {
+    let child: LocationSpecNode;
+    if (parent.children.length === 0) {
+      child = {
+        key: freshKey(),
+        name: 'Item 1',
+        kind: 'item',
+        code: deriveCodeFor('Item 1', 'item', parent.code),
+        is_stockable: true,
+        is_qr_anchor: false,
+        children: [],
+      };
+    } else {
+      const last = parent.children[parent.children.length - 1];
+      child = cloneSubtree(last, parent.code, nextSiblingName(parent.children, last));
+    }
+    return { ...parent, children: [...parent.children, child] };
+  });
+}
+
+/** Re-stamp is_qr_anchor by depth across the whole tree (after the QR-level
+ *  selector changes while the tree is hand-edited). */
+export function applyQrAnchorByDepth(nodes: LocationSpecNode[], depth: number): LocationSpecNode[] {
+  const walk = (ns: LocationSpecNode[], d: number): LocationSpecNode[] =>
+    ns.map((n) => ({ ...n, is_qr_anchor: d === depth, children: walk(n.children, d + 1) }));
+  return walk(nodes, 0);
+}

--- a/utils/locationSpec.ts
+++ b/utils/locationSpec.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure (DB-free) assembly of the visual builder's in-memory location tree.
+ *
+ * The builder collects an ordered list of LevelSpecs (level 0 = the top
+ * containers, level 1 = their divisions, …) and this module turns them into a
+ * LocationSpecNode tree with names, zero-padded sortable codes, is_stockable on
+ * the deepest level only, and is_qr_anchor on a chosen level. The code scheme is
+ * shared with bulkGenerateChildren so the visual and manual builders agree.
+ */
+import type { LevelSpec, LocationSpecNode } from '@/types/inventoryLocations';
+
+/** Zero-pad a 1-based index to a uniform width (warehouse naming discipline). */
+export function pad(n: number, width: number): string {
+  return String(n).padStart(width, '0');
+}
+
+/** Code for a generated node, e.g. parent "CAB1" + row 3 → "CAB1-R03". */
+export function generatedCode(
+  parentCode: string | null,
+  kind: string,
+  idx: number,
+  width: number,
+): string {
+  const initial = (kind || 'N').charAt(0).toUpperCase();
+  return `${parentCode ? parentCode + '-' : ''}${initial}${pad(idx, width)}`;
+}
+
+/** Code for an explicitly-named node, e.g. parent "CAB1-R03" + "Left" → "CAB1-R03-L". */
+export function explicitCode(parentCode: string | null, name: string): string {
+  const initial = (name.trim().charAt(0) || 'X').toUpperCase();
+  return `${parentCode ? parentCode + '-' : ''}${initial}`;
+}
+
+export interface BuildSpecOptions {
+  /** Code of the parent the tree will be created under (null = top-level). */
+  parentCode?: string | null;
+  /** Which level (0-based) gets printed QR anchors. Default 0 = top containers
+   *  (container-level QR + on-screen drill-down, per the inventory design). */
+  qrAnchorDepth?: number;
+}
+
+/**
+ * Assemble the LocationSpecNode roots from ordered levels. Deepest level's nodes
+ * are the stockable leaves. Keys are deterministic (path-based) for stable React
+ * keys and prune.
+ */
+export function buildSpecFromLevels(
+  levels: LevelSpec[],
+  opts: BuildSpecOptions = {},
+): LocationSpecNode[] {
+  const deepest = levels.length - 1;
+  const qrDepth = opts.qrAnchorDepth ?? 0;
+
+  const buildLevel = (
+    depth: number,
+    parentCode: string | null,
+    parentKey: string,
+  ): LocationSpecNode[] => {
+    if (depth >= levels.length) return [];
+    const level = levels[depth];
+    const isLeafLevel = depth === deepest;
+
+    const makeNode = (i: number, name: string, code: string): LocationSpecNode => {
+      const key = parentKey ? `${parentKey}/${i}` : `${i}`;
+      return {
+        key,
+        name,
+        kind: level.kind || null,
+        code,
+        is_stockable: isLeafLevel,
+        is_qr_anchor: depth === qrDepth,
+        children: buildLevel(depth + 1, code, key),
+      };
+    };
+
+    if (level.names && level.names.length > 0) {
+      return level.names
+        .map((n) => n.trim())
+        .filter(Boolean)
+        .map((nm, i) => makeNode(i, nm, explicitCode(parentCode, nm)));
+    }
+
+    const count = Math.max(0, level.count ?? 0);
+    const width = Math.max(2, String(count).length);
+    const pattern = level.namePattern || '{n}';
+    const nodes: LocationSpecNode[] = [];
+    for (let i = 0; i < count; i++) {
+      const idx = i + 1;
+      nodes.push(
+        makeNode(i, pattern.replace('{n}', String(idx)), generatedCode(parentCode, level.kind, idx, width)),
+      );
+    }
+    return nodes;
+  };
+
+  return buildLevel(0, opts.parentCode ?? null, '');
+}
+
+/** Total node count across the spec forest (for the live "will create N" count). */
+export function countSpecNodes(nodes: LocationSpecNode[]): number {
+  return nodes.reduce((sum, n) => sum + 1 + countSpecNodes(n.children), 0);
+}
+
+/** Remove a node (and its subtree) by key — used by the prune step. */
+export function removeSpecNode(nodes: LocationSpecNode[], key: string): LocationSpecNode[] {
+  return nodes
+    .filter((n) => n.key !== key)
+    .map((n) => ({ ...n, children: removeSpecNode(n.children, key) }));
+}

--- a/utils/locationSpec.ts
+++ b/utils/locationSpec.ts
@@ -138,15 +138,21 @@ function cloneSubtree(node: LocationSpecNode, parentCode: string | null, overrid
   };
 }
 
-/** Next sibling name: bump the trailing number (Bin 4 → Bin 5), skipping gaps. */
+/** Next sibling name for a clone: bump past the highest number sharing the same
+ *  base (Bin 4 → Bin 5, keeping a gap), or count the same-base siblings when
+ *  they're unnumbered (Left among [Left, Right] → Left 2). */
 function nextSiblingName(siblings: LocationSpecNode[], last: LocationSpecNode): string {
   const base = last.name.replace(/\s*\d+\s*$/, '').trim();
-  let max = 0;
+  let maxNum = 0;
+  let sameBase = 0;
   for (const s of siblings) {
-    const m = s.name.match(/(\d+)\s*$/);
-    if (m) max = Math.max(max, parseInt(m[1], 10));
+    if (s.name.replace(/\s*\d+\s*$/, '').trim() === base) {
+      sameBase += 1;
+      const m = s.name.match(/(\d+)\s*$/);
+      if (m) maxNum = Math.max(maxNum, parseInt(m[1], 10));
+    }
   }
-  const next = (max || siblings.length) + 1;
+  const next = (maxNum > 0 ? maxNum : sameBase) + 1;
   return base ? `${base} ${next}` : `${last.name} ${next}`;
 }
 
@@ -193,4 +199,30 @@ export function applyQrAnchorByDepth(nodes: LocationSpecNode[], depth: number): 
   const walk = (ns: LocationSpecNode[], d: number): LocationSpecNode[] =>
     ns.map((n) => ({ ...n, is_qr_anchor: d === depth, children: walk(n.children, d + 1) }));
   return walk(nodes, 0);
+}
+
+/** Parent's code, inferred from a child's code ("C01-R03" → "C01", "C01" → null). */
+function parentCodeOf(code: string | null): string | null {
+  if (!code) return null;
+  const i = code.lastIndexOf('-');
+  return i >= 0 ? code.slice(0, i) : null;
+}
+
+/**
+ * Duplicate a node (and its subtree) as the NEXT sibling — fresh keys, a bumped
+ * name (Cabinet 1 → Cabinet 2), and re-derived codes under the same parent.
+ * Works at any level, including top-level entries.
+ */
+export function duplicateNode(tree: LocationSpecNode[], key: string): LocationSpecNode[] {
+  const walk = (nodes: LocationSpecNode[]): LocationSpecNode[] => {
+    const out: LocationSpecNode[] = [];
+    for (const n of nodes) {
+      out.push({ ...n, children: walk(n.children) });
+      if (n.key === key) {
+        out.push(cloneSubtree(n, parentCodeOf(n.code), nextSiblingName(nodes, n)));
+      }
+    }
+    return out;
+  };
+  return walk(tree);
 }


### PR DESCRIPTION
Cuts the upfront friction of building the location tree by hand. A shop owner picks a recognizable storage type, configures its rows/bins, sees a friendly board, and one tap materializes the whole structure into the existing `inventory_locations` tree.

**Stacked on `feature/inventory-locations-core` (PR #414)** — all reuse lives there. Retarget to `main` once #414 merges.

## How we got here (evaluation, not just build)
The original idea was an AI "describe your storage → confirm → generate" flow. I evaluated it with two research workflows (17 agents) and **dropped the AI**, with the user's agreement:
- It's a **one-time setup task** — no SMB/WMS competitor ships conversational location setup (a skeptical check *refuted* it as an "expected" capability); AI adds token cost + hallucination risk for value a deterministic builder delivers better.
- Chose an **icon/board builder over a spatial floor-plan**: storing x/y would be a second source of truth that drifts from the tree (forbidden by the no-multi-source rule), QR + breadcrumb already solve wayfinding, spatial ROI only exists in high-SKU fulfillment centers, and a labeled card-palette + drill-in board is the evidence-backed pattern for 50–60yo tablet users.

**No AI, no voice, no CSV, and NO DB schema change.**

## What's here
- **`utils/locationSpec.ts`** (pure, fully unit-tested): `buildSpecFromLevels` assembles an N-level `LocationSpecNode` tree — names, zero-padded sortable codes (shared with `bulkGenerateChildren` via extracted `generatedCode`/`explicitCode`), `is_stockable` on the deepest level, `is_qr_anchor` on a chosen level — plus `countSpecNodes` / `removeSpecNode` (prune).
- **`materializeLocationSpec`**: recursively composes the existing `createLocation` (Supabase-first, no FastAPI) to insert the spec on Create.
- **`builder/`**: `VisualLocationBuilder` stepper (Type → Layout → Review) + `StorageTypePalette` (labeled cards that double as starter templates) + `LevelConfigStep` (mirrors the bulk-generate fields, per level) + read-only `LocationBoardPreview` with **drill-in + prune + QR-anchor-level toggle**.
- **Entry point**: a "Build visually" primary action in the `LocationsManager` toolbar + empty state. The tree manager stays the editor of record (one-time first-fill, then hand off).
- **Accessibility**: tap-primary with no drag-only path (WCAG 2.5.7), ≥48px targets, every storage-type icon carries a persistent text label.

## Verification
`tsc` clean; full **Vitest 675** (11 pure spec tests covering counts/codes/`is_stockable`/QR/prune + the materializer + 2 stepper component tests); lint consistent with baseline. End-to-end: Inventory → Locations → **Build visually** → Cabinet → 5 rows × {Left, Right} → board (1 cabinet → 5 rows → 10 bins, drill-in) → prune one → Create → lands in the tree → Print all QR anchors.

## Follow-ups (not this PR)
Usability-test the storage-type icon set with Johnny/Shane and lock it; batch multi-row insert if specs get large; (deferred, trigger-gated) light tile-order persistence only if shops ask to "arrange to match my shop" — full geometry stays out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)