### PR TITLE
fix(pricing): resolve bought-part sell price as cost × markup

### DIFF
--- a/__tests__/utils/partPricingTiersAccess.test.ts
+++ b/__tests__/utils/partPricingTiersAccess.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RoutingCostBreakdown } from '@/utils/routingCostCalculation';
+
+// Awaitable query-builder mock: getTiersForPart awaits
+// `.from().select().eq().order()`, and `await <non-thenable>` resolves to the
+// object itself, so destructuring `{ data, error }` reads these props.
+const { mockBuilder, mockSupabase } = vi.hoisted(() => {
+  const builder: Record<string, unknown> = {};
+  ['from', 'select', 'eq', 'order'].forEach((m) => {
+    builder[m] = vi.fn(() => builder);
+  });
+  builder.data = null;
+  builder.error = null;
+  const supabase = { from: vi.fn(() => builder), rpc: vi.fn() };
+  return { mockBuilder: builder, mockSupabase: supabase };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+
+// calculateRoutingCost is mocked per-test (null = no routing/BOM → bought-part
+// path; a breakdown = made-part path). calculateTierPricing stays real so the
+// made-part regression test exercises the genuine markup math.
+vi.mock('@/utils/routingCostCalculation', async (importActual) => {
+  const actual = await importActual<typeof import('@/utils/routingCostCalculation')>();
+  return { ...actual, calculateRoutingCost: vi.fn() };
+});
+
+vi.mock('@/utils/partsAccess', () => ({
+  getComputedPartCost: vi.fn(),
+  getPartCostExplain: vi.fn(),
+}));
+
+import { getTiersWithComputedPrices } from '@/utils/partPricingTiersAccess';
+import { calculateRoutingCost } from '@/utils/routingCostCalculation';
+import { getComputedPartCost } from '@/utils/partsAccess';
+
+const mockCalcRoutingCost = vi.mocked(calculateRoutingCost);
+const mockComputedPartCost = vi.mocked(getComputedPartCost);
+
+function tierRow(partial: { id: string; quantity: number; markup_percent: number | null }) {
+  return {
+    id: partial.id,
+    part_id: 'part-1',
+    company_id: 'co-1',
+    sequence: 0,
+    quantity: partial.quantity,
+    markup_percent: partial.markup_percent,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+describe('getTiersWithComputedPrices — bought parts (no routing/BOM)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuilder.error = null;
+  });
+
+  it('prices a bought part as procurement cost × markup (the $55.74 case)', async () => {
+    mockBuilder.data = [
+      tierRow({ id: 't1', quantity: 1, markup_percent: 122.96 }),
+      tierRow({ id: 't10', quantity: 10, markup_percent: 100 }),
+    ];
+    mockCalcRoutingCost.mockResolvedValue(null); // bought part: no routing/BOM
+    mockComputedPartCost.mockImplementation(async (_partId, qty) =>
+      qty === 1 ? 25 : 20,
+    );
+
+    const tiers = await getTiersWithComputedPrices('part-1');
+
+    expect(tiers).toHaveLength(2);
+    // 25 × (1 + 122.96/100) = 55.74 — the manually-typed price is now derived.
+    expect(tiers[0].unit_price).toBe(55.74);
+    // 20 × (1 + 100/100) = 40.
+    expect(tiers[1].unit_price).toBe(40);
+    // Base cost is resolved per tier quantity via compute_part_cost_at_qty.
+    expect(mockComputedPartCost).toHaveBeenCalledWith('part-1', 1);
+    expect(mockComputedPartCost).toHaveBeenCalledWith('part-1', 10);
+  });
+
+  it('leaves unit_price null when the base cost cannot resolve (no procurement tier)', async () => {
+    mockBuilder.data = [tierRow({ id: 't1', quantity: 1, markup_percent: 50 })];
+    mockCalcRoutingCost.mockResolvedValue(null);
+    mockComputedPartCost.mockResolvedValue(null);
+
+    const tiers = await getTiersWithComputedPrices('part-1');
+
+    expect(tiers[0].unit_price).toBeNull();
+  });
+
+  it('leaves unit_price null when markup is null (no price yet), matching made-part semantics', async () => {
+    mockBuilder.data = [tierRow({ id: 't1', quantity: 1, markup_percent: null })];
+    mockCalcRoutingCost.mockResolvedValue(null);
+    mockComputedPartCost.mockResolvedValue(25);
+
+    const tiers = await getTiersWithComputedPrices('part-1');
+
+    expect(tiers[0].unit_price).toBeNull();
+  });
+});
+
+describe('getTiersWithComputedPrices — made parts (routing/BOM) unchanged', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuilder.error = null;
+  });
+
+  it('prices made parts from the routing breakdown and never calls compute_part_cost_at_qty', async () => {
+    mockBuilder.data = [tierRow({ id: 't1', quantity: 1, markup_percent: 100 })];
+    const breakdown: RoutingCostBreakdown = {
+      labor_items: [],
+      material_items: [],
+      total_labor_cost: 10,
+      total_setup_cost: 0,
+      total_material_cost: 5,
+      total_cost: 15,
+      materials_complete: true,
+      warnings: [],
+    };
+    mockCalcRoutingCost.mockResolvedValue(breakdown);
+
+    const tiers = await getTiersWithComputedPrices('part-1');
+
+    // base = 10 + 5 + 0 = 15; 15 × (1 + 100/100) = 30.
+    expect(tiers[0].unit_price).toBe(30);
+    // The made-part path must not touch the procurement cost fallback.
+    expect(mockComputedPartCost).not.toHaveBeenCalled();
+  });
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,7 +193,7 @@ bulkSoftDeleteCustomers(ids)      // Bulk delete
 
 - parts - Part definitions (company-wide, no customer_id)
 
-- part_pricing_tiers - Quantity break-points with markup % per tier; markup is the source of truth, unit price is derived live against the routing
+- part_pricing_tiers - Quantity break-points with markup % per tier; markup is the source of truth, unit price is derived live as `base_cost × (1 + markup/100)` — base cost from the routing/BOM for made parts, from procurement tiers for bought parts
 
 - operation_types - Available operations
 

--- a/docs/modules/markup-rates.md
+++ b/docs/modules/markup-rates.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-A **markup rate** is a named pattern of quantity break-points + markup percentages that can be applied to a part to materialize its pricing tiers. Markup rates are company-scoped, snapshot-applied (deleting the rate keeps the tiers it produced), and one rate per company can be marked as the default for new parts.
+A **markup rate** is a named pattern of quantity break-points + markup percentages that can be applied to a part to materialize its pricing tiers. The resulting tiers resolve to a sell price for **both made and bought parts** — markup is applied to the routing/BOM cost for made parts and to the procurement-tier cost for bought parts. Markup rates are company-scoped, snapshot-applied (deleting the rate keeps the tiers it produced), and one rate per company can be marked as the default for new parts.
 
 **Priority:** Built; in production.
 

--- a/docs/modules/parts.md
+++ b/docs/modules/parts.md
@@ -231,7 +231,7 @@ A part's cost flows in three layers:
    ```
 3. **Quote line item** — a frozen snapshot of `(part_id, quantity, unit_price, total_price, markup_percent, base_cost_per_unit, is_quote_override)` taken at quote creation. See [Quotes Module — Snapshotted Line Items](quotes.md#snapshotted-line-items).
 
-Parts without a routing show "No cost data" in the cost breakdown card; the user can still add tiers and type unit prices manually (the back-calculated markup will look unusual until a routing exists).
+**Bought parts** have no routing, so their base cost comes from the part's **procurement tiers** (the Cost card) via `compute_part_cost_at_qty` instead of `calculateRoutingCost`. The shared resolver `getTiersWithComputedPrices` falls back to that procurement cost when a part has no routing/BOM, so a bought part's pricing tiers still resolve a sell price = `procurement_cost(qty) × (1 + markup/100)`. A made part with no routing yet shows "No cost data" in the cost breakdown card; the user can still add tiers and type unit prices manually (the back-calculated markup will look unusual until a routing exists).
 
 ---
 

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -397,7 +397,7 @@ base_cost_per_unit (at tier qty Q) = run_per_unit + material_per_unit + (total_s
 unit_price                         = base_cost_per_unit × (1 + markup_percent / 100)
 ```
 
-Markup % is the source of truth on a part tier. Typing a unit price in the part Pricing card back-calculates and stores the markup; routing changes still propagate to every tier's unit price.
+Markup % is the source of truth on a part tier. Typing a unit price in the part Pricing card back-calculates and stores the markup; routing changes still propagate to every tier's unit price. For **bought parts** (no routing) the `base_cost_per_unit` comes from the part's procurement tiers via `compute_part_cost_at_qty` rather than the routing rollup above — so bought parts resolve a tier price (`cost × (1 + markup/100)`) and no longer require a manual per-line override.
 
 **On the quote (createQuote):**
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -53,7 +53,7 @@ Success looks like:
 | Operation | A single step in a routing (e.g., CNC Turning). |
 | Operation Type | A category of operation (e.g., Machining, QC). |
 | Part | A company-wide product with name and description. Cost derived from routing when one exists. Not tied to a specific customer. |
-| Pricing Tier | A quantity break-point on a part with its own markup % (e.g., "Qty 4 @ 25%"). Unit price is derived live as `base_cost × (1 + markup/100)`. |
+| Pricing Tier | A quantity break-point on a part with its own markup % (e.g., "Qty 4 @ 25%"). Unit price is derived live as `base_cost × (1 + markup/100)` — base cost comes from the routing for made parts and from the part's procurement tiers for bought parts. |
 | Quote | A cost-plus price estimate. Multi-part; the salesperson quotes one or more quantities per part (each a snapshotted line item, with optional per-line overrides), and each quantity's price is resolved from the part's tiers. Firm (one qty/part → grand total) or price-options (2+ qtys → per-part break tables, no total) is implicit by quantity count. Convert produces one job, one work cell per (part, selected quantity). |
 
 ### 2. Users and Use Cases
@@ -308,7 +308,7 @@ Shop floors are noisy, dirty, and workers may have gloves on. UI elements should
 
 - **Inventory Transaction**: id, item_id, quantity_change, unit, transaction_type (add/deplete/adjust), work_order_id, user_id, notes, created_at
 
-- **Part**: id, company_id, part_name, description, created_at, updated_at (company-wide entity, no customer_id). Pricing is cost-plus and lives on `part_pricing_tiers`: each tier carries its own quantity + markup %; unit price is derived live as `base_cost × (1 + markup/100)` against the routing. Quotes snapshot one `quote_line_items` row per quoted (part, quantity) — the price resolved from these tiers and frozen by default — and may carry per-line price overrides.
+- **Part**: id, company_id, part_name, description, created_at, updated_at (company-wide entity, no customer_id). Pricing is cost-plus and lives on `part_pricing_tiers`: each tier carries its own quantity + markup %; unit price is derived live as `base_cost × (1 + markup/100)`, where base cost comes from the routing/BOM for made parts and from the part's procurement tiers (`compute_part_cost_at_qty`) for bought parts. Quotes snapshot one `quote_line_items` row per quoted (part, quantity) — the price resolved from these tiers and frozen by default — and may carry per-line price overrides.
 
 - **Part Pricing Tier**: id, part_id, company_id, sequence, quantity, base_cost_per_unit, markup_percent, unit_price, created_at, updated_at. Markup % is the source of truth; typing a unit price back-calculates markup. No per-tier "lock" — for stable customer prices, override at the quote line item.
 

--- a/utils/partPricingTiersAccess.ts
+++ b/utils/partPricingTiersAccess.ts
@@ -9,6 +9,7 @@ import {
   calculateRoutingCost,
   calculateTierPricing,
 } from '@/utils/routingCostCalculation';
+import { getComputedPartCost } from '@/utils/partsAccess';
 
 /**
  * Get all pricing tiers for a part (raw DB shape), ordered by sequence.
@@ -31,9 +32,11 @@ export async function getTiersForPart(partId: string): Promise<PartPricingTier[]
 
 /**
  * Single source of truth for tier pricing: load the tier rows (markup % is
- * the user-controlled source of truth), compute the current base cost from
- * the part's live routing + BOM, then derive `unit_price = base × (1 +
- * markup/100)` per tier qty.
+ * the user-controlled source of truth), compute the current base cost — from
+ * the part's live routing + BOM for made parts, or from its procurement tiers
+ * (`compute_part_cost_at_qty`) for bought parts that have no routing — then
+ * derive `unit_price = base × (1 + markup/100)` per tier qty. Both part kinds
+ * price through this one resolver so no read path can drift.
  *
  * Use this anywhere a user sees a tier price (quote form chip, PDF, the
  * resolved tier picked for a quote line item). The Part detail page already
@@ -54,10 +57,25 @@ export async function getTiersWithComputedPrices(
   ]);
 
   if (!breakdown) {
-    // No routing/BOM (e.g. bought parts) — unit_price cannot be computed
-    // from a parent routing. Surface as null so the consumer's "no usable
-    // tier" check fires; bought parts hit a different pricing flow.
-    return tiers.map((t) => ({ ...t, unit_price: null }));
+    // No routing/BOM (e.g. bought parts): the base cost comes from the part's
+    // procurement tiers via `compute_part_cost_at_qty`, not a parent routing.
+    // Sell price is still the same cost-plus model — base × (1 + markup/100) —
+    // so bought parts price in every read path that uses this resolver (quote
+    // form preview, quote PDF, quote line items). Matches `calculateTierPricing`
+    // semantics exactly: a null markup yields a null price ("no price yet"), and
+    // a tier whose base cost can't resolve (no procurement tier covers its qty)
+    // keeps unit_price = null so the "no usable tier" check still fires.
+    return Promise.all(
+      tiers.map(async (t) => {
+        const rawBase = await getComputedPartCost(partId, t.quantity).catch(() => null);
+        if (rawBase === null || t.markup_percent == null || Number.isNaN(t.markup_percent)) {
+          return { ...t, unit_price: null };
+        }
+        const baseCostPerUnit = Math.round(rawBase * 100) / 100;
+        const unitPrice = Math.round(baseCostPerUnit * (1 + t.markup_percent / 100) * 100) / 100;
+        return { ...t, unit_price: unitPrice };
+      }),
+    );
   }
 
   return tiers.map((t) => {


### PR DESCRIPTION
## Why

The shared sell-price resolver `getTiersWithComputedPrices` used `calculateRoutingCost` as the base cost, which returns `null` for any part with no routing/BOM — i.e. **every bought part**. That blanked all tier `unit_price`s, so `resolveTier` returned `null` and a quote line item could only be created with a **manually-typed override**. Bought parts could never auto-price (the $55.74 on a usability quote was typed by hand). The user flagged this as a bug.

## What

Fix the **one shared resolver** so the same component prices made *and* bought parts:

- When there's no routing/BOM, derive the base cost from the part's **procurement tiers** via `compute_part_cost_at_qty` (`getComputedPartCost`) and apply markup the same cost-plus way: `base × (1 + markup/100)`.
- A `null` markup or an unresolvable base still yields `null` (matches `calculateTierPricing` semantics exactly), so the "no usable tier" check still fires.
- **Made parts are untouched** — the fallback only runs when there is no routing/BOM.

Because every sell-price read funnels through this resolver, bought parts now price correctly in the quote form preview, the quote PDF, and quote line items. PR-D's PO→Job expected price reuses the same `getTiersWithComputedPrices` + `resolveTier` pair with no new pricing code.

## Tests

- New `__tests__/utils/partPricingTiersAccess.test.ts`: bought path (the $55.74 case), null-cost and null-markup edges, and a made-part regression guard (asserts `compute_part_cost_at_qty` is **not** called for made parts).
- Re-ran `quotePricingResolver`, `quotesAccess`, `markupRatesAccess`, `routingCostCalculation`, `quotePdf`, and the `QuoteForm` component test — all green (137 tests).
- `pnpm exec tsc --noEmit` clean.

## Docs

`prd.md`, `architecture.md`, `docs/modules/parts.md`, `docs/modules/quotes.md`, `docs/modules/markup-rates.md` — base cost is from routing (made) or procurement tiers (bought); bought parts no longer require a manual override.

## Notes

First of five PRs from a batch of 13 improvements; this is the foundational one. Follow-up (not in scope): the bought-part branch of `PartPricing.tsx` still shows a blank unit price on the part page because it calls `calculateRoutingCost` directly — could later read through this resolver for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)