### PR TITLE
feat(parts): bought-part Cost card — explicit Save, single vendor, red inline tier

### DIFF
--- a/__tests__/components/parts/PartProcurementPricingPanel.test.tsx
+++ b/__tests__/components/parts/PartProcurementPricingPanel.test.tsx
@@ -70,8 +70,11 @@ describe('PartProcurementPricingPanel — explicit save + red no-cost state', ()
 
     await screen.findByText(/Add at least one cost tier/i);
 
-    // The two table inputs are the only textboxes (the vendor picker is a combobox).
-    const inputs = screen.getAllByRole('textbox');
+    // The empty starter row is seeded by an effect one render after the red
+    // prompt appears, so AWAIT the inputs — a synchronous getAllByRole can race
+    // the seed render under CI's slower/instrumented run. The two table inputs
+    // are the only textboxes (the vendor picker is a combobox).
+    const inputs = await screen.findAllByRole('textbox');
     await user.type(inputs[0], '10'); // Min qty
     await user.type(inputs[1], '2.5'); // Unit cost
 

--- a/__tests__/components/parts/PartProcurementPricingPanel.test.tsx
+++ b/__tests__/components/parts/PartProcurementPricingPanel.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../test-utils';
+import PartProcurementPricingPanel from '@/components/parts/PartProcurementPricingPanel';
+import type { ProcurementTierGroup } from '@/types/procurementTier';
+import type { Vendor } from '@/types/vendor';
+
+const mockGetTiersForPart = vi.fn();
+const mockAddTier = vi.fn();
+const mockUpdateTier = vi.fn();
+const mockDeleteTier = vi.fn();
+const mockGetAllVendors = vi.fn();
+const mockUpdatePartPreferredVendor = vi.fn();
+
+vi.mock('@/utils/procurementTiersAccess', () => ({
+  getTiersForPart: (...a: unknown[]) => mockGetTiersForPart(...a),
+  addTier: (...a: unknown[]) => mockAddTier(...a),
+  updateTier: (...a: unknown[]) => mockUpdateTier(...a),
+  deleteTier: (...a: unknown[]) => mockDeleteTier(...a),
+}));
+vi.mock('@/utils/vendorsAccess', () => ({
+  getAllVendors: (...a: unknown[]) => mockGetAllVendors(...a),
+}));
+vi.mock('@/utils/partsAccess', () => ({
+  updatePartPreferredVendor: (...a: unknown[]) => mockUpdatePartPreferredVendor(...a),
+}));
+
+const vendor: Vendor = { id: 'v1', name: 'Acme Supply' } as Vendor;
+
+describe('PartProcurementPricingPanel — explicit save + red no-cost state', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTiersForPart.mockResolvedValue([] as ProcurementTierGroup[]);
+    mockGetAllVendors.mockResolvedValue([vendor]);
+    mockUpdatePartPreferredVendor.mockResolvedValue(undefined);
+    mockAddTier.mockResolvedValue({ id: 't1', min_quantity: 10, cost_per_unit: 2.5 });
+  });
+
+  it('shows the red no-cost prompt + an empty starter row, with Save disabled until edited', async () => {
+    render(
+      <PartProcurementPricingPanel partId="p1" companyId="c1" primaryUnit="each" />,
+    );
+
+    // The vendor auto-selects; with no saved tier the red prompt appears.
+    expect(
+      await screen.findByText(/Add at least one cost tier so this part can be priced/i),
+    ).toBeInTheDocument();
+
+    // The yellow "Add first tier" bubble copy is gone.
+    expect(screen.queryByRole('button', { name: /Add first tier/i })).toBeNull();
+
+    // Save is disabled until something is edited (no auto-save).
+    const save = screen.getByRole('button', { name: /Save costs/i });
+    expect(save).toBeDisabled();
+  });
+
+  it('saves a typed tier via the Save button (not on blur) and fires onSaved', async () => {
+    const onSaved = vi.fn();
+    render(
+      <PartProcurementPricingPanel
+        partId="p1"
+        companyId="c1"
+        primaryUnit="each"
+        onSaved={onSaved}
+      />,
+    );
+
+    await screen.findByText(/Add at least one cost tier/i);
+
+    // The two table inputs are the only textboxes (the vendor picker is a combobox).
+    const inputs = screen.getAllByRole('textbox');
+    await user.type(inputs[0], '10'); // Min qty
+    await user.type(inputs[1], '2.5'); // Unit cost
+
+    // Nothing persisted yet — edits are not auto-saved on blur.
+    expect(mockAddTier).not.toHaveBeenCalled();
+
+    const save = screen.getByRole('button', { name: /Save costs/i });
+    expect(save).toBeEnabled();
+    await user.click(save);
+
+    await waitFor(() => {
+      expect(mockAddTier).toHaveBeenCalledWith(
+        expect.objectContaining({ vendor_id: 'v1', min_quantity: '10', cost_per_unit: '2.5' }),
+      );
+    });
+    // Preferred vendor is re-asserted before the tier write.
+    expect(mockUpdatePartPreferredVendor).toHaveBeenCalledWith('p1', 'v1');
+    // Parent is told to re-derive priceability so the "Needs cost" chip clears.
+    expect(onSaved).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/parts/partSetupStatus.test.ts
+++ b/__tests__/components/parts/partSetupStatus.test.ts
@@ -52,14 +52,17 @@ describe('getPartSetupStatus', () => {
     }
   });
 
-  it('a not-priceable bought part warns needs_cost and points at a vendor cost', () => {
+  it('a not-priceable bought part is needs_cost for the chip but emits NO banner (nextStep null)', () => {
+    // Bought parts surface the missing-cost gap inline in the Cost card (a red
+    // starter tier in PartProcurementPricingPanel), not as a workspace banner —
+    // so the chip still reads "Needs cost" (warning) but nextStep is null.
     const status = getPartSetupStatus(
       { source: 'bought', routing: null, bom_lines_count: 0 },
       false,
     );
     expect(status.state).toBe('needs_cost');
     expect(status.color).toBe('warning');
-    expect(status.nextStep).toMatch(/vendor/i);
+    expect(status.nextStep).toBeNull();
   });
 
   it('only ever emits theme palette colour keys (never a hardcoded hex)', () => {

--- a/components/parts/PartProcurementPricingPanel.tsx
+++ b/components/parts/PartProcurementPricingPanel.tsx
@@ -8,7 +8,6 @@ import TextField from '@mui/material/TextField';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import Alert from '@mui/material/Alert';
-import AlertTitle from '@mui/material/AlertTitle';
 import CircularProgress from '@mui/material/CircularProgress';
 import Table from '@mui/material/Table';
 import TableHead from '@mui/material/TableHead';
@@ -19,9 +18,8 @@ import TableContainer from '@mui/material/TableContainer';
 import Autocomplete from '@mui/material/Autocomplete';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import SaveStatus from '@/components/common/SaveStatus';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import SaveStatus, { type SaveState } from '@/components/common/SaveStatus';
 import {
   getTiersForPart,
   addTier as addTierApi,
@@ -43,6 +41,12 @@ interface PartProcurementPricingPanelProps {
    * first mount and to surface a "Preferred" badge in the picker.
    */
   preferredVendorId?: string | null;
+  /**
+   * Called after a successful save (cost tiers or preferred-vendor change) so
+   * the parent can re-derive priceability — this is what clears the "Needs
+   * cost" indicator live, without a page reload.
+   */
+  onSaved?: () => void;
 }
 
 interface EditRow {
@@ -73,58 +77,50 @@ function tempId(): string {
  * Cost source contract: only the part's preferred vendor's sheet drives
  * cost (in `compute_part_cost_at_qty` and `get_procurement_cost`). Picking
  * a vendor in this panel sets it as preferred AND switches the displayed
- * sheet — keeping the two concepts unified. The first tier save under a
- * freshly-picked vendor also re-asserts the preferred vendor in the DB,
- * so legacy parts that loaded with a NULL preferred_vendor_id can't end
- * up with tiers that the SQL filter then ignores. Sheets under
- * non-preferred vendors and `vendor_id=NULL` "Internal estimate" rows
- * remain editable for reference but never feed rollup.
+ * sheet — keeping the two concepts unified. Sheets under non-preferred
+ * vendors and `vendor_id=NULL` "Internal estimate" rows remain editable for
+ * reference but never feed rollup.
  *
- * Saves are optimistic, per-row, and triggered on field blur. Each row
- * shows a "Saving…" / "Saved ✓" badge so the auto-save isn't invisible
- * (users were looking for a Save button before this).
+ * Cost edits are financial data, so — like the made-part Pricing card — they
+ * are committed via an explicit **Save** button (not auto-saved on blur);
+ * `dirty` tracks unsaved edits. When the selected vendor has no priced tier
+ * yet, the table shows a single empty starter row highlighted red (instead of
+ * a separate yellow banner) so the user fills the cost in directly.
  */
 export default function PartProcurementPricingPanel({
   partId,
   companyId,
   primaryUnit,
   preferredVendorId,
+  onSaved,
 }: PartProcurementPricingPanelProps) {
   const [vendors, setVendors] = useState<Vendor[]>([]);
   const [groups, setGroups] = useState<ProcurementTierGroup[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [savingCount, setSavingCount] = useState(0);
 
   const [selectedVendorId, setSelectedVendorId] = useState<string | null>(null);
   const [rows, setRows] = useState<EditRow[]>([]);
 
+  // Cost edits commit via an explicit Save (financial data — no silent
+  // auto-save). `dirty` tracks unsaved tier edits; `saveState` drives the
+  // SaveStatus chip + the Save button's disabled state.
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+  const [dirty, setDirty] = useState(false);
+  const saving = saveState === 'saving';
+
   // Tracks parts.preferred_vendor_id as it currently is in the DB. Distinct
-  // from the prop (which is the value at mount) and from selectedVendorId
-  // (which is the picker's local selection — the auto-select effect below
-  // can set this without persisting). compute_part_cost_at_qty filters tiers
-  // by parts.preferred_vendor_id; if the panel saves a tier under
-  // selectedVendorId but the DB's preferred_vendor_id is still NULL (or a
-  // stale other vendor), the cost rollup silently returns NULL. saveRow
-  // syncs this just before saving the tier.
+  // from the prop (the value at mount) and from selectedVendorId (the picker's
+  // local selection). compute_part_cost_at_qty filters tiers by
+  // parts.preferred_vendor_id; saveRow/handleSave re-assert it just before
+  // saving so a tier can't end up under a vendor the SQL filter then ignores.
   const [effectivePreferredVendorId, setEffectivePreferredVendorId] = useState<
     string | null
   >(preferredVendorId ?? null);
 
-  // Per-row save status: "saving" while the API call is in flight, "saved"
-  // for ~2 s after success so the user sees a confirmation tick. Keyed by
-  // row id (or tempKey for unsaved rows). Auto-save with no Save button is
-  // confusing without this — multiple users have asked "did it save?".
-  const [rowStatus, setRowStatus] = useState<Map<string, 'saving' | 'saved'>>(
-    new Map(),
-  );
-  const setRowStatusFor = (key: string, status: 'saving' | 'saved' | null) => {
-    setRowStatus((prev) => {
-      const next = new Map(prev);
-      if (status === null) next.delete(key);
-      else next.set(key, status);
-      return next;
-    });
+  const markDirty = () => {
+    setDirty(true);
+    setSaveState('idle');
   };
 
   const initialLoad = useCallback(async () => {
@@ -171,24 +167,29 @@ export default function PartProcurementPricingPanel({
   }, [loading, groups, preferredVendorId, selectedVendorId, vendors]);
 
   // Sync the working-copy rows whenever the selected vendor or persisted
-  // groups change. An empty vendor (no sheet yet) shows zero rows.
+  // groups change (vendor switch, or a reload after Save). A vendor with no
+  // saved tier seeds ONE empty starter row so the user fills the cost in
+  // directly (rendered red below). Resets `dirty` — these rows mirror the DB.
   useEffect(() => {
     if (!selectedVendorId) {
       setRows([]);
+      setDirty(false);
       return;
     }
     const group = groups.find((g) => g.vendor_id === selectedVendorId);
-    if (!group) {
-      setRows([]);
-      return;
+    const tiers = group?.tiers ?? [];
+    if (tiers.length === 0) {
+      setRows([{ tempKey: tempId(), quantity: '', cost: '' }]);
+    } else {
+      setRows(
+        tiers.map((t) => ({
+          id: t.id,
+          quantity: String(t.min_quantity),
+          cost: String(t.cost_per_unit),
+        })),
+      );
     }
-    setRows(
-      group.tiers.map((t) => ({
-        id: t.id,
-        quantity: String(t.min_quantity),
-        cost: String(t.cost_per_unit),
-      })),
-    );
+    setDirty(false);
   }, [selectedVendorId, groups]);
 
   const sheetCounts = useMemo(() => {
@@ -201,188 +202,132 @@ export default function PartProcurementPricingPanel({
 
   const selectedVendor = vendors.find((v) => v.id === selectedVendorId) ?? null;
 
+  // True when the selected vendor has no SAVED tier yet → the part can't be
+  // priced. Drives the red starter-tier styling + prompt. Recomputes from
+  // `groups` (persisted), so it clears the instant a Save reloads the sheet.
+  const needsCost = useMemo(() => {
+    if (!selectedVendorId) return false;
+    const group = groups.find((g) => g.vendor_id === selectedVendorId);
+    return (group?.tiers.length ?? 0) === 0;
+  }, [selectedVendorId, groups]);
+
   const vendorOptionLabel = (v: Vendor): string => {
     const count = sheetCounts.get(v.id);
     return count ? `${v.name} (${count} tier${count === 1 ? '' : 's'})` : v.name;
   };
 
-  // Per-row save handlers --------------------------------------------------
+  // Row editing -----------------------------------------------------------
 
   const setRowsAt = (mapper: (rows: EditRow[]) => EditRow[]) => {
     setRows((prev) => mapper(prev));
   };
 
-  const saveRow = async (idx: number) => {
+  const addRow = () => {
     if (!selectedVendorId) return;
-    const row = rows[idx];
-    if (!row) return;
-    const qty = parseNumber(row.quantity);
-    const cost = parseNumber(row.cost);
-    if (qty === null || qty <= 0) return;
-    if (cost === null || cost <= 0) return;
+    setRowsAt((prev) => [...prev, { tempKey: tempId(), quantity: '', cost: '' }]);
+    markDirty();
+  };
 
-    // Skip save if the persisted values match what the user typed —
-    // tab-out on an unchanged row shouldn't cause a network round-trip
-    // or a "Saved" flash.
-    if (row.id) {
-      const persisted = rows[idx];
-      // We compare against the current rows snapshot's source-of-truth in
-      // `groups` rather than itself; the editor mirrors groups, so if
-      // values match, the row hasn't been touched. Cheap string compare.
-      const group = groups.find((g) => g.vendor_id === selectedVendorId);
-      const tier = group?.tiers.find((t) => t.id === row.id);
-      if (
-        tier &&
-        String(tier.min_quantity) === persisted.quantity &&
-        String(tier.cost_per_unit) === persisted.cost
-      ) {
+  const deleteRow = (idx: number) => {
+    // Deletes are deferred to Save (reconciled against the persisted sheet),
+    // matching the explicit-save model for the rest of the cost edits.
+    setRowsAt((prev) => prev.filter((_, i) => i !== idx));
+    markDirty();
+  };
+
+  const handleSave = async () => {
+    if (!selectedVendorId) return;
+    // Fully-empty rows (both fields blank) are "not filled in yet" — drop them
+    // rather than erroring, so an extra blank Add-tier row never blocks Save.
+    const nonEmpty = rows.filter(
+      (r) => r.quantity.trim() !== '' || r.cost.trim() !== '',
+    );
+    for (const r of nonEmpty) {
+      const q = parseNumber(r.quantity);
+      const c = parseNumber(r.cost);
+      if (q === null || q <= 0 || c === null || c <= 0) {
+        setError('Every cost tier needs a quantity and a unit cost greater than 0.');
         return;
       }
     }
 
-    const rowKey = row.id ?? row.tempKey ?? `idx-${idx}`;
-    setRowStatusFor(rowKey, 'saving');
-    setSavingCount((c) => c + 1);
+    setSaveState('saving');
+    setError(null);
     try {
-      // First save under a freshly-picked vendor whose preferred-vendor-id
-      // never made it to the DB (auto-select on mount doesn't persist).
-      // Without this, compute_part_cost_at_qty silently returns NULL because
-      // it filters on parts.preferred_vendor_id and finds no match.
+      // Re-assert the preferred vendor if the picked vendor isn't yet the DB's
+      // (e.g. auto-selected on mount). Without this, compute_part_cost_at_qty
+      // filters on parts.preferred_vendor_id and silently returns NULL.
       if (effectivePreferredVendorId !== selectedVendorId) {
         await updatePartPreferredVendor(partId, selectedVendorId);
         setEffectivePreferredVendorId(selectedVendorId);
       }
 
-      if (row.id) {
-        const updated = await updateTierApi(row.id, {
-          part_id: partId,
-          vendor_id: selectedVendorId,
-          min_quantity: row.quantity,
-          cost_per_unit: row.cost,
-          quoted_at: null,
-          expires_at: null,
-          notes: '',
-        });
-        setRowsAt((prev) =>
-          prev.map((r, i) =>
-            i === idx
-              ? { id: updated.id, quantity: String(updated.min_quantity), cost: String(updated.cost_per_unit) }
-              : r,
-          ),
-        );
-        // Mirror into groups so the next computed snapshot matches.
-        setGroups((prev) =>
-          prev.map((g) =>
-            g.vendor_id === selectedVendorId
-              ? {
-                  ...g,
-                  tiers: g.tiers.map((t) => (t.id === updated.id ? updated : t)),
-                }
-              : g,
-          ),
-        );
-      } else {
-        const created = await addTierApi({
-          part_id: partId,
-          vendor_id: selectedVendorId,
-          min_quantity: row.quantity,
-          cost_per_unit: row.cost,
-          quoted_at: null,
-          expires_at: null,
-          notes: '',
-        });
-        setRowsAt((prev) =>
-          prev.map((r, i) =>
-            i === idx
-              ? { id: created.id, quantity: String(created.min_quantity), cost: String(created.cost_per_unit) }
-              : r,
-          ),
-        );
-        // Update the in-memory groups so sheet count caption stays current.
-        setGroups((prev) => {
-          const existingIdx = prev.findIndex((g) => g.vendor_id === selectedVendorId);
-          if (existingIdx >= 0) {
-            const next = [...prev];
-            const g = next[existingIdx];
-            next[existingIdx] = { ...g, tiers: [...g.tiers, created] };
-            return next;
-          }
-          // First tier ever for this vendor — synthesize a minimal group.
-          const vendor = vendors.find((v) => v.id === selectedVendorId);
-          return [
-            ...prev,
-            {
+      const persisted =
+        groups.find((g) => g.vendor_id === selectedVendorId)?.tiers ?? [];
+      const keptIds = new Set(
+        nonEmpty.map((r) => r.id).filter((id): id is string => Boolean(id)),
+      );
+
+      // Deletes first (persisted tiers no longer present in the editor).
+      for (const t of persisted) {
+        if (!keptIds.has(t.id)) await deleteTierApi(t.id);
+      }
+      // Upserts.
+      for (const r of nonEmpty) {
+        if (r.id) {
+          const prev = persisted.find((t) => t.id === r.id);
+          const changed =
+            !prev ||
+            String(prev.min_quantity) !== r.quantity ||
+            String(prev.cost_per_unit) !== r.cost;
+          if (changed) {
+            await updateTierApi(r.id, {
+              part_id: partId,
               vendor_id: selectedVendorId,
-              vendor_name: vendor?.name ?? '(unknown)',
+              min_quantity: r.quantity,
+              cost_per_unit: r.cost,
               quoted_at: null,
               expires_at: null,
-              is_expiring: false,
-              is_expired: false,
-              tiers: [created],
-            },
-          ];
-        });
-        // The new row is now persisted under `created.id`; route the
-        // "saved" flash to that key rather than the stale tempKey.
-        const newKey = created.id;
-        setRowStatusFor(rowKey, null);
-        setRowStatusFor(newKey, 'saved');
-        window.setTimeout(() => setRowStatusFor(newKey, null), 2000);
-        return; // skip the default flash path below; we already routed it
+              notes: '',
+            });
+          }
+        } else {
+          await addTierApi({
+            part_id: partId,
+            vendor_id: selectedVendorId,
+            min_quantity: r.quantity,
+            cost_per_unit: r.cost,
+            quoted_at: null,
+            expires_at: null,
+            notes: '',
+          });
+        }
       }
-      setRowStatusFor(rowKey, 'saved');
-      window.setTimeout(() => setRowStatusFor(rowKey, null), 2000);
-    } catch (err) {
-      setRowStatusFor(rowKey, null);
-      setError(err instanceof Error ? err.message : 'Failed to save tier');
-    } finally {
-      setSavingCount((c) => c - 1);
-    }
-  };
 
-  const addRow = () => {
-    if (!selectedVendorId) return;
-    setRowsAt((prev) => [...prev, { tempKey: tempId(), quantity: '', cost: '' }]);
-  };
-
-  const deleteRow = async (idx: number) => {
-    const row = rows[idx];
-    if (!row) return;
-    if (!row.id) {
-      setRowsAt((prev) => prev.filter((_, i) => i !== idx));
-      return;
-    }
-    setSavingCount((c) => c + 1);
-    try {
-      await deleteTierApi(row.id);
-      setRowsAt((prev) => prev.filter((_, i) => i !== idx));
-      // Keep groups in sync so the picker caption updates.
-      setGroups((prev) =>
-        prev.map((g) =>
-          g.vendor_id === selectedVendorId
-            ? { ...g, tiers: g.tiers.filter((t) => t.id !== row.id) }
-            : g,
-        ),
-      );
-      // Drop any in-flight save state for the deleted row.
-      setRowStatusFor(row.id, null);
+      // Reload the sheet — the sync effect re-syncs rows + clears `dirty`, and
+      // `needsCost` recomputes from the fresh groups.
+      const fresh = await getTiersForPart(partId);
+      setGroups(fresh);
+      setSaveState('saved');
+      // Let the parent re-derive priceability so the "Needs cost" chip clears
+      // immediately (no reload).
+      onSaved?.();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete tier');
-    } finally {
-      setSavingCount((c) => c - 1);
+      setSaveState('error');
+      setError(err instanceof Error ? err.message : 'Failed to save costs');
     }
   };
 
   // Render -----------------------------------------------------------------
 
   const unit = primaryUnit && primaryUnit.trim() ? primaryUnit : 'unit';
-  const saving = savingCount > 0;
 
   /**
-   * Pick a vendor: switch the displayed tier sheet AND set the picked
-   * vendor as preferred. The picker doubles as both setter and selector
-   * so users only think about one vendor concept per part. Optimistic
-   * local switch; failures revert and surface in the error alert.
+   * Pick a vendor: switch the displayed tier sheet AND set the picked vendor
+   * as preferred. The picker doubles as both setter and selector so users only
+   * think about one vendor concept per part. Optimistic local switch; failures
+   * revert and surface in the error alert. Unsaved tier edits on the previous
+   * sheet are discarded — the sync effect reloads rows for the new vendor.
    */
   const handleVendorPick = async (vendor: Vendor | null) => {
     const nextId = vendor ? vendor.id : null;
@@ -392,9 +337,9 @@ export default function PartProcurementPricingPanel({
     setSelectedVendorId(nextId);
     try {
       await updatePartPreferredVendor(partId, nextId);
-      // Track DB-side preferred vendor so saveRow knows whether it needs
-      // to re-persist on the next tier write.
       setEffectivePreferredVendorId(nextId);
+      // Preferred vendor drives priceability, so refresh the parent's chip.
+      onSaved?.();
     } catch (err) {
       setSelectedVendorId(prevId);
       setError(
@@ -405,11 +350,9 @@ export default function PartProcurementPricingPanel({
 
   return (
     <Box>
-      {/* Section header: just "Cost" h6 + saving indicator. The vendor
-          picker lives below as a labeled "Preferred vendor" field — it
+      {/* Section header: "Cost" h6 + save status. The vendor picker below
           doubles as the preferred-vendor setter and the cost-tier-sheet
-          selector. Picking a vendor sets it as preferred AND switches
-          the displayed sheet. */}
+          selector. */}
       <Box
         sx={{
           display: 'flex',
@@ -422,7 +365,7 @@ export default function PartProcurementPricingPanel({
         <Typography variant="h6" sx={{ fontWeight: 600 }}>
           Cost
         </Typography>
-        <SaveStatus state={saving ? 'saving' : 'idle'} />
+        <SaveStatus state={saveState} />
       </Box>
 
       {error && (
@@ -477,152 +420,129 @@ export default function PartProcurementPricingPanel({
           <CircularProgress size={24} />
         </Box>
       ) : !selectedVendorId ? (
-        <Alert severity="warning" icon={<WarningAmberIcon fontSize="inherit" />}>
-          <AlertTitle sx={{ fontWeight: 700, mb: 0.5 }}>
-            No cost on file
-          </AlertTitle>
-          Pick a preferred vendor above and add at least one qty-break tier.
-          Quotes can&apos;t price this part until a cost is on file.
-        </Alert>
-      ) : rows.length === 0 ? (
-        <Alert
-          severity="warning"
-          icon={<WarningAmberIcon fontSize="inherit" />}
-          action={
-            <Button
-              color="warning"
-              size="small"
-              variant="contained"
-              startIcon={<AddIcon />}
-              onClick={addRow}
-              sx={{ alignSelf: 'center', whiteSpace: 'nowrap' }}
-            >
-              Add first tier
-            </Button>
-          }
-          sx={{ alignItems: 'center' }}
-        >
-          <AlertTitle sx={{ fontWeight: 700, mb: 0.5 }}>
-            No cost tiers set for {selectedVendor?.name ?? 'this vendor'}
-          </AlertTitle>
-          Quotes can&apos;t price this part until you add at least one
-          qty-break tier.
+        <Alert severity="error">
+          No vendors yet — add a vendor first, then set a cost tier so this part
+          can be priced and quoted.
         </Alert>
       ) : (
         <>
-          <TableContainer>
+          {/* Red inline prompt when there's no saved cost yet — replaces the
+              old yellow banner. The starter row's empty fields render red too,
+              pointing the user straight at what to fill in. */}
+          {needsCost && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                mb: 1,
+                color: 'error.main',
+              }}
+            >
+              <WarningAmberIcon fontSize="small" />
+              <Typography variant="body2" color="error.main">
+                Add at least one cost tier so this part can be priced and quoted.
+              </Typography>
+            </Box>
+          )}
 
+          <TableContainer>
             <Table size="small">
               <TableHead>
                 <TableRow>
                   <TableCell>Min qty</TableCell>
                   <TableCell align="right">Unit cost</TableCell>
-                  <TableCell align="right" sx={{ width: 64 }}></TableCell>
+                  <TableCell align="right" sx={{ width: 56 }}></TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
                 {rows.map((row, idx) => {
-                    const rowKey = row.id ?? row.tempKey ?? `idx-${idx}`;
-                    const status = rowStatus.get(rowKey);
-                    return (
-                      <TableRow key={rowKey}>
-                        <TableCell sx={{ minWidth: 110 }}>
-                          <TextField
-                            size="small"
-                            value={row.quantity}
-                            onChange={(e) =>
-                              setRowsAt((prev) =>
-                                prev.map((r, i) =>
-                                  i === idx ? { ...r, quantity: e.target.value } : r,
-                                ),
-                              )
-                            }
-                            onBlur={() => saveRow(idx)}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') {
-                                e.preventDefault();
-                                (e.currentTarget as HTMLElement).blur();
-                              }
-                            }}
-                            inputMode="decimal"
-                            sx={{ width: 110 }}
-                          />
-                        </TableCell>
-                        <TableCell align="right" sx={{ minWidth: 140 }}>
-                          <TextField
-                            size="small"
-                            value={row.cost}
-                            onChange={(e) =>
-                              setRowsAt((prev) =>
-                                prev.map((r, i) =>
-                                  i === idx ? { ...r, cost: e.target.value } : r,
-                                ),
-                              )
-                            }
-                            onBlur={() => saveRow(idx)}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') {
-                                e.preventDefault();
-                                (e.currentTarget as HTMLElement).blur();
-                              }
-                            }}
-                            inputMode="decimal"
-                            sx={{ width: 130 }}
-                            slotProps={{
-                              input: {
-                                startAdornment: (
-                                  <Typography
-                                    variant="body2"
-                                    color="text.secondary"
-                                    sx={{ mr: 0.5 }}
-                                  >
-                                    $
-                                  </Typography>
-                                ),
-                              },
-                            }}
-                          />
-                        </TableCell>
-                        <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
-                          {/* Per-row save state. Inline in the actions cell so
-                              the user sees the auto-save take effect right next
-                              to the field they just left. Renders nothing while
-                              idle to keep the row visually quiet. */}
-                          {status === 'saving' && (
-                            <Tooltip title="Saving…">
-                              <CircularProgress
-                                size={14}
-                                sx={{ mr: 1, verticalAlign: 'middle', color: 'text.secondary' }}
-                              />
-                            </Tooltip>
-                          )}
-                          {status === 'saved' && (
-                            <Tooltip title="Saved">
-                              <CheckCircleOutlineIcon
-                                fontSize="small"
-                                sx={{ mr: 1, verticalAlign: 'middle', color: 'success.main' }}
-                              />
-                            </Tooltip>
-                          )}
-                          <Tooltip title="Delete tier">
+                  const rowKey = row.id ?? row.tempKey ?? `idx-${idx}`;
+                  const qtyError = needsCost && row.quantity.trim() === '';
+                  const costError = needsCost && row.cost.trim() === '';
+                  return (
+                    <TableRow key={rowKey}>
+                      <TableCell sx={{ minWidth: 110 }}>
+                        <TextField
+                          size="small"
+                          value={row.quantity}
+                          error={qtyError}
+                          onChange={(e) => {
+                            const v = e.target.value;
+                            setRowsAt((prev) =>
+                              prev.map((r, i) =>
+                                i === idx ? { ...r, quantity: v } : r,
+                              ),
+                            );
+                            markDirty();
+                          }}
+                          inputMode="decimal"
+                          sx={{ width: 110 }}
+                        />
+                      </TableCell>
+                      <TableCell align="right" sx={{ minWidth: 140 }}>
+                        <TextField
+                          size="small"
+                          value={row.cost}
+                          error={costError}
+                          onChange={(e) => {
+                            const v = e.target.value;
+                            setRowsAt((prev) =>
+                              prev.map((r, i) =>
+                                i === idx ? { ...r, cost: v } : r,
+                              ),
+                            );
+                            markDirty();
+                          }}
+                          inputMode="decimal"
+                          sx={{ width: 130 }}
+                          slotProps={{
+                            input: {
+                              startAdornment: (
+                                <Typography
+                                  variant="body2"
+                                  color="text.secondary"
+                                  sx={{ mr: 0.5 }}
+                                >
+                                  $
+                                </Typography>
+                              ),
+                            },
+                          }}
+                        />
+                      </TableCell>
+                      <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
+                        <Tooltip title="Remove tier">
+                          <span>
                             <IconButton
                               size="small"
                               color="error"
                               onClick={() => deleteRow(idx)}
                               aria-label="Remove tier"
+                              disabled={rows.length === 1}
                             >
                               <DeleteOutlineIcon fontSize="small" />
                             </IconButton>
-                          </Tooltip>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
+                          </span>
+                        </Tooltip>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
               </TableBody>
             </Table>
           </TableContainer>
 
-          <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 1,
+              mt: 1.5,
+              flexWrap: 'wrap',
+            }}
+          >
             <Button
               size="small"
               variant="outlined"
@@ -631,12 +551,30 @@ export default function PartProcurementPricingPanel({
             >
               Add tier
             </Button>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+              {dirty && saveState !== 'saving' && (
+                <Typography variant="caption" color="text.secondary">
+                  Unsaved changes
+                </Typography>
+              )}
+              <Button
+                variant="contained"
+                size="small"
+                onClick={handleSave}
+                disabled={!dirty || saving}
+                startIcon={
+                  saving ? <CircularProgress size={16} color="inherit" /> : undefined
+                }
+              >
+                Save costs
+              </Button>
+            </Box>
           </Box>
 
           <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
-            Costs are per {unit}. Tiers save automatically when you click
-            out of a field — there&apos;s no Save button. Quotes use the
-            cheapest applicable tier under the preferred vendor.
+            Costs are per {unit}. Changes are saved when you click <strong>Save
+            costs</strong>. Quotes use the cheapest applicable tier under the
+            preferred vendor.
           </Typography>
         </>
       )}

--- a/components/parts/workspace/PartIdentitySection.tsx
+++ b/components/parts/workspace/PartIdentitySection.tsx
@@ -71,7 +71,11 @@ export default function PartIdentitySection({
   const [saveStatus, setSaveStatus] = useState<SaveState>('idle');
 
   const showReorder = formData.is_stocked;
-  const showVendor = formData.source === 'bought';
+  // Preferred vendor lives on the Cost card (PartProcurementPricingPanel) for an
+  // existing bought part — so we only surface it here in the CREATE flow, where
+  // the Cost card doesn't exist yet. This avoids the two-controls-for-one-value
+  // duplication on the live part page.
+  const showVendor = formData.source === 'bought' && mode === 'create';
 
   const collectErrors = async (data: PartFormData): Promise<Record<string, string>> => {
     const errors: Record<string, string> = {};

--- a/components/parts/workspace/partSetupStatus.ts
+++ b/components/parts/workspace/partSetupStatus.ts
@@ -61,11 +61,14 @@ export function getPartSetupStatus(
     };
   }
 
-  // Bought parts, or made parts that have some structure but still don't
-  // resolve to a price (missing labour rates / material costs / vendor cost).
+  // Made parts that have some structure but still don't resolve to a price
+  // (missing labour rates / material costs) get a guidance banner. Bought parts
+  // surface the same gap INLINE in the Cost card instead (a red starter tier in
+  // PartProcurementPricingPanel), so we emit no banner for them — the chip still
+  // reads "Needs cost", but the workspace doesn't double up with a yellow alert.
   const nextStep =
     part.source === 'bought'
-      ? 'Add a vendor cost so this part can be priced and quoted.'
+      ? null
       : 'This part isn’t priceable yet — check that operations have labour rates and materials have costs.';
 
   return {

--- a/components/parts/workspace/tabs/WorkspaceTab.tsx
+++ b/components/parts/workspace/tabs/WorkspaceTab.tsx
@@ -148,6 +148,7 @@ export default function WorkspaceTab({
                       companyId={companyId}
                       primaryUnit={part.primary_unit}
                       preferredVendorId={part.preferred_vendor_id}
+                      onSaved={() => refreshAfterMutation()}
                     />
                   </CardContent>
                 </Card>

--- a/docs/modules/parts.md
+++ b/docs/modules/parts.md
@@ -197,6 +197,14 @@ Editing model — markup % is the source of truth:
 
 **Live updates from routing**: the card watches the part-page-level `refreshKey` counter. When the routing panel auto-saves, the parent bumps `refreshKey`, which reloads the breakdown and recomputes every tier's `base_cost_per_unit` and `unit_price` against the new cost basis.
 
+▸ **Bought-part Cost card (`PartProcurementPricingPanel`)**
+
+For **bought** parts, the workspace shows a **Cost** card with a single **Preferred vendor** picker (the *only* preferred-vendor control — it is no longer duplicated on the part-details/identity card; that field now appears only in the create flow) and a per-vendor qty-break cost-tier sheet (Min qty / Unit cost).
+
+- **Explicit Save** — cost is financial data, so edits are committed via a **Save costs** button (with an "Unsaved changes" hint), not auto-saved on blur, matching the made-part Pricing card. Deletes and additions are reconciled against the persisted sheet on save.
+- **No-cost state** — when the selected vendor has no saved tier yet, the sheet shows **one empty starter row highlighted red** plus a short red prompt ("Add at least one cost tier so this part can be priced and quoted."), replacing the previous yellow banner/"Add first tier" bubble. The red styling uses the theme `error` palette (never a hardcoded hex).
+- **Indicator clears on save** — the panel calls an `onSaved` callback so the workspace re-derives priceability immediately; the "Needs cost" chip (and the red prompt) clear on Save **without a page reload**. (Previously the chip lingered until reload because the panel had no refresh callback.)
+
 ▸ **Files tab (`FilesTab`)**
 
 A workspace tab (`?tab=files`, always visible) for engineering file attachments. This surface is part of the **office/admin dashboard** — it is not the operator shop-floor view, so nothing here is operator-facing.


### PR DESCRIPTION
Reworks the bought-part **Cost** card (`PartProcurementPricingPanel`) — items 10, 11, 12, 13 of the 13-item batch.

## Changes

- **#10 — De-duplicate preferred vendor.** The part-details/identity card no longer renders a "Preferred Vendor" field for an existing bought part; it stays only in the **create** flow (where the Cost card doesn't exist yet). The Cost card's picker is the single source.
- **#11 — Explicit Save.** Cost is financial data, so edits now commit via a **Save costs** button (with an "Unsaved changes" hint) instead of auto-saving on blur — matching the made-part Pricing card. Deletes, edits, and additions reconcile against the persisted sheet on save.
- **#12 — Indicator clears without reload.** The panel gains an `onSaved` callback that `WorkspaceTab` wires to `refreshAfterMutation()`, so the "Needs cost" chip re-derives immediately after a save. (Root cause: the panel previously had no refresh callback, so the chip lingered until a page reload.)
- **#13 — Red inline starter tier replaces the yellow banner.** For bought parts, `partSetupStatus` emits no `nextStep` banner; instead, when the selected vendor has no saved tier, the Cost sheet shows **one empty starter row highlighted red** (theme `error` palette — no hardcoded hex) plus a short red prompt, pointing the user straight at the cost to fill in. The made-part banner is unchanged.

## Tests

- `partSetupStatus.test.ts` — bought parts now yield `nextStep: null` (chip stays "Needs cost"); made-part guidance unchanged.
- New `PartProcurementPricingPanel.test.tsx` — red no-cost prompt + empty starter row, Save disabled until edited, saves via the button (not on blur), `onSaved` fired, preferred vendor re-asserted.
- `procurementTiersAccess.test.ts` unchanged (access layer untouched) and green.
- `pnpm exec tsc --noEmit` clean; 26 parts component tests pass.

## Docs

`docs/modules/parts.md` — new "Bought-part Cost card" subsection (explicit save, single vendor control, red no-cost state, indicator-clears-on-save).

🤖 Generated with [Claude Code](https://claude.com/claude-code)