### PR TITLE
feat(operator): scan-to-act inventory bin view

### DIFF
--- a/__tests__/components/operator/OperatorBinView.test.tsx
+++ b/__tests__/components/operator/OperatorBinView.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@mui/material/styles';
+import jiggedTheme from '@/lib/theme';
+
+import OperatorBinViewPage from '@/app/operator/[companyId]/inventory/locations/[locationId]/page';
+import {
+  resolveScan,
+  depleteStockAtLocation,
+} from '@/utils/inventoryLocationsAccess';
+import { getCurrentOperator } from '@/utils/operatorAccess';
+
+const mockPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ companyId: 'co1', locationId: 'loc1' }),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('@/utils/inventoryLocationsAccess', () => ({
+  resolveScan: vi.fn(),
+  addStockAtLocation: vi.fn(),
+  depleteStockAtLocation: vi.fn(),
+  adjustStockAtLocation: vi.fn(),
+}));
+
+vi.mock('@/utils/operatorAccess', () => ({
+  getCurrentOperator: vi.fn(),
+}));
+
+const loc = (over: { id: string; name: string; code?: string | null; parent_id?: string | null }) => ({
+  id: over.id,
+  company_id: 'co1',
+  parent_id: over.parent_id ?? null,
+  name: over.name,
+  kind: 'bin',
+  code: over.code ?? null,
+  is_stockable: true,
+  is_qr_anchor: false,
+  sort_order: 0,
+  created_at: '',
+  updated_at: '',
+});
+
+const scanWith = (children: ReturnType<typeof loc>[], contents: Array<{ part_id: string; part_name: string; primary_unit: string | null; quantity: number }>) => ({
+  node: loc({ id: 'loc1', name: 'Bin 3', code: 'C01-B03', parent_id: 'cab' }),
+  path: [loc({ id: 'cab', name: 'Cabinet 1' }), loc({ id: 'loc1', name: 'Bin 3', parent_id: 'cab' })],
+  children,
+  contents,
+});
+
+const renderPage = () => render(<OperatorBinViewPage />, { wrapper: ({ children }) => <ThemeProvider theme={jiggedTheme}>{children}</ThemeProvider> });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getCurrentOperator as ReturnType<typeof vi.fn>).mockResolvedValue({ id: 'op1', name: 'Sam', user_id: 'u1' });
+});
+
+describe('OperatorBinViewPage', () => {
+  it('shows the path, sub-locations (drill-down), and stock here', async () => {
+    (resolveScan as ReturnType<typeof vi.fn>).mockResolvedValue(
+      scanWith(
+        [loc({ id: 'sub1', name: 'Sub A', code: 'C01-B03-A' })],
+        [{ part_id: 'p1', part_name: 'Steel Rod', primary_unit: 'ea', quantity: 12 }],
+      ),
+    );
+    renderPage();
+
+    expect(await screen.findByText('Bin 3')).toBeInTheDocument();
+    expect(screen.getByText('Cabinet 1 › Bin 3')).toBeInTheDocument();
+    expect(screen.getByText('Sub A')).toBeInTheDocument(); // drill-down
+    expect(screen.getByText('Steel Rod')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+
+    // tapping a sub-location navigates into its bin view
+    await userEvent.click(screen.getByText('Sub A'));
+    expect(mockPush).toHaveBeenCalledWith('/operator/co1/inventory/locations/sub1');
+  });
+
+  it('shows an empty state when nothing is stored here', async () => {
+    (resolveScan as ReturnType<typeof vi.fn>).mockResolvedValue(scanWith([], []));
+    renderPage();
+    expect(await screen.findByText('Nothing stored here yet.')).toBeInTheDocument();
+  });
+
+  it('Remove depletes gracefully and stamps the operator', async () => {
+    (resolveScan as ReturnType<typeof vi.fn>).mockResolvedValue(
+      scanWith([], [{ part_id: 'p1', part_name: 'Steel Rod', primary_unit: 'ea', quantity: 12 }]),
+    );
+    (depleteStockAtLocation as ReturnType<typeof vi.fn>).mockResolvedValue({ location_balance: 7, part_quantity: 7 });
+    renderPage();
+
+    await userEvent.click(await screen.findByRole('button', { name: /^remove$/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    await userEvent.type(within(dialog).getByLabelText(/quantity/i), '5');
+    await userEvent.click(within(dialog).getByRole('button', { name: /^remove$/i }));
+
+    await waitFor(() =>
+      expect(depleteStockAtLocation).toHaveBeenCalledWith(
+        'p1',
+        'loc1',
+        5,
+        'ea',
+        expect.objectContaining({ graceful: true, operatorId: 'op1' }),
+      ),
+    );
+  });
+});

--- a/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
+++ b/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Card from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Chip from '@mui/material/Chip';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
+import TuneIcon from '@mui/icons-material/Tune';
+import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
+
+import { resolveScan } from '@/utils/inventoryLocationsAccess';
+import { getCurrentOperator } from '@/utils/operatorAccess';
+import { getStandardUnitsForUnit } from '@/lib/unitPresets';
+import type { ResolvedScan, LocationContent } from '@/types/inventoryLocations';
+import OperatorLocationActionModal, {
+  type OperatorLocationAction,
+} from '@/components/operator/OperatorLocationActionModal';
+
+const num = (n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 4 });
+
+export default function OperatorBinViewPage() {
+  const params = useParams();
+  const router = useRouter();
+  const companyId = params.companyId as string;
+  const locationId = params.locationId as string;
+
+  const [scan, setScan] = useState<ResolvedScan | null>(null);
+  const [operatorId, setOperatorId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [modal, setModal] = useState<{ action: OperatorLocationAction; part: LocationContent } | null>(
+    null,
+  );
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setScan(await resolveScan(locationId));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not open this location.');
+    } finally {
+      setLoading(false);
+    }
+  }, [locationId]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  // Operator id stamps the ledger; best-effort, never blocks the view.
+  useEffect(() => {
+    let cancelled = false;
+    getCurrentOperator(companyId)
+      .then((op) => {
+        if (!cancelled) setOperatorId(op?.id ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setOperatorId(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [companyId]);
+
+  const node = scan?.node ?? null;
+  const path = scan?.path ?? [];
+  const parent = path.length > 1 ? path[path.length - 2] : null;
+
+  const goBack = () => {
+    if (parent) router.push(`/operator/${companyId}/inventory/locations/${parent.id}`);
+    else router.push(`/operator/${companyId}/jobs`);
+  };
+
+  const modalUnit = modal?.part.primary_unit || 'ea';
+  const unitOptions = useMemo(
+    () => Array.from(new Set([modalUnit, ...getStandardUnitsForUnit(modalUnit)])).filter(Boolean),
+    [modalUnit],
+  );
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error || !node) {
+    return (
+      <Box>
+        <IconButton onClick={() => router.push(`/operator/${companyId}/jobs`)} aria-label="Back" sx={{ mb: 2 }}>
+          <ArrowBackIcon />
+        </IconButton>
+        <Alert severity="error">{error ?? 'Location not found.'}</Alert>
+      </Box>
+    );
+  }
+
+  const children = scan?.children ?? [];
+  const contents = scan?.contents ?? [];
+
+  return (
+    <Box sx={{ pb: 4 }}>
+      {/* Header: back + name + full path */}
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 3 }}>
+        <IconButton onClick={goBack} aria-label="Back" sx={{ mt: 0.5 }}>
+          <ArrowBackIcon />
+        </IconButton>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+            <Typography variant="h5" sx={{ fontWeight: 700 }}>
+              {node.name}
+            </Typography>
+            {node.code && <Chip size="small" label={node.code} variant="outlined" />}
+          </Stack>
+          {path.length > 1 && (
+            <Typography variant="body2" color="text.secondary">
+              {path.map((p) => p.name).join(' › ')}
+            </Typography>
+          )}
+        </Box>
+      </Box>
+
+      {/* Sub-locations: drill down */}
+      {children.length > 0 && (
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="overline" color="text.secondary">
+            Sub-locations
+          </Typography>
+          <Stack spacing={1} sx={{ mt: 0.5 }}>
+            {children.map((child) => (
+              <Card key={child.id} elevation={2}>
+                <CardActionArea
+                  onClick={() => router.push(`/operator/${companyId}/inventory/locations/${child.id}`)}
+                  sx={{ minHeight: 56 }}
+                >
+                  <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 1.5 }}>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography sx={{ fontWeight: 600 }}>{child.name}</Typography>
+                      {child.code && (
+                        <Typography variant="caption" color="text.secondary">
+                          {child.code}
+                        </Typography>
+                      )}
+                    </Box>
+                    <KeyboardArrowRightIcon color="action" />
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            ))}
+          </Stack>
+        </Box>
+      )}
+
+      {/* Stock here: act on each part */}
+      <Box>
+        <Typography variant="overline" color="text.secondary">
+          Stock here
+        </Typography>
+        {contents.length === 0 ? (
+          <Card elevation={2} sx={{ mt: 0.5 }}>
+            <CardContent sx={{ textAlign: 'center', py: 4 }}>
+              <Inventory2OutlinedIcon sx={{ fontSize: 40, color: 'text.disabled', mb: 1 }} />
+              <Typography color="text.secondary">
+                {children.length > 0
+                  ? 'No stock recorded directly here — open a sub-location above.'
+                  : 'Nothing stored here yet.'}
+              </Typography>
+            </CardContent>
+          </Card>
+        ) : (
+          <Stack spacing={1} sx={{ mt: 0.5 }}>
+            {contents.map((part) => (
+              <Card key={part.part_id} elevation={2}>
+                <CardContent>
+                  <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, flexWrap: 'wrap' }}>
+                    <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }}>
+                      {part.part_name}
+                    </Typography>
+                    <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                      {num(part.quantity)}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {part.primary_unit ?? ''}
+                    </Typography>
+                  </Box>
+                  <Stack direction="row" spacing={1} sx={{ mt: 1.5 }}>
+                    <Button
+                      fullWidth
+                      variant="contained"
+                      color="success"
+                      startIcon={<AddIcon />}
+                      onClick={() => setModal({ action: 'add', part })}
+                    >
+                      Add
+                    </Button>
+                    <Button
+                      fullWidth
+                      variant="contained"
+                      color="error"
+                      startIcon={<RemoveIcon />}
+                      onClick={() => setModal({ action: 'deplete', part })}
+                    >
+                      Remove
+                    </Button>
+                    <Button
+                      fullWidth
+                      variant="outlined"
+                      color="info"
+                      startIcon={<TuneIcon />}
+                      onClick={() => setModal({ action: 'adjust', part })}
+                    >
+                      Set
+                    </Button>
+                  </Stack>
+                </CardContent>
+              </Card>
+            ))}
+          </Stack>
+        )}
+      </Box>
+
+      {modal && (
+        <OperatorLocationActionModal
+          open
+          action={modal.action}
+          partId={modal.part.part_id}
+          partName={modal.part.part_name}
+          currentQuantity={modal.part.quantity}
+          primaryUnit={modalUnit}
+          unitOptions={unitOptions}
+          locationId={node.id}
+          locationName={node.name}
+          operatorId={operatorId}
+          onClose={() => setModal(null)}
+          onDone={reload}
+        />
+      )}
+    </Box>
+  );
+}

--- a/app/operator/[companyId]/login/page.tsx
+++ b/app/operator/[companyId]/login/page.tsx
@@ -35,12 +35,16 @@ export default function OperatorLoginPage() {
   const jobId = searchParams.get('job') || undefined;
   const partId = searchParams.get('part') || undefined;
   const operationId = searchParams.get('operation') || undefined;
+  const locationId = searchParams.get('location') || undefined;
 
-  // Where to land after auth, given the scanned QR's params. A per-operation QR
-  // (job + part + operation) jumps straight to that step's action view; a
-  // per-part QR (legacy travelers) to the part traveler; anything else — incl. a
-  // job-only scan, which we no longer print — falls back to the station jobs list.
+  // Where to land after auth, given the scanned QR's params. A location QR
+  // (printed on a bin/cabinet label) opens that location's bin view; a
+  // per-operation QR (job + part + operation) jumps straight to that step's
+  // action view; a per-part QR (legacy travelers) to the part traveler;
+  // anything else — incl. a job-only scan, which we no longer print — falls back
+  // to the station jobs list.
   const postLoginPath = () => {
+    if (locationId) return `/operator/${companyId}/inventory/locations/${locationId}`;
     if (jobId && partId && operationId) {
       return `/operator/${companyId}/jobs/${jobId}/parts/${partId}/operations/${operationId}`;
     }
@@ -95,7 +99,7 @@ export default function OperatorLoginPage() {
 
     checkSession();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [companyId, router, stationId, jobId, partId, operationId, supabase]);
+  }, [companyId, router, stationId, jobId, partId, operationId, locationId, supabase]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/components/operator/OperatorLocationActionModal.tsx
+++ b/components/operator/OperatorLocationActionModal.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+
+import {
+  addStockAtLocation,
+  depleteStockAtLocation,
+  adjustStockAtLocation,
+} from '@/utils/inventoryLocationsAccess';
+
+export type OperatorLocationAction = 'add' | 'deplete' | 'adjust';
+
+const TITLES: Record<OperatorLocationAction, string> = {
+  add: 'Add stock',
+  deplete: 'Remove stock',
+  adjust: 'Set stock (cycle count)',
+};
+
+const CONFIRM: Record<OperatorLocationAction, string> = {
+  add: 'Add',
+  deplete: 'Remove',
+  adjust: 'Set',
+};
+
+interface OperatorLocationActionModalProps {
+  open: boolean;
+  action: OperatorLocationAction;
+  partId: string;
+  partName: string;
+  /** Current on-hand at this location, for context. */
+  currentQuantity: number;
+  primaryUnit: string;
+  unitOptions: string[];
+  locationId: string;
+  locationName: string;
+  /** user_company_access.id of the signed-in operator (for the ledger). */
+  operatorId: string | null;
+  onClose: () => void;
+  onDone: () => void | Promise<void>;
+}
+
+/**
+ * Operator-facing Add / Remove / Set for ONE part at ONE (already-scanned)
+ * location. Unlike the admin PartLocationActionModal the part and location are
+ * fixed (no pickers), and a removal is ALWAYS graceful — over-consumption is
+ * clamped to zero and flagged as a discrepancy rather than blocked, and is
+ * stamped with the operator id — matching the shop-floor persona.
+ */
+export default function OperatorLocationActionModal({
+  open,
+  action,
+  partId,
+  partName,
+  currentQuantity,
+  primaryUnit,
+  unitOptions,
+  locationId,
+  locationName,
+  operatorId,
+  onClose,
+  onDone,
+}: OperatorLocationActionModalProps) {
+  const [quantity, setQuantity] = useState('');
+  const [unit, setUnit] = useState(primaryUnit);
+  const [notes, setNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleEnter = () => {
+    setQuantity('');
+    setUnit(primaryUnit);
+    setNotes('');
+    setError(null);
+  };
+
+  const qtyLabel = action === 'adjust' ? 'New quantity here' : 'Quantity';
+
+  const handleSubmit = async () => {
+    const qty = parseFloat(quantity);
+    if (!Number.isFinite(qty) || (action === 'adjust' ? qty < 0 : qty <= 0)) {
+      setError(action === 'adjust' ? 'Quantity cannot be negative.' : 'Quantity must be positive.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      if (action === 'add') {
+        await addStockAtLocation(partId, locationId, qty, unit, notes || undefined);
+      } else if (action === 'deplete') {
+        await depleteStockAtLocation(partId, locationId, qty, unit, {
+          graceful: true,
+          notes: notes || undefined,
+          operatorId: operatorId || undefined,
+        });
+      } else {
+        await adjustStockAtLocation(partId, locationId, qty, unit, notes || undefined);
+      }
+      await onDone();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update stock.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={saving ? undefined : onClose}
+      maxWidth="xs"
+      fullWidth
+      TransitionProps={{ onEnter: handleEnter }}
+    >
+      <DialogTitle>{TITLES[action]}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            <strong>{partName}</strong> at <strong>{locationName}</strong> — {currentQuantity}{' '}
+            {primaryUnit} here now
+          </Typography>
+          <Stack direction="row" spacing={1}>
+            <TextField
+              label={qtyLabel}
+              type="number"
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+              inputProps={{ min: 0, step: 'any', inputMode: 'decimal' }}
+              fullWidth
+              autoFocus
+            />
+            <TextField
+              select
+              label="Unit"
+              value={unit}
+              onChange={(e) => setUnit(e.target.value)}
+              sx={{ minWidth: 120 }}
+            >
+              {unitOptions.map((u) => (
+                <MenuItem key={u} value={u}>
+                  {u}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Stack>
+          {action === 'deplete' && (
+            <Typography variant="caption" color="text.secondary">
+              Removing more than is here records the shortfall and sets the count to zero — it
+              won&apos;t block you.
+            </Typography>
+          )}
+          <TextField
+            label="Notes (optional)"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            multiline
+            minRows={2}
+            fullWidth
+          />
+          {error && <Alert severity="error">{error}</Alert>}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving} size="large">
+          Cancel
+        </Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={saving} size="large">
+          {CONFIRM[action]}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## What & why

Completes the **operator-facing half** of inventory locations — the actual shop-floor payoff of the whole feature. Admins could already build the location tree and **print QR labels** (PRs #414/#419), but scanning one logged the operator in and **dumped them on the jobs list**: `postLoginPath()` ignored `?location=`, the bin-view page didn't exist, and `resolveScan()` had zero consumers. So per-bin balances + printed labels weren't actionable from the floor.

## Changes

- **Bin-view page** `app/operator/[companyId]/inventory/locations/[locationId]/page.tsx`
  - **Parent** → drill-down list of sub-locations (full path shown), each opening its own bin view.
  - **Contents** → the parts + quantities stored *at this location*, each with **Add / Remove / Set**.
  - Mobile-first, ≥48px touch targets, dark shop-floor theme; auth handled by the existing operator layout. Wires the existing `resolveScan()`.
- **`OperatorLocationActionModal`** — part + location are fixed (no pickers, unlike the admin modal). **Removal is always graceful**: over-consumption clamps to zero and is flagged, never blocked, and is stamped with the operator id (`getCurrentOperator`).
- **Login routing** — `postLoginPath()` now routes a scanned `?location=` to the bin view (the URL the printed labels already encode via `buildLocationScanUrl`).

## Deferred (follow-ups)
- **Tag a removal to a job/operation + BOM-expected prefill** — a bare bin scan has no station/job context (`getOperatorJobs` returns nothing without a station), so this needs a small flow design. The ledger already records operator + location + notes.
- **"Add a part not yet here" picker** (receiving a new SKU into a bin) — current view acts on parts already present.

## Validation
- `tsc` clean; full **Vitest 700** (3 new tests: drill-down nav, empty state, graceful-remove stamps operator); lint clean (baseline data-fetch warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)