### PR TITLE
feat(work-centers): remove external setup cost (external work bills once per part)

### DIFF
--- a/__tests__/utils/routingCostCalculation.test.ts
+++ b/__tests__/utils/routingCostCalculation.test.ts
@@ -7,7 +7,7 @@ import type { BomLineWithChildPart } from '@/types/bom';
  *
  * Behaviors under test:
  *   - Internal ops: cost = (cycle + setup) × COALESCE(override, wc.labor_rate) / 60
- *   - External ops: cost = unit_price (per-unit) + setup_cost (one-time)
+ *   - External ops: cost = unit_price (per-unit); no setup cost (external work bills once)
  *   - BOM materials: per-unit cost = bom.quantity × getComputedPartCost(child_id, qty)
  *     (the SQL function compute_part_cost_at_qty handles tier cascade and
  *     unit conversion internally — the TS layer just multiplies)
@@ -89,7 +89,6 @@ interface OpOverrides {
   cycle_minutes_per_unit?: number | null;
   labor_rate_override?: number | null;
   external_unit_price?: number | null;
-  external_setup_cost?: number | null;
   work_center?: RoutingOperationWithWorkCenter['work_center'];
 }
 
@@ -103,7 +102,6 @@ function makeOp(overrides: OpOverrides = {}): RoutingOperationWithWorkCenter {
     cycle_minutes_per_unit: overrides.cycle_minutes_per_unit ?? null,
     labor_rate_override: overrides.labor_rate_override ?? null,
     external_unit_price: overrides.external_unit_price ?? null,
-    external_setup_cost: overrides.external_setup_cost ?? null,
     instructions: null,
     metadata: {},
     created_at: '2024-01-01T00:00:00Z',
@@ -310,10 +308,9 @@ describe('calculateRoutingCost', () => {
       vendor: { id: 'v-1', name: 'PerformCoat Finishing' },
     };
 
-    it('prices unit_price as per-unit and setup_cost as one-time', async () => {
+    it('prices external ops as per-unit unit_price with zero setup', async () => {
       const op = makeOp({
         external_unit_price: 4.5,
-        external_setup_cost: 75,
         work_center: externalWc,
       });
       mockGetRoutingForPart.mockResolvedValue(makeRouting([op]));
@@ -323,33 +320,19 @@ describe('calculateRoutingCost', () => {
       expect(result!.warnings).toEqual([]);
       expect(result!.labor_items).toHaveLength(1);
       expect(result!.labor_items[0].cost).toBe(4.5);
-      expect(result!.labor_items[0].setup_cost).toBe(75);
+      // External work bills once per part — there is no setup cost.
+      expect(result!.labor_items[0].setup_cost).toBe(0);
       // External ops never carry time — those fields stay zero
       expect(result!.labor_items[0].run_time_minutes).toBe(0);
       expect(result!.labor_items[0].setup_time_minutes).toBe(0);
       expect(result!.labor_items[0].labor_rate).toBe(0);
     });
 
-    it('treats unit_price-only as zero setup', async () => {
-      const op = makeOp({
-        external_unit_price: 10,
-        external_setup_cost: null,
-        work_center: externalWc,
-      });
-      mockGetRoutingForPart.mockResolvedValue(makeRouting([op]));
-
-      const result = await calculateRoutingCost('part-1');
-
-      expect(result!.labor_items[0].cost).toBe(10);
-      expect(result!.labor_items[0].setup_cost).toBe(0);
-    });
-
-    it('emits missing_external_pricing when both fields are null', async () => {
-      // Mirrors recalculate_part_cost's SQL guard: free outside ops are
-      // meaningless, so we refuse to price as $0.
+    it('emits missing_external_pricing when there is no unit price', async () => {
+      // Mirrors compute_part_cost_at_qty's SQL guard: an external op with no
+      // unit price is meaningless, so we refuse to price it as $0.
       const op = makeOp({
         external_unit_price: null,
-        external_setup_cost: null,
         work_center: externalWc,
       });
       mockGetRoutingForPart.mockResolvedValue(makeRouting([op]));
@@ -382,7 +365,6 @@ describe('calculateRoutingCost', () => {
       const externalOp = makeOp({
         id: 'op-ext',
         external_unit_price: 4.5,
-        external_setup_cost: 75,
         work_center: {
           id: 'wc-ext',
           name: 'PerformCoat',
@@ -399,8 +381,8 @@ describe('calculateRoutingCost', () => {
       expect(result!.labor_items).toHaveLength(2);
       // labor (per-unit run + per-unit external unit_price)
       expect(result!.total_labor_cost).toBeCloseTo(12 + 4.5, 2);
-      // setup (internal + external one-time)
-      expect(result!.total_setup_cost).toBeCloseTo(60 + 75, 2);
+      // setup (internal only — external work has no setup cost)
+      expect(result!.total_setup_cost).toBeCloseTo(60, 2);
     });
   });
 

--- a/__tests__/utils/routingsAccess.test.ts
+++ b/__tests__/utils/routingsAccess.test.ts
@@ -123,7 +123,6 @@ describe('routingsAccess', () => {
           cycle_minutes_per_unit: '2.5',
           labor_rate_override: '',
           external_unit_price: '',
-          external_setup_cost: '',
           instructions: '  do the thing  ',
         },
         30,

--- a/app/dashboard/[companyId]/work-centers/[workCenterId]/page.tsx
+++ b/app/dashboard/[companyId]/work-centers/[workCenterId]/page.tsx
@@ -251,8 +251,8 @@ export default function WorkCenterDetailPage() {
                     <Typography variant="body2" sx={{ mt: 0.5 }}>
                       External work centers price per routing operation. Each
                       routing op sets its own{' '}
-                      <strong>external_unit_price</strong> and{' '}
-                      <strong>external_setup_cost</strong> for this vendor.
+                      <strong>vendor unit price</strong> for this vendor — external
+                      work bills once per part, so there is no setup cost.
                     </Typography>
                   </Box>
                 )}

--- a/components/parts/PartRoutingPanel.tsx
+++ b/components/parts/PartRoutingPanel.tsx
@@ -42,7 +42,6 @@ function rowFromOperation(op: RoutingOperationWithWorkCenter): OperationRowData 
     laborRateOverride: op.labor_rate_override,
     workCenterLaborRate: op.work_center?.labor_rate ?? null,
     externalUnitPrice: op.external_unit_price,
-    externalSetupCost: op.external_setup_cost,
     instructions: op.instructions,
   };
 }
@@ -114,7 +113,6 @@ export default function PartRoutingPanel({
               cycleMinutesPerUnit: o.cycleMinutesPerUnit,
               laborRateOverride: o.laborRateOverride,
               externalUnitPrice: o.externalUnitPrice,
-              externalSetupCost: o.externalSetupCost,
               instructions: o.instructions,
             })),
             originalOpIds,

--- a/components/routings/RoutingOperationRow.tsx
+++ b/components/routings/RoutingOperationRow.tsx
@@ -42,10 +42,8 @@ export interface OperationRowData {
    *  `laborRateOverride` this flags a missing rate (neither set → the
    *  operation can't be priced), highlighted inline on the row. */
   workCenterLaborRate: number | null;
-  /** External: per-unit price the vendor charges. */
+  /** External: per-unit price the vendor charges (external work has no setup). */
   externalUnitPrice: number | null;
-  /** External: flat per-batch setup cost the vendor charges. */
-  externalSetupCost: number | null;
   instructions: string | null;
 }
 
@@ -79,7 +77,7 @@ export default function RoutingOperationRow({
   // Localized validation: surface the exact blocker on the offending row
   // (instead of only a top-of-card "Heads up" banner). An internal op with no
   // labor rate (override or work-center default) can't be priced; an external
-  // op needs at least a unit price or a setup cost.
+  // op needs a unit price (external work has no setup cost).
   const missingLaborRate =
     !placeholder &&
     !isExternal &&
@@ -88,12 +86,11 @@ export default function RoutingOperationRow({
   const missingExternalPricing =
     !placeholder &&
     isExternal &&
-    !(row.externalUnitPrice && row.externalUnitPrice > 0) &&
-    !(row.externalSetupCost && row.externalSetupCost > 0);
+    !(row.externalUnitPrice && row.externalUnitPrice > 0);
   const errorMessage = missingLaborRate
     ? 'Missing labor rate — set a rate on this operation, or a default on its work center.'
     : missingExternalPricing
-      ? 'Missing pricing — add a unit price or setup cost for this external step.'
+      ? 'Missing pricing — add a unit price for this external step.'
       : null;
 
   // Build the per-row caption based on kind.
@@ -101,9 +98,7 @@ export default function RoutingOperationRow({
   let captionRight: string;
   let captionRightWarning = false;
   if (isExternal) {
-    captionLeft = row.externalSetupCost && row.externalSetupCost > 0
-      ? `Setup $${row.externalSetupCost.toFixed(2)}`
-      : 'No setup cost';
+    captionLeft = 'External';
     captionRight = row.externalUnitPrice && row.externalUnitPrice > 0
       ? `$${row.externalUnitPrice.toFixed(2)}/unit`
       : 'No unit price';

--- a/components/routings/RoutingOperationRowEditor.tsx
+++ b/components/routings/RoutingOperationRowEditor.tsx
@@ -32,10 +32,8 @@ export interface OperationEditorValue {
   cycleMinutesPerUnit: number | null;
   /** Internal: optional override for the work center's labor rate ($/hr). */
   laborRateOverride: number | null;
-  /** External: per-unit price ($). */
+  /** External: per-unit price ($). External work bills once per part — no setup. */
   externalUnitPrice: number | null;
-  /** External: flat per-batch setup cost ($). */
-  externalSetupCost: number | null;
   instructions: string | null;
 }
 
@@ -84,9 +82,6 @@ export default function RoutingOperationRowEditor({
   const [externalUnitPriceStr, setExternalUnitPriceStr] = useState(
     numToStr(initial?.externalUnitPrice),
   );
-  const [externalSetupCostStr, setExternalSetupCostStr] = useState(
-    numToStr(initial?.externalSetupCost),
-  );
   const [instructions, setInstructions] = useState(initial?.instructions ?? '');
   const [touched, setTouched] = useState(false);
 
@@ -96,7 +91,6 @@ export default function RoutingOperationRowEditor({
     setCycleStr(numToStr(initial?.cycleMinutesPerUnit));
     setLaborOverrideStr(initialLaborStr(initial));
     setExternalUnitPriceStr(numToStr(initial?.externalUnitPrice));
-    setExternalSetupCostStr(numToStr(initial?.externalSetupCost));
     setInstructions(initial?.instructions ?? '');
     setTouched(false);
   }, [initial]);
@@ -129,21 +123,14 @@ export default function RoutingOperationRowEditor({
     touched && cycleStr !== '' && (cycleParsed === null || cycleParsed < 0);
 
   const externalUnitPriceParsed = parseOptionalNumber(externalUnitPriceStr);
-  const externalSetupCostParsed = parseOptionalNumber(externalSetupCostStr);
   const extUnitPriceError =
     touched &&
     externalUnitPriceStr !== '' &&
     (externalUnitPriceParsed === null || externalUnitPriceParsed < 0);
-  const extSetupCostError =
-    touched &&
-    externalSetupCostStr !== '' &&
-    (externalSetupCostParsed === null || externalSetupCostParsed < 0);
 
   const internalHasAny =
     (setupParsed !== null && setupParsed > 0) || (cycleParsed !== null && cycleParsed > 0);
-  const externalHasAny =
-    (externalUnitPriceParsed !== null && externalUnitPriceParsed > 0) ||
-    (externalSetupCostParsed !== null && externalSetupCostParsed > 0);
+  const externalHasAny = externalUnitPriceParsed !== null && externalUnitPriceParsed > 0;
   const hasAnyValue = isExternal ? externalHasAny : internalHasAny;
   const atLeastOneError = touched && !hasAnyValue;
 
@@ -151,14 +138,13 @@ export default function RoutingOperationRowEditor({
     setTouched(true);
     if (!workCenter) return;
     if (isExternal) {
-      if (extUnitPriceError || extSetupCostError || !externalHasAny) return;
+      if (extUnitPriceError || !externalHasAny) return;
       onSave({
         workCenter,
         setupMinutes: null,
         cycleMinutesPerUnit: null,
         laborRateOverride: null,
         externalUnitPrice: externalUnitPriceParsed,
-        externalSetupCost: externalSetupCostParsed,
         instructions: instructions.trim() || null,
       });
     } else {
@@ -180,7 +166,6 @@ export default function RoutingOperationRowEditor({
         cycleMinutesPerUnit: cycleParsed,
         laborRateOverride,
         externalUnitPrice: null,
-        externalSetupCost: null,
         instructions: instructions.trim() || null,
       });
     }
@@ -258,6 +243,8 @@ export default function RoutingOperationRowEditor({
 
       {isExternal ? (
         <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap' }}>
+          {/* External (vendor) work bills once per part — a unit price only,
+              no setup cost (setup is an internal-only concept). */}
           <TextField
             size="small"
             label="Vendor unit price ($)"
@@ -271,20 +258,6 @@ export default function RoutingOperationRowEditor({
             }}
             error={!!extUnitPriceError}
             helperText={extUnitPriceError ? 'Enter a non-negative number.' : ' '}
-            sx={{ flex: 1, minWidth: 180 }}
-          />
-          <TextField
-            size="small"
-            label="Vendor setup cost ($)"
-            type="text"
-            inputMode="decimal"
-            value={externalSetupCostStr}
-            onChange={(e) => {
-              const v = e.target.value;
-              if (v === '' || /^\d*\.?\d*$/.test(v)) setExternalSetupCostStr(v);
-            }}
-            error={!!extSetupCostError}
-            helperText={extSetupCostError ? 'Enter a non-negative number.' : ' '}
             sx={{ flex: 1, minWidth: 180 }}
           />
         </Box>

--- a/components/routings/RoutingOperationsList.tsx
+++ b/components/routings/RoutingOperationsList.tsx
@@ -85,7 +85,6 @@ export default function RoutingOperationsList({
         cycleMinutesPerUnit: value.cycleMinutesPerUnit,
         laborRateOverride: value.laborRateOverride,
         externalUnitPrice: value.externalUnitPrice,
-        externalSetupCost: value.externalSetupCost,
         instructions: value.instructions,
       };
       onChange([...rows, newRow]);
@@ -98,7 +97,6 @@ export default function RoutingOperationsList({
         cycleMinutesPerUnit: value.cycleMinutesPerUnit,
         laborRateOverride: value.laborRateOverride,
         externalUnitPrice: value.externalUnitPrice,
-        externalSetupCost: value.externalSetupCost,
         instructions: value.instructions,
       };
       onChange(copy);
@@ -124,7 +122,6 @@ export default function RoutingOperationsList({
         cycleMinutesPerUnit: editingRow.cycleMinutesPerUnit,
         laborRateOverride: editingRow.laborRateOverride,
         externalUnitPrice: editingRow.externalUnitPrice,
-        externalSetupCost: editingRow.externalSetupCost,
         instructions: editingRow.instructions,
       }
     : undefined;

--- a/components/routings/RoutingViewer.tsx
+++ b/components/routings/RoutingViewer.tsx
@@ -41,10 +41,6 @@ export default function RoutingViewer({ routing }: RoutingViewerProps) {
                 const isExternal = op.work_center?.kind === 'external';
                 const secondaryText = isExternal
                   ? `Vendor ${op.work_center?.vendor?.name ?? 'unknown'} • ${
-                      op.external_setup_cost && op.external_setup_cost > 0
-                        ? `Setup $${op.external_setup_cost.toFixed(2)}`
-                        : 'No setup cost'
-                    } • ${
                       op.external_unit_price && op.external_unit_price > 0
                         ? `$${op.external_unit_price.toFixed(2)}/unit`
                         : 'No unit price'

--- a/components/work-centers/WorkCenterForm.tsx
+++ b/components/work-centers/WorkCenterForm.tsx
@@ -269,8 +269,9 @@ export default function WorkCenterForm({
             </Grid>
 
             {/* Kind-conditional fields: only one of these is valid at a time per the DB CHECK constraint.
-                External work centers price per routing operation (external_unit_price +
-                external_setup_cost), so labor_rate is hidden entirely — see hint below. */}
+                External work centers price per routing operation (external_unit_price —
+                external work bills once per part, no setup cost), so labor_rate is hidden
+                entirely — see hint below. */}
             {formData.kind === 'internal' && (
               <Grid size={{ xs: 12, sm: 6 }}>
                 <TextField
@@ -306,9 +307,9 @@ export default function WorkCenterForm({
                     External work centers price per routing operation
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
-                    Set <strong>external_unit_price</strong> and{' '}
-                    <strong>external_setup_cost</strong> on each routing operation
-                    that uses this work center, not on the work center itself.
+                    Set the <strong>vendor unit price</strong> on each routing
+                    operation that uses this work center, not on the work center
+                    itself. External work bills once per part — there is no setup cost.
                   </Typography>
                 </Alert>
               </Grid>

--- a/docs/modules/work-centers.md
+++ b/docs/modules/work-centers.md
@@ -28,7 +28,7 @@ A **work center** is a unit of production capacity. It can be **internal** (a ma
 | `metadata` | jsonb (e.g. `{code: "WC-LATHE-01"}` used for the Station QR code on internal work centers) |
 | `created_at`, `updated_at` | |
 
-External work centers do **not** carry a labor_rate on the work-center row. Their cost is set per routing operation (`routing_operations.external_unit_price`, `routing_operations.external_setup_cost`) — pricing is per-operation, not per-vendor.
+External work centers do **not** carry a labor_rate on the work-center row. Their cost is a single **vendor unit price** set per routing operation (`routing_operations.external_unit_price`) — pricing is per-operation, not per-vendor. External (vendor) work **bills once per part, so there is no setup cost** — setup is an internal-only concept (the `external_setup_cost` column was dropped in June 2026).
 
 ---
 

--- a/supabase/migrations/20260623022617_drop_external_setup_cost.sql
+++ b/supabase/migrations/20260623022617_drop_external_setup_cost.sql
@@ -1,0 +1,484 @@
+-- Remove external work-center setup cost: external (vendor) work bills once
+-- per part, so setup is an internal-only concept. Drops
+-- routing_operations.external_setup_cost, and updates the three functions that
+-- reference it (compute_part_cost_at_qty, get_priceable_part_ids, seed_demo_data)
+-- to treat an external op as priced iff external_unit_price IS NOT NULL.
+
+-- ---------------------------------------------------------------------------
+-- 1. compute_part_cost_at_qty — drop the external_setup_cost amortization term
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.compute_part_cost_at_qty(p_part_id uuid, p_qty numeric)
+ RETURNS numeric
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+DECLARE
+    v_source text;
+    v_part_name text;
+    v_preferred_vendor_id uuid;
+    v_routing_id uuid;
+    v_total numeric := 0;
+    v_op RECORD;
+    v_op_cost numeric;
+    v_bom RECORD;
+    v_to_primary_factor numeric;
+    v_qty_in_primary_unit numeric;
+    v_child_cost numeric;
+    v_tier_cost numeric;
+BEGIN
+    IF p_qty IS NULL OR p_qty <= 0 THEN
+        RAISE EXCEPTION 'compute_part_cost_at_qty: p_qty must be > 0 (got %)', p_qty
+            USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT source, part_name, preferred_vendor_id
+      INTO v_source, v_part_name, v_preferred_vendor_id
+      FROM public.parts
+     WHERE id = p_part_id;
+    IF v_source IS NULL THEN
+        RAISE EXCEPTION 'compute_part_cost_at_qty: part % not found', p_part_id;
+    END IF;
+
+    -- ---------- Bought parts: resolve to a preferred-vendor tier ----------
+    IF v_source = 'bought' THEN
+        IF v_preferred_vendor_id IS NULL THEN
+            RETURN NULL;
+        END IF;
+        SELECT t.cost_per_unit
+          INTO v_tier_cost
+          FROM public.part_procurement_tiers t
+         WHERE t.part_id = p_part_id
+           AND t.vendor_id = v_preferred_vendor_id
+           AND t.min_quantity <= p_qty
+           AND (t.expires_at IS NULL OR t.expires_at >= CURRENT_DATE)
+         ORDER BY t.cost_per_unit ASC,
+                  t.min_quantity DESC
+         LIMIT 1;
+        RETURN v_tier_cost;
+    END IF;
+
+    -- ---------- Made parts: own routing + BOM rollup ----------
+    SELECT id INTO v_routing_id FROM public.routings WHERE part_id = p_part_id;
+
+    IF v_routing_id IS NOT NULL THEN
+        FOR v_op IN
+            SELECT ro.setup_minutes,
+                   ro.cycle_minutes_per_unit,
+                   ro.labor_rate_override,
+                   ro.external_unit_price,
+                   wc.kind          AS wc_kind,
+                   wc.labor_rate    AS wc_labor_rate
+              FROM public.routing_operations ro
+              JOIN public.work_centers wc ON wc.id = ro.work_center_id
+             WHERE ro.routing_id = v_routing_id
+        LOOP
+            IF v_op.wc_kind = 'internal' THEN
+                IF v_op.labor_rate_override IS NULL AND v_op.wc_labor_rate IS NULL THEN
+                    RAISE EXCEPTION
+                        'Cannot compute cost for part %: internal routing op has no labor rate (neither override nor work_center default)',
+                        v_part_name
+                        USING ERRCODE = 'check_violation';
+                END IF;
+                v_op_cost := (COALESCE(v_op.setup_minutes, 0) / p_qty
+                              + COALESCE(v_op.cycle_minutes_per_unit, 0))
+                             * COALESCE(v_op.labor_rate_override, v_op.wc_labor_rate)
+                             / 60.0;
+            ELSE
+                IF v_op.external_unit_price IS NULL THEN
+                    RAISE EXCEPTION
+                        'Cannot compute cost for part %: external routing op has no unit price (external_unit_price is required)',
+                        v_part_name
+                        USING ERRCODE = 'check_violation';
+                END IF;
+                v_op_cost := COALESCE(v_op.external_unit_price, 0);
+            END IF;
+            v_total := v_total + v_op_cost;
+        END LOOP;
+    END IF;
+
+    FOR v_bom IN
+        SELECT b.quantity,
+               b.unit,
+               b.child_part_id,
+               c.primary_unit AS child_primary_unit,
+               c.part_name    AS child_part_name
+          FROM public.parts_bom b
+          JOIN public.parts c ON c.id = b.child_part_id
+         WHERE b.parent_part_id = p_part_id
+    LOOP
+        IF v_bom.unit IS DISTINCT FROM v_bom.child_primary_unit THEN
+            SELECT to_primary_factor INTO v_to_primary_factor
+              FROM public.parts_unit_conversions
+             WHERE part_id = v_bom.child_part_id
+               AND from_unit = v_bom.unit;
+            IF v_to_primary_factor IS NULL THEN
+                RAISE EXCEPTION
+                    'No unit conversion from % to % for part %',
+                    v_bom.unit, v_bom.child_primary_unit, v_bom.child_part_name
+                    USING ERRCODE = 'check_violation';
+            END IF;
+            v_qty_in_primary_unit := v_bom.quantity * v_to_primary_factor;
+        ELSE
+            v_qty_in_primary_unit := v_bom.quantity;
+        END IF;
+
+        v_child_cost := public.compute_part_cost_at_qty(
+            v_bom.child_part_id,
+            p_qty * v_qty_in_primary_unit
+        );
+
+        IF v_child_cost IS NULL THEN
+            RETURN NULL;
+        END IF;
+
+        v_total := v_total + v_qty_in_primary_unit * v_child_cost;
+    END LOOP;
+
+    RETURN v_total;
+END;
+$function$
+
+;
+
+-- ---------------------------------------------------------------------------
+-- 2. get_priceable_part_ids — external op is priced iff external_unit_price set
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_priceable_part_ids(p_company_id uuid)
+ RETURNS uuid[]
+ LANGUAGE plpgsql
+ STABLE
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_priceable uuid[];
+    v_new uuid[];
+BEGIN
+    -- Base case: bought parts that have at least one pricing tier AND a
+    -- non-expired procurement tier on their preferred vendor.
+    SELECT COALESCE(array_agg(DISTINCT p.id), ARRAY[]::uuid[])
+    INTO v_priceable
+    FROM public.parts p
+    WHERE p.company_id = p_company_id
+      AND p.source = 'bought'
+      AND p.preferred_vendor_id IS NOT NULL
+      AND EXISTS (
+          SELECT 1
+          FROM public.part_pricing_tiers t
+          WHERE t.part_id = p.id
+      )
+      AND EXISTS (
+          SELECT 1
+          FROM public.part_procurement_tiers pt
+          WHERE pt.part_id = p.id
+            AND pt.vendor_id = p.preferred_vendor_id
+            AND (pt.expires_at IS NULL OR pt.expires_at >= CURRENT_DATE)
+      );
+
+    -- Fixed-point: add made parts whose routing is complete and whose BOM
+    -- children (if any) are all already in v_priceable. Loop terminates
+    -- when no new parts are added — bounded by BOM depth.
+    LOOP
+        SELECT COALESCE(array_agg(p.id), ARRAY[]::uuid[])
+        INTO v_new
+        FROM public.parts p
+        WHERE p.company_id = p_company_id
+          AND p.source = 'made'
+          AND NOT (p.id = ANY(v_priceable))
+          AND EXISTS (
+              SELECT 1
+              FROM public.part_pricing_tiers t
+              WHERE t.part_id = p.id
+          )
+          -- Every routing op (if any) must have full pricing. NOT EXISTS
+          -- with an unpriced op is the negative form of "all priced".
+          AND NOT EXISTS (
+              SELECT 1
+              FROM public.routings r
+              JOIN public.routing_operations ro ON ro.routing_id = r.id
+              JOIN public.work_centers wc ON wc.id = ro.work_center_id
+              WHERE r.part_id = p.id
+                AND (
+                    (wc.kind = 'internal'
+                        AND ro.labor_rate_override IS NULL
+                        AND wc.labor_rate IS NULL)
+                    OR
+                    (wc.kind <> 'internal'
+                        AND ro.external_unit_price IS NULL)
+                )
+          )
+          -- Every BOM child must already be priceable. A made part with no
+          -- BOM children passes this check trivially (NOT EXISTS over empty).
+          AND NOT EXISTS (
+              SELECT 1
+              FROM public.parts_bom b
+              WHERE b.parent_part_id = p.id
+                AND NOT (b.child_part_id = ANY(v_priceable))
+          );
+
+        EXIT WHEN cardinality(v_new) = 0;
+        v_priceable := v_priceable || v_new;
+    END LOOP;
+
+    RETURN v_priceable;
+END;
+$function$
+
+;
+
+-- ---------------------------------------------------------------------------
+-- 3. seed_demo_data — stop inserting external_setup_cost on demo routing ops
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.seed_demo_data(p_company_id uuid, p_user_id uuid, p_template_name text DEFAULT 'default'::text)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+    v_template jsonb;
+    v_ref_map jsonb := '{}'::jsonb;
+    v_item jsonb;
+    v_inner jsonb;
+    v_contact jsonb;
+    v_new_id uuid;
+    v_routing_id uuid;
+    v_quote_id uuid;
+    v_job_id uuid;
+    v_job_part_id uuid;
+    v_part_id uuid;
+    v_part_source text;
+    v_part_cost numeric;
+BEGIN
+    SELECT template_data INTO v_template
+    FROM demo_data_templates
+    WHERE name = p_template_name AND is_active = true
+    LIMIT 1;
+
+    IF v_template IS NULL THEN
+        RAISE EXCEPTION 'No active demo template found with name: %', p_template_name;
+    END IF;
+
+    IF v_template->'vendors' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'vendors') LOOP
+            v_new_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_new_id::text));
+            INSERT INTO vendors (id, company_id, name,
+                                 address_line1, address_line2, city, state, postal_code, country,
+                                 legacy_id)
+            VALUES (v_new_id, p_company_id, v_item->>'name',
+                    v_item->>'address_line1', v_item->>'address_line2',
+                    v_item->>'city', v_item->>'state', v_item->>'postal_code',
+                    COALESCE(v_item->>'country', 'USA'),
+                    v_item->>'legacy_id');
+
+            IF v_item->'contacts' IS NOT NULL THEN
+                FOR v_contact IN SELECT * FROM jsonb_array_elements(v_item->'contacts') LOOP
+                    INSERT INTO vendor_contacts (vendor_id, name, role, role_label,
+                                                 email, phone, is_primary)
+                    VALUES (v_new_id,
+                            v_contact->>'name',
+                            COALESCE(v_contact->>'role', 'sales'),
+                            v_contact->>'role_label',
+                            v_contact->>'email',
+                            v_contact->>'phone',
+                            COALESCE((v_contact->>'is_primary')::boolean, false));
+                END LOOP;
+            END IF;
+        END LOOP;
+    END IF;
+
+    IF v_template->'work_centers' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'work_centers') LOOP
+            v_new_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_new_id::text));
+            INSERT INTO work_centers (id, company_id, name, kind, vendor_id,
+                                      labor_rate, description)
+            VALUES (v_new_id, p_company_id,
+                    v_item->>'name',
+                    COALESCE(v_item->>'kind', 'internal'),
+                    CASE WHEN v_item->>'vendor_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'vendor_ref'))::uuid
+                         ELSE NULL END,
+                    NULLIF(v_item->>'labor_rate', '')::numeric,
+                    v_item->>'description');
+        END LOOP;
+    END IF;
+
+    -- Parts: cost_per_unit dropped from parts. For bought parts with a
+    -- template-supplied cost, emit a NULL-vendor procurement tier.
+    IF v_template->'parts' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'parts') LOOP
+            v_new_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_new_id::text));
+            v_part_source := COALESCE(v_item->>'source', 'made');
+            v_part_cost := NULLIF(v_item->>'cost_per_unit', '')::numeric;
+
+            INSERT INTO parts (id, company_id, part_name, description,
+                               source, is_stocked,
+                               primary_unit, quantity,
+                               reorder_point, preferred_vendor_id, legacy_id)
+            VALUES (v_new_id, p_company_id,
+                    v_item->>'part_name', v_item->>'description',
+                    v_part_source,
+                    COALESCE((v_item->>'is_stocked')::boolean, false),
+                    v_item->>'primary_unit',
+                    COALESCE((v_item->>'quantity')::numeric, 0),
+                    NULLIF(v_item->>'reorder_point', '')::numeric,
+                    CASE WHEN v_item->>'preferred_vendor_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'preferred_vendor_ref'))::uuid
+                         ELSE NULL END,
+                    v_item->>'legacy_id');
+
+            IF v_part_source = 'bought' AND v_part_cost IS NOT NULL AND v_part_cost > 0 THEN
+                INSERT INTO part_procurement_tiers
+                    (part_id, vendor_id, min_quantity, cost_per_unit)
+                VALUES (v_new_id, NULL, 1, v_part_cost);
+            END IF;
+        END LOOP;
+    END IF;
+
+    IF v_template->'parts_bom' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'parts_bom') LOOP
+            INSERT INTO parts_bom (parent_part_id, child_part_id, quantity, unit, sequence, notes)
+            VALUES ((v_ref_map->>(v_item->>'parent_ref'))::uuid,
+                    (v_ref_map->>(v_item->>'child_ref'))::uuid,
+                    (v_item->>'quantity')::numeric,
+                    v_item->>'unit',
+                    COALESCE((v_item->>'sequence')::integer, 0),
+                    v_item->>'notes');
+        END LOOP;
+    END IF;
+
+    IF v_template->'routings' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'routings') LOOP
+            v_routing_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_routing_id::text));
+            INSERT INTO routings (id, company_id, part_id, name, description, created_by)
+            VALUES (v_routing_id, p_company_id,
+                    (v_ref_map->>(v_item->>'part_ref'))::uuid,
+                    v_item->>'name', v_item->>'description', p_user_id);
+
+            IF v_item->'operations' IS NOT NULL THEN
+                FOR v_inner IN SELECT * FROM jsonb_array_elements(v_item->'operations') LOOP
+                    INSERT INTO routing_operations (
+                        routing_id, work_center_id, sequence,
+                        setup_minutes, cycle_minutes_per_unit,
+                        labor_rate_override,
+                        external_unit_price,
+                        instructions
+                    ) VALUES (
+                        v_routing_id,
+                        (v_ref_map->>(v_inner->>'work_center_ref'))::uuid,
+                        COALESCE((v_inner->>'sequence')::integer, 10),
+                        NULLIF(v_inner->>'setup_minutes', '')::numeric,
+                        NULLIF(v_inner->>'cycle_minutes_per_unit', '')::numeric,
+                        NULLIF(v_inner->>'labor_rate_override', '')::numeric,
+                        NULLIF(v_inner->>'external_unit_price', '')::numeric,
+                        v_inner->>'instructions'
+                    );
+                END LOOP;
+            END IF;
+        END LOOP;
+    END IF;
+
+    IF v_template->'customers' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'customers') LOOP
+            v_new_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_new_id::text));
+            INSERT INTO customers (id, company_id, name,
+                                   contact_name, contact_email, contact_phone,
+                                   address_line1, address_line2, city, state, postal_code, country,
+                                   website)
+            VALUES (v_new_id, p_company_id,
+                    v_item->>'name',
+                    v_item->>'contact_name', v_item->>'contact_email', v_item->>'contact_phone',
+                    v_item->>'address_line1', v_item->>'address_line2',
+                    v_item->>'city', v_item->>'state', v_item->>'postal_code',
+                    COALESCE(v_item->>'country', 'USA'),
+                    v_item->>'website');
+        END LOOP;
+    END IF;
+
+    IF v_template->'quotes' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'quotes') LOOP
+            v_quote_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_quote_id::text));
+            INSERT INTO quotes (id, company_id, customer_id, status,
+                                lead_time_days, expiration_date, created_by)
+            VALUES (v_quote_id, p_company_id,
+                    CASE WHEN v_item->>'customer_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'customer_ref'))::uuid
+                         ELSE NULL END,
+                    COALESCE(v_item->>'status', 'active'),
+                    NULLIF(v_item->>'lead_time_days', '')::integer,
+                    NULLIF(v_item->>'expiration_date', '')::date,
+                    p_user_id);
+
+            IF v_item->'line_items' IS NOT NULL THEN
+                FOR v_inner IN SELECT * FROM jsonb_array_elements(v_item->'line_items') LOOP
+                    INSERT INTO quote_line_items (
+                        quote_id, company_id, part_id,
+                        sequence, quantity, unit_price, total_price
+                    ) VALUES (
+                        v_quote_id, p_company_id,
+                        (v_ref_map->>(v_inner->>'part_ref'))::uuid,
+                        COALESCE((v_inner->>'sequence')::integer, 10),
+                        (v_inner->>'quantity')::integer,
+                        (v_inner->>'unit_price')::numeric,
+                        NULLIF(v_inner->>'total_price', '')::numeric
+                    );
+                END LOOP;
+            END IF;
+        END LOOP;
+    END IF;
+
+    IF v_template->'jobs' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'jobs') LOOP
+            v_job_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_job_id::text));
+
+            INSERT INTO jobs (id, company_id, customer_id, quote_id,
+                              job_number, status, created_by)
+            VALUES (v_job_id, p_company_id,
+                    CASE WHEN v_item->>'customer_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'customer_ref'))::uuid
+                         ELSE NULL END,
+                    CASE WHEN v_item->>'quote_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'quote_ref'))::uuid
+                         ELSE NULL END,
+                    COALESCE(v_item->>'job_number',
+                             'J-DEMO-' || substr(v_job_id::text, 1, 8)),
+                    COALESCE(v_item->>'status', 'not_started'),
+                    p_user_id);
+
+            IF v_item->'parts' IS NOT NULL THEN
+                FOR v_inner IN SELECT * FROM jsonb_array_elements(v_item->'parts') LOOP
+                    v_part_id := (v_ref_map->>(v_inner->>'part_ref'))::uuid;
+                    v_job_part_id := gen_random_uuid();
+
+                    INSERT INTO job_parts (id, job_id, company_id, part_id,
+                                           sequence, quantity, status)
+                    VALUES (v_job_part_id, v_job_id, p_company_id, v_part_id,
+                            COALESCE((v_inner->>'sequence')::integer, 10),
+                            COALESCE((v_inner->>'quantity')::integer, 1),
+                            COALESCE(v_inner->>'status', 'not_started'));
+
+                    IF v_inner->>'routing_ref' IS NOT NULL THEN
+                        PERFORM create_job_part_operations_from_routing(
+                            v_job_part_id,
+                            (v_ref_map->>(v_inner->>'routing_ref'))::uuid
+                        );
+                    END IF;
+                END LOOP;
+            END IF;
+        END LOOP;
+    END IF;
+END;
+$function$
+
+;
+
+-- ---------------------------------------------------------------------------
+-- 4. Drop the column (after the functions above no longer reference it).
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.routing_operations DROP COLUMN external_setup_cost;

--- a/types/routings.ts
+++ b/types/routings.ts
@@ -37,8 +37,8 @@ export interface Routing {
  * The cost-relevant fields split by the work_center's kind:
  * - kind='internal' uses `setup_minutes` + `cycle_minutes_per_unit` priced at
  *   `COALESCE(labor_rate_override, work_center.labor_rate)`.
- * - kind='external' uses `external_unit_price` + `external_setup_cost` and
- *   ignores the time/rate fields.
+ * - kind='external' uses `external_unit_price` only (external work bills once
+ *   per part, so there is no setup cost) and ignores the time/rate fields.
  */
 export interface RoutingOperation {
   id: string;
@@ -49,7 +49,6 @@ export interface RoutingOperation {
   cycle_minutes_per_unit: number | null;
   labor_rate_override: number | null;
   external_unit_price: number | null;
-  external_setup_cost: number | null;
   instructions: string | null;
   metadata: Record<string, unknown>;
   created_at: string;
@@ -118,7 +117,6 @@ export interface RoutingOperationFormData {
   cycle_minutes_per_unit: string;
   labor_rate_override: string;
   external_unit_price: string;
-  external_setup_cost: string;
   instructions: string;
 }
 
@@ -128,7 +126,6 @@ export const EMPTY_OPERATION_FORM: RoutingOperationFormData = {
   cycle_minutes_per_unit: '',
   labor_rate_override: '',
   external_unit_price: '',
-  external_setup_cost: '',
   instructions: '',
 };
 
@@ -144,7 +141,6 @@ export function routingOperationToFormData(op: RoutingOperation): RoutingOperati
       op.cycle_minutes_per_unit !== null ? String(op.cycle_minutes_per_unit) : '',
     labor_rate_override: op.labor_rate_override !== null ? String(op.labor_rate_override) : '',
     external_unit_price: op.external_unit_price !== null ? String(op.external_unit_price) : '',
-    external_setup_cost: op.external_setup_cost !== null ? String(op.external_setup_cost) : '',
     instructions: op.instructions || '',
   };
 }

--- a/utils/routingCostCalculation.ts
+++ b/utils/routingCostCalculation.ts
@@ -126,12 +126,13 @@ export async function calculateRoutingCost(
       const operationName = wc?.name || 'Unknown Operation';
 
       if (wc?.kind === 'external') {
+        // External (vendor) work bills once per part — a unit price only, no
+        // setup cost (setup is an internal-only concept).
         const unitPrice = op.external_unit_price !== null ? Number(op.external_unit_price) : null;
-        const setupCost = op.external_setup_cost !== null ? Number(op.external_setup_cost) : null;
-        if (unitPrice === null && setupCost === null) {
+        if (unitPrice === null) {
           warnings.push({
             type: 'missing_external_pricing',
-            message: `${operationName}: external op has no unit price or setup cost`,
+            message: `${operationName}: external op has no unit price`,
             node_id: op.id,
           });
           continue;
@@ -141,8 +142,8 @@ export async function calculateRoutingCost(
           run_time_minutes: 0,
           setup_time_minutes: 0,
           labor_rate: 0,
-          cost: Math.round((unitPrice ?? 0) * 100) / 100,
-          setup_cost: Math.round((setupCost ?? 0) * 100) / 100,
+          cost: Math.round(unitPrice * 100) / 100,
+          setup_cost: 0,
         });
         continue;
       }

--- a/utils/routingsAccess.ts
+++ b/utils/routingsAccess.ts
@@ -33,7 +33,7 @@ import type {
 // ============================================
 
 const ROUTING_OP_COLUMNS =
-  'id, routing_id, work_center_id, sequence, setup_minutes, cycle_minutes_per_unit, labor_rate_override, external_unit_price, external_setup_cost, instructions, metadata, created_at, updated_at';
+  'id, routing_id, work_center_id, sequence, setup_minutes, cycle_minutes_per_unit, labor_rate_override, external_unit_price, instructions, metadata, created_at, updated_at';
 
 const WC_JOIN = 'work_center:work_centers(id, name, kind, labor_rate, vendor:vendors(id, name))';
 
@@ -324,7 +324,6 @@ function formDataToOpInsert(
     cycle_minutes_per_unit: parseNumOrNull(formData.cycle_minutes_per_unit),
     labor_rate_override: parseNumOrNull(formData.labor_rate_override),
     external_unit_price: parseNumOrNull(formData.external_unit_price),
-    external_setup_cost: parseNumOrNull(formData.external_setup_cost),
     instructions: formData.instructions.trim() || null,
   };
 }
@@ -412,7 +411,6 @@ export interface PendingOperation {
   cycleMinutesPerUnit: number | null;
   laborRateOverride: number | null;
   externalUnitPrice: number | null;
-  externalSetupCost: number | null;
   instructions: string | null;
 }
 
@@ -504,7 +502,6 @@ export async function saveRoutingWithOperations(
         cycle_minutes_per_unit: op.cycleMinutesPerUnit,
         labor_rate_override: op.laborRateOverride,
         external_unit_price: op.externalUnitPrice,
-        external_setup_cost: op.externalSetupCost,
         instructions: op.instructions,
         sequence: seq,
       };


### PR DESCRIPTION
External (vendor) work centers bill a single per-part **unit price** — setup is an internal-only concept — so `external_setup_cost` is removed end to end (item 7 of the 13-item batch).

## Migration

`supabase/migrations/20260623022617_drop_external_setup_cost.sql`:
- `CREATE OR REPLACE compute_part_cost_at_qty` — drops the `+ external_setup_cost / qty` amortization term; an external op is priced iff `external_unit_price IS NOT NULL`.
- `CREATE OR REPLACE get_priceable_part_ids` — external op priced iff `external_unit_price IS NOT NULL`.
- `CREATE OR REPLACE seed_demo_data` — stops inserting `external_setup_cost`.
- `ALTER TABLE routing_operations DROP COLUMN external_setup_cost`.

The three functions are reproduced verbatim from the live schema with only the `external_setup_cost` references removed, then the column is dropped. **Validated against the local DB in a rolled-back transaction** — all three `CREATE FUNCTION` rewrites + the `DROP COLUMN` apply cleanly.

> ⚠️ **Not yet pushed to staging.** `supabase db push` reports a migration-history mismatch because staging carries two newer migrations from other in-flight branches (`20260623021524`, `20260623021901`) that aren't in `main`. Pulling/repairing them would pollute this PR with others' work, so I left it. **Action needed:** apply this migration to staging + prod once those land (or by whoever owns them), then run `pnpm gen:db-types` to drop `external_setup_cost` from `types/database.ts`. The app compiles against the current generated types (the column is nullable and now unreferenced).

## App code

Removed `external_setup_cost` / `externalSetupCost` from:
- `types/routings.ts` (row type, form data, default, hydration)
- `utils/routingsAccess.ts` (SELECT list + both insert paths)
- `utils/routingCostCalculation.ts` — external branch now prices the unit price only (`setup_cost: 0`)
- UI: `RoutingOperationRowEditor` (drops the "Vendor setup cost ($)" field), `RoutingOperationRow` + `RoutingViewer` (drop the Setup chip/caption), `RoutingOperationsList`, `PartRoutingPanel`
- Work-center help text (`WorkCenterForm`, work-center detail page)

## Tests / docs

- `routingCostCalculation.test.ts` — external ops price as unit price with zero setup; mixed internal+external totals no longer add external setup.
- `routingsAccess.test.ts` — form fixture drops the field.
- `docs/modules/work-centers.md`.
- Full suite green (692 tests) with coverage; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)