### PR TITLE
feat(operator): Inventory tab + warehouse home (fix bin-view back-out)

### DIFF
--- a/__tests__/components/operator/OperatorWarehouseHome.test.tsx
+++ b/__tests__/components/operator/OperatorWarehouseHome.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@mui/material/styles';
+import jiggedTheme from '@/lib/theme';
+
+import OperatorWarehouseHomePage from '@/app/operator/[companyId]/inventory/page';
+import { getLocations } from '@/utils/inventoryLocationsAccess';
+
+const mockPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ companyId: 'co1' }),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('@/utils/inventoryLocationsAccess', () => ({
+  getLocations: vi.fn(),
+}));
+
+const loc = (over: { id: string; name: string; parent_id?: string | null; code?: string | null }) => ({
+  id: over.id,
+  company_id: 'co1',
+  parent_id: over.parent_id ?? null,
+  name: over.name,
+  kind: 'cabinet',
+  code: over.code ?? null,
+  is_stockable: true,
+  is_qr_anchor: false,
+  sort_order: 0,
+  created_at: '',
+  updated_at: '',
+});
+
+const renderPage = () =>
+  render(<OperatorWarehouseHomePage />, {
+    wrapper: ({ children }) => <ThemeProvider theme={jiggedTheme}>{children}</ThemeProvider>,
+  });
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('OperatorWarehouseHomePage', () => {
+  it('lists only top-level locations and drills into the bin view', async () => {
+    (getLocations as ReturnType<typeof vi.fn>).mockResolvedValue([
+      loc({ id: 'cab1', name: 'Cabinet 1', code: 'C01' }),
+      loc({ id: 'bin1', name: 'Bin 1', parent_id: 'cab1' }), // child — must NOT appear at root
+    ]);
+    renderPage();
+
+    expect(await screen.findByText('Cabinet 1')).toBeInTheDocument();
+    expect(screen.queryByText('Bin 1')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Cabinet 1'));
+    expect(mockPush).toHaveBeenCalledWith('/operator/co1/inventory/locations/cab1');
+  });
+
+  it('shows an empty state when no locations exist', async () => {
+    (getLocations as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    renderPage();
+    expect(await screen.findByText(/No storage locations yet/i)).toBeInTheDocument();
+  });
+});

--- a/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
+++ b/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
@@ -82,7 +82,7 @@ export default function OperatorBinViewPage() {
 
   const goBack = () => {
     if (parent) router.push(`/operator/${companyId}/inventory/locations/${parent.id}`);
-    else router.push(`/operator/${companyId}/jobs`);
+    else router.push(`/operator/${companyId}/inventory`);
   };
 
   const modalUnit = modal?.part.primary_unit || 'ea';
@@ -102,7 +102,7 @@ export default function OperatorBinViewPage() {
   if (error || !node) {
     return (
       <Box>
-        <IconButton onClick={() => router.push(`/operator/${companyId}/jobs`)} aria-label="Back" sx={{ mb: 2 }}>
+        <IconButton onClick={() => router.push(`/operator/${companyId}/inventory`)} aria-label="Back" sx={{ mb: 2 }}>
           <ArrowBackIcon />
         </IconButton>
         <Alert severity="error">{error ?? 'Location not found.'}</Alert>

--- a/app/operator/[companyId]/inventory/page.tsx
+++ b/app/operator/[companyId]/inventory/page.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Card from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
+import CardContent from '@mui/material/CardContent';
+import Stack from '@mui/material/Stack';
+import Chip from '@mui/material/Chip';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import QrCodeScannerIcon from '@mui/icons-material/QrCodeScanner';
+import WarehouseOutlinedIcon from '@mui/icons-material/WarehouseOutlined';
+
+import { getLocations } from '@/utils/inventoryLocationsAccess';
+import type { InventoryLocation } from '@/types/inventoryLocations';
+
+/**
+ * Operator "warehouse home" — the root of the Inventory tab. Lists the
+ * top-level storage locations to browse (drill down into the bin view), so the
+ * warehouse is reachable and orientable without a physical QR scan. Scanning a
+ * printed label still jumps straight to a bin (the fast path).
+ */
+export default function OperatorWarehouseHomePage() {
+  const params = useParams();
+  const router = useRouter();
+  const companyId = params.companyId as string;
+
+  const [locations, setLocations] = useState<InventoryLocation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setLocations(await getLocations(companyId));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load the warehouse.');
+    } finally {
+      setLoading(false);
+    }
+  }, [companyId]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  // Top-level locations are the warehouse roots to browse from.
+  const roots = useMemo(() => locations.filter((l) => l.parent_id === null), [locations]);
+
+  return (
+    <Box sx={{ pb: 4 }}>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5 }}>
+        <WarehouseOutlinedIcon color="primary" />
+        <Typography variant="h5" sx={{ fontWeight: 700 }}>
+          Inventory
+        </Typography>
+      </Stack>
+      <Stack direction="row" spacing={0.5} alignItems="center" sx={{ mb: 3, color: 'text.secondary' }}>
+        <QrCodeScannerIcon fontSize="small" />
+        <Typography variant="body2">Scan a printed label to jump straight to a bin.</Typography>
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : roots.length === 0 ? (
+        <Card elevation={2}>
+          <CardContent sx={{ textAlign: 'center', py: 6 }}>
+            <WarehouseOutlinedIcon sx={{ fontSize: 44, color: 'text.disabled', mb: 1 }} />
+            <Typography color="text.secondary">
+              No storage locations yet. Once they&apos;re set up, you can browse them here.
+            </Typography>
+          </CardContent>
+        </Card>
+      ) : (
+        <Stack spacing={1}>
+          {roots.map((loc) => (
+            <Card key={loc.id} elevation={2}>
+              <CardActionArea
+                onClick={() => router.push(`/operator/${companyId}/inventory/locations/${loc.id}`)}
+                sx={{ minHeight: 56 }}
+              >
+                <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 1.5 }}>
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography sx={{ fontWeight: 600 }}>{loc.name}</Typography>
+                    {loc.kind && (
+                      <Typography variant="caption" color="text.secondary">
+                        {loc.kind}
+                      </Typography>
+                    )}
+                  </Box>
+                  {loc.code && <Chip size="small" label={loc.code} variant="outlined" />}
+                  <KeyboardArrowRightIcon color="action" />
+                </CardContent>
+              </CardActionArea>
+            </Card>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -17,9 +17,11 @@ import ListItemText from '@mui/material/ListItemText';
 import LogoutIcon from '@mui/icons-material/Logout';
 import WorkIcon from '@mui/icons-material/Work';
 import PersonIcon from '@mui/icons-material/Person';
+import WarehouseOutlinedIcon from '@mui/icons-material/WarehouseOutlined';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import { getSupabase } from '@/lib/supabase';
+import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 import { OperatorStationProvider, useStationContext } from '@/components/operator/OperatorStationContext';
 import JiggedIcon from '@/components/branding/JiggedIcon';
 import type { AuthChangeEvent } from '@supabase/supabase-js';
@@ -45,7 +47,7 @@ export default function OperatorLayout({
   const companyId = params.companyId as string;
 
   const [userRole, setUserRole] = useState<string>('operator');
-  const [navValue, setNavValue] = useState(0);
+  const [navValue, setNavValue] = useState<string>('jobs');
   const [isLoading, setIsLoading] = useState(true);
 
   const supabase = getSupabase();
@@ -102,11 +104,9 @@ export default function OperatorLayout({
 
   // Update nav value based on current path
   useEffect(() => {
-    if (pathname?.includes('/profile')) {
-      setNavValue(1);
-    } else {
-      setNavValue(0);
-    }
+    if (pathname?.includes('/profile')) setNavValue('profile');
+    else if (pathname?.includes('/inventory')) setNavValue('inventory');
+    else setNavValue('jobs');
   }, [pathname]);
 
   const handleLogout = async () => {
@@ -117,16 +117,11 @@ export default function OperatorLayout({
     router.push(`/operator/${companyId}/login`);
   };
 
-  const handleNavChange = (_event: React.SyntheticEvent, newValue: number) => {
+  const handleNavChange = (_event: React.SyntheticEvent, newValue: string) => {
     setNavValue(newValue);
-    switch (newValue) {
-      case 0:
-        router.push(`/operator/${companyId}/jobs`);
-        break;
-      case 1:
-        router.push(`/operator/${companyId}/profile`);
-        break;
-    }
+    if (newValue === 'inventory') router.push(`/operator/${companyId}/inventory`);
+    else if (newValue === 'profile') router.push(`/operator/${companyId}/profile`);
+    else router.push(`/operator/${companyId}/jobs`);
   };
 
   // Don't show header/nav on login page
@@ -192,13 +187,20 @@ function OperatorShell({
 }: {
   userRole: string;
   companyId: string;
-  navValue: number;
-  onNavChange: (event: React.SyntheticEvent, newValue: number) => void;
+  navValue: string;
+  onNavChange: (event: React.SyntheticEvent, newValue: string) => void;
   onLogout: () => void;
   children: React.ReactNode;
 }) {
   const { stationId, stationName, stations, setStation } = useStationContext();
+  const { features } = useCompanyFeatures();
+  const pathname = usePathname();
   const router = useRouter();
+  const showInventory = Boolean(features.inventory_locations);
+  // The warehouse is station-independent, so keep the nav (and a way out) on
+  // inventory routes even before a station is picked.
+  const isInventoryRoute = pathname?.includes('/inventory') ?? false;
+  const navVisible = Boolean(stationId) || isInventoryRoute;
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   const handleStationMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
@@ -332,7 +334,7 @@ function OperatorShell({
         sx={{
           flex: 1,
           mt: '48px', // Single-row AppBar height
-          mb: stationId ? '56px' : 0, // BottomNavigation height (hidden during station selection)
+          mb: navVisible ? '56px' : 0, // BottomNavigation height
           overflow: 'auto',
           p: 2,
         }}
@@ -340,8 +342,8 @@ function OperatorShell({
         {children}
       </Box>
 
-      {/* Bottom Navigation — hidden during station selection */}
-      {stationId && (
+      {/* Bottom Navigation — hidden only on the bare station-selection screen */}
+      {navVisible && (
         <Paper
           sx={{
             position: 'fixed',
@@ -369,11 +371,21 @@ function OperatorShell({
           >
             <BottomNavigationAction
               label="Jobs"
+              value="jobs"
               icon={<WorkIcon />}
               sx={{ minHeight: 56 }}
             />
+            {showInventory && (
+              <BottomNavigationAction
+                label="Inventory"
+                value="inventory"
+                icon={<WarehouseOutlinedIcon />}
+                sx={{ minHeight: 56 }}
+              />
+            )}
             <BottomNavigationAction
               label="Profile"
+              value="profile"
               icon={<PersonIcon />}
               sx={{ minHeight: 56 }}
             />


### PR DESCRIPTION
## Problem

Backing out of a scanned bin (PR #425) climbed the location tree and then **dumped the operator on the station-select screen** — an IA mismatch (warehouse mode bleeding into work mode), made worse because the bottom nav is hidden there, so it felt like a dead end. Inventory had no home of its own; the only way in was a physical QR scan.

## Fix

- **New "Inventory" bottom-nav tab** (feature-flagged by `inventory_locations`) → a **warehouse home** (`app/operator/[companyId]/inventory/page.tsx`) that lists the top-level locations to browse and drill into the bin view, with a *"scan a label"* hint. This adds **browse-to-find** alongside **scan-to-jump** — the standard warehouse-mobile pairing.
- **Station-independent nav.** The bottom nav was gated on `stationId`; it now also shows on `/inventory` routes so the warehouse (and a way out) is reachable before a station is picked. Tabs are keyed by string (`'jobs' | 'inventory' | 'profile'`) so the conditional Inventory tab can't shift indices.
- **Back-out fixed.** A top-level "up" in the bin view now lands on the warehouse home, not `/jobs` — you stay in warehouse mode, never stranded on station-select.

## Notes
- There's no single "root location" in the data model, so the home is a synthetic overview of the top-level location forest (incl. the system "Unassigned" bucket).
- Part search ("where is X?") and an in-app scanner are deliberate non-goals here — browse + drill-down is the MVP; scanning stays the URL-deep-link fast path.

## Validation
`tsc` clean; full **Vitest 711** (2 new: lists only top-level + drill-down, empty state); lint clean (baseline data-fetch warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)