### PR TITLE
feat(jobs): inline PO viewer + expected sell price in the PO→Job flow

### DIFF
--- a/__tests__/components/jobs/AcceptPurchaseOrderModal.test.tsx
+++ b/__tests__/components/jobs/AcceptPurchaseOrderModal.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../test-utils';
+import AcceptPurchaseOrderModal from '@/components/jobs/AcceptPurchaseOrderModal';
+
+const mockGetTiers = vi.fn();
+
+vi.mock('@/utils/partPricingTiersAccess', () => ({
+  getTiersWithComputedPrices: (...a: unknown[]) => mockGetTiers(...a),
+}));
+// resolveTier stays the REAL pure implementation — we want to exercise the
+// actual quote-line resolution path the PO→Job flow reuses.
+vi.mock('@/utils/jobsAccess', () => ({
+  getCustomersForSelect: vi.fn().mockResolvedValue([{ id: 'c1', name: 'Acme Machining' }]),
+  createJobFromPurchaseOrder: vi.fn(),
+}));
+vi.mock('@/utils/jobAttachmentsAccess', () => ({
+  uploadJobAttachment: vi.fn(),
+}));
+// A trivial part picker that fires onChange with a fixed part when clicked, so
+// the test can drive the expected-price lookup without the real Autocomplete.
+vi.mock('@/components/parts/PartAutocomplete', () => ({
+  default: ({ onChange }: { onChange: (p: { id: string; part_name: string }) => void }) => (
+    <button type="button" onClick={() => onChange({ id: 'part-1', part_name: 'BRKT-001' })}>
+      pick-part
+    </button>
+  ),
+}));
+vi.mock('@/components/jobs/AttachmentUploadField', () => ({ default: () => null }));
+
+function pricedTier(unit_price: number) {
+  return {
+    id: 't1',
+    part_id: 'part-1',
+    company_id: 'c1',
+    sequence: 0,
+    quantity: 1,
+    markup_percent: 100,
+    unit_price,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+describe('AcceptPurchaseOrderModal — expected (sell) price', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTiers.mockResolvedValue([pricedTier(55.74)]);
+  });
+
+  it('pre-fills the unit price with the expected sell price when a part is picked', async () => {
+    render(
+      <AcceptPurchaseOrderModal open onClose={vi.fn()} companyId="c1" onCreated={vi.fn()} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'pick-part' }));
+
+    // After the debounce, resolveTier(getTiersWithComputedPrices) resolves and
+    // the caption + pre-filled price appear (findBy rides the ~350ms debounce).
+    expect(await screen.findByText(/Expected \$55\.74/i)).toBeInTheDocument();
+    await waitFor(() => {
+      const priceInput = screen.getByLabelText('Unit price') as HTMLInputElement;
+      expect(priceInput.value).toBe('55.74');
+    });
+    expect(mockGetTiers).toHaveBeenCalledWith('part-1');
+  });
+
+  it('flags drift (non-blocking) when the entered price differs from expected', async () => {
+    render(
+      <AcceptPurchaseOrderModal open onClose={vi.fn()} companyId="c1" onCreated={vi.fn()} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'pick-part' }));
+    await screen.findByText(/Expected \$55\.74/i);
+
+    const priceInput = screen.getByLabelText('Unit price');
+    await user.clear(priceInput);
+    await user.type(priceInput, '60');
+
+    expect(await screen.findByText(/Differs from expected \$55\.74/i)).toBeInTheDocument();
+    // A "Reset" affordance restores the expected price.
+    await user.click(screen.getByRole('button', { name: /^Reset$/i }));
+    await waitFor(() => {
+      expect((screen.getByLabelText('Unit price') as HTMLInputElement).value).toBe('55.74');
+    });
+  });
+
+  it('leaves the price blank when the part has no priced tier (no pre-fill)', async () => {
+    mockGetTiers.mockResolvedValue([{ ...pricedTier(0), unit_price: null }]);
+    render(
+      <AcceptPurchaseOrderModal open onClose={vi.fn()} companyId="c1" onCreated={vi.fn()} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'pick-part' }));
+
+    // Give the debounce + lookup time to run, then assert no pre-fill / caption.
+    await waitFor(() => expect(mockGetTiers).toHaveBeenCalledWith('part-1'));
+    await waitFor(() => {
+      expect((screen.getByLabelText('Unit price') as HTMLInputElement).value).toBe('');
+    });
+    expect(screen.queryByText(/Expected \$/i)).toBeNull();
+  });
+});

--- a/components/jobs/AcceptPurchaseOrderModal.tsx
+++ b/components/jobs/AcceptPurchaseOrderModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -21,6 +21,8 @@ import PartAutocomplete, { type PartSelectOption } from '@/components/parts/Part
 import AttachmentUploadField from '@/components/jobs/AttachmentUploadField';
 import { createJobFromPurchaseOrder, getCustomersForSelect } from '@/utils/jobsAccess';
 import { uploadJobAttachment } from '@/utils/jobAttachmentsAccess';
+import { getTiersWithComputedPrices } from '@/utils/partPricingTiersAccess';
+import { resolveTier } from '@/utils/quotePricingResolver';
 
 interface AcceptPurchaseOrderModalProps {
   open: boolean;
@@ -35,12 +37,24 @@ interface PoLineDraft {
   part: PartSelectOption | null;
   quantity: string;
   unitPrice: string;
+  /** Computed sell price (cost + markup) at the chosen qty, or null if it can't
+   *  be resolved (e.g. the part has no priced tier). Advisory only. */
+  expectedPrice: number | null;
+  /** True while the async expected-price lookup is in flight for this line. */
+  priceLoading: boolean;
 }
 
 let lineKeySeq = 0;
 function emptyLine(): PoLineDraft {
   lineKeySeq += 1;
-  return { key: `line-${lineKeySeq}`, part: null, quantity: '1', unitPrice: '' };
+  return {
+    key: `line-${lineKeySeq}`,
+    part: null,
+    quantity: '1',
+    unitPrice: '',
+    expectedPrice: null,
+    priceLoading: false,
+  };
 }
 
 function formatCurrency(value: number): string {
@@ -100,6 +114,12 @@ export default function AcceptPurchaseOrderModal({
     getCustomersForSelect(companyId)
       .then(setCustomers)
       .catch((err) => console.error('Error loading customers:', err));
+    const timers = priceTimers.current;
+    return () => {
+      // Cancel any pending expected-price lookups on close/unmount.
+      timers.forEach((t) => clearTimeout(t));
+      timers.clear();
+    };
   }, [open, companyId]);
 
   const customerOptions: SelectOption[] = useMemo(
@@ -115,6 +135,65 @@ export default function AcceptPurchaseOrderModal({
   const addLine = () => setLines((prev) => [...prev, emptyLine()]);
   const removeLine = (key: string) =>
     setLines((prev) => (prev.length === 1 ? prev : prev.filter((l) => l.key !== key)));
+
+  // Per-line debounce timers + a monotonically-increasing token so a slow
+  // lookup that resolves after the part/qty changed again is discarded.
+  const priceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const priceTokens = useRef<Map<string, number>>(new Map());
+
+  /**
+   * Resolve the expected SELL price (cost + markup) for a line at its qty using
+   * the SAME resolver quote line items use — `resolveTier` over the part's
+   * computed pricing tiers. Debounced ~350ms on part/qty change. Pure DB reads,
+   * no AI. Pre-fills the price only when the user hasn't typed one yet; the
+   * entered price is never overwritten.
+   */
+  const resolveExpected = (
+    key: string,
+    part: PartSelectOption | null,
+    quantity: string,
+  ) => {
+    const timers = priceTimers.current;
+    const existing = timers.get(key);
+    if (existing) clearTimeout(existing);
+
+    const qty = Number(quantity);
+    if (!part || !Number.isInteger(qty) || qty <= 0) {
+      updateLine(key, { expectedPrice: null, priceLoading: false });
+      return;
+    }
+
+    updateLine(key, { priceLoading: true });
+    const token = (priceTokens.current.get(key) ?? 0) + 1;
+    priceTokens.current.set(key, token);
+
+    const partId = part.id;
+    const timer = setTimeout(async () => {
+      try {
+        const tiers = await getTiersWithComputedPrices(partId);
+        const resolved = resolveTier(tiers, qty);
+        if (priceTokens.current.get(key) !== token) return; // stale — superseded
+        const expected = resolved?.unit_price ?? null;
+        setLines((prev) =>
+          prev.map((l) => {
+            if (l.key !== key) return l;
+            // Seed the override only when the user hasn't typed a price yet.
+            const shouldPrefill = expected !== null && l.unitPrice.trim() === '';
+            return {
+              ...l,
+              expectedPrice: expected,
+              priceLoading: false,
+              unitPrice: shouldPrefill ? String(expected) : l.unitPrice,
+            };
+          }),
+        );
+      } catch {
+        if (priceTokens.current.get(key) !== token) return;
+        updateLine(key, { expectedPrice: null, priceLoading: false });
+      }
+    }, 350);
+    timers.set(key, timer);
+  };
 
   // Due date is mandatory and may not be in the past — a job created today
   // can't legitimately be due before today (this is what let a wrong-year
@@ -260,52 +339,102 @@ export default function AcceptPurchaseOrderModal({
           </Typography>
 
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            {lines.map((line) => (
-              <Box key={line.key} sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <PartAutocomplete
-                    companyId={companyId}
-                    value={line.part}
-                    onChange={(part) => updateLine(line.key, { part })}
-                    excludeIds={pickedPartIds.filter((id) => id !== line.part?.id)}
-                    label="Part"
-                    size="small"
-                    disabled={loading}
-                  />
+            {lines.map((line) => {
+              const enteredPrice = Number(line.unitPrice);
+              const priceDiffers =
+                line.expectedPrice !== null &&
+                line.unitPrice.trim() !== '' &&
+                Number.isFinite(enteredPrice) &&
+                Math.abs(enteredPrice - line.expectedPrice) > 0.005;
+              const qtyLabel = Number.isInteger(Number(line.quantity)) && Number(line.quantity) > 0
+                ? Number(line.quantity)
+                : '—';
+              return (
+                <Box key={line.key} sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                  <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <PartAutocomplete
+                        companyId={companyId}
+                        value={line.part}
+                        onChange={(part) => {
+                          updateLine(line.key, { part });
+                          resolveExpected(line.key, part, line.quantity);
+                        }}
+                        excludeIds={pickedPartIds.filter((id) => id !== line.part?.id)}
+                        label="Part"
+                        size="small"
+                        disabled={loading}
+                      />
+                    </Box>
+                    <TextField
+                      label="Qty"
+                      size="small"
+                      value={line.quantity}
+                      onChange={(e) => {
+                        const q = e.target.value;
+                        updateLine(line.key, { quantity: q });
+                        resolveExpected(line.key, line.part, q);
+                      }}
+                      disabled={loading}
+                      sx={{ width: 80 }}
+                      slotProps={{ htmlInput: { inputMode: 'numeric' } }}
+                    />
+                    <TextField
+                      label="Unit price"
+                      size="small"
+                      value={line.unitPrice}
+                      onChange={(e) => updateLine(line.key, { unitPrice: e.target.value })}
+                      disabled={loading}
+                      error={priceDiffers}
+                      sx={{ width: 120 }}
+                      slotProps={{
+                        htmlInput: { inputMode: 'decimal' },
+                        input: {
+                          startAdornment: <InputAdornment position="start">$</InputAdornment>,
+                        },
+                      }}
+                    />
+                    <IconButton
+                      onClick={() => removeLine(line.key)}
+                      disabled={loading || lines.length === 1}
+                      aria-label="Remove part"
+                      sx={{ mt: 0.5 }}
+                    >
+                      <DeleteOutlineIcon fontSize="small" />
+                    </IconButton>
+                  </Box>
+
+                  {/* Expected price (cost + markup at qty) — advisory; never blocks
+                      submit. Drift from the entered price is flagged in warning. */}
+                  {line.priceLoading ? (
+                    <Typography variant="caption" color="text.secondary" sx={{ pl: 0.5 }}>
+                      Calculating expected price…
+                    </Typography>
+                  ) : line.expectedPrice !== null ? (
+                    priceDiffers ? (
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, pl: 0.5, flexWrap: 'wrap' }}>
+                        <Typography variant="caption" color="warning.main">
+                          Differs from expected {formatCurrency(line.expectedPrice)} (cost + markup at qty {qtyLabel})
+                        </Typography>
+                        <Button
+                          size="small"
+                          onClick={() =>
+                            updateLine(line.key, { unitPrice: String(line.expectedPrice) })
+                          }
+                          sx={{ minWidth: 'auto', p: 0, textTransform: 'none' }}
+                        >
+                          Reset
+                        </Button>
+                      </Box>
+                    ) : (
+                      <Typography variant="caption" color="text.secondary" sx={{ pl: 0.5 }}>
+                        Expected {formatCurrency(line.expectedPrice)} (cost + markup at qty {qtyLabel})
+                      </Typography>
+                    )
+                  ) : null}
                 </Box>
-                <TextField
-                  label="Qty"
-                  size="small"
-                  value={line.quantity}
-                  onChange={(e) => updateLine(line.key, { quantity: e.target.value })}
-                  disabled={loading}
-                  sx={{ width: 80 }}
-                  slotProps={{ htmlInput: { inputMode: 'numeric' } }}
-                />
-                <TextField
-                  label="Unit price"
-                  size="small"
-                  value={line.unitPrice}
-                  onChange={(e) => updateLine(line.key, { unitPrice: e.target.value })}
-                  disabled={loading}
-                  sx={{ width: 120 }}
-                  slotProps={{
-                    htmlInput: { inputMode: 'decimal' },
-                    input: {
-                      startAdornment: <InputAdornment position="start">$</InputAdornment>,
-                    },
-                  }}
-                />
-                <IconButton
-                  onClick={() => removeLine(line.key)}
-                  disabled={loading || lines.length === 1}
-                  aria-label="Remove part"
-                  sx={{ mt: 0.5 }}
-                >
-                  <DeleteOutlineIcon fontSize="small" />
-                </IconButton>
-              </Box>
-            ))}
+              );
+            })}
           </Box>
 
           <Button

--- a/components/jobs/JobAttachmentsCard.tsx
+++ b/components/jobs/JobAttachmentsCard.tsx
@@ -12,9 +12,16 @@ import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Tooltip from '@mui/material/Tooltip';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
+import VisibilityIcon from '@mui/icons-material/Visibility';
 import DownloadIcon from '@mui/icons-material/Download';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import CloseIcon from '@mui/icons-material/Close';
 import {
   listJobAttachments,
   uploadJobAttachment,
@@ -36,6 +43,19 @@ function formatBytes(bytes: number | null): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+/** Can this attachment be previewed inline (PDF or image)? Falls back to the
+ *  filename extension when mime_type is missing. */
+function isImageAttachment(att: JobAttachment): boolean {
+  const mime = att.mime_type ?? '';
+  const name = att.file_name.toLowerCase();
+  return mime.startsWith('image/') || /\.(png|jpe?g|gif|webp|svg)$/.test(name);
+}
+function isViewable(att: JobAttachment): boolean {
+  const mime = att.mime_type ?? '';
+  const name = att.file_name.toLowerCase();
+  return mime === 'application/pdf' || name.endsWith('.pdf') || isImageAttachment(att);
+}
+
 /**
  * Attachments panel for the job detail page — the customer PO PDF and any other
  * reference files. Listing on mount is a plain Supabase read (no AI). Upload is
@@ -47,6 +67,10 @@ export default function JobAttachmentsCard({ jobId, companyId }: JobAttachmentsC
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  // Inline preview state: the attachment being viewed + its fresh signed URL.
+  const [viewing, setViewing] = useState<JobAttachment | null>(null);
+  const [viewUrl, setViewUrl] = useState<string | null>(null);
+  const [viewLoading, setViewLoading] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -91,6 +115,27 @@ export default function JobAttachmentsCard({ jobId, companyId }: JobAttachmentsC
     } catch {
       setError('Could not open the file.');
     }
+  };
+
+  // Open the inline viewer: fetch a fresh signed URL and show it in a dialog
+  // (iframe for PDFs, <img> for images). Keeps the user on the job page.
+  const handleView = async (att: JobAttachment) => {
+    setViewing(att);
+    setViewUrl(null);
+    setViewLoading(true);
+    try {
+      setViewUrl(await getJobAttachmentUrl(att.storage_path));
+    } catch {
+      setError('Could not open the file.');
+      setViewing(null);
+    } finally {
+      setViewLoading(false);
+    }
+  };
+
+  const handleCloseViewer = () => {
+    setViewing(null);
+    setViewUrl(null);
   };
 
   const handleDelete = async (att: JobAttachment) => {
@@ -140,6 +185,13 @@ export default function JobAttachmentsCard({ jobId, companyId }: JobAttachmentsC
                 disableGutters
                 secondaryAction={
                   <Box>
+                    {isViewable(att) && (
+                      <Tooltip title="View">
+                        <IconButton edge="end" aria-label="View" onClick={() => handleView(att)}>
+                          <VisibilityIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    )}
                     <IconButton edge="end" aria-label="Download" onClick={() => handleDownload(att)}>
                       <DownloadIcon fontSize="small" />
                     </IconButton>
@@ -160,6 +212,52 @@ export default function JobAttachmentsCard({ jobId, companyId }: JobAttachmentsC
           </List>
         )}
       </CardContent>
+
+      {/* Inline preview — keeps the user on the job page instead of forcing a
+          download. PDFs render in an iframe, images in an <img>. */}
+      <Dialog open={!!viewing} onClose={handleCloseViewer} fullScreen>
+        <DialogTitle sx={{ pr: 6 }}>
+          {viewing?.file_name ?? 'Attachment'}
+          <IconButton
+            aria-label="Close"
+            onClick={handleCloseViewer}
+            sx={{ position: 'absolute', right: 12, top: 12 }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers sx={{ p: 0, bgcolor: 'background.default' }}>
+          {viewLoading || !viewUrl ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+              <CircularProgress />
+            </Box>
+          ) : viewing && isImageAttachment(viewing) ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%', p: 2 }}>
+              <Box
+                component="img"
+                src={viewUrl}
+                alt={viewing.file_name}
+                sx={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+              />
+            </Box>
+          ) : (
+            <Box
+              component="iframe"
+              src={viewUrl}
+              title={viewing?.file_name ?? 'Attachment'}
+              sx={{ width: '100%', height: '100%', border: 0, display: 'block' }}
+            />
+          )}
+        </DialogContent>
+        <DialogActions>
+          {viewing && (
+            <Button startIcon={<DownloadIcon />} onClick={() => handleDownload(viewing)}>
+              Download
+            </Button>
+          )}
+          <Button onClick={handleCloseViewer}>Close</Button>
+        </DialogActions>
+      </Dialog>
     </Card>
   );
 }

--- a/docs/modules/jobs.md
+++ b/docs/modules/jobs.md
@@ -137,7 +137,7 @@ A job can be created two ways:
 
 **(a) Convert a quote.** Build a quote, open its detail page, and use **Convert to Job**; one job is produced with one work cell per `(part, selected quantity)`. This flow lives in [Quotes](quotes.md).
 
-**(b) New Job from PO (direct).** When a customer sends a PO with no prior quote, click **New Job from PO** on the jobs list. The "Accept Purchase Order" modal (a modal, not a `/jobs/new` route) captures the customer, PO #, due date, and one-or-more **existing** parts — each with a quantity and the agreed unit price — plus an optional PO PDF. On accept, `createJobFromPurchaseOrder` (`utils/jobsAccess.ts`) creates the job (`quote_id` null, job number `J-NNNN` from the shared per-company order counter — same sequence as quotes) and clones each part's routing into operations + materials via the same `create_job_part_operations_from_routing` RPC the quote path uses. v1 is **existing parts only** — every part must already have a routing (the create fails fast otherwise).
+**(b) New Job from PO (direct).** When a customer sends a PO with no prior quote, click **New Job from PO** on the jobs list. The "Accept Purchase Order" modal (a modal, not a `/jobs/new` route) captures the customer, PO #, due date, and one-or-more **existing** parts — each with a quantity and the agreed unit price — plus an optional PO PDF. When a part + quantity are chosen, the modal **pre-fills the expected sell price** (cost + markup at that quantity, resolved by the *same* `getTiersWithComputedPrices` + `resolveTier` path quote line items use — pure DB reads, no AI). The user can override it; if the entered price differs from expected, a non-blocking "Differs from expected $X" hint appears with a one-tap **Reset**. A part with no priced tier just leaves the price blank. On accept, `createJobFromPurchaseOrder` (`utils/jobsAccess.ts`) creates the job (`quote_id` null, job number `J-NNNN` from the shared per-company order counter — same sequence as quotes) and clones each part's routing into operations + materials via the same `create_job_part_operations_from_routing` RPC the quote path uses. v1 is **existing parts only** — every part must already have a routing (the create fails fast otherwise).
 
 Both paths store the agreed price on each `job_part` (`unit_price` / `total_price`), so PO-sourced and quote-sourced jobs invoice identically.
 
@@ -159,7 +159,7 @@ Both paths store the agreed price on each `job_part` (`unit_price` / `total_pric
 
 ▸ **Attachments**
 
-- Customer PO PDFs and other reference files — listed with download + delete and an "Upload PDF" button. File bytes live in the private `attachments` bucket; metadata in `job_attachments`. Attached during PO intake / quote conversion (optional) or added here later. Backed by `utils/jobAttachmentsAccess.ts` + `components/jobs/JobAttachmentsCard.tsx`.
+- Customer PO PDFs and other reference files — listed with **view (inline)**, download, and delete actions plus an "Upload PDF" button. **View** opens the file in a dialog (an `<iframe>` for PDFs, an `<img>` for images) off a fresh signed URL, so the user can read the PO without leaving the job page; download/delete still work as before. File bytes live in the private `attachments` bucket; metadata in `job_attachments`. Attached during PO intake / quote conversion (optional) or added here later. Backed by `utils/jobAttachmentsAccess.ts` + `components/jobs/JobAttachmentsCard.tsx`.
 
 ▸ **Invoicing (QuickBooks)**
 


### PR DESCRIPTION
Jobs improvements — items 4 and 9 of the 13-item batch.

## #4 — Inline PO viewer

`JobAttachmentsCard` gains a **View** (eye) action for viewable attachments (PDF / image). It opens a fullscreen dialog — an `<iframe>` for PDFs, an `<img>` for images — off a fresh signed URL, so the user can read the customer PO **without leaving the job page**. Download + delete are unchanged. Reuses the iframe-preview pattern from `QuotePdfPreviewDialog`.

## #9 — PO→Job expected (sell) price

In `AcceptPurchaseOrderModal`, when a part + quantity are chosen the modal **pre-fills the expected sell price** (cost + markup at that qty) using the **same** resolver quote line items use — `resolveTier` over `getTiersWithComputedPrices` — debounced ~350ms with a stale-result token guard. **Pure DB reads, no AI.**

- The user can override the price.
- When the entered price differs from expected, a **non-blocking** "Differs from expected \$X (cost + markup at qty N)" hint shows with a one-tap **Reset**.
- A part with no priced tier leaves the price blank (consistent with the quote form).

## Tests / docs

- New `AcceptPurchaseOrderModal.test.tsx` — pre-fill, drift + reset, and the no-priced-tier blank case (mocks `getTiersWithComputedPrices`, uses the real `resolveTier`).
- `docs/modules/jobs.md` — PO viewer + expected-price behavior.
- Full suite green (696 tests) with coverage; `tsc` clean.

## Dependency

Bought-part pre-fill activates once the shared-resolver fix in **#422** (PR-E) lands in `main` — this branch reuses that resolver, so **made** parts price immediately and **bought** parts price after #422 merges. No code change needed here when it does (different files, no conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)