### PR TITLE
Enable deleting referenced addresses via Document Snapshot Standard

### DIFF
--- a/__tests__/utils/quotePdf.test.ts
+++ b/__tests__/utils/quotePdf.test.ts
@@ -468,27 +468,20 @@ describe('generateQuotePdf', () => {
 
     vi.clearAllMocks();
 
-    // Distinct shipping address → SHIP TO column with the shipping address lines.
+    // Distinct shipping-address snapshot → SHIP TO column with its lines. The
+    // PDF reads the frozen ship_to_address snapshot (compared by value against
+    // bill_to_address), not the live address book.
     const twoAddr: QuoteWithRelations = {
       ...baseQuote,
       shipping_address_id: 'addr-2',
-      customers: {
-        ...baseQuote.customers!,
-        addresses: [
-          baseQuote.customers!.addresses![0],
-          {
-            id: 'addr-2',
-            address_line1: '99 Dock Road',
-            address_line2: null,
-            city: 'Toledo',
-            state: 'OH',
-            postal_code: '43601',
-            country: 'USA',
-            default_billing: false,
-            default_shipping: true,
-            attention_to: null,
-          },
-        ],
+      ship_to_address: {
+        address_line1: '99 Dock Road',
+        address_line2: null,
+        city: 'Toledo',
+        state: 'OH',
+        postal_code: '43601',
+        country: 'USA',
+        attention_to: null,
       },
     };
     await generateQuotePdf(twoAddr, baseCompany);

--- a/__tests__/utils/quotePdf.test.ts
+++ b/__tests__/utils/quotePdf.test.ts
@@ -81,6 +81,28 @@ const baseQuote: QuoteWithRelations = {
   created_by: null,
   created_at: '2026-04-16T10:00:00Z',
   updated_at: '2026-04-16T10:00:00Z',
+  // Document Snapshot Standard: the PDF renders these frozen snapshots, not the
+  // live customers/addresses join below (which now only feeds the edit form).
+  customer_name: 'Acme Machining',
+  bill_to_address: {
+    address_line1: '500 Industrial Ave',
+    address_line2: null,
+    city: 'Detroit',
+    state: 'MI',
+    postal_code: '48201',
+    country: 'USA',
+    attention_to: null,
+  },
+  ship_to_address: {
+    address_line1: '500 Industrial Ave',
+    address_line2: null,
+    city: 'Detroit',
+    state: 'MI',
+    postal_code: '48201',
+    country: 'USA',
+    attention_to: null,
+  },
+  contact_snapshot: { name: 'Jane Smith', email: 'jane@acme.example', phone: '555-0123' },
   customers: {
     id: 'customer-1',
     name: 'Acme Machining',
@@ -340,10 +362,7 @@ describe('generateQuotePdf', () => {
   it('does not render the billing address attention_to (Attn:) line in the CUSTOMER block', async () => {
     const quoteWithAttn: QuoteWithRelations = {
       ...baseQuote,
-      customers: {
-        ...baseQuote.customers!,
-        addresses: [{ ...baseQuote.customers!.addresses![0], attention_to: 'Receiving Dept' }],
-      },
+      bill_to_address: { ...baseQuote.bill_to_address!, attention_to: 'Receiving Dept' },
     };
 
     await generateQuotePdf(quoteWithAttn, baseCompany);
@@ -356,6 +375,31 @@ describe('generateQuotePdf', () => {
     expect(rendered).toContain('CUSTOMER');
     expect(rendered).not.toContain('Attn: Receiving Dept');
     expect(rendered.some((t) => t.includes('Receiving Dept'))).toBe(false);
+  });
+
+  it('renders the customer block from the frozen snapshot, surviving address deletion (FK nulled)', async () => {
+    // Simulate an address deleted after the quote was issued: ON DELETE SET NULL
+    // nulls billing_address_id and strips it from the live customers join, but
+    // the snapshot persists and is what the PDF must render.
+    const afterDelete: QuoteWithRelations = {
+      ...baseQuote,
+      billing_address_id: null,
+      shipping_address_id: null,
+      customers: { ...baseQuote.customers!, addresses: [] },
+    };
+
+    await generateQuotePdf(afterDelete, baseCompany);
+
+    const docInstance = jsPDFCtor.mock.results[0].value;
+    const rendered = docInstance.text.mock.calls
+      .map((c: unknown[]) => c[0])
+      .filter((t: unknown): t is string => typeof t === 'string');
+
+    expect(rendered).toContain('Acme Machining');
+    expect(rendered).toContain('500 Industrial Ave');
+    expect(rendered.some((t) => t.includes('Detroit'))).toBe(true);
+    // Contact snapshot still renders too.
+    expect(rendered).toContain('Jane Smith');
   });
 
   it('renders the ACCEPTANCE block with reply-with-a-PO copy and NO signature/date lines', async () => {

--- a/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
+++ b/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
@@ -203,19 +203,17 @@ export default function QuoteDetailPage() {
   }
   const isFirmQuote = partGroups.length > 0 && partGroups.every((g) => g.items.length === 1);
 
-  // Resolve the quote's frozen address/contact FKs against the customer's
-  // address book for display. These were captured at quote creation.
-  const customerAddresses = quote.customers?.addresses ?? [];
-  const customerContacts = quote.customers?.customer_contacts ?? [];
-  const shippingAddress = customerAddresses.find((a) => a.id === quote.shipping_address_id) ?? null;
-  const billingAddress = customerAddresses.find((a) => a.id === quote.billing_address_id) ?? null;
-  const quoteContact = customerContacts.find((c) => c.id === quote.contact_id) ?? null;
-  // Ship-to is its own column only when a distinct shipping address is set;
-  // otherwise the card is just Customer (name + billing) + Contact.
+  // Display the quote's frozen customer/address/contact snapshots (Document
+  // Snapshot Standard), not the live address book — so the view matches the PDF
+  // and survives the master address/contact being edited or deleted.
+  const shippingAddress = quote.ship_to_address;
+  const billingAddress = quote.bill_to_address;
+  const quoteContact = quote.contact_snapshot;
+  // Ship-to is its own column only when a distinct shipping address snapshot is
+  // set (compared by value, so it survives the master address being deleted).
   const showShippingColumn =
-    !!quote.shipping_address_id &&
-    quote.shipping_address_id !== quote.billing_address_id &&
-    shippingAddress !== null;
+    shippingAddress !== null &&
+    JSON.stringify(shippingAddress) !== JSON.stringify(billingAddress);
 
   if (editMode && isEditable) {
     const handleSaveSuccess = async () => {

--- a/components/jobs/JobBillingShippingCard.tsx
+++ b/components/jobs/JobBillingShippingCard.tsx
@@ -61,9 +61,13 @@ export default function JobBillingShippingCard({
     !job.billing_address_id || job.billing_address_id === job.shipping_address_id,
   );
 
-  const shippingAddress = addresses.find((a) => a.id === job.shipping_address_id) ?? null;
-  const billingAddress = addresses.find((a) => a.id === job.billing_address_id) ?? null;
-  const contact = contacts.find((c) => c.id === job.contact_id) ?? null;
+  // Read-only display renders the job's frozen snapshots (Document Snapshot
+  // Standard), not the live address book — so a deleted/edited address doesn't
+  // blank or rewrite what the job was issued with. Editing still picks from the
+  // live book (addresses/contacts) below.
+  const shippingAddress = job.ship_to_address;
+  const billingAddress = job.bill_to_address;
+  const contact = job.contact_snapshot;
   const billingSameAsShipping =
     !!job.shipping_address_id && job.billing_address_id === job.shipping_address_id;
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -396,3 +396,67 @@ job_materials        -- Per-(job, part) materials snapshot (expected + actual co
 - Company context persists across page refreshes
 
 - JWT tokens managed by Supabase Auth with automatic refresh
+
+---
+
+### 15. Document Snapshot Standard
+
+**Problem it solves.** Documents like quotes, jobs, shipments/packing slips, and
+invoices are *point-in-time records*. Master data they reference (customer name,
+addresses, contacts, part names) can change or be deleted later. If a document reads
+that master data live by FK, editing or deleting the master silently rewrites
+history — and FKs that block deletion (`ON DELETE RESTRICT`) trap users who simply
+want to retire an old address. This is the industry-standard ERP/accounting approach
+(NetSuite freezes the address onto the transaction; an invoice is "a frozen official
+legal snapshot").
+
+**The standard.**
+
+> A transactional document must store an **immutable copy** of every master-data
+> field it renders that should reflect the document's *issue date*. Any retained
+> master FK is **nullable** (`ON DELETE SET NULL`) and used only for
+> navigation/relinking — never as the read source for the rendered document.
+
+**Decision rule for any new master→document reference:** *"If this master row is
+later edited or deleted, must this document still show the original value?"*
+Yes → snapshot. No → a live FK is correct (pickers, dashboards, "where-used",
+navigation should always reflect current state).
+
+**Mechanisms (both in use):**
+- **Field / JSON snapshot on the document row** — for rich data. Examples:
+  `quote_line_items.pricing_basis_snapshot`; the customer/address/contact block on
+  `quotes`/`jobs`/`shipments` (`customer_name`, `bill_to_address`, `ship_to_address`,
+  `contact_snapshot`).
+- **Denormalized label + `ON DELETE SET NULL`** — for simple ledger references.
+  Examples: `inventory_transactions.item_name` (deleted parts),
+  `inventory_transactions.location_name` (deleted locations).
+
+**Capture & freeze.** Snapshots are written by `BEFORE INSERT/UPDATE` triggers
+(`snapshot_document_party` on quotes/jobs, `snapshot_shipment_party` on shipments;
+cf. `snapshot_transaction_location_name`). A column is (re)snapshotted only when its
+FK changes to a **non-null** value — so clearing an FK to NULL (including the
+`ON DELETE SET NULL` fired by deleting the master) **preserves** the existing
+snapshot rather than wiping it. Editing the master row never touches the document
+tables, so the snapshot stays frozen.
+
+**On snapshot, enable deletion.** Flip the document's FK to `ON DELETE SET NULL` and
+**backfill every existing row** in the same migration (no "compute live if missing"
+read-path fallback — see the "No silent runtime fallbacks" principle in CLAUDE.md).
+
+#### Snapshot coverage (audit)
+
+| Document | Field | Status |
+|---|---|---|
+| Quote PDF / view | bill-to & ship-to address, customer name, contact | ✅ snapshot (`quotes.bill_to_address` / `ship_to_address` / `customer_name` / `contact_snapshot`) |
+| Quote line items | pricing basis, unit/total price, operation & material names | ✅ snapshot (pre-existing) |
+| Job | address block, customer name, contact | ✅ snapshot (`jobs.*`) |
+| Shipment / packing slip | bill-to & ship-to address, customer name | ✅ snapshot (`shipments.*`) |
+| Inventory ledger | part name (`item_name`), location (`location_name`) | ✅ snapshot (pre-existing) |
+| **Quote line items / packing slip** | **part name & description** | ⚠️ **gap — rendered live** (follow-up) |
+| **QuickBooks invoice push** | **customer name, part names, billing address** | ⚠️ **gap — rendered live at push** (follow-up) |
+
+**Follow-up gaps** (tracked, not yet implemented): snapshot part name/description onto
+`quote_line_items` and packing-slip lines; snapshot customer name / part names /
+billing address into the QuickBooks invoice push (`api/services/quickbooks.py`).
+These are the remaining live-FK reads of identity fields on customer-facing/financial
+documents; apply the standard above when closing them.

--- a/supabase/migrations/20260623021524_add_document_address_snapshots.sql
+++ b/supabase/migrations/20260623021524_add_document_address_snapshots.sql
@@ -1,0 +1,154 @@
+-- Document Snapshot Standard — freeze the customer/address/contact block onto
+-- the documents that render it (quotes, jobs, shipments), so a master address
+-- (or customer name / contact) can be edited or DELETED without rewriting the
+-- history shown on a printed quote / packing slip.
+--
+-- See docs/architecture.md "Document Snapshot Standard". This mirrors the
+-- existing snapshots (quote pricing_basis, quote_operations.operation_name,
+-- inventory_transactions.location_name / item_name): the document carries its
+-- own immutable copy; the master FK is a nullable navigation link only.
+--
+-- Snapshot shapes (jsonb):
+--   address: { address_line1, address_line2, city, state, postal_code, country, attention_to }
+--   contact: { name, email, phone }
+-- customer_name is a discrete text column (house style for name snapshots).
+
+-- ============================================================
+-- 1. Snapshot columns
+-- ============================================================
+ALTER TABLE public.quotes
+    ADD COLUMN IF NOT EXISTS customer_name    text,
+    ADD COLUMN IF NOT EXISTS bill_to_address  jsonb,
+    ADD COLUMN IF NOT EXISTS ship_to_address  jsonb,
+    ADD COLUMN IF NOT EXISTS contact_snapshot jsonb;
+
+ALTER TABLE public.jobs
+    ADD COLUMN IF NOT EXISTS customer_name    text,
+    ADD COLUMN IF NOT EXISTS bill_to_address  jsonb,
+    ADD COLUMN IF NOT EXISTS ship_to_address  jsonb,
+    ADD COLUMN IF NOT EXISTS contact_snapshot jsonb;
+
+ALTER TABLE public.shipments
+    ADD COLUMN IF NOT EXISTS customer_name    text,
+    ADD COLUMN IF NOT EXISTS bill_to_address  jsonb,
+    ADD COLUMN IF NOT EXISTS ship_to_address  jsonb;
+
+COMMENT ON COLUMN public.quotes.bill_to_address IS
+    'Immutable snapshot of the billing address block at quote issue time (Document Snapshot Standard). The rendered quote reads this, not the live billing_address_id row.';
+COMMENT ON COLUMN public.quotes.ship_to_address IS
+    'Immutable snapshot of the shipping address block at quote issue time.';
+COMMENT ON COLUMN public.quotes.contact_snapshot IS
+    'Immutable snapshot of the customer contact { name, email, phone } at quote issue time.';
+COMMENT ON COLUMN public.quotes.customer_name IS
+    'Immutable snapshot of the customer name at quote issue time.';
+COMMENT ON COLUMN public.shipments.bill_to_address IS
+    'Immutable snapshot of the bill-to address block at shipment/packing-slip issue time.';
+COMMENT ON COLUMN public.shipments.ship_to_address IS
+    'Immutable snapshot of the ship-to address block at shipment issue time.';
+
+-- ============================================================
+-- 2. Reusable snapshot expressions (used by the backfill below)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.address_block_snapshot(p_address_id uuid)
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT jsonb_build_object(
+           'address_line1', a.address_line1,
+           'address_line2', a.address_line2,
+           'city',          a.city,
+           'state',         a.state,
+           'postal_code',   a.postal_code,
+           'country',       a.country,
+           'attention_to',  a.attention_to
+         )
+    FROM public.customer_addresses a
+   WHERE a.id = p_address_id;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.contact_block_snapshot(p_contact_id uuid)
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT jsonb_build_object(
+           'name',  c.name,
+           'email', c.email,
+           'phone', c.phone
+         )
+    FROM public.customer_contacts c
+   WHERE c.id = p_contact_id;
+$function$;
+
+-- ============================================================
+-- 3. Backfill existing rows (data-at-rest: every document that has an FK gets
+--    its snapshot; no runtime "compute live if missing" fallback).
+-- ============================================================
+UPDATE public.quotes q
+   SET customer_name    = c.name,
+       bill_to_address  = public.address_block_snapshot(q.billing_address_id),
+       ship_to_address  = public.address_block_snapshot(q.shipping_address_id),
+       contact_snapshot = public.contact_block_snapshot(q.contact_id)
+  FROM public.customers c
+ WHERE q.customer_id = c.id;
+
+UPDATE public.quotes q
+   SET bill_to_address  = public.address_block_snapshot(q.billing_address_id),
+       ship_to_address  = public.address_block_snapshot(q.shipping_address_id),
+       contact_snapshot = public.contact_block_snapshot(q.contact_id)
+ WHERE q.customer_id IS NULL;
+
+UPDATE public.jobs j
+   SET customer_name    = c.name,
+       bill_to_address  = public.address_block_snapshot(j.billing_address_id),
+       ship_to_address  = public.address_block_snapshot(j.shipping_address_id),
+       contact_snapshot = public.contact_block_snapshot(j.contact_id)
+  FROM public.customers c
+ WHERE j.customer_id = c.id;
+
+UPDATE public.jobs j
+   SET bill_to_address  = public.address_block_snapshot(j.billing_address_id),
+       ship_to_address  = public.address_block_snapshot(j.shipping_address_id),
+       contact_snapshot = public.contact_block_snapshot(j.contact_id)
+ WHERE j.customer_id IS NULL;
+
+-- Shipments: ship-to is the shipment's own shipping_address_id; bill-to is the
+-- customer's default-billing row at issue time (matches today's packing-slip render).
+UPDATE public.shipments s
+   SET customer_name   = c.name,
+       ship_to_address = public.address_block_snapshot(s.shipping_address_id),
+       bill_to_address = public.address_block_snapshot(
+                           (SELECT a.id FROM public.customer_addresses a
+                             WHERE a.customer_id = s.customer_id AND a.default_billing
+                             LIMIT 1))
+  FROM public.customers c
+ WHERE s.customer_id = c.id;
+
+-- ============================================================
+-- 4. FK: RESTRICT -> SET NULL so an address can be deleted; snapshots preserve
+--    history, the live FK simply nulls. (jobs.*_address_id already SET NULL.)
+-- ============================================================
+ALTER TABLE public.quotes
+    DROP CONSTRAINT IF EXISTS quotes_billing_address_id_fkey,
+    DROP CONSTRAINT IF EXISTS quotes_shipping_address_id_fkey;
+ALTER TABLE public.quotes
+    ADD CONSTRAINT quotes_billing_address_id_fkey
+        FOREIGN KEY (billing_address_id) REFERENCES public.customer_addresses(id) ON DELETE SET NULL,
+    ADD CONSTRAINT quotes_shipping_address_id_fkey
+        FOREIGN KEY (shipping_address_id) REFERENCES public.customer_addresses(id) ON DELETE SET NULL;
+
+-- Shipments: the ship-to snapshot is now the source of truth for the rendered
+-- address, so the old "shipping_address_id XOR one_time_address" guarantee is no
+-- longer needed (and would block SET NULL on address deletion). Drop it, then
+-- flip the FK to SET NULL.
+ALTER TABLE public.shipments
+    DROP CONSTRAINT IF EXISTS shipments_one_address_source;
+ALTER TABLE public.shipments
+    DROP CONSTRAINT IF EXISTS shipments_shipping_address_id_fkey;
+ALTER TABLE public.shipments
+    ADD CONSTRAINT shipments_shipping_address_id_fkey
+        FOREIGN KEY (shipping_address_id) REFERENCES public.customer_addresses(id) ON DELETE SET NULL;
+
+GRANT ALL ON FUNCTION public.address_block_snapshot(uuid) TO anon, authenticated, service_role;
+GRANT ALL ON FUNCTION public.contact_block_snapshot(uuid) TO anon, authenticated, service_role;

--- a/supabase/migrations/20260623021901_add_document_snapshot_triggers.sql
+++ b/supabase/migrations/20260623021901_add_document_snapshot_triggers.sql
@@ -1,0 +1,105 @@
+-- Document Snapshot Standard — capture triggers.
+--
+-- Populate the customer/address/contact snapshot columns on quotes/jobs/shipments
+-- from their FKs, at INSERT and whenever an FK changes to a NEW non-null value.
+-- This mirrors inventory_transactions' snapshot_transaction_location_name trigger
+-- and means no application write path needs to resolve snapshots by hand.
+--
+-- Freeze semantics (critical):
+--   * On INSERT: snapshot from the FKs.
+--   * On UPDATE: re-snapshot a column ONLY when its FK changed to a non-null value
+--     (the user picked a different address/contact). When an FK is cleared to NULL
+--     — including the ON DELETE SET NULL fired by deleting the master address —
+--     the existing snapshot is PRESERVED, so deleting an address never wipes the
+--     history rendered on a past quote/packing slip.
+--   * Editing the master row itself (customer_addresses / customers / contacts)
+--     does not touch these tables, so existing snapshots stay frozen.
+
+-- ============================================================
+-- quotes & jobs (same column set: customer_id, billing/shipping_address_id, contact_id)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.snapshot_document_party()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+    IF TG_OP = 'INSERT' OR NEW.customer_id IS DISTINCT FROM OLD.customer_id THEN
+        IF NEW.customer_id IS NOT NULL THEN
+            NEW.customer_name := (SELECT name FROM public.customers WHERE id = NEW.customer_id);
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' OR NEW.billing_address_id IS DISTINCT FROM OLD.billing_address_id THEN
+        IF NEW.billing_address_id IS NOT NULL THEN
+            NEW.bill_to_address := public.address_block_snapshot(NEW.billing_address_id);
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' OR NEW.shipping_address_id IS DISTINCT FROM OLD.shipping_address_id THEN
+        IF NEW.shipping_address_id IS NOT NULL THEN
+            NEW.ship_to_address := public.address_block_snapshot(NEW.shipping_address_id);
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' OR NEW.contact_id IS DISTINCT FROM OLD.contact_id THEN
+        IF NEW.contact_id IS NOT NULL THEN
+            NEW.contact_snapshot := public.contact_block_snapshot(NEW.contact_id);
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS trg_snapshot_quote_party ON public.quotes;
+CREATE TRIGGER trg_snapshot_quote_party
+    BEFORE INSERT OR UPDATE OF customer_id, billing_address_id, shipping_address_id, contact_id
+    ON public.quotes
+    FOR EACH ROW EXECUTE FUNCTION public.snapshot_document_party();
+
+DROP TRIGGER IF EXISTS trg_snapshot_job_party ON public.jobs;
+CREATE TRIGGER trg_snapshot_job_party
+    BEFORE INSERT OR UPDATE OF customer_id, billing_address_id, shipping_address_id, contact_id
+    ON public.jobs
+    FOR EACH ROW EXECUTE FUNCTION public.snapshot_document_party();
+
+-- ============================================================
+-- shipments (no contact; bill-to derives from the customer's default-billing row)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.snapshot_shipment_party()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+    IF TG_OP = 'INSERT' OR NEW.customer_id IS DISTINCT FROM OLD.customer_id THEN
+        IF NEW.customer_id IS NOT NULL THEN
+            NEW.customer_name := (SELECT name FROM public.customers WHERE id = NEW.customer_id);
+            NEW.bill_to_address := public.address_block_snapshot(
+                (SELECT a.id FROM public.customer_addresses a
+                  WHERE a.customer_id = NEW.customer_id AND a.default_billing
+                  LIMIT 1));
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' OR NEW.shipping_address_id IS DISTINCT FROM OLD.shipping_address_id THEN
+        IF NEW.shipping_address_id IS NOT NULL THEN
+            NEW.ship_to_address := public.address_block_snapshot(NEW.shipping_address_id);
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS trg_snapshot_shipment_party ON public.shipments;
+CREATE TRIGGER trg_snapshot_shipment_party
+    BEFORE INSERT OR UPDATE OF customer_id, shipping_address_id
+    ON public.shipments
+    FOR EACH ROW EXECUTE FUNCTION public.snapshot_shipment_party();
+
+GRANT ALL ON FUNCTION public.snapshot_document_party() TO anon, authenticated, service_role;
+GRANT ALL ON FUNCTION public.snapshot_shipment_party() TO anon, authenticated, service_role;

--- a/types/database.ts
+++ b/types/database.ts
@@ -1112,13 +1112,16 @@ export type Database = {
       }
       jobs: {
         Row: {
+          bill_to_address: Json | null
           billing_address_id: string | null
           company_id: string
           completed_at: string | null
           contact_id: string | null
+          contact_snapshot: Json | null
           created_at: string | null
           created_by: string | null
           customer_id: string | null
+          customer_name: string | null
           customer_po_number: string | null
           due_date: string | null
           fulfillment_status: string
@@ -1127,19 +1130,23 @@ export type Database = {
           lead_time_days: number | null
           production_status: string
           quote_id: string | null
+          ship_to_address: Json | null
           shipping_address_id: string | null
           started_at: string | null
           status_changed_at: string | null
           updated_at: string | null
         }
         Insert: {
+          bill_to_address?: Json | null
           billing_address_id?: string | null
           company_id: string
           completed_at?: string | null
           contact_id?: string | null
+          contact_snapshot?: Json | null
           created_at?: string | null
           created_by?: string | null
           customer_id?: string | null
+          customer_name?: string | null
           customer_po_number?: string | null
           due_date?: string | null
           fulfillment_status: string
@@ -1148,19 +1155,23 @@ export type Database = {
           lead_time_days?: number | null
           production_status: string
           quote_id?: string | null
+          ship_to_address?: Json | null
           shipping_address_id?: string | null
           started_at?: string | null
           status_changed_at?: string | null
           updated_at?: string | null
         }
         Update: {
+          bill_to_address?: Json | null
           billing_address_id?: string | null
           company_id?: string
           completed_at?: string | null
           contact_id?: string | null
+          contact_snapshot?: Json | null
           created_at?: string | null
           created_by?: string | null
           customer_id?: string | null
+          customer_name?: string | null
           customer_po_number?: string | null
           due_date?: string | null
           fulfillment_status?: string
@@ -1169,6 +1180,7 @@ export type Database = {
           lead_time_days?: number | null
           production_status?: string
           quote_id?: string | null
+          ship_to_address?: Json | null
           shipping_address_id?: string | null
           started_at?: string | null
           status_changed_at?: string | null
@@ -2116,13 +2128,16 @@ export type Database = {
       }
       quotes: {
         Row: {
+          bill_to_address: Json | null
           billing_address_id: string | null
           company_id: string
           contact_id: string | null
+          contact_snapshot: Json | null
           converted_at: string | null
           created_at: string | null
           created_by: string | null
           customer_id: string | null
+          customer_name: string | null
           expiration_date: string | null
           id: string
           lead_time_days: number | null
@@ -2130,19 +2145,23 @@ export type Database = {
           lead_time_value: number | null
           payment_terms: string | null
           quote_number: string
+          ship_to_address: Json | null
           shipping_address_id: string | null
           status: string
           status_changed_at: string | null
           updated_at: string | null
         }
         Insert: {
+          bill_to_address?: Json | null
           billing_address_id?: string | null
           company_id: string
           contact_id?: string | null
+          contact_snapshot?: Json | null
           converted_at?: string | null
           created_at?: string | null
           created_by?: string | null
           customer_id?: string | null
+          customer_name?: string | null
           expiration_date?: string | null
           id?: string
           lead_time_days?: number | null
@@ -2150,19 +2169,23 @@ export type Database = {
           lead_time_value?: number | null
           payment_terms?: string | null
           quote_number: string
+          ship_to_address?: Json | null
           shipping_address_id?: string | null
           status?: string
           status_changed_at?: string | null
           updated_at?: string | null
         }
         Update: {
+          bill_to_address?: Json | null
           billing_address_id?: string | null
           company_id?: string
           contact_id?: string | null
+          contact_snapshot?: Json | null
           converted_at?: string | null
           created_at?: string | null
           created_by?: string | null
           customer_id?: string | null
+          customer_name?: string | null
           expiration_date?: string | null
           id?: string
           lead_time_days?: number | null
@@ -2170,6 +2193,7 @@ export type Database = {
           lead_time_value?: number | null
           payment_terms?: string | null
           quote_number?: string
+          ship_to_address?: Json | null
           shipping_address_id?: string | null
           status?: string
           status_changed_at?: string | null
@@ -2403,51 +2427,60 @@ export type Database = {
       }
       shipments: {
         Row: {
+          bill_to_address: Json | null
           carrier: string | null
           company_id: string
           created_at: string
           created_by: string | null
           customer_id: string
+          customer_name: string | null
           id: string
           job_id: string
           notes: string | null
           one_time_address: Json | null
           packing_slip_number: string
           ship_date: string
+          ship_to_address: Json | null
           shipping_address_id: string | null
           shipping_method: string | null
           voided_at: string | null
           voided_by: string | null
         }
         Insert: {
+          bill_to_address?: Json | null
           carrier?: string | null
           company_id: string
           created_at?: string
           created_by?: string | null
           customer_id: string
+          customer_name?: string | null
           id?: string
           job_id: string
           notes?: string | null
           one_time_address?: Json | null
           packing_slip_number: string
           ship_date?: string
+          ship_to_address?: Json | null
           shipping_address_id?: string | null
           shipping_method?: string | null
           voided_at?: string | null
           voided_by?: string | null
         }
         Update: {
+          bill_to_address?: Json | null
           carrier?: string | null
           company_id?: string
           created_at?: string
           created_by?: string | null
           customer_id?: string
+          customer_name?: string | null
           id?: string
           job_id?: string
           notes?: string | null
           one_time_address?: Json | null
           packing_slip_number?: string
           ship_date?: string
+          ship_to_address?: Json | null
           shipping_address_id?: string | null
           shipping_method?: string | null
           voided_at?: string | null
@@ -2792,6 +2825,7 @@ export type Database = {
         }
         Returns: Json
       }
+      address_block_snapshot: { Args: { p_address_id: string }; Returns: Json }
       adjust_stock_at_location: {
         Args: {
           p_converted_new_quantity: number
@@ -2830,6 +2864,7 @@ export type Database = {
           unit_cost: number
         }[]
       }
+      contact_block_snapshot: { Args: { p_contact_id: string }; Returns: Json }
       create_demo_company: {
         Args: {
           p_source_company_id: string

--- a/types/documentSnapshot.ts
+++ b/types/documentSnapshot.ts
@@ -1,0 +1,27 @@
+/**
+ * Document Snapshot Standard — shared snapshot shapes.
+ *
+ * Transactional documents (quotes, jobs, shipments) freeze the customer/address/
+ * contact block they render onto their own row, so editing or deleting the master
+ * record never rewrites a historical quote/packing slip. See docs/architecture.md
+ * "Document Snapshot Standard". These shapes match the jsonb the DB triggers write
+ * (snapshot_document_party / snapshot_shipment_party).
+ */
+
+/** Frozen copy of a customer_addresses row's printable fields. */
+export interface AddressSnapshot {
+  address_line1: string | null;
+  address_line2: string | null;
+  city: string | null;
+  state: string | null;
+  postal_code: string | null;
+  country: string | null;
+  attention_to: string | null;
+}
+
+/** Frozen copy of a customer_contacts row's printable fields. */
+export interface ContactSnapshot {
+  name: string | null;
+  email: string | null;
+  phone: string | null;
+}

--- a/types/job.ts
+++ b/types/job.ts
@@ -3,6 +3,8 @@
  * by recomputeJobPartStatus, aggregated to the parent job via the
  * sync_job_production_status_from_parts trigger.
  */
+import type { AddressSnapshot, ContactSnapshot } from '@/types/documentSnapshot';
+
 export type ProductionStatus = 'not_started' | 'in_progress' | 'completed' | 'cancelled';
 
 /**
@@ -76,6 +78,12 @@ export interface Job {
   created_by: string | null;
   created_at: string;
   updated_at: string;
+  // Document Snapshot Standard: frozen customer/address/contact block captured
+  // by the snapshot_document_party trigger. See docs/architecture.md.
+  customer_name: string | null;
+  bill_to_address: AddressSnapshot | null;
+  ship_to_address: AddressSnapshot | null;
+  contact_snapshot: ContactSnapshot | null;
 }
 
 /**

--- a/types/quote.ts
+++ b/types/quote.ts
@@ -1,3 +1,5 @@
+import type { AddressSnapshot, ContactSnapshot } from '@/types/documentSnapshot';
+
 /**
  * Quote status values
  */
@@ -126,6 +128,13 @@ export interface Quote {
   created_by: string | null;
   created_at: string;
   updated_at: string;
+  // Document Snapshot Standard: frozen customer/address/contact block captured
+  // at issue time by the snapshot_document_party trigger. The quote PDF renders
+  // these, not the live FKs, so editing/deleting the master never rewrites it.
+  customer_name: string | null;
+  bill_to_address: AddressSnapshot | null;
+  ship_to_address: AddressSnapshot | null;
+  contact_snapshot: ContactSnapshot | null;
 }
 
 /**

--- a/types/shipment.ts
+++ b/types/shipment.ts
@@ -13,6 +13,7 @@
  */
 
 import type { CustomerAddress } from '@/types/customer';
+import type { AddressSnapshot } from '@/types/documentSnapshot';
 
 export type ShippingMethod =
   | 'customer_pickup'
@@ -45,6 +46,12 @@ export interface Shipment {
   created_at: string;
   voided_at: string | null;
   voided_by: string | null;
+  // Document Snapshot Standard: frozen bill-to/ship-to block + customer name,
+  // captured by the snapshot_shipment_party trigger. The packing slip renders
+  // these, not the live address rows. See docs/architecture.md.
+  customer_name: string | null;
+  bill_to_address: AddressSnapshot | null;
+  ship_to_address: AddressSnapshot | null;
 }
 
 export interface ShipmentLineItem {

--- a/utils/packingSlipPdf.ts
+++ b/utils/packingSlipPdf.ts
@@ -30,7 +30,7 @@
 import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import type { Company } from '@/utils/companyAccess';
-import type { CustomerAddress } from '@/types/customer';
+import type { AddressSnapshot } from '@/types/documentSnapshot';
 import { SHIPPING_METHOD_LABELS, type ShipmentWithRelations } from '@/types/shipment';
 import { resolveAttentionLine } from '@/utils/shipmentsAccess';
 
@@ -100,7 +100,7 @@ export function buildShopHeaderLines(company: Company): string[] {
 
 function buildAddressBlockLines(
   customerName: string | null | undefined,
-  address: CustomerAddress | null,
+  address: AddressSnapshot | null,
   attentionText: string | null,
 ): string[] {
   const lines: string[] = [];
@@ -300,19 +300,19 @@ export async function generatePackingSlipPdf(
   const leftX = MARGIN;
   const rightX = MARGIN + colWidth + 8;
 
+  // Render the frozen snapshots captured on the shipment at issue time
+  // (Document Snapshot Standard — snapshot_shipment_party trigger), not the live
+  // address rows, so the slip is unchanged after the master address edits/deletes.
   const attention = resolveAttentionLine(shipment);
-  const shipToAddress = shipment.shipping_address ?? null;
   const shipLines = buildAddressBlockLines(
-    shipment.customer?.name ?? null,
-    shipToAddress,
+    shipment.customer_name,
+    shipment.ship_to_address,
     attention.text,
   );
 
-  const billToAddress =
-    shipment.customer?.addresses?.find((a) => a.default_billing) ?? null;
   const billLines = buildAddressBlockLines(
-    shipment.customer?.name ?? null,
-    billToAddress,
+    shipment.customer_name,
+    shipment.bill_to_address,
     null,
   );
 

--- a/utils/quotePdf.ts
+++ b/utils/quotePdf.ts
@@ -8,6 +8,7 @@
 import { jsPDF } from 'jspdf';
 import autoTable, { type RowInput } from 'jspdf-autotable';
 import type { QuoteWithRelations } from '@/types/quote';
+import type { AddressSnapshot } from '@/types/documentSnapshot';
 import type { Company } from '@/utils/companyAccess';
 import { isQuoteExpired, daysUntilExpiration, formatLeadTime } from '@/types/quote';
 
@@ -66,38 +67,9 @@ function buildShopHeaderLines(company: Company): string[] {
   return lines;
 }
 
-type QuoteCustomer = NonNullable<QuoteWithRelations['customers']>;
-type QuoteCustomerAddress = NonNullable<QuoteCustomer['addresses']>[number];
-type QuoteCustomerContact = NonNullable<QuoteCustomer['customer_contacts']>[number];
-
-/**
- * Resolve an embedded customer_addresses row by id. The quote carries
- * billing_address_id (rendered on the PDF under the CUSTOMER block) and
- * shipping_address_id (stored for downstream fulfillment, not rendered) —
- * both point at the address rows joined under quote.customers.addresses.
- * Returns null when the FK is null or the lookup misses (e.g. address was
- * deleted after the quote was issued).
- */
-function findAddressById(
-  addresses: QuoteCustomerAddress[] | undefined,
-  addressId: string | null | undefined,
-): QuoteCustomerAddress | null {
-  if (!addressId || !addresses || addresses.length === 0) return null;
-  return addresses.find((a) => a.id === addressId) ?? null;
-}
-
-/**
- * Resolve an embedded customer_contacts row by id. Used for the Customer
- * Contact section rendered below the metadata block. Returns null when
- * the FK is null or the lookup misses.
- */
-function findContactById(
-  contacts: QuoteCustomerContact[] | undefined,
-  contactId: string | null | undefined,
-): QuoteCustomerContact | null {
-  if (!contactId || !contacts || contacts.length === 0) return null;
-  return contacts.find((c) => c.id === contactId) ?? null;
-}
+// The customer/address/contact block is now read from the quote's frozen
+// snapshot columns (see generateQuotePdf), not resolved from the live joined
+// customer rows — so editing or deleting the master never rewrites a past quote.
 
 /**
  * The address-only lines (line1, line2, city/state/zip, non-US country) for a
@@ -105,7 +77,7 @@ function findContactById(
  * SHIP TO column (the customer name already heads the CUSTOMER column) and as
  * the address half of the Customer block.
  */
-function buildAddressOnlyLines(address: QuoteCustomerAddress | null): string[] {
+function buildAddressOnlyLines(address: AddressSnapshot | null): string[] {
   if (!address) return [];
   const lines: string[] = [];
   const cityStateZip = [address.city, address.state].filter(Boolean).join(', ');
@@ -126,14 +98,13 @@ function buildAddressOnlyLines(address: QuoteCustomerAddress | null): string[] {
  * or contact info either.
  */
 function buildBillingAddressLines(
-  customer: QuoteCustomer | null | undefined,
-  address: QuoteCustomerAddress | null,
+  customerName: string | null,
+  address: AddressSnapshot | null,
 ): string[] {
-  if (!customer) return ['(No customer)'];
   const lines: string[] = [];
-  if (customer.name) lines.push(customer.name);
+  if (customerName) lines.push(customerName);
   lines.push(...buildAddressOnlyLines(address));
-  return lines;
+  return lines.length > 0 ? lines : ['(No customer)'];
 }
 
 /**
@@ -243,23 +214,21 @@ export async function generateQuotePdf(
   cursorY += 20;
 
   // ---------- CUSTOMER · SHIP TO (if different) · CUSTOMER CONTACT ----------
-  // Order: Customer (name + billing address) | Ship to (only when the shipping
-  // address differs from billing) | Customer contact. When shipping == billing
-  // we show just two columns. These FKs are set at quote creation (legacy
-  // quotes were backfilled in migrations 20260520 + 20260522) so the printed
-  // quote always renders what the customer originally saw. "Prepared by" is no
-  // longer a column here — it moved to the acceptance block below now that a
-  // quote is accepted by returning a PO rather than a signature.
-  const billingAddress = findAddressById(quote.customers?.addresses, quote.billing_address_id);
-  const shippingAddress = findAddressById(quote.customers?.addresses, quote.shipping_address_id);
-  const contact = findContactById(quote.customers?.customer_contacts, quote.contact_id);
-  const billingLines = buildBillingAddressLines(quote.customers ?? null, billingAddress);
+  // Render the frozen customer/address/contact snapshot captured on the quote at
+  // issue time (Document Snapshot Standard — snapshot_document_party trigger;
+  // legacy rows backfilled in 20260623021524). The printed quote shows what the
+  // customer originally saw even if the master address/customer/contact is later
+  // edited or deleted. "Prepared by" is not a column here — it lives in the
+  // acceptance block now that a quote is accepted by returning a PO.
+  const shippingAddress = quote.ship_to_address;
+  const contact = quote.contact_snapshot ?? null;
+  const billingLines = buildBillingAddressLines(quote.customer_name, quote.bill_to_address);
 
-  // Shipping is its own column only when a distinct shipping address is set.
+  // Shipping is its own column only when a distinct shipping address snapshot is
+  // set (compared by value, so it survives the master address being deleted).
   const shippingDiffers =
-    !!quote.shipping_address_id &&
-    quote.shipping_address_id !== quote.billing_address_id &&
-    shippingAddress !== null;
+    shippingAddress !== null &&
+    JSON.stringify(shippingAddress) !== JSON.stringify(quote.bill_to_address);
 
   const customerBody: Array<{ text: string; bold: boolean }> = billingLines.map(
     (line: string, i: number) => ({ text: line, bold: i === 0 }),
@@ -270,7 +239,7 @@ export async function generateQuotePdf(
 
   const contactLines: Array<{ text: string; bold: boolean }> = [];
   if (contact) {
-    contactLines.push({ text: contact.name, bold: true });
+    if (contact.name) contactLines.push({ text: contact.name, bold: true });
     if (contact.email) contactLines.push({ text: contact.email, bold: false });
     if (contact.phone) contactLines.push({ text: contact.phone, bold: false });
   }

--- a/utils/shipmentsAccess.ts
+++ b/utils/shipmentsAccess.ts
@@ -553,9 +553,11 @@ export async function getOpenJobPartsForCustomer(
  * the PDF so they can't drift.
  */
 export function resolveAttentionLine(
-  shipment: Pick<ShipmentWithRelations, 'shipping_address'> | null | undefined,
+  shipment: Pick<ShipmentWithRelations, 'ship_to_address'> | null | undefined,
 ): ResolvedAttention {
-  const text = shipment?.shipping_address?.attention_to?.trim() ?? '';
+  // Read the frozen ship-to snapshot, not the live address row, so the ATTN line
+  // matches what the slip was issued with even after the address changes/deletes.
+  const text = shipment?.ship_to_address?.attention_to?.trim() ?? '';
   if (!text) return { source: 'none', text: null };
   return { source: 'address', text };
 }


### PR DESCRIPTION
## Problem

Users couldn't delete a customer shipping/billing address once it had been used on a quote — the address FKs were `ON DELETE RESTRICT`, so the app surfaced *"This address can't be deleted because it's still referenced by quotes."* More broadly, addresses were **live FK references** on quotes/jobs/shipments, so even *editing* an address silently rewrote historical quote PDFs.

## Approach — Document Snapshot Standard

After research (how NetSuite/QuickBooks/ERP systems treat invoice addresses) and an audit of the codebase, we adopted **snapshot-on-document** — the same pattern the team just merged for inventory locations/parts (`location_name`/`item_name` + `ON DELETE SET NULL`). A transactional document freezes the master-data block it renders; the live FK becomes a nullable navigation link.

- Snapshot the customer/address/contact block onto `quotes` / `jobs` / `shipments` at issue time.
- Read paths (quote PDF, packing slip, job card, quote view) render the **snapshot**, not the live row.
- Flip address FKs `RESTRICT → SET NULL` so an address can be truly deleted; history is preserved by the snapshot.

This fixes the original "can't delete" block **and** the latent "editing an address rewrites old quotes" bug.

## Changes

- **Migration `20260623021524`** — `customer_name` + `bill_to_address`/`ship_to_address`/`contact_snapshot` (jsonb) on quotes/jobs/shipments; backfills all existing rows; flips quotes/shipments address FKs to `SET NULL`; drops the now-moot `shipments_one_address_source` XOR check.
- **Migration `20260623021901`** — `BEFORE INSERT/UPDATE` triggers (`snapshot_document_party`, `snapshot_shipment_party`) that freeze the snapshot on issue and **preserve it when an FK is nulled** (so deleting an address can't wipe history).
- Read paths switched to snapshots: `utils/quotePdf.ts`, `utils/packingSlipPdf.ts`, `components/jobs/JobBillingShippingCard.tsx`, quote detail view.
- Shared `types/documentSnapshot.ts` (AddressSnapshot/ContactSnapshot); snapshot fields added to quote/job/shipment types; `types/database.ts` regenerated.
- **Standard documented** in `docs/architecture.md` §15 with a coverage audit table and tracked follow-up gaps.

## Follow-up gaps (documented, not in this PR)

- Snapshot part name/description onto quote line items + packing-slip lines.
- Snapshot customer name / part names / billing address into the QuickBooks invoice push (`api/services/quickbooks.py`).

## Verification

- `pnpm exec tsc --noEmit` clean; full Vitest suite **710 passing**.
- Transactional DB test confirmed end-to-end: deleting a referenced address now **succeeds**, nulls the FK, and **preserves the snapshot** (quote PDF still renders the original block).
- Both migrations applied to **staging**. **Prod push is owned by the human** (per CLAUDE.md) — after prod, run `python scripts/export_schema.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)