### PR TITLE
chore(inventory): drop vestigial is_stockable + is_qr_anchor columns

### DIFF
--- a/__tests__/components/operator/OperatorBinView.test.tsx
+++ b/__tests__/components/operator/OperatorBinView.test.tsx
@@ -36,8 +36,6 @@ const loc = (over: { id: string; name: string; code?: string | null; parent_id?:
   name: over.name,
   kind: 'bin',
   code: over.code ?? null,
-  is_stockable: true,
-  is_qr_anchor: false,
   sort_order: 0,
   created_at: '',
   updated_at: '',

--- a/__tests__/components/operator/OperatorWarehouseHome.test.tsx
+++ b/__tests__/components/operator/OperatorWarehouseHome.test.tsx
@@ -25,8 +25,6 @@ const loc = (over: { id: string; name: string; parent_id?: string | null; code?:
   name: over.name,
   kind: 'cabinet',
   code: over.code ?? null,
-  is_stockable: true,
-  is_qr_anchor: false,
   sort_order: 0,
   created_at: '',
   updated_at: '',

--- a/__tests__/utils/inventoryLocationsAccess.test.ts
+++ b/__tests__/utils/inventoryLocationsAccess.test.ts
@@ -64,8 +64,6 @@ const loc = (over: Partial<InventoryLocation> & { id: string }): InventoryLocati
   name: over.id,
   kind: null,
   code: null,
-  is_stockable: true,
-  is_qr_anchor: false,
   sort_order: 0,
   created_at: '',
   updated_at: '',

--- a/supabase/migrations/20260623031347_drop_location_display_flags.sql
+++ b/supabase/migrations/20260623031347_drop_location_display_flags.sql
@@ -1,0 +1,73 @@
+-- Drop the per-location display flags is_stockable + is_qr_anchor.
+--
+-- Product decision: every location can hold stock, and every location is
+-- printable — so these two flags were bogus. The app stopped reading them in
+-- the #419 changes (PartLocationInventory filter, the Print-QR anchor guard, the
+-- builder QR-depth selector + LocationSpecNode fields all removed); they have
+-- since been vestigial NOT-NULL columns. No RPC / trigger / RLS policy reads
+-- them — the ONLY remaining reference is enable_location_tracking's INSERT of
+-- the system "Unassigned" location, updated below.
+
+-- Re-create enable_location_tracking without the two columns in its INSERT
+-- (the column defaults previously supplied true/false). Body is otherwise
+-- identical to migration 20260622023407.
+CREATE OR REPLACE FUNCTION public.enable_location_tracking(p_part_id uuid, p_initial_location_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_qty numeric; v_tracked boolean; v_loc uuid; v_rollup numeric;
+BEGIN
+    SELECT company_id, quantity, is_location_tracked
+      INTO v_company, v_qty, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+
+    -- Idempotent: already tracked -> no-op.
+    IF v_tracked THEN
+        SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+        RETURN jsonb_build_object('part_quantity', v_rollup, 'tracked', true, 'noop', true);
+    END IF;
+
+    -- Resolve the backfill location: caller-chosen, else find-or-create "Unassigned".
+    IF p_initial_location_id IS NOT NULL THEN
+        PERFORM public.inv_assert_location_in_company(p_initial_location_id, v_company);
+        v_loc := p_initial_location_id;
+    ELSE
+        PERFORM pg_advisory_xact_lock(hashtext('inv_unassigned:' || v_company::text));
+        SELECT id INTO v_loc
+          FROM public.inventory_locations
+         WHERE company_id = v_company AND name = 'Unassigned';
+        IF v_loc IS NULL THEN
+            INSERT INTO public.inventory_locations (company_id, name, kind)
+            VALUES (v_company, 'Unassigned', 'system')
+            RETURNING id INTO v_loc;
+        END IF;
+    END IF;
+
+    -- Flip the flag FIRST (quantity unchanged -> guard skipped), THEN seed the
+    -- backfill balance equal to the pre-existing quantity so the rollup overwrites
+    -- parts.quantity with the same SUM. Never let a standalone value coexist.
+    UPDATE public.parts SET is_location_tracked = true, updated_at = now() WHERE id = p_part_id;
+
+    INSERT INTO public.part_location_stock AS pls (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, v_loc, v_qty)
+    ON CONFLICT (part_id, location_id)
+        DO UPDATE SET quantity = pls.quantity + EXCLUDED.quantity;
+
+    SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+    RETURN jsonb_build_object('location_id', v_loc, 'part_quantity', v_rollup, 'tracked', true);
+END;
+$function$;
+
+-- Now the columns are unreferenced everywhere — drop them.
+ALTER TABLE public.inventory_locations
+    DROP COLUMN IF EXISTS is_stockable,
+    DROP COLUMN IF EXISTS is_qr_anchor;

--- a/types/database.ts
+++ b/types/database.ts
@@ -7,11 +7,6 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.4"
-  }
   graphql_public: {
     Tables: {
       [_ in never]: never
@@ -512,8 +507,6 @@ export type Database = {
           company_id: string
           created_at: string
           id: string
-          is_qr_anchor: boolean
-          is_stockable: boolean
           kind: string | null
           name: string
           parent_id: string | null
@@ -525,8 +518,6 @@ export type Database = {
           company_id: string
           created_at?: string
           id?: string
-          is_qr_anchor?: boolean
-          is_stockable?: boolean
           kind?: string | null
           name: string
           parent_id?: string | null
@@ -538,8 +529,6 @@ export type Database = {
           company_id?: string
           created_at?: string
           id?: string
-          is_qr_anchor?: boolean
-          is_stockable?: boolean
           kind?: string | null
           name?: string
           parent_id?: string | null
@@ -2241,7 +2230,6 @@ export type Database = {
         Row: {
           created_at: string | null
           cycle_minutes_per_unit: number | null
-          external_setup_cost: number | null
           external_unit_price: number | null
           id: string
           instructions: string | null
@@ -2256,7 +2244,6 @@ export type Database = {
         Insert: {
           created_at?: string | null
           cycle_minutes_per_unit?: number | null
-          external_setup_cost?: number | null
           external_unit_price?: number | null
           id?: string
           instructions?: string | null
@@ -2271,7 +2258,6 @@ export type Database = {
         Update: {
           created_at?: string | null
           cycle_minutes_per_unit?: number | null
-          external_setup_cost?: number | null
           external_unit_price?: number | null
           id?: string
           instructions?: string | null
@@ -3146,3 +3132,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+

--- a/types/inventoryLocations.ts
+++ b/types/inventoryLocations.ts
@@ -13,8 +13,6 @@ export interface InventoryLocation {
   name: string;
   kind: string | null;
   code: string | null;
-  is_stockable: boolean;
-  is_qr_anchor: boolean;
   sort_order: number;
   created_at: string;
   updated_at: string;
@@ -31,16 +29,11 @@ export interface CreateLocationInput {
   name: string;
   kind?: string | null;
   code?: string | null;
-  is_stockable?: boolean;
-  is_qr_anchor?: boolean;
   sort_order?: number;
 }
 
 export type UpdateLocationInput = Partial<
-  Pick<
-    InventoryLocation,
-    'name' | 'kind' | 'code' | 'is_stockable' | 'is_qr_anchor' | 'sort_order'
-  >
+  Pick<InventoryLocation, 'name' | 'kind' | 'code' | 'sort_order'>
 >;
 
 /**

--- a/utils/inventoryLocationsAccess.ts
+++ b/utils/inventoryLocationsAccess.ts
@@ -29,7 +29,7 @@ import type {
 } from '@/types/inventoryLocations';
 
 const LOCATION_COLUMNS =
-  'id, company_id, parent_id, name, kind, code, is_stockable, is_qr_anchor, sort_order, created_at, updated_at';
+  'id, company_id, parent_id, name, kind, code, sort_order, created_at, updated_at';
 
 // ===========================================================================
 // Tree CRUD
@@ -121,8 +121,6 @@ export async function createLocation(
       name: input.name.trim(),
       kind: input.kind ?? null,
       code: input.code ?? null,
-      is_stockable: input.is_stockable ?? true,
-      is_qr_anchor: input.is_qr_anchor ?? false,
       sort_order: input.sort_order ?? 0,
     })
     .select(LOCATION_COLUMNS)


### PR DESCRIPTION
## What

Removes the two per-location flags that the "every location can hold stock + is printable" decision (#419) made meaningless. The app stopped *reading* them back then; they've been vestigial NOT-NULL columns since. This was deliberately deferred until #414 + #419 + #425 + #427 all merged (so nothing on `main` still selects them) — now done.

## Migration `20260623031347_drop_location_display_flags.sql`
- `CREATE OR REPLACE enable_location_tracking` — its "Unassigned" INSERT was the **only** DB reference to the columns; rewritten to list `(company_id, name, kind)` (the dropped columns previously supplied `true`/`false` via defaults). Body otherwise identical to `20260622023407`.
- `ALTER TABLE inventory_locations DROP COLUMN is_stockable, is_qr_anchor`.
- Verified no RPC/trigger/RLS policy reads them (`pg_proc` scan) and no index/view/constraint depends on them.

## Code
- Regenerated `types/database.ts` from staging.
- Removed the fields from `InventoryLocation` / `CreateLocationInput` / `UpdateLocationInput`, `LOCATION_COLUMNS`, the `createLocation` insert, and the test fixtures.

## Validation
- **Applied to staging**; rolled-back smoke test confirmed `enable_location_tracking` still re-creates the "Unassigned" bucket via the new INSERT and seeds the backfill balance. E2E data left intact.
- `tsc` clean; full **Vitest 714**; lint clean.

## ⚠️ Prod
Prod doesn't have the inventory-locations tables yet — the whole feature's migrations are still owed to prod. **Push them all to prod together** (this drop is the latest in the chain), then re-run `scripts/export_schema.py` to refresh the schema snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)