### PR TITLE
feat(operator): receive a part into a scanned bin

### DIFF
--- a/__tests__/components/operator/OperatorBinView.test.tsx
+++ b/__tests__/components/operator/OperatorBinView.test.tsx
@@ -29,6 +29,13 @@ vi.mock('@/utils/operatorAccess', () => ({
   getCurrentOperator: vi.fn(),
 }));
 
+// The bin view embeds the "Stock a part" receive modal, which imports
+// partsAccess (→ lib/supabase). Mock it so the module graph doesn't eval the
+// real Supabase client. The modal isn't opened in these tests.
+vi.mock('@/utils/partsAccess', () => ({
+  getStockedParts: vi.fn().mockResolvedValue([]),
+}));
+
 const loc = (over: { id: string; name: string; code?: string | null; parent_id?: string | null }) => ({
   id: over.id,
   company_id: 'co1',

--- a/__tests__/components/operator/OperatorReceivePartModal.test.tsx
+++ b/__tests__/components/operator/OperatorReceivePartModal.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@mui/material/styles';
+import jiggedTheme from '@/lib/theme';
+
+import OperatorReceivePartModal from '@/components/operator/OperatorReceivePartModal';
+import { addStockAtLocation } from '@/utils/inventoryLocationsAccess';
+import { getStockedParts } from '@/utils/partsAccess';
+import type { Part } from '@/types/part';
+
+vi.mock('@/utils/inventoryLocationsAccess', () => ({ addStockAtLocation: vi.fn() }));
+vi.mock('@/utils/partsAccess', () => ({ getStockedParts: vi.fn() }));
+
+const part = (over: { id: string; part_name: string; is_location_tracked: boolean }) =>
+  ({ ...over, primary_unit: 'ea' }) as unknown as Part;
+
+const renderModal = (props: Partial<React.ComponentProps<typeof OperatorReceivePartModal>> = {}) =>
+  render(
+    <OperatorReceivePartModal
+      open
+      companyId="co1"
+      locationId="loc1"
+      locationName="Bin 3"
+      excludePartIds={['pC']}
+      onClose={vi.fn()}
+      onDone={vi.fn()}
+      {...props}
+    />,
+    { wrapper: ({ children }) => <ThemeProvider theme={jiggedTheme}>{children}</ThemeProvider> },
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getStockedParts as ReturnType<typeof vi.fn>).mockResolvedValue([
+    part({ id: 'pA', part_name: 'Part A', is_location_tracked: true }),
+    part({ id: 'pB', part_name: 'Part B', is_location_tracked: false }), // not tracked → excluded
+    part({ id: 'pC', part_name: 'Part C', is_location_tracked: true }), // already here → excluded
+  ]);
+});
+
+describe('OperatorReceivePartModal', () => {
+  const openPartPicker = async () => {
+    const input = await screen.findByRole('combobox', { name: 'Part' });
+    await userEvent.click(input);
+    await userEvent.keyboard('{ArrowDown}'); // ensure the listbox opens
+    return input;
+  };
+
+  it('offers only tracked parts not already in the bin', async () => {
+    renderModal();
+    await openPartPicker();
+    expect(await screen.findByRole('option', { name: 'Part A' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Part B' })).not.toBeInTheDocument(); // untracked
+    expect(screen.queryByRole('option', { name: 'Part C' })).not.toBeInTheDocument(); // already here
+  });
+
+  it('adds the chosen part at this location', async () => {
+    (addStockAtLocation as ReturnType<typeof vi.fn>).mockResolvedValue({ location_balance: 10, part_quantity: 10 });
+    const onDone = vi.fn();
+    renderModal({ onDone });
+
+    await openPartPicker();
+    await userEvent.click(await screen.findByRole('option', { name: 'Part A' }));
+    await userEvent.type(screen.getByRole('spinbutton', { name: 'Quantity' }), '10');
+    await userEvent.click(screen.getByRole('button', { name: /^add$/i }));
+
+    await waitFor(() =>
+      expect(addStockAtLocation).toHaveBeenCalledWith('pA', 'loc1', 10, 'ea', undefined),
+    );
+    expect(onDone).toHaveBeenCalled();
+  });
+});

--- a/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
+++ b/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
@@ -18,6 +18,7 @@ import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import TuneIcon from '@mui/icons-material/Tune';
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
 
 import { resolveScan } from '@/utils/inventoryLocationsAccess';
@@ -27,6 +28,7 @@ import type { ResolvedScan, LocationContent } from '@/types/inventoryLocations';
 import OperatorLocationActionModal, {
   type OperatorLocationAction,
 } from '@/components/operator/OperatorLocationActionModal';
+import OperatorReceivePartModal from '@/components/operator/OperatorReceivePartModal';
 
 const num = (n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 4 });
 
@@ -44,6 +46,7 @@ export default function OperatorBinViewPage() {
   const [modal, setModal] = useState<{ action: OperatorLocationAction; part: LocationContent } | null>(
     null,
   );
+  const [receiveOpen, setReceiveOpen] = useState(false);
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -168,9 +171,14 @@ export default function OperatorBinViewPage() {
 
       {/* Stock here: act on each part */}
       <Box>
-        <Typography variant="overline" color="text.secondary">
-          Stock here
-        </Typography>
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
+          <Typography variant="overline" color="text.secondary" sx={{ flex: 1 }}>
+            Stock here
+          </Typography>
+          <Button size="small" startIcon={<AddCircleOutlineIcon />} onClick={() => setReceiveOpen(true)}>
+            Stock a part
+          </Button>
+        </Stack>
         {contents.length === 0 ? (
           <Card elevation={2} sx={{ mt: 0.5 }}>
             <CardContent sx={{ textAlign: 'center', py: 4 }}>
@@ -250,6 +258,16 @@ export default function OperatorBinViewPage() {
           onDone={reload}
         />
       )}
+
+      <OperatorReceivePartModal
+        open={receiveOpen}
+        companyId={companyId}
+        locationId={node.id}
+        locationName={node.name}
+        excludePartIds={contents.map((c) => c.part_id)}
+        onClose={() => setReceiveOpen(false)}
+        onDone={reload}
+      />
     </Box>
   );
 }

--- a/components/operator/OperatorReceivePartModal.tsx
+++ b/components/operator/OperatorReceivePartModal.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Autocomplete from '@mui/material/Autocomplete';
+import Alert from '@mui/material/Alert';
+
+import { addStockAtLocation } from '@/utils/inventoryLocationsAccess';
+import { getStockedParts } from '@/utils/partsAccess';
+import { getStandardUnitsForUnit } from '@/lib/unitPresets';
+import type { Part } from '@/types/part';
+
+interface OperatorReceivePartModalProps {
+  open: boolean;
+  companyId: string;
+  locationId: string;
+  locationName: string;
+  /** Parts already stored here — excluded from the picker (act on them in-place). */
+  excludePartIds: string[];
+  onClose: () => void;
+  onDone: () => void | Promise<void>;
+}
+
+/**
+ * Operator "receive a part into this bin" — pick a location-tracked part that
+ * isn't already here, then add the received quantity. Only tracked parts are
+ * offered, because the stock RPCs require a part to be location-tracked first
+ * (that opt-in stays an admin action). Parts already in the bin are excluded —
+ * top those up from their card instead.
+ */
+export default function OperatorReceivePartModal({
+  open,
+  companyId,
+  locationId,
+  locationName,
+  excludePartIds,
+  onClose,
+  onDone,
+}: OperatorReceivePartModalProps) {
+  const [parts, setParts] = useState<Part[]>([]);
+  const [loadingParts, setLoadingParts] = useState(false);
+  const [part, setPart] = useState<Part | null>(null);
+  const [quantity, setQuantity] = useState('');
+  const [unit, setUnit] = useState('');
+  const [notes, setNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load the offerable parts (tracked, not already here) each time it opens.
+  useEffect(() => {
+    if (!open) return;
+    setPart(null);
+    setQuantity('');
+    setUnit('');
+    setNotes('');
+    setError(null);
+    setLoadingParts(true);
+    let cancelled = false;
+    getStockedParts(companyId)
+      .then((all) => {
+        if (cancelled) return;
+        const exclude = new Set(excludePartIds);
+        setParts(all.filter((p) => p.is_location_tracked && !exclude.has(p.id)));
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Could not load parts.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingParts(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // excludePartIds is read at load time; not a dep (avoids reload churn).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, companyId]);
+
+  const unitOptions = useMemo(() => {
+    const pu = part?.primary_unit || 'ea';
+    return Array.from(new Set([pu, ...getStandardUnitsForUnit(pu)])).filter(Boolean);
+  }, [part]);
+
+  const pickPart = (p: Part | null) => {
+    setPart(p);
+    setUnit(p?.primary_unit || 'ea');
+  };
+
+  const handleSubmit = async () => {
+    if (!part) {
+      setError('Choose a part.');
+      return;
+    }
+    const qty = parseFloat(quantity);
+    if (!Number.isFinite(qty) || qty <= 0) {
+      setError('Quantity must be positive.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await addStockAtLocation(part.id, locationId, qty, unit, notes || undefined);
+      await onDone();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to add stock.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Stock a part — {locationName}</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Autocomplete
+            options={parts}
+            loading={loadingParts}
+            value={part}
+            onChange={(_, v) => pickPart(v)}
+            getOptionLabel={(p) => p.part_name}
+            isOptionEqualToValue={(a, b) => a.id === b.id}
+            renderInput={(params) => <TextField {...params} label="Part" autoFocus required />}
+            noOptionsText="No more tracked parts to add here"
+            loadingText="Loading parts…"
+          />
+          <Stack direction="row" spacing={1}>
+            <TextField
+              label="Quantity"
+              type="number"
+              value={quantity}
+              onChange={(e) => setQuantity(e.target.value)}
+              inputProps={{ min: 0, step: 'any', inputMode: 'decimal' }}
+              fullWidth
+              disabled={!part}
+            />
+            <TextField
+              select
+              label="Unit"
+              value={unit}
+              onChange={(e) => setUnit(e.target.value)}
+              sx={{ minWidth: 120 }}
+              disabled={!part}
+            >
+              {unitOptions.map((u) => (
+                <MenuItem key={u} value={u}>
+                  {u}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Stack>
+          <TextField
+            label="Notes (optional)"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            multiline
+            minRows={2}
+            fullWidth
+          />
+          {error && <Alert severity="error">{error}</Alert>}
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving} size="large">
+          Cancel
+        </Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={saving || !part} size="large">
+          Add
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/operator/OperatorReceivePartModal.tsx
+++ b/components/operator/OperatorReceivePartModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -53,34 +53,25 @@ export default function OperatorReceivePartModal({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Load the offerable parts (tracked, not already here) each time it opens.
-  useEffect(() => {
-    if (!open) return;
+  // Reset + load the offerable parts each time the dialog opens (house
+  // convention: Dialog onEnter, not a setState-in-effect).
+  const handleEnter = async () => {
     setPart(null);
     setQuantity('');
     setUnit('');
     setNotes('');
     setError(null);
     setLoadingParts(true);
-    let cancelled = false;
-    getStockedParts(companyId)
-      .then((all) => {
-        if (cancelled) return;
-        const exclude = new Set(excludePartIds);
-        setParts(all.filter((p) => p.is_location_tracked && !exclude.has(p.id)));
-      })
-      .catch((e) => {
-        if (!cancelled) setError(e instanceof Error ? e.message : 'Could not load parts.');
-      })
-      .finally(() => {
-        if (!cancelled) setLoadingParts(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-    // excludePartIds is read at load time; not a dep (avoids reload churn).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, companyId]);
+    try {
+      const all = await getStockedParts(companyId);
+      const exclude = new Set(excludePartIds);
+      setParts(all.filter((p) => p.is_location_tracked && !exclude.has(p.id)));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load parts.');
+    } finally {
+      setLoadingParts(false);
+    }
+  };
 
   const unitOptions = useMemo(() => {
     const pu = part?.primary_unit || 'ea';
@@ -116,7 +107,13 @@ export default function OperatorReceivePartModal({
   };
 
   return (
-    <Dialog open={open} onClose={saving ? undefined : onClose} maxWidth="xs" fullWidth>
+    <Dialog
+      open={open}
+      onClose={saving ? undefined : onClose}
+      maxWidth="xs"
+      fullWidth
+      TransitionProps={{ onEnter: handleEnter }}
+    >
       <DialogTitle>Stock a part — {locationName}</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>


### PR DESCRIPTION
## What & why

Completes the operator stock loop. From a scanned bin you could already **top-up / remove / set** the parts *already there*, but not put a **new** part into it. The PRD operator persona "scans a QR… **adds received stock**" — this is that receiving step.

## Changes
- **`OperatorReceivePartModal`** — a **"Stock a part"** button in the bin view's "Stock here" header opens a picker of the company's **location-tracked** parts that **aren't already in this bin**, then adds the received quantity at this location (`addStockAtLocation`).
  - Only **tracked** parts are offered — the stock RPCs require a part to be location-tracked, and that opt-in stays an admin action.
  - Parts already in the bin are excluded (top those up from their existing card instead).
  - The picker loads its options on open, filtered against the bin's current contents.

## Notes
- This is independent of the column-drop (#430) — branched off `main`, no file overlap.
- Still deferred: tagging a removal to a job/operation + BOM prefill (needs station/job context a bare scan lacks).

## Validation
`tsc` clean; full **Vitest 716** (2 new: tracked-only/exclude-already-here, and Add-at-location); lint clean (baseline data-fetch warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)