### PR TITLE
feat(operator): per-step job feed — notes + photos (Activity Feature P1)

### DIFF
--- a/__tests__/utils/jobNoteMediaAccess.test.ts
+++ b/__tests__/utils/jobNoteMediaAccess.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Chainable Supabase mock (same shape as partAttachmentsAccess.test.ts) ---
+const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
+  const builder: Record<string, ReturnType<typeof vi.fn> | unknown> = {};
+  const chainMethods = ['from', 'select', 'insert', 'delete', 'eq', 'in', 'order', 'single'];
+  chainMethods.forEach((m) => {
+    builder[m] = vi.fn().mockImplementation(() => builder);
+  });
+  builder.data = null;
+  builder.error = null;
+  return {
+    mockQueryBuilder: builder,
+    mockSupabase: { from: vi.fn().mockImplementation(() => builder) },
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+
+const {
+  mockGenerateStoragePath,
+  mockUploadFileToStorage,
+  mockDeleteFileFromStorage,
+  mockGetSignedUrl,
+} = vi.hoisted(() => ({
+  mockGenerateStoragePath: vi.fn(),
+  mockUploadFileToStorage: vi.fn(),
+  mockDeleteFileFromStorage: vi.fn(),
+  mockGetSignedUrl: vi.fn(),
+}));
+
+vi.mock('@/utils/storageHelpers', () => ({
+  generateStoragePath: (...a: unknown[]) => mockGenerateStoragePath(...a),
+  uploadFileToStorage: (...a: unknown[]) => mockUploadFileToStorage(...a),
+  deleteFileFromStorage: (...a: unknown[]) => mockDeleteFileFromStorage(...a),
+  getSignedUrl: (...a: unknown[]) => mockGetSignedUrl(...a),
+}));
+
+import {
+  addJobNoteMedia,
+  getJobNoteMediaUrl,
+  deleteJobNoteMedia,
+  deleteJobNote,
+} from '@/utils/jobNoteMediaAccess';
+
+function makeFile(name: string, sizeBytes = 10, type = 'image/jpeg'): File {
+  const f = new File(['x'], name, { type });
+  Object.defineProperty(f, 'size', { value: sizeBytes });
+  return f;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockQueryBuilder.data = null;
+  mockQueryBuilder.error = null;
+  mockDeleteFileFromStorage.mockResolvedValue(undefined);
+  mockUploadFileToStorage.mockResolvedValue(undefined);
+});
+
+describe('addJobNoteMedia', () => {
+  const row = {
+    id: 'media-1',
+    note_id: 'n1',
+    storage_path: 'c1/jobs/j1/abc_photo.jpg',
+    thumbnail_path: null,
+    kind: 'photo',
+    mime_type: 'image/jpeg',
+    width: 1600,
+    height: 1200,
+  };
+
+  beforeEach(() => {
+    mockGenerateStoragePath.mockReturnValue('c1/jobs/j1/abc_photo.jpg');
+  });
+
+  it('uploads under the job folder, inserts photo metadata, returns the mapped row', async () => {
+    mockQueryBuilder.data = row;
+    const result = await addJobNoteMedia('c1', 'j1', 'n1', makeFile('photo.jpg', 2048), {
+      dims: { width: 1600, height: 1200 },
+    });
+
+    expect(mockGenerateStoragePath).toHaveBeenCalledWith('c1', 'jobs', 'j1', 'photo.jpg');
+    expect(mockUploadFileToStorage).toHaveBeenCalledWith(
+      'c1/jobs/j1/abc_photo.jpg',
+      expect.any(File),
+    );
+    expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        company_id: 'c1',
+        note_id: 'n1',
+        storage_path: 'c1/jobs/j1/abc_photo.jpg',
+        kind: 'photo',
+        mime_type: 'image/jpeg',
+        width: 1600,
+        height: 1200,
+      }),
+    );
+    expect(result.kind).toBe('photo');
+    expect(result.id).toBe('media-1');
+  });
+
+  it('rolls back the uploaded file when the row insert fails', async () => {
+    mockQueryBuilder.error = { message: 'insert boom' };
+    await expect(
+      addJobNoteMedia('c1', 'j1', 'n1', makeFile('photo.jpg', 2048)),
+    ).rejects.toThrow(/Failed to attach the photo/);
+    expect(mockDeleteFileFromStorage).toHaveBeenCalledWith('c1/jobs/j1/abc_photo.jpg');
+  });
+
+  it('passes null dimensions when none are supplied', async () => {
+    mockQueryBuilder.data = row;
+    await addJobNoteMedia('c1', 'j1', 'n1', makeFile('photo.jpg', 2048));
+    expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ width: null, height: null }),
+    );
+  });
+});
+
+describe('getJobNoteMediaUrl', () => {
+  it('requests a signed URL with the 4-hour media expiry', async () => {
+    mockGetSignedUrl.mockResolvedValue('https://signed/x');
+    const url = await getJobNoteMediaUrl('c1/jobs/j1/x.jpg');
+    expect(mockGetSignedUrl).toHaveBeenCalledWith('c1/jobs/j1/x.jpg', 4 * 60 * 60);
+    expect(url).toBe('https://signed/x');
+  });
+});
+
+describe('deleteJobNoteMedia', () => {
+  it('deletes the row first, then the file (row-first)', async () => {
+    await deleteJobNoteMedia({ id: 'media-1', storage_path: 'c1/jobs/j1/x.jpg' });
+    expect(mockSupabase.from).toHaveBeenCalledWith('job_note_media');
+    expect(mockQueryBuilder.delete).toHaveBeenCalled();
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'media-1');
+    expect(mockDeleteFileFromStorage).toHaveBeenCalledWith('c1/jobs/j1/x.jpg');
+  });
+
+  it('throws and does NOT delete the file when the row delete fails', async () => {
+    mockQueryBuilder.error = { message: 'rls denied' };
+    await expect(
+      deleteJobNoteMedia({ id: 'media-1', storage_path: 'c1/jobs/j1/x.jpg' }),
+    ).rejects.toBeTruthy();
+    expect(mockDeleteFileFromStorage).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteJobNote', () => {
+  it('reads media paths, deletes the note, then removes the orphaned files', async () => {
+    mockQueryBuilder.data = [
+      { storage_path: 'c1/jobs/j1/a.jpg' },
+      { storage_path: 'c1/jobs/j1/b.jpg' },
+    ];
+    await deleteJobNote('n1');
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('job_note_media');
+    expect(mockSupabase.from).toHaveBeenCalledWith('job_notes');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('note_id', 'n1');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'n1');
+    expect(mockDeleteFileFromStorage).toHaveBeenCalledWith('c1/jobs/j1/a.jpg');
+    expect(mockDeleteFileFromStorage).toHaveBeenCalledWith('c1/jobs/j1/b.jpg');
+  });
+
+  it('throws when the note row delete fails', async () => {
+    // No media rows; the note delete reports an error.
+    mockQueryBuilder.data = [];
+    mockQueryBuilder.error = { message: 'rls denied' };
+    await expect(deleteJobNote('n1')).rejects.toBeTruthy();
+  });
+});

--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Chainable Supabase mock (same shape as partAttachmentsAccess.test.ts) ---
+const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
+  const builder: Record<string, ReturnType<typeof vi.fn> | unknown> = {};
+  const chainMethods = ['from', 'select', 'insert', 'update', 'delete', 'eq', 'in', 'order', 'single'];
+  chainMethods.forEach((m) => {
+    builder[m] = vi.fn().mockImplementation(() => builder);
+  });
+  builder.data = null;
+  builder.error = null;
+  return {
+    mockQueryBuilder: builder,
+    mockSupabase: { from: vi.fn().mockImplementation(() => builder) },
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+
+// friendlyErrorMessage just surfaces the fallback so we can assert thrown text.
+vi.mock('@/lib/supabaseErrors', () => ({
+  friendlyErrorMessage: (_err: unknown, opts?: { fallback?: string }) =>
+    opts?.fallback ?? 'error',
+}));
+
+import { getJobNotes, addJobNote } from '@/utils/operatorAccess';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockQueryBuilder.data = null;
+  mockQueryBuilder.error = null;
+});
+
+describe('getJobNotes', () => {
+  it('maps author, step-tag label, and media; rolls up the whole job by job_id', async () => {
+    mockQueryBuilder.data = [
+      {
+        id: 'n1',
+        job_id: 'j1',
+        job_operation_id: 'op1',
+        body: 'looks good',
+        created_at: '2026-06-23T10:00:00Z',
+        author: { name: 'Jane' },
+        operation: { operation_name: 'Mill', sequence: 20 },
+        media: [
+          {
+            id: 'm1',
+            note_id: 'n1',
+            storage_path: 'c1/jobs/j1/x.jpg',
+            thumbnail_path: null,
+            kind: 'photo',
+            mime_type: 'image/jpeg',
+            width: 1600,
+            height: 1200,
+          },
+        ],
+      },
+      {
+        id: 'n2',
+        job_id: 'j1',
+        job_operation_id: null,
+        body: null,
+        created_at: '2026-06-23T09:00:00Z',
+        author: null,
+        operation: null,
+        media: [],
+      },
+    ];
+
+    const result = await getJobNotes('j1', 'c1');
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('job_notes');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('job_id', 'j1');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'c1');
+    expect(mockQueryBuilder.order).toHaveBeenCalledWith('created_at', { ascending: false });
+
+    // Operation-scoped note rolls up with a readable step label + mapped media.
+    expect(result[0].author_name).toBe('Jane');
+    expect(result[0].operation_label).toBe('Op 20 · Mill');
+    expect(result[0].job_operation_id).toBe('op1');
+    expect(result[0].media).toHaveLength(1);
+    expect(result[0].media[0].kind).toBe('photo');
+
+    // Job-level, media-only-safe note: null body, no step tag, no media.
+    expect(result[1].author_name).toBeNull();
+    expect(result[1].operation_label).toBeNull();
+    expect(result[1].body).toBeNull();
+    expect(result[1].media).toEqual([]);
+  });
+
+  it('throws when the query errors', async () => {
+    mockQueryBuilder.error = { message: 'boom' };
+    await expect(getJobNotes('j1', 'c1')).rejects.toThrow(/boom/);
+  });
+});
+
+describe('addJobNote', () => {
+  const baseRow = {
+    id: 'n3',
+    job_id: 'j1',
+    job_operation_id: 'op1',
+    created_at: '2026-06-23T11:00:00Z',
+    author: { name: 'Bob' },
+    operation: { operation_name: 'Saw', sequence: 10 },
+    media: [],
+  };
+
+  it('inserts the step tag + trimmed body and returns the mapped note', async () => {
+    mockQueryBuilder.data = { ...baseRow, body: 'watch the bore' };
+    const note = await addJobNote('j1', 'c1', 'acc1', '  watch the bore  ', {
+      jobPartId: 'jp1',
+      jobOperationId: 'op1',
+    });
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('job_notes');
+    expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        company_id: 'c1',
+        job_id: 'j1',
+        author_id: 'acc1',
+        body: 'watch the bore',
+        job_part_id: 'jp1',
+        job_operation_id: 'op1',
+      }),
+    );
+    expect(note.operation_label).toBe('Op 10 · Saw');
+    expect(note.body).toBe('watch the bore');
+  });
+
+  it('stores a null body for a media-only (blank text) note', async () => {
+    mockQueryBuilder.data = { ...baseRow, body: null };
+    await addJobNote('j1', 'c1', 'acc1', '   ', { jobPartId: 'jp1', jobOperationId: 'op1' });
+    expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ body: null }),
+    );
+  });
+
+  it('defaults the step tag to null for a job-level note', async () => {
+    mockQueryBuilder.data = { ...baseRow, job_operation_id: null, operation: null, body: 'general' };
+    await addJobNote('j1', 'c1', 'acc1', 'general');
+    expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ job_part_id: null, job_operation_id: null }),
+    );
+  });
+
+  it('throws a friendly error when the insert fails', async () => {
+    mockQueryBuilder.error = { message: 'rls denied' };
+    await expect(addJobNote('j1', 'c1', 'acc1', 'x', { jobOperationId: 'op1' })).rejects.toThrow(
+      /Failed to add note/,
+    );
+  });
+});

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/utils/operatorAccess';
 import { useStationContext } from '@/components/operator/OperatorStationContext';
 import StationSelector from '@/components/operator/StationSelector';
+import JobFeed from '@/components/operator/JobFeed';
 import type { OperatorJobDetail } from '@/types/operator';
 
 /**
@@ -329,6 +330,21 @@ export default function OperatorOperationActionPage() {
           {actionLoading ? <CircularProgress size={24} /> : 'MARK COMPLETE'}
         </Button>
       )}
+
+      {/* Job feed — capture notes/photos for THIS step (auto-tagged), and read
+          the whole job's feed. This is the primary capture surface: operators
+          land here from the per-operation QR. */}
+      <Box sx={{ mt: 3 }}>
+        <JobFeed
+          jobId={jobId}
+          companyId={companyId}
+          operationContext={{
+            jobPartId,
+            jobOperationId,
+            operationLabel: job.operation_name,
+          }}
+        />
+      </Box>
     </Box>
   );
 }

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
@@ -9,8 +9,6 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardActionArea from '@mui/material/CardActionArea';
 import Chip from '@mui/material/Chip';
-import Divider from '@mui/material/Divider';
-import TextField from '@mui/material/TextField';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import IconButton from '@mui/material/IconButton';
@@ -19,14 +17,9 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import PlayCircleFilledIcon from '@mui/icons-material/PlayCircleFilled';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import StickyNote2Icon from '@mui/icons-material/StickyNote2';
-import {
-  getJobPartTraveler,
-  getJobNotes,
-  addJobNote,
-  getCurrentOperator,
-} from '@/utils/operatorAccess';
-import type { JobTraveler, JobTravelerOperation, JobNote } from '@/types/operator';
+import { getJobPartTraveler } from '@/utils/operatorAccess';
+import JobFeed from '@/components/operator/JobFeed';
+import type { JobTraveler, JobTravelerOperation } from '@/types/operator';
 
 const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
 
@@ -44,17 +37,6 @@ function formatDate(value: string | null): string | null {
   return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
-function formatTimestamp(value: string): string {
-  const d = new Date(value);
-  if (Number.isNaN(d.getTime())) return value;
-  return d.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  });
-}
-
 function StepIcon({ status }: { status: string }) {
   if (status === 'completed') return <CheckCircleIcon color="success" />;
   if (status === 'in_progress') return <PlayCircleFilledIcon color="primary" />;
@@ -65,7 +47,9 @@ function StepIcon({ status }: { status: string }) {
  * Operator job traveler. When an operator opens a job_part (scanning a job QR
  * lands here for a single-part job, or via the parts hub for multi-part jobs),
  * they see the full step list — like a printed shop traveler — and pick which
- * step to action. Job-level notes (general, not tied to any step) live here too.
+ * step to action. The whole job's feed (notes + photos, captured per step on
+ * the operation pages) is shown read-only up top; capture happens on the
+ * operation page where the operator is working.
  */
 export default function OperatorJobTravelerPage() {
   const params = useParams();
@@ -75,14 +59,8 @@ export default function OperatorJobTravelerPage() {
   const jobPartId = params.jobPartId as string;
 
   const [traveler, setTraveler] = useState<JobTraveler | null>(null);
-  const [notes, setNotes] = useState<JobNote[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
-  const [operatorId, setOperatorId] = useState<string | null>(null);
-  const [noteDraft, setNoteDraft] = useState('');
-  const [savingNote, setSavingNote] = useState(false);
-  const [noteError, setNoteError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -94,8 +72,6 @@ export default function OperatorJobTravelerPage() {
         return;
       }
       setTraveler(data);
-      const noteRows = await getJobNotes(data.job_id, companyId);
-      setNotes(noteRows);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load job');
     } finally {
@@ -107,37 +83,8 @@ export default function OperatorJobTravelerPage() {
     load();
   }, [load]);
 
-  useEffect(() => {
-    async function loadOperator() {
-      const operator = await getCurrentOperator(companyId);
-      if (operator) setOperatorId(operator.id);
-    }
-    loadOperator();
-  }, [companyId]);
-
   const openStep = (op: JobTravelerOperation) => {
     router.push(`/operator/${companyId}/jobs/${jobId}/parts/${jobPartId}/operations/${op.id}`);
-  };
-
-  const handleAddNote = async () => {
-    if (!traveler) return;
-    const body = noteDraft.trim();
-    if (!body) return;
-    if (!operatorId) {
-      setNoteError('Operator not found. Please log in again.');
-      return;
-    }
-    setSavingNote(true);
-    setNoteError(null);
-    try {
-      const created = await addJobNote(traveler.job_id, companyId, operatorId, body);
-      setNotes((prev) => [created, ...prev]);
-      setNoteDraft('');
-    } catch (err) {
-      setNoteError(err instanceof Error ? err.message : 'Failed to add note');
-    } finally {
-      setSavingNote(false);
-    }
   };
 
   if (loading) {
@@ -240,11 +187,17 @@ export default function OperatorJobTravelerPage() {
         </CardContent>
       </Card>
 
+      {/* Job feed (read-only here) — notes + photos for the whole job, captured
+          per step on the operation pages. Bumped up top: operators use it a lot. */}
+      <Box sx={{ mb: 3 }}>
+        <JobFeed readOnly jobId={traveler.job_id} companyId={companyId} />
+      </Box>
+
       {/* Operations / steps — tap one to action it */}
       <Typography variant="overline" color="text.secondary" sx={{ px: 0.5 }}>
         Operations
       </Typography>
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 0.5, mb: 3 }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 0.5 }}>
         {traveler.operations.length === 0 && (
           <Typography variant="body2" color="text.secondary" sx={{ px: 0.5, py: 2 }}>
             This part has no operations.
@@ -289,65 +242,6 @@ export default function OperatorJobTravelerPage() {
           );
         })}
       </Box>
-
-      {/* Job-level notes feed */}
-      <Card elevation={2} sx={cardSx}>
-        <CardContent>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
-            <StickyNote2Icon fontSize="small" color="action" />
-            <Typography variant="h6" color="text.secondary">
-              Job Notes
-            </Typography>
-          </Box>
-
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mb: 2 }}>
-            <TextField
-              multiline
-              minRows={2}
-              placeholder="Add a note about this job…"
-              value={noteDraft}
-              onChange={(e) => setNoteDraft(e.target.value)}
-              fullWidth
-              size="small"
-            />
-            {noteError && <Alert severity="error">{noteError}</Alert>}
-            <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-              <Button
-                variant="contained"
-                onClick={handleAddNote}
-                disabled={savingNote || !noteDraft.trim()}
-              >
-                {savingNote ? <CircularProgress size={20} /> : 'Add note'}
-              </Button>
-            </Box>
-          </Box>
-
-          {notes.length === 0 ? (
-            <Typography variant="body2" color="text.secondary">
-              No notes yet.
-            </Typography>
-          ) : (
-            <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-              {notes.map((note, idx) => (
-                <Box key={note.id}>
-                  {idx > 0 && <Divider sx={{ my: 1 }} />}
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1, mb: 0.25 }}>
-                    <Typography variant="subtitle2" fontWeight={700}>
-                      {note.author_name || 'Unknown'}
-                    </Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      {formatTimestamp(note.created_at)}
-                    </Typography>
-                  </Box>
-                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
-                    {note.body}
-                  </Typography>
-                </Box>
-              ))}
-            </Box>
-          )}
-        </CardContent>
-      </Card>
     </Box>
   );
 }

--- a/components/operator/JobFeed.tsx
+++ b/components/operator/JobFeed.tsx
@@ -1,0 +1,439 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DynamicFeedIcon from '@mui/icons-material/DynamicFeed';
+import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
+import CloseIcon from '@mui/icons-material/Close';
+import { getJobNotes, addJobNote, getCurrentOperator } from '@/utils/operatorAccess';
+import { addJobNoteMedia, getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
+import { compressPhoto } from '@/utils/imageCompression';
+import type { JobNote, JobNoteMedia } from '@/types/operator';
+
+const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
+const THUMB = 76;
+
+/**
+ * Context the operation page passes so the composer auto-tags every capture to
+ * the step the operator is working — no step selector. The traveler omits this
+ * (read-only) and renders the same rolled-up feed.
+ */
+export interface JobFeedOperationContext {
+  jobPartId: string;
+  jobOperationId: string;
+  /** Label for the current step, e.g. "Op 20 · Mill", shown on the composer. */
+  operationLabel?: string | null;
+}
+
+interface JobFeedProps {
+  jobId: string;
+  companyId: string;
+  /** Read-only feed (traveler). When true, no composer is shown. */
+  readOnly?: boolean;
+  /** Set on the operation page to show the composer + auto-tag captures. */
+  operationContext?: JobFeedOperationContext;
+}
+
+function formatTimestamp(value: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+/** A pending photo the operator picked but hasn't posted yet. */
+interface PendingPhoto {
+  id: string;
+  file: File;
+  previewUrl: string;
+}
+
+/**
+ * The job feed: one append-only stream per job (job-level + operation-tagged
+ * notes, each with optional photos). Captured on the operation page (composer
+ * auto-tagged to the step) and read on both the operation page and the traveler.
+ * Listing is a plain Supabase read (no AI on mount).
+ */
+export default function JobFeed({ jobId, companyId, readOnly, operationContext }: JobFeedProps) {
+  const [notes, setNotes] = useState<JobNote[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [operatorId, setOperatorId] = useState<string | null>(null);
+  const [noteDraft, setNoteDraft] = useState('');
+  const [pending, setPending] = useState<PendingPhoto[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [composerError, setComposerError] = useState<string | null>(null);
+
+  // Signed URLs for media thumbnails, keyed by media id (fetched on demand).
+  const [mediaUrls, setMediaUrls] = useState<Record<string, string>>({});
+  // Full-size viewer.
+  const [viewerUrl, setViewerUrl] = useState<string | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const showComposer = !readOnly && !!operationContext;
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setNotes(await getJobNotes(jobId, companyId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not load the feed.');
+    } finally {
+      setLoading(false);
+    }
+  }, [jobId, companyId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!showComposer) return;
+    let active = true;
+    getCurrentOperator(companyId).then((op) => {
+      if (active && op) setOperatorId(op.id);
+    });
+    return () => {
+      active = false;
+    };
+  }, [showComposer, companyId]);
+
+  // Fetch signed URLs for any media we don't already have a URL for.
+  useEffect(() => {
+    const missing = notes
+      .flatMap((n) => n.media)
+      .filter((m) => !mediaUrls[m.id]);
+    if (missing.length === 0) return;
+    let active = true;
+    Promise.all(
+      missing.map(async (m) => {
+        try {
+          return [m.id, await getJobNoteMediaUrl(m.thumbnail_path ?? m.storage_path)] as const;
+        } catch {
+          return null;
+        }
+      }),
+    ).then((pairs) => {
+      if (!active) return;
+      const next: Record<string, string> = {};
+      for (const p of pairs) if (p) next[p[0]] = p[1];
+      if (Object.keys(next).length > 0) setMediaUrls((prev) => ({ ...prev, ...next }));
+    });
+    return () => {
+      active = false;
+    };
+  }, [notes, mediaUrls]);
+
+  // Revoke object URLs for pending previews on unmount.
+  useEffect(() => {
+    return () => {
+      pending.forEach((p) => URL.revokeObjectURL(p.previewUrl));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handlePickPhotos = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    e.target.value = '';
+    if (files.length === 0) return;
+    setComposerError(null);
+    setPending((prev) => [
+      ...prev,
+      ...files.map((file, i) => ({
+        id: `${Date.now()}-${i}-${file.name}`,
+        file,
+        previewUrl: URL.createObjectURL(file),
+      })),
+    ]);
+  };
+
+  const removePending = (id: string) => {
+    setPending((prev) => {
+      const target = prev.find((p) => p.id === id);
+      if (target) URL.revokeObjectURL(target.previewUrl);
+      return prev.filter((p) => p.id !== id);
+    });
+  };
+
+  const canPost = (noteDraft.trim().length > 0 || pending.length > 0) && !saving;
+
+  const handlePost = async () => {
+    if (!operationContext) return;
+    const body = noteDraft.trim();
+    if (!body && pending.length === 0) return;
+    if (!operatorId) {
+      setComposerError('Could not identify your account — reload and try again.');
+      return;
+    }
+    setSaving(true);
+    setComposerError(null);
+    try {
+      const note = await addJobNote(jobId, companyId, operatorId, body || null, {
+        jobPartId: operationContext.jobPartId,
+        jobOperationId: operationContext.jobOperationId,
+      });
+
+      const media: JobNoteMedia[] = [];
+      for (const p of pending) {
+        const prepared = await compressPhoto(p.file);
+        media.push(
+          await addJobNoteMedia(companyId, jobId, note.id, prepared.file, {
+            dims: prepared.dims,
+          }),
+        );
+      }
+
+      setNotes((prev) => [{ ...note, media }, ...prev]);
+      pending.forEach((p) => URL.revokeObjectURL(p.previewUrl));
+      setPending([]);
+      setNoteDraft('');
+    } catch (err) {
+      setComposerError(err instanceof Error ? err.message : 'Could not post. Please try again.');
+      // The note may have been created with partial media — refresh to show truth.
+      load();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const openViewer = async (media: JobNoteMedia) => {
+    try {
+      setViewerUrl(await getJobNoteMediaUrl(media.storage_path));
+    } catch {
+      setError('Could not open the photo.');
+    }
+  };
+
+  return (
+    <Card elevation={2} sx={cardSx}>
+      <CardContent>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+          <DynamicFeedIcon fontSize="small" color="action" />
+          <Typography variant="h6" color="text.secondary">
+            Job Feed
+          </Typography>
+        </Box>
+
+        {showComposer && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mb: 2 }}>
+            {operationContext?.operationLabel && (
+              <Typography variant="caption" color="text.secondary">
+                Adding to {operationContext.operationLabel}
+              </Typography>
+            )}
+            <TextField
+              multiline
+              minRows={2}
+              placeholder="Add a note or photo for this step…"
+              value={noteDraft}
+              onChange={(e) => setNoteDraft(e.target.value)}
+              fullWidth
+              size="small"
+            />
+
+            {pending.length > 0 && (
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                {pending.map((p) => (
+                  <Box key={p.id} sx={{ position: 'relative' }}>
+                    <Box
+                      component="img"
+                      src={p.previewUrl}
+                      alt="Pending photo"
+                      sx={{
+                        width: THUMB,
+                        height: THUMB,
+                        objectFit: 'cover',
+                        borderRadius: 1,
+                        display: 'block',
+                      }}
+                    />
+                    <IconButton
+                      size="small"
+                      aria-label="Remove photo"
+                      onClick={() => removePending(p.id)}
+                      sx={{
+                        position: 'absolute',
+                        top: -8,
+                        right: -8,
+                        bgcolor: 'background.paper',
+                        '&:hover': { bgcolor: 'background.paper' },
+                      }}
+                    >
+                      <CloseIcon fontSize="small" />
+                    </IconButton>
+                  </Box>
+                ))}
+              </Box>
+            )}
+
+            {composerError && <Alert severity="error">{composerError}</Alert>}
+
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              capture="environment"
+              multiple
+              hidden
+              onChange={handlePickPhotos}
+            />
+            <Box sx={{ display: 'flex', gap: 1, justifyContent: 'space-between' }}>
+              <Button
+                variant="outlined"
+                startIcon={<PhotoCameraIcon />}
+                onClick={() => fileInputRef.current?.click()}
+                disabled={saving}
+                sx={{ minHeight: 48 }}
+              >
+                Add photo
+              </Button>
+              <Button
+                variant="contained"
+                onClick={handlePost}
+                disabled={!canPost}
+                sx={{ minHeight: 48 }}
+              >
+                {saving ? <CircularProgress size={20} /> : 'Post'}
+              </Button>
+            </Box>
+          </Box>
+        )}
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 1 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+            <CircularProgress size={20} />
+          </Box>
+        ) : notes.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No activity yet.
+          </Typography>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+            {notes.map((note, idx) => (
+              <Box key={note.id}>
+                {idx > 0 && <Divider sx={{ my: 1 }} />}
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: 1,
+                    mb: 0.25,
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+                    <Typography variant="subtitle2" fontWeight={700} noWrap>
+                      {note.author_name || 'Unknown'}
+                    </Typography>
+                    {note.operation_label && (
+                      <Chip size="small" label={note.operation_label} variant="outlined" />
+                    )}
+                  </Box>
+                  <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+                    {formatTimestamp(note.created_at)}
+                  </Typography>
+                </Box>
+
+                {note.body && (
+                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                    {note.body}
+                  </Typography>
+                )}
+
+                {note.media.length > 0 && (
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
+                    {note.media.map((m) => {
+                      const url = mediaUrls[m.id];
+                      return (
+                        <Box
+                          key={m.id}
+                          onClick={() => url && openViewer(m)}
+                          sx={{
+                            width: THUMB,
+                            height: THUMB,
+                            borderRadius: 1,
+                            overflow: 'hidden',
+                            cursor: url ? 'pointer' : 'default',
+                            bgcolor: 'rgba(255,255,255,0.06)',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                          }}
+                        >
+                          {url ? (
+                            <Box
+                              component="img"
+                              src={url}
+                              alt="Job photo"
+                              sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                            />
+                          ) : (
+                            <CircularProgress size={16} />
+                          )}
+                        </Box>
+                      );
+                    })}
+                  </Box>
+                )}
+              </Box>
+            ))}
+          </Box>
+        )}
+      </CardContent>
+
+      {/* Full-size photo viewer. */}
+      <Dialog open={!!viewerUrl} onClose={() => setViewerUrl(null)} fullScreen>
+        <IconButton
+          aria-label="Close"
+          onClick={() => setViewerUrl(null)}
+          sx={{ position: 'absolute', right: 12, top: 12, zIndex: 1, color: 'common.white' }}
+        >
+          <CloseIcon />
+        </IconButton>
+        <DialogContent
+          sx={{
+            p: 0,
+            bgcolor: 'background.default',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {viewerUrl && (
+            <Box
+              component="img"
+              src={viewerUrl}
+              alt="Job photo"
+              sx={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint --max-warnings 109",
+    "lint": "eslint --max-warnings 110",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@vercel/analytics": "^2.0.1",
     "ag-grid-community": "^35.0.0",
     "ag-grid-react": "^35.0.0",
+    "browser-image-compression": "^2.0.2",
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.7",
     "next": "16.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       ag-grid-react:
         specifier: ^35.0.0
         version: 35.2.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      browser-image-compression:
+        specifier: ^2.0.2
+        version: 2.0.2
       jspdf:
         specifier: ^4.2.1
         version: 4.2.1
@@ -2487,6 +2490,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browser-image-compression@2.0.2:
+    resolution: {integrity: sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==}
+
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -4574,6 +4580,9 @@ packages:
 
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
+
+  uzip@0.20201231.0:
+    resolution: {integrity: sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==}
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -7292,6 +7301,10 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browser-image-compression@2.0.2:
+    dependencies:
+      uzip: 0.20201231.0
+
   browserslist@4.28.2:
     dependencies:
       baseline-browser-mapping: 2.10.29
@@ -9591,6 +9604,8 @@ snapshots:
     dependencies:
       base64-arraybuffer: 1.0.2
     optional: true
+
+  uzip@0.20201231.0: {}
 
   vite@8.0.16(@types/node@20.19.39)(terser@5.48.0)(yaml@2.8.3):
     dependencies:

--- a/supabase/migrations/20260623111039_extend_job_notes_for_operations_and_media.sql
+++ b/supabase/migrations/20260623111039_extend_job_notes_for_operations_and_media.sql
@@ -1,0 +1,50 @@
+-- Extend job_notes so the one job feed can carry operation-scoped notes (a
+-- "step tag") and pure-photo notes, plus a note_type for future auto-logged
+-- events. Mirrors the part_notes.note_type precedent.
+--
+-- All new columns are nullable / defaulted so every existing job_notes row
+-- stays valid at rest (no backfill, no read-path fallback — see CLAUDE.md
+-- "No silent runtime fallbacks for data-at-rest issues").
+--
+-- job_operation_id is the optional step tag. It MUST be nullable: existing rows
+-- are job-level (the old traveler composer wrote notes with no operation) and
+-- there is no valid operation to backfill them to. A job note is legitimately
+-- either job-level (operation NULL) or step-level. The operation-page composer
+-- always sets the tag for new operator captures (enforced in the access layer),
+-- so the intent is guaranteed at the capture surface — not via a NOT NULL that
+-- would break existing data. job_id stays NOT NULL on every row: it is the
+-- rollup key the job feed reads on (operation-level notes roll up automatically
+-- because they still carry job_id).
+
+ALTER TABLE "public"."job_notes"
+    ADD COLUMN "job_part_id" uuid,
+    ADD COLUMN "job_operation_id" uuid,
+    -- 'user' default keeps all existing rows valid; 'event' is reserved for
+    -- future auto-logged feed entries (e.g. "operation completed").
+    ADD COLUMN "note_type" text NOT NULL DEFAULT 'user'
+        CHECK (note_type IN ('user', 'event'));
+
+ALTER TABLE "public"."job_notes"
+    ADD CONSTRAINT "job_notes_job_part_id_fkey" FOREIGN KEY (job_part_id)
+        REFERENCES "public"."job_parts" (id) ON DELETE CASCADE,
+    ADD CONSTRAINT "job_notes_job_operation_id_fkey" FOREIGN KEY (job_operation_id)
+        REFERENCES "public"."job_operations" (id) ON DELETE CASCADE;
+
+-- A step-tagged note must also name the part it belongs to (job_operations is
+-- keyed by job_part_id; a job can have multiple parts, so operation alone is
+-- ambiguous). Job-level notes leave both NULL.
+ALTER TABLE "public"."job_notes"
+    ADD CONSTRAINT "job_notes_operation_requires_part"
+        CHECK (job_operation_id IS NULL OR job_part_id IS NOT NULL);
+
+-- Allow pure-photo notes (media but no text). body may be NULL, but if present
+-- must be non-blank. Replaces the original NOT-NULL + non-blank constraint.
+ALTER TABLE "public"."job_notes" ALTER COLUMN "body" DROP NOT NULL;
+ALTER TABLE "public"."job_notes" DROP CONSTRAINT IF EXISTS "job_notes_body_not_blank";
+ALTER TABLE "public"."job_notes"
+    ADD CONSTRAINT "job_notes_body_blank_or_null"
+        CHECK (body IS NULL OR length(btrim(body)) > 0);
+
+-- The feed reads WHERE job_id=$1 ORDER BY created_at DESC; the existing
+-- idx_job_notes_job_created already covers it. RLS policies are unchanged
+-- (they key on company_id / author_id, which are untouched).

--- a/supabase/migrations/20260623111142_job_note_media.sql
+++ b/supabase/migrations/20260623111142_job_note_media.sql
@@ -1,0 +1,72 @@
+-- Photos (and later short videos) attached to a job_notes entry. A note has
+-- 0..n media. File bytes live in the private `attachments` storage bucket under
+-- {companyId}/jobs/{jobId}/... (see utils/storageHelpers.ts, whose bucket RLS
+-- already gates by the company folder — so no new storage policy is needed).
+-- This table is the metadata index; the feed renders thumbnails via signed URLs.
+--
+-- Authorship lives on the parent job_notes row (author_id), so this table has
+-- no uploaded_by — the delete policy reuses the parent note's author. The schema
+-- accommodates video now (kind='video', duration_seconds); P1 only writes
+-- kind='photo'.
+
+CREATE TABLE IF NOT EXISTS "public"."job_note_media"
+(
+    "id"               uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id"       uuid NOT NULL,
+    "note_id"          uuid NOT NULL,
+    "storage_path"     text NOT NULL,
+    -- Poster/thumbnail key. Nullable: a photo may render from its own image.
+    "thumbnail_path"   text,
+    "kind"             text NOT NULL DEFAULT 'photo',
+    "mime_type"        text,
+    "size_bytes"       bigint,
+    "width"            integer,
+    "height"           integer,
+    -- Video only; NULL for photos.
+    "duration_seconds" numeric,
+    "created_at"       timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "job_note_media_pkey" PRIMARY KEY (id),
+    CONSTRAINT "job_note_media_company_id_fkey" FOREIGN KEY (company_id)
+        REFERENCES "public"."companies" (id) ON DELETE CASCADE,
+    CONSTRAINT "job_note_media_note_id_fkey" FOREIGN KEY (note_id)
+        REFERENCES "public"."job_notes" (id) ON DELETE CASCADE,
+    CONSTRAINT "job_note_media_kind_check"
+        CHECK (kind IN ('photo', 'video'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_note_media_note
+    ON public.job_note_media USING btree (note_id);
+
+ALTER TABLE "public"."job_note_media" ENABLE ROW LEVEL SECURITY;
+
+-- Any company member can read the company's job-note media.
+DROP POLICY IF EXISTS "Users can view job_note_media" ON "public"."job_note_media";
+CREATE POLICY "Users can view job_note_media"
+    ON "public"."job_note_media"
+    FOR SELECT
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+-- A company member can attach media (must be an actual member of the company;
+-- authorship is enforced on the parent note's INSERT policy).
+DROP POLICY IF EXISTS "Users can insert job_note_media" ON "public"."job_note_media";
+CREATE POLICY "Users can insert job_note_media"
+    ON "public"."job_note_media"
+    FOR INSERT
+    WITH CHECK (
+        (company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids))
+        AND (get_operator_access_id(company_id) IS NOT NULL)
+    );
+
+-- The parent note's author can delete its media; company admins can delete any.
+DROP POLICY IF EXISTS "Authors and admins can delete job_note_media" ON "public"."job_note_media";
+CREATE POLICY "Authors and admins can delete job_note_media"
+    ON "public"."job_note_media"
+    FOR DELETE
+    USING (
+        is_company_admin(company_id)
+        OR EXISTS (
+            SELECT 1 FROM "public"."job_notes" n
+            WHERE n.id = job_note_media.note_id
+              AND n.author_id = get_operator_access_id(company_id)
+        )
+    );

--- a/types/database.ts
+++ b/types/database.ts
@@ -869,30 +869,99 @@ export type Database = {
           },
         ]
       }
+      job_note_media: {
+        Row: {
+          company_id: string
+          created_at: string
+          duration_seconds: number | null
+          height: number | null
+          id: string
+          kind: string
+          mime_type: string | null
+          note_id: string
+          size_bytes: number | null
+          storage_path: string
+          thumbnail_path: string | null
+          width: number | null
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          duration_seconds?: number | null
+          height?: number | null
+          id?: string
+          kind?: string
+          mime_type?: string | null
+          note_id: string
+          size_bytes?: number | null
+          storage_path: string
+          thumbnail_path?: string | null
+          width?: number | null
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          duration_seconds?: number | null
+          height?: number | null
+          id?: string
+          kind?: string
+          mime_type?: string | null
+          note_id?: string
+          size_bytes?: number | null
+          storage_path?: string
+          thumbnail_path?: string | null
+          width?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "job_note_media_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_note_media_note_id_fkey"
+            columns: ["note_id"]
+            isOneToOne: false
+            referencedRelation: "job_notes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       job_notes: {
         Row: {
           author_id: string | null
-          body: string
+          body: string | null
           company_id: string
           created_at: string
           id: string
           job_id: string
+          job_operation_id: string | null
+          job_part_id: string | null
+          note_type: string
         }
         Insert: {
           author_id?: string | null
-          body: string
+          body?: string | null
           company_id: string
           created_at?: string
           id?: string
           job_id: string
+          job_operation_id?: string | null
+          job_part_id?: string | null
+          note_type?: string
         }
         Update: {
           author_id?: string | null
-          body?: string
+          body?: string | null
           company_id?: string
           created_at?: string
           id?: string
           job_id?: string
+          job_operation_id?: string | null
+          job_part_id?: string | null
+          note_type?: string
         }
         Relationships: [
           {
@@ -914,6 +983,20 @@ export type Database = {
             columns: ["job_id"]
             isOneToOne: false
             referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_notes_job_operation_id_fkey"
+            columns: ["job_operation_id"]
+            isOneToOne: false
+            referencedRelation: "job_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_notes_job_part_id_fkey"
+            columns: ["job_part_id"]
+            isOneToOne: false
+            referencedRelation: "job_parts"
             referencedColumns: ["id"]
           },
         ]

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -138,16 +138,42 @@ export interface JobTraveler {
 }
 
 /**
- * One job-level note in the traveler's notes feed. Notes are general (not tied
- * to an operation) and append-only — many notes by different people over time.
+ * A photo (or, later, short video) attached to a job note. Bytes live in the
+ * private `attachments` bucket; the feed renders thumbnails via signed URLs.
+ */
+export interface JobNoteMedia {
+  id: string;
+  note_id: string;
+  /** Object key in the attachments bucket — pass to getJobNoteMediaUrl(). */
+  storage_path: string;
+  /** Optional poster/thumbnail key (video, or a smaller image variant). */
+  thumbnail_path: string | null;
+  kind: 'photo' | 'video';
+  mime_type: string | null;
+  width: number | null;
+  height: number | null;
+}
+
+/**
+ * One note in the job feed. The feed is one append-only stream per job: every
+ * note carries `job_id` (the rollup key) and may optionally be tagged to a step
+ * via `job_operation_id` — operation-scoped notes (captured on the operation
+ * page) roll up into the same feed. A note may carry text, media, or both.
  */
 export interface JobNote {
   id: string;
   job_id: string;
-  body: string;
+  /** Optional step tag — null for job-level notes, set for operation-scoped ones. */
+  job_operation_id: string | null;
+  /** Human label for the tagged step, e.g. "Op 20 · Mill"; null when untagged. */
+  operation_label: string | null;
+  /** Free text. Null when the note is media-only. */
+  body: string | null;
   created_at: string;
   /** Author display name (from user_company_access.name); null if unknown. */
   author_name: string | null;
+  /** Attached photos/videos, in insertion order. */
+  media: JobNoteMedia[];
 }
 
 // ============================================================================

--- a/utils/imageCompression.ts
+++ b/utils/imageCompression.ts
@@ -1,0 +1,57 @@
+import imageCompression from 'browser-image-compression';
+
+/**
+ * Client-only photo preparation for the operator job feed.
+ *
+ * Shop-floor tablets/phones produce 4–12 MB photos; raw uploads crush floor
+ * wifi. We downscale to ~2048px on the long edge and re-encode to JPEG before
+ * upload (typically 5–10× smaller). Re-encoding through the library's canvas
+ * pipeline also bakes EXIF orientation into the pixels, so iPhone photos don't
+ * render sideways, and normalizes HEIC to JPEG. Compression runs in a Web Worker
+ * (useWebWorker) so the UI doesn't jank.
+ *
+ * Import only from client components — browser-image-compression uses canvas /
+ * Web Workers and has no Node fallback.
+ */
+const PHOTO_COMPRESSION_OPTIONS = {
+  maxWidthOrHeight: 2048,
+  maxSizeMB: 1.5,
+  initialQuality: 0.8,
+  useWebWorker: true,
+  fileType: 'image/jpeg' as const,
+};
+
+export interface PreparedPhoto {
+  file: File;
+  dims?: { width: number; height: number };
+}
+
+function renameToJpg(name: string): string {
+  const dot = name.lastIndexOf('.');
+  const base = (dot === -1 ? name : name.slice(0, dot)).trim();
+  return `${base || 'photo'}.jpg`;
+}
+
+/** Compress + downscale a captured image and read its final pixel dimensions. */
+export async function compressPhoto(input: File): Promise<PreparedPhoto> {
+  const compressed = await imageCompression(input, PHOTO_COMPRESSION_OPTIONS);
+
+  // Normalize to a File with a .jpg name and image/jpeg type regardless of what
+  // the library returns (File or Blob, original extension).
+  const lower = compressed.name?.toLowerCase() ?? '';
+  const file =
+    compressed instanceof File && (lower.endsWith('.jpg') || lower.endsWith('.jpeg'))
+      ? compressed
+      : new File([compressed], renameToJpg(input.name), { type: 'image/jpeg' });
+
+  let dims: { width: number; height: number } | undefined;
+  try {
+    const bmp = await createImageBitmap(file);
+    dims = { width: bmp.width, height: bmp.height };
+    bmp.close();
+  } catch {
+    dims = undefined;
+  }
+
+  return { file, dims };
+}

--- a/utils/jobNoteMediaAccess.ts
+++ b/utils/jobNoteMediaAccess.ts
@@ -1,0 +1,154 @@
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import {
+  generateStoragePath,
+  uploadFileToStorage,
+  deleteFileFromStorage,
+  getSignedUrl,
+} from '@/utils/storageHelpers';
+import type { JobNoteMedia } from '@/types/operator';
+
+/**
+ * Access layer for job-note media — photos (and, later, short videos) attached
+ * to a job_notes entry. File bytes live in the private `attachments` storage
+ * bucket under {companyId}/jobs/{jobId}/... (see utils/storageHelpers.ts, whose
+ * bucket RLS already gates by the company folder); this module manages the
+ * job_note_media metadata rows and ties the two together.
+ *
+ * Mirrors partAttachmentsAccess.ts. Heavy media work (compression, EXIF fix,
+ * dimension reading) happens in the browser BEFORE these calls — they only see
+ * an already-compressed File and upload it (Supabase-first, no FastAPI/ffmpeg).
+ */
+
+/** Signed-URL lifetime for feed thumbnails; long enough that an open feed won't 403. */
+const MEDIA_URL_EXPIRY_SECONDS = 4 * 60 * 60;
+
+const MEDIA_SELECT =
+  'id, note_id, storage_path, thumbnail_path, kind, mime_type, width, height';
+
+type MediaRow = {
+  id: string;
+  note_id: string;
+  storage_path: string;
+  thumbnail_path: string | null;
+  kind: string;
+  mime_type: string | null;
+  width: number | null;
+  height: number | null;
+};
+
+function rowToMedia(row: MediaRow): JobNoteMedia {
+  return {
+    id: row.id,
+    note_id: row.note_id,
+    storage_path: row.storage_path,
+    thumbnail_path: row.thumbnail_path,
+    kind: row.kind === 'video' ? 'video' : 'photo',
+    mime_type: row.mime_type,
+    width: row.width,
+    height: row.height,
+  };
+}
+
+/**
+ * Attach one (already-compressed) photo to a job note. Uploads to
+ * {companyId}/jobs/{jobId}/... then records the metadata row. Rolls back the
+ * storage object if the row insert fails so a failed attach never leaks an
+ * orphaned file. `dims` (the compressed image's pixel size) is optional.
+ */
+export async function addJobNoteMedia(
+  companyId: string,
+  jobId: string,
+  noteId: string,
+  file: File,
+  opts?: { dims?: { width: number; height: number } },
+): Promise<JobNoteMedia> {
+  const supabase = getSupabase();
+  const storagePath = generateStoragePath(companyId, 'jobs', jobId, file.name);
+  await uploadFileToStorage(storagePath, file);
+
+  const { data, error } = await supabase
+    .from('job_note_media')
+    .insert({
+      company_id: companyId,
+      note_id: noteId,
+      storage_path: storagePath,
+      kind: 'photo',
+      mime_type: file.type || null,
+      size_bytes: file.size,
+      width: opts?.dims?.width ?? null,
+      height: opts?.dims?.height ?? null,
+    })
+    .select(MEDIA_SELECT)
+    .single();
+
+  if (error) {
+    // Roll back the orphaned upload so a failed insert doesn't leak a file.
+    await deleteFileFromStorage(storagePath).catch(() => {});
+    console.error('Error inserting job note media:', error);
+    throw new Error('Failed to attach the photo. Please try again.');
+  }
+
+  return rowToMedia(data as unknown as MediaRow);
+}
+
+/** A fresh, time-limited URL for rendering a photo/thumbnail in the feed. */
+export function getJobNoteMediaUrl(storagePath: string): Promise<string> {
+  return getSignedUrl(storagePath, MEDIA_URL_EXPIRY_SECONDS);
+}
+
+/**
+ * Delete one media item: remove the metadata row first, then the stored file.
+ * Row-first (matches partAttachments): a failed file delete after the row is
+ * gone leaks an *invisible* orphan (cleanable later) rather than a *visible* row
+ * that 404s. RLS restricts the row delete to the parent note's author or an admin.
+ */
+export async function deleteJobNoteMedia(media: {
+  id: string;
+  storage_path: string;
+}): Promise<void> {
+  const supabase = getSupabase();
+  const { error } = await supabase.from('job_note_media').delete().eq('id', media.id);
+  if (error) {
+    console.error('Error deleting job note media row:', error);
+    throw error;
+  }
+  await deleteFileFromStorage(media.storage_path).catch((err) =>
+    console.warn('Failed to delete media file after row delete:', err),
+  );
+}
+
+/**
+ * Delete a whole note and clean up its media files. The job_note_media rows
+ * cascade away with the note, so read the storage paths FIRST (while the rows
+ * still exist), delete the note, then best-effort remove the orphaned files.
+ * RLS restricts the note delete to its author or a company admin.
+ */
+export async function deleteJobNote(noteId: string): Promise<void> {
+  const supabase = getSupabase();
+
+  // Read media storage paths before the cascade removes the rows.
+  let paths: string[] = [];
+  const { data: mediaRows, error: listError } = await supabase
+    .from('job_note_media')
+    .select('storage_path')
+    .eq('note_id', noteId);
+  if (listError) {
+    console.warn('Could not list note media for cleanup:', listError);
+  } else {
+    paths = ((mediaRows ?? []) as Array<{ storage_path: string }>)
+      .map((r) => r.storage_path)
+      .filter(Boolean);
+  }
+
+  const { error } = await supabase.from('job_notes').delete().eq('id', noteId);
+  if (error) {
+    console.error('Error deleting job note:', error);
+    throw error;
+  }
+
+  for (const path of paths) {
+    await deleteFileFromStorage(path).catch((err) =>
+      console.warn('Failed to delete media file after note delete:', err),
+    );
+  }
+}

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -32,6 +32,7 @@ import type {
   JobTraveler,
   JobTravelerOperation,
   JobNote,
+  JobNoteMedia,
 } from '@/types/operator';
 
 // Operator type from user_company_access. role and created_at are
@@ -747,9 +748,74 @@ export async function getJobPartTraveler(
   };
 }
 
+// One read shape backs the whole job feed (traveler read-only + operation page).
+// Each note carries its optional step tag (job_operations) and its media so the
+// feed renders thumbnails without a second round-trip.
+const JOB_NOTE_SELECT =
+  'id, job_id, job_operation_id, body, created_at, ' +
+  'author:user_company_access(name), ' +
+  'operation:job_operations(operation_name, sequence), ' +
+  'media:job_note_media(id, note_id, storage_path, thumbnail_path, kind, mime_type, width, height)';
+
+type JobNoteRow = {
+  id: string;
+  job_id: string;
+  job_operation_id: string | null;
+  body: string | null;
+  created_at: string;
+  author: { name: string | null } | { name: string | null }[] | null;
+  operation:
+    | { operation_name: string | null; sequence: number | null }
+    | { operation_name: string | null; sequence: number | null }[]
+    | null;
+  media: Array<{
+    id: string;
+    note_id: string;
+    storage_path: string;
+    thumbnail_path: string | null;
+    kind: string;
+    mime_type: string | null;
+    width: number | null;
+    height: number | null;
+  }> | null;
+};
+
+function mapJobNoteRow(n: JobNoteRow): JobNote {
+  const author = Array.isArray(n.author) ? n.author[0] : n.author;
+  const op = Array.isArray(n.operation) ? n.operation[0] : n.operation;
+  const operationLabel = op?.operation_name
+    ? op.sequence != null
+      ? `Op ${op.sequence} · ${op.operation_name}`
+      : op.operation_name
+    : null;
+  const media: JobNoteMedia[] = (n.media ?? []).map((m) => ({
+    id: m.id,
+    note_id: m.note_id,
+    storage_path: m.storage_path,
+    thumbnail_path: m.thumbnail_path,
+    kind: m.kind === 'video' ? 'video' : 'photo',
+    mime_type: m.mime_type,
+    width: m.width,
+    height: m.height,
+  }));
+  return {
+    id: n.id,
+    job_id: n.job_id,
+    job_operation_id: n.job_operation_id,
+    operation_label: operationLabel,
+    body: n.body,
+    created_at: n.created_at,
+    author_name: author?.name ?? null,
+    media,
+  };
+}
+
 /**
- * Job-level notes feed (newest first). General notes about the job, not tied to
- * any operation. Authored by operators/admins over time.
+ * The job feed (newest first): one append-only stream per job. Returns both
+ * job-level notes and operation-scoped notes — operation notes roll up here
+ * automatically because they still carry job_id. Each note includes its step
+ * tag label (if any) and its attached media. Backs both the traveler (read-only)
+ * and the operation page.
  */
 export async function getJobNotes(
   jobId: string,
@@ -759,47 +825,37 @@ export async function getJobNotes(
 
   const { data, error } = await supabase
     .from('job_notes')
-    .select('id, job_id, body, created_at, author:user_company_access(name)')
+    .select(JOB_NOTE_SELECT)
     .eq('job_id', jobId)
     .eq('company_id', companyId)
     .order('created_at', { ascending: false });
 
   if (error) throw new Error(error.message);
 
-  type NoteRow = {
-    id: string;
-    job_id: string;
-    body: string;
-    created_at: string;
-    author: { name: string | null } | { name: string | null }[] | null;
-  };
-
-  return ((data ?? []) as NoteRow[]).map((n) => {
-    const author = Array.isArray(n.author) ? n.author[0] : n.author;
-    return {
-      id: n.id,
-      job_id: n.job_id,
-      body: n.body,
-      created_at: n.created_at,
-      author_name: author?.name ?? null,
-    };
-  });
+  return ((data ?? []) as unknown as JobNoteRow[]).map(mapJobNoteRow);
 }
 
 /**
- * Append a job-level note. `authorId` is the author's user_company_access id
- * (from getCurrentOperator); RLS requires it to match the caller's access row.
+ * Append a note to the job feed. `authorId` is the author's user_company_access
+ * id (from getCurrentOperator); RLS requires it to match the caller's access row.
+ *
+ * `opts.jobOperationId` is the optional step tag. The operation page always
+ * passes it (with `jobPartId`) so operator captures are step-scoped; the
+ * read-only traveler never calls this. `body` may be null/blank for a media-only
+ * note — callers must guarantee body-or-media (a fully empty note is useless);
+ * the returned note's `media` is empty until media is attached via
+ * addJobNoteMedia.
  */
 export async function addJobNote(
   jobId: string,
   companyId: string,
   authorId: string,
-  body: string,
+  body: string | null,
+  opts?: { jobPartId?: string | null; jobOperationId?: string | null },
 ): Promise<JobNote> {
   const supabase = getSupabase();
 
-  const trimmed = body.trim();
-  if (!trimmed) throw new Error('Note cannot be empty.');
+  const trimmed = body?.trim() || null;
 
   const { data, error } = await supabase
     .from('job_notes')
@@ -808,8 +864,10 @@ export async function addJobNote(
       job_id: jobId,
       author_id: authorId,
       body: trimmed,
+      job_part_id: opts?.jobPartId ?? null,
+      job_operation_id: opts?.jobOperationId ?? null,
     })
-    .select('id, job_id, body, created_at, author:user_company_access(name)')
+    .select(JOB_NOTE_SELECT)
     .single();
 
   if (error) {
@@ -821,20 +879,5 @@ export async function addJobNote(
     );
   }
 
-  type NoteRow = {
-    id: string;
-    job_id: string;
-    body: string;
-    created_at: string;
-    author: { name: string | null } | { name: string | null }[] | null;
-  };
-  const n = data as NoteRow;
-  const author = Array.isArray(n.author) ? n.author[0] : n.author;
-  return {
-    id: n.id,
-    job_id: n.job_id,
-    body: n.body,
-    created_at: n.created_at,
-    author_name: author?.name ?? null,
-  };
+  return mapJobNoteRow(data as unknown as JobNoteRow);
 }


### PR DESCRIPTION
## Phase 1 of the Activity Feature

Operators capture **notes + photos on the operation page** (auto-tagged to the step they're working — no selector); the **traveler** shows the whole job's feed **read-only, moved to the top**. It's **one append-only feed** (`job_notes`, rolled up by `job_id`), reached from two contexts. This matches the real flow: the per-operation QR lands operators on the operation page.

Plan: P1 of a 3-phase feature (P2 = dashboard Recent Activity card + `/activity` page; P3 = "last time we ran this part" guidance).

### Schema (2 migrations — applied to **staging**)
- `extend_job_notes_for_operations_and_media` — adds nullable `job_part_id`, `job_operation_id` (step tag), `note_type`; makes `body` nullable (pure-photo notes); CHECK that a step tag requires a part. Existing rows stay valid at rest (no backfill).
- `job_note_media` — new table (photo now; `kind`/`duration_seconds` ready for video), RLS mirroring `job_notes`. Reuses the private `attachments` bucket + its company-folder storage RLS (no new storage policy).

Why `job_operation_id` is nullable: existing `job_notes` are job-level with nothing valid to backfill to; the table legitimately holds both job- and step-level notes. The operation-page composer always sets the tag for operator captures (access-layer enforced).

### Access layer (typed client, Supabase-first — no FastAPI)
- `utils/operatorAccess.ts` — `getJobNotes` returns step label + media; `addJobNote` takes the optional step tag and allows media-only notes.
- `utils/jobNoteMediaAccess.ts` — upload (storage rollback on failure), signed-URL, delete-media, delete-note-with-cleanup.
- `utils/imageCompression.ts` — client downscale → 2048px/JPEG (EXIF-orientation + HEIC handled), Web Worker.

### UI
- `components/operator/JobFeed.tsx` — feed list (author, timestamp, **step chip**, photo thumbnails + full-size viewer) + composer with native camera (`capture="environment"`), shown only with operation context.
- Operation page: composer below Mark Complete, auto-tagged to the step.
- Traveler page: feed bumped to the top, read-only.

### Validation
- Migrations apply cleanly on local (full set, post-rebase) and on staging.
- `tsc --noEmit` clean · **728/728** unit tests pass (14 new) · eslint 0 errors.

### Notes / follow-ups
- **Manual tablet verification** still needed (camera capture can't be exercised headlessly).
- `supabase/schema.staging.sql` snapshot intentionally not regenerated — left for the post-prod export per CLAUDE.md.
- Short **video** capture is deferred (schema already accommodates it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)