### PR TITLE
feat(activity): dashboard Recent Activity card + /activity page (Activity P2)

### DIFF
--- a/__tests__/utils/dashboardAccess.test.ts
+++ b/__tests__/utils/dashboardAccess.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Per-table Supabase mock: each supabase.from(table) returns its own thenable
+// builder that resolves to table-specific fixture data, so the UNION-on-read
+// across jobs/quotes/shipments/job_notes/job_operations can be exercised.
+const DATA: Record<string, unknown[]> & { error?: unknown } = {
+  jobsCreated: [],
+  jobsCompleted: [],
+  quotes: [],
+  shipments: [],
+  notes: [],
+  operations: [],
+};
+
+function resolveData(state: { table: string; completedFilter: boolean }) {
+  if (DATA.error) return { data: null, error: DATA.error };
+  switch (state.table) {
+    case 'jobs':
+      return { data: state.completedFilter ? DATA.jobsCompleted : DATA.jobsCreated, error: null };
+    case 'quotes':
+      return { data: DATA.quotes, error: null };
+    case 'shipments':
+      return { data: DATA.shipments, error: null };
+    case 'job_notes':
+      return { data: DATA.notes, error: null };
+    case 'job_operations':
+      return { data: DATA.operations, error: null };
+    default:
+      return { data: [], error: null };
+  }
+}
+
+function makeBuilder(table: string) {
+  const state = { table, completedFilter: false };
+  const b: Record<string, unknown> = {};
+  const ret = () => b;
+  b.select = vi.fn(ret);
+  b.eq = vi.fn(ret);
+  b.in = vi.fn(ret);
+  b.not = vi.fn((col: string) => {
+    if (col === 'completed_at') state.completedFilter = true;
+    return b;
+  });
+  b.order = vi.fn(ret);
+  b.limit = vi.fn(ret);
+  b.lt = vi.fn(ret);
+  // Thenable: `await builder` (or `.then`) resolves to the table's data.
+  b.then = (resolve: (v: unknown) => void) => resolve(resolveData(state));
+  return b;
+}
+
+const mockSupabase = { from: vi.fn((t: string) => makeBuilder(t)) };
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+
+import { getDashboardActivity, getActivityStream } from '@/utils/dashboardAccess';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  DATA.jobsCreated = [];
+  DATA.jobsCompleted = [];
+  DATA.quotes = [];
+  DATA.shipments = [];
+  DATA.notes = [];
+  DATA.operations = [];
+  delete DATA.error;
+});
+
+describe('getDashboardActivity', () => {
+  beforeEach(() => {
+    DATA.jobsCreated = [
+      { id: 'j1', job_number: 'J-1', created_at: '2026-06-23T05:00:00Z', completed_at: null, customer: { name: 'Acme' } },
+    ];
+    DATA.jobsCompleted = [
+      { id: 'j2', job_number: 'J-2', created_at: '2026-06-20T00:00:00Z', completed_at: '2026-06-23T06:00:00Z', customer: null },
+    ];
+    DATA.quotes = [
+      { id: 'q1', quote_number: 'Q-1', created_at: '2026-06-23T04:00:00Z', customer: { name: 'Beta' } },
+    ];
+    DATA.shipments = [
+      { id: 's1', created_at: '2026-06-23T07:00:00Z', job_id: 'j9', job: { job_number: 'J-9' }, customer: { name: 'Gamma' } },
+    ];
+    // These must NOT appear on the compact dashboard card.
+    DATA.notes = [
+      { id: 'n1', created_at: '2026-06-23T08:00:00Z', job_id: 'j1', job: { job_number: 'J-1' }, author: { name: 'Sam' }, media: [] },
+    ];
+    DATA.operations = [
+      { id: 'o1', completed_at: '2026-06-23T08:30:00Z', job_id: 'j1', jobs: { job_number: 'J-1' } },
+    ];
+  });
+
+  it('returns only business milestones (no notes/photos/operations), newest first', async () => {
+    const items = await getDashboardActivity('c1', { limit: 6 });
+
+    expect(items.map((i) => i.type).sort()).toEqual(['job', 'job', 'quote', 'shipment']);
+    expect(items.every((i) => ['job', 'quote', 'shipment'].includes(i.type))).toBe(true);
+    // Newest first: shipment 07:00 > job-completed 06:00 > job-created 05:00 > quote 04:00.
+    expect(items.map((i) => i.timestamp)).toEqual([
+      '2026-06-23T07:00:00Z',
+      '2026-06-23T06:00:00Z',
+      '2026-06-23T05:00:00Z',
+      '2026-06-23T04:00:00Z',
+    ]);
+    // Mapped fields: shipment uses the joined job number + customer + deep link.
+    const shipment = items[0];
+    expect(shipment.entityNumber).toBe('J-9');
+    expect(shipment.customerName).toBe('Gamma');
+    expect(shipment.href).toBe('/dashboard/c1/jobs/j9');
+  });
+
+  it('caps the card to the requested limit', async () => {
+    const items = await getDashboardActivity('c1', { limit: 2 });
+    expect(items).toHaveLength(2);
+    expect(items[0].timestamp).toBe('2026-06-23T07:00:00Z'); // still newest-first
+  });
+});
+
+describe('getActivityStream', () => {
+  beforeEach(() => {
+    DATA.notes = [
+      { id: 'n1', created_at: '2026-06-23T03:00:00Z', job_id: 'j1', job: { job_number: 'J-1' }, author: { name: 'Sam' }, media: [] },
+      { id: 'n2', created_at: '2026-06-23T02:00:00Z', job_id: 'j1', job: { job_number: 'J-1' }, author: { name: 'Lee' }, media: [{ id: 'm1' }] },
+    ];
+    DATA.jobsCreated = [
+      { id: 'j1', job_number: 'J-1', created_at: '2026-06-23T01:00:00Z', completed_at: null, customer: { name: 'Acme' } },
+    ];
+  });
+
+  it('includes floor activity and separates text notes from photo notes', async () => {
+    const noteOnly = await getActivityStream('c1', { types: ['note'] });
+    expect(noteOnly).toHaveLength(1);
+    expect(noteOnly[0].type).toBe('note');
+    expect(noteOnly[0].authorName).toBe('Sam');
+
+    const photoOnly = await getActivityStream('c1', { types: ['photo'] });
+    expect(photoOnly).toHaveLength(1);
+    expect(photoOnly[0].type).toBe('photo');
+    expect(photoOnly[0].action).toBe('photo_added');
+  });
+
+  it('merges multiple sources newest-first and caps to the limit', async () => {
+    const all = await getActivityStream('c1', { limit: 2 });
+    expect(all).toHaveLength(2);
+    // Newest two across notes(03:00, 02:00) + job(01:00) → the two notes.
+    expect(all.map((i) => i.timestamp)).toEqual(['2026-06-23T03:00:00Z', '2026-06-23T02:00:00Z']);
+  });
+
+  it('returns [] (best-effort) when a source query errors', async () => {
+    DATA.error = { message: 'boom' };
+    const items = await getActivityStream('c1', { types: ['job'] });
+    expect(items).toEqual([]);
+  });
+});

--- a/app/dashboard/[companyId]/activity/page.tsx
+++ b/app/dashboard/[companyId]/activity/page.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Chip from '@mui/material/Chip';
+import Card from '@mui/material/Card';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Tooltip from '@mui/material/Tooltip';
+import { getActivityStream } from '@/utils/dashboardAccess';
+import type { ActivityItem, ActivityType } from '@/utils/dashboardAccess';
+import {
+  getActivityVisual,
+  formatActivityText,
+  formatRelativeTime,
+  formatAbsoluteTime,
+} from '@/components/dashboard/activityFormat';
+
+const PAGE_SIZE = 30;
+
+// Module-level so each filter's `types` reference is stable across renders.
+const FILTERS: { label: string; types?: ActivityType[] }[] = [
+  { label: 'All' },
+  { label: 'Jobs', types: ['job'] },
+  { label: 'Quotes', types: ['quote'] },
+  { label: 'Shipments', types: ['shipment'] },
+  { label: 'Notes', types: ['note'] },
+  { label: 'Photos', types: ['photo'] },
+  { label: 'Operations', types: ['operation'] },
+];
+
+function ActivityRow({ item }: { item: ActivityItem }) {
+  const { icon: Icon, color } = getActivityVisual(item);
+  const content = (
+    <>
+      <ListItemIcon sx={{ minWidth: 44 }}>
+        <Icon sx={{ color }} />
+      </ListItemIcon>
+      <ListItemText
+        primary={
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+            {item.entityNumber && (
+              <Typography variant="body2" component="span" sx={{ fontWeight: 600 }}>
+                {item.entityNumber}
+              </Typography>
+            )}
+            <Typography variant="body2" component="span" color="text.secondary">
+              {formatActivityText(item)}
+            </Typography>
+          </Box>
+        }
+        secondary={
+          <Tooltip title={formatAbsoluteTime(item.timestamp)}>
+            <Typography variant="caption" color="text.secondary">
+              {formatRelativeTime(item.timestamp)}
+            </Typography>
+          </Tooltip>
+        }
+      />
+    </>
+  );
+  const rowSx = {
+    borderBottom: '1px solid rgba(255, 255, 255, 0.06)',
+    '&:last-child': { borderBottom: 'none' },
+    minHeight: 56,
+  };
+  return item.href ? (
+    <ListItemButton component={Link} href={item.href} sx={rowSx}>
+      {content}
+    </ListItemButton>
+  ) : (
+    <ListItem sx={rowSx}>{content}</ListItem>
+  );
+}
+
+/**
+ * The full cross-module activity stream — what's happening across the shop,
+ * filterable by type and paginated. The compact dashboard "Recent Activity"
+ * card links here ("View all"). Plain Supabase reads (no AI on mount).
+ */
+export default function ActivityPage() {
+  const params = useParams();
+  const companyId = params.companyId as string;
+
+  const [filterIdx, setFilterIdx] = useState(0);
+  const [items, setItems] = useState<ActivityItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+
+  const types = FILTERS[filterIdx].types;
+
+  // Initial / filter-change load. Async-only setState (loading reset happens in
+  // the filter handler) so this effect doesn't trip set-state-in-effect.
+  useEffect(() => {
+    if (!companyId) return;
+    let active = true;
+    getActivityStream(companyId, { types, limit: PAGE_SIZE })
+      .then((rows) => {
+        if (!active) return;
+        setItems(rows);
+        setHasMore(rows.length === PAGE_SIZE);
+      })
+      .catch(() => {
+        if (active) {
+          setItems([]);
+          setHasMore(false);
+        }
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [companyId, types]);
+
+  const selectFilter = (idx: number) => {
+    if (idx === filterIdx) return;
+    setFilterIdx(idx);
+    setItems([]);
+    setLoading(true);
+  };
+
+  const loadMore = useCallback(async () => {
+    const last = items[items.length - 1];
+    if (!last) return;
+    setLoadingMore(true);
+    try {
+      const rows = await getActivityStream(companyId, {
+        types,
+        limit: PAGE_SIZE,
+        before: last.timestamp,
+      });
+      setItems((prev) => [...prev, ...rows]);
+      setHasMore(rows.length === PAGE_SIZE);
+    } catch {
+      setHasMore(false);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [companyId, types, items]);
+
+  return (
+    <Box>
+      {/* Filter chips */}
+      <Stack direction="row" spacing={1} sx={{ mb: 3, flexWrap: 'wrap', gap: 1 }}>
+        {FILTERS.map((f, idx) => (
+          <Chip
+            key={f.label}
+            label={f.label}
+            onClick={() => selectFilter(idx)}
+            color={idx === filterIdx ? 'primary' : 'default'}
+            variant={idx === filterIdx ? 'filled' : 'outlined'}
+          />
+        ))}
+      </Stack>
+
+      <Card elevation={2}>
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+            <CircularProgress />
+          </Box>
+        ) : items.length === 0 ? (
+          <Box sx={{ py: 6, textAlign: 'center' }}>
+            <Typography variant="body2" color="text.secondary">
+              No activity yet.
+            </Typography>
+          </Box>
+        ) : (
+          <>
+            <List disablePadding>
+              {items.map((item) => (
+                <ActivityRow key={item.id} item={item} />
+              ))}
+            </List>
+            {hasMore && (
+              <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+                <Button onClick={loadMore} disabled={loadingMore}>
+                  {loadingMore ? <CircularProgress size={20} /> : 'Load more'}
+                </Button>
+              </Box>
+            )}
+          </>
+        )}
+      </Card>
+    </Box>
+  );
+}

--- a/app/dashboard/[companyId]/page.tsx
+++ b/app/dashboard/[companyId]/page.tsx
@@ -4,10 +4,10 @@ import { useState, useCallback, useEffect } from 'react';
 import { useParams } from 'next/navigation';
 import Box from '@mui/material/Box';
 
-import { InsightsSection, PinnedMetrics } from '@/components/dashboard';
+import { InsightsSection, PinnedMetrics, RecentActivity } from '@/components/dashboard';
 import { InsightsChat } from '@/components/insights';
 import OnboardingCard from '@/components/demo/OnboardingCard';
-import { getMetricValue } from '@/utils/dashboardAccess';
+import { getMetricValue, getDashboardActivity, type ActivityItem } from '@/utils/dashboardAccess';
 
 export default function DashboardPage() {
   const params = useParams();
@@ -15,6 +15,8 @@ export default function DashboardPage() {
   const [savedVersion, setSavedVersion] = useState(0);
   const [savedCount, setSavedCount] = useState(0);
   const [isEmpty, setIsEmpty] = useState(false);
+  const [activities, setActivities] = useState<ActivityItem[]>([]);
+  const [activitiesLoading, setActivitiesLoading] = useState(true);
 
   const handleInsightSaved = useCallback(() => {
     setSavedVersion((v) => v + 1);
@@ -36,6 +38,18 @@ export default function DashboardPage() {
     }).catch(() => {});
   }, [companyId]);
 
+  // Recent Activity card — a plain Supabase read (no AI on mount). Async-only
+  // setState (loading starts true) to stay clear of set-state-in-effect.
+  useEffect(() => {
+    if (!companyId) return;
+    let active = true;
+    getDashboardActivity(companyId, { limit: 6 })
+      .then((items) => { if (active) setActivities(items); })
+      .catch(() => {})
+      .finally(() => { if (active) setActivitiesLoading(false); });
+    return () => { active = false; };
+  }, [companyId]);
+
   return (
     <Box>
       {/* Onboarding Card — shown when dashboard is empty and no demo exists */}
@@ -44,6 +58,15 @@ export default function DashboardPage() {
       {/* Pinned Metrics */}
       <Box sx={{ mb: 4 }}>
         <PinnedMetrics companyId={companyId} />
+      </Box>
+
+      {/* Recent Activity — compact business-milestone feed + "View all" hop */}
+      <Box sx={{ mb: 4 }}>
+        <RecentActivity
+          activities={activities}
+          loading={activitiesLoading}
+          viewAllHref={`/dashboard/${companyId}/activity`}
+        />
       </Box>
 
       {/* Ask Bar */}

--- a/components/dashboard/RecentActivity.tsx
+++ b/components/dashboard/RecentActivity.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
@@ -9,110 +10,72 @@ import Chip from '@mui/material/Chip';
 import Typography from '@mui/material/Typography';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Skeleton from '@mui/material/Skeleton';
+import Tooltip from '@mui/material/Tooltip';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
-import WorkOutlineIcon from '@mui/icons-material/WorkOutline';
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import LocalShippingOutlinedIcon from '@mui/icons-material/LocalShippingOutlined';
 import type { ActivityItem } from '@/utils/dashboardAccess';
+import {
+  formatRelativeTime,
+  formatAbsoluteTime,
+  getActivityVisual,
+  formatActivityText,
+} from './activityFormat';
 
 const STORAGE_KEY = 'jigged-recent-activity-expanded';
 
 interface RecentActivityProps {
   activities: ActivityItem[];
   loading?: boolean;
+  /** When set, a "View all" link to the full activity page is shown. */
+  viewAllHref?: string;
+}
+
+/** The inner content of one activity row (icon + entity + action + relative time). */
+function ActivityRowContent({ activity }: { activity: ActivityItem }) {
+  const { icon: Icon, color } = getActivityVisual(activity);
+  return (
+    <>
+      <ListItemIcon sx={{ minWidth: 40 }}>
+        <Icon sx={{ color, fontSize: 20 }} />
+      </ListItemIcon>
+      <ListItemText
+        primary={
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            {activity.entityNumber && (
+              <Typography variant="body2" component="span" sx={{ fontWeight: 600 }}>
+                {activity.entityNumber}
+              </Typography>
+            )}
+            <Typography variant="body2" component="span" color="text.secondary" noWrap>
+              {formatActivityText(activity)}
+            </Typography>
+          </Box>
+        }
+        secondary={
+          <Tooltip title={formatAbsoluteTime(activity.timestamp)}>
+            <Typography variant="caption" color="text.secondary">
+              {formatRelativeTime(activity.timestamp)}
+            </Typography>
+          </Tooltip>
+        }
+      />
+    </>
+  );
 }
 
 /**
- * Format a timestamp as a relative time string
- */
-function formatRelativeTime(timestamp: string): string {
-  const date = new Date(timestamp);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffSeconds = Math.floor(diffMs / 1000);
-  const diffMinutes = Math.floor(diffSeconds / 60);
-  const diffHours = Math.floor(diffMinutes / 60);
-  const diffDays = Math.floor(diffHours / 24);
-
-  if (diffSeconds < 60) {
-    return 'just now';
-  } else if (diffMinutes < 60) {
-    return `${diffMinutes}m ago`;
-  } else if (diffHours < 24) {
-    return `${diffHours}h ago`;
-  } else if (diffDays === 1) {
-    return 'yesterday';
-  } else if (diffDays < 7) {
-    return `${diffDays}d ago`;
-  } else {
-    return date.toLocaleDateString();
-  }
-}
-
-/**
- * Get icon and color for activity type
- */
-function getActivityIcon(type: 'quote' | 'job', action: string) {
-  if (type === 'quote') {
-    return {
-      icon: DescriptionOutlinedIcon,
-      color: 'primary.main',
-    };
-  }
-
-  switch (action) {
-    case 'created':
-      return { icon: WorkOutlineIcon, color: 'primary.main' };
-    case 'started':
-      return { icon: PlayArrowIcon, color: 'info.main' };
-    case 'completed':
-      return { icon: CheckCircleOutlineIcon, color: 'success.main' };
-    case 'shipped':
-      return { icon: LocalShippingOutlinedIcon, color: 'secondary.main' };
-    default:
-      return { icon: WorkOutlineIcon, color: 'text.secondary' };
-  }
-}
-
-/**
- * Format the activity action text
- */
-function formatActionText(
-  type: 'quote' | 'job',
-  action: string,
-  customerName?: string
-): string {
-  const entityType = type === 'quote' ? 'Quote' : 'Job';
-
-  switch (action) {
-    case 'created':
-      return customerName
-        ? `${entityType} created for ${customerName}`
-        : `${entityType} created`;
-    case 'started':
-      return 'Work started';
-    case 'completed':
-      return 'Marked complete';
-    case 'shipped':
-      return customerName ? `Shipped to ${customerName}` : 'Shipped';
-    default:
-      return action;
-  }
-}
-
-/**
- * Recent activity feed component.
- * Uses an Accordion with a summary strip showing title, count, and a
- * preview of the most recent activity when collapsed.
+ * Recent activity feed card for the dashboard. A compact, glanceable summary of
+ * the latest business milestones with a "View all" hop to the full /activity
+ * page (progressive disclosure). Data is fetched by the parent (plain Supabase,
+ * no AI on mount) and passed in.
  */
 export default function RecentActivity({
   activities,
   loading = false,
+  viewAllHref,
 }: RecentActivityProps) {
   const [expanded, setExpanded] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false;
@@ -184,19 +147,9 @@ export default function RecentActivity({
           />
         )}
         {!expanded && latestActivity && (
-          <Typography
-            variant="body2"
-            color="text.secondary"
-            noWrap
-            sx={{ flex: 1, ml: 0.5 }}
-          >
-            {latestActivity.entityNumber} &mdash;{' '}
-            {formatActionText(
-              latestActivity.type,
-              latestActivity.action,
-              latestActivity.customerName
-            )}
-            , {formatRelativeTime(latestActivity.timestamp)}
+          <Typography variant="body2" color="text.secondary" noWrap sx={{ flex: 1, ml: 0.5 }}>
+            {latestActivity.entityNumber} &mdash; {formatActivityText(latestActivity)},{' '}
+            {formatRelativeTime(latestActivity.timestamp)}
           </Typography>
         )}
       </AccordionSummary>
@@ -223,65 +176,44 @@ export default function RecentActivity({
             </Typography>
           </Box>
         ) : (
-          <List disablePadding>
-            {activities.map((activity) => {
-              const { icon: Icon, color } = getActivityIcon(
-                activity.type,
-                activity.action
-              );
-
-              return (
-                <ListItem
-                  key={activity.id}
-                  disableGutters
-                  sx={{
-                    py: 1,
-                    borderBottom: '1px solid rgba(255, 255, 255, 0.05)',
-                    '&:last-child': { borderBottom: 'none' },
-                  }}
+          <>
+            <List disablePadding>
+              {activities.map((activity) => {
+                const rowSx = {
+                  py: 1,
+                  borderBottom: '1px solid rgba(255, 255, 255, 0.05)',
+                  '&:last-child': { borderBottom: 'none' },
+                };
+                return activity.href ? (
+                  <ListItemButton
+                    key={activity.id}
+                    component={Link}
+                    href={activity.href}
+                    disableGutters
+                    sx={rowSx}
+                  >
+                    <ActivityRowContent activity={activity} />
+                  </ListItemButton>
+                ) : (
+                  <ListItem key={activity.id} disableGutters sx={rowSx}>
+                    <ActivityRowContent activity={activity} />
+                  </ListItem>
+                );
+              })}
+            </List>
+            {viewAllHref && (
+              <Box sx={{ textAlign: 'center', pt: 1 }}>
+                <Typography
+                  variant="body2"
+                  component={Link}
+                  href={viewAllHref}
+                  sx={{ color: 'primary.main', textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}
                 >
-                  <ListItemIcon sx={{ minWidth: 40 }}>
-                    <Icon sx={{ color, fontSize: 20 }} />
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 1,
-                        }}
-                      >
-                        <Typography
-                          variant="body2"
-                          component="span"
-                          sx={{ fontWeight: 600 }}
-                        >
-                          {activity.entityNumber}
-                        </Typography>
-                        <Typography
-                          variant="body2"
-                          component="span"
-                          color="text.secondary"
-                        >
-                          {formatActionText(
-                            activity.type,
-                            activity.action,
-                            activity.customerName
-                          )}
-                        </Typography>
-                      </Box>
-                    }
-                    secondary={
-                      <Typography variant="caption" color="text.secondary">
-                        {formatRelativeTime(activity.timestamp)}
-                      </Typography>
-                    }
-                  />
-                </ListItem>
-              );
-            })}
-          </List>
+                  View all activity
+                </Typography>
+              </Box>
+            )}
+          </>
         )}
       </AccordionDetails>
     </Accordion>

--- a/components/dashboard/activityFormat.tsx
+++ b/components/dashboard/activityFormat.tsx
@@ -1,0 +1,103 @@
+import type { SvgIconComponent } from '@mui/icons-material';
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
+import WorkOutlineIcon from '@mui/icons-material/WorkOutline';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import LocalShippingOutlinedIcon from '@mui/icons-material/LocalShippingOutlined';
+import StickyNote2OutlinedIcon from '@mui/icons-material/StickyNote2Outlined';
+import PhotoCameraOutlinedIcon from '@mui/icons-material/PhotoCameraOutlined';
+import PrecisionManufacturingOutlinedIcon from '@mui/icons-material/PrecisionManufacturingOutlined';
+import type { ActivityItem } from '@/utils/dashboardAccess';
+
+/**
+ * Shared formatting for the activity feed so the dashboard card, the /activity
+ * page, and any future surface render identical icons, labels, and timestamps
+ * (one source of truth — no drift between surfaces).
+ */
+
+/** Relative time for recency-focused reading ("5m ago", "2h ago", "yesterday"). */
+export function formatRelativeTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  const diffMs = Date.now() - date.getTime();
+  const diffSeconds = Math.floor(diffMs / 1000);
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSeconds < 60) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays === 1) return 'yesterday';
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+/** Absolute timestamp for tooltip/long-press (older items need the real date). */
+export function formatAbsoluteTime(timestamp: string): string {
+  const d = new Date(timestamp);
+  if (Number.isNaN(d.getTime())) return timestamp;
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+/** Icon + theme color for an activity row, keyed by type then action. */
+export function getActivityVisual(item: ActivityItem): { icon: SvgIconComponent; color: string } {
+  switch (item.type) {
+    case 'quote':
+      return { icon: DescriptionOutlinedIcon, color: 'primary.main' };
+    case 'note':
+      return { icon: StickyNote2OutlinedIcon, color: 'text.secondary' };
+    case 'photo':
+      return { icon: PhotoCameraOutlinedIcon, color: 'info.main' };
+    case 'shipment':
+      return { icon: LocalShippingOutlinedIcon, color: 'secondary.main' };
+    case 'operation':
+      return { icon: PrecisionManufacturingOutlinedIcon, color: 'success.main' };
+    case 'job':
+    default:
+      switch (item.action) {
+        case 'started':
+          return { icon: PlayArrowIcon, color: 'info.main' };
+        case 'completed':
+          return { icon: CheckCircleOutlineIcon, color: 'success.main' };
+        case 'shipped':
+          return { icon: LocalShippingOutlinedIcon, color: 'secondary.main' };
+        case 'created':
+        default:
+          return { icon: WorkOutlineIcon, color: 'primary.main' };
+      }
+  }
+}
+
+/** One-line, scannable description of what happened (the entity number is shown separately). */
+export function formatActivityText(item: ActivityItem): string {
+  const who = item.authorName || 'Someone';
+  switch (item.type) {
+    case 'quote':
+      return item.customerName ? `Quote created for ${item.customerName}` : 'Quote created';
+    case 'shipment':
+      return item.customerName ? `Shipped to ${item.customerName}` : 'Shipped';
+    case 'note':
+      return `${who} added a note`;
+    case 'photo':
+      return `${who} added a photo`;
+    case 'operation':
+      return 'Operation completed';
+    case 'job':
+    default:
+      switch (item.action) {
+        case 'started':
+          return 'Work started';
+        case 'completed':
+          return 'Job completed';
+        case 'created':
+        default:
+          return item.customerName ? `Job created for ${item.customerName}` : 'Job created';
+      }
+  }
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -133,7 +133,7 @@ function getPageTitle(pathname: string): string {
   }
 
   // Map other route segments to display titles
-  const titleMap: Record<string, string> = {};
+  const titleMap: Record<string, string> = { activity: 'Activity' };
 
   // Check from the end backwards for known segments
   for (let i = segments.length - 1; i >= 0; i--) {

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Skeleton from '@mui/material/Skeleton';
 import DashboardIcon from '@mui/icons-material/Dashboard';
+import DynamicFeedIcon from '@mui/icons-material/DynamicFeed';
 import WorkIcon from '@mui/icons-material/Work';
 import BusinessIcon from '@mui/icons-material/Business';
 import CategoryIcon from '@mui/icons-material/Category';
@@ -45,6 +46,7 @@ interface MenuItem {
 
 const menuItems: MenuItem[] = [
   { name: 'Dashboard', path: '', icon: DashboardIcon },
+  { name: 'Activity', path: '/activity', icon: DynamicFeedIcon },
   { name: 'Jobs', path: '/jobs', icon: WorkIcon },
   { name: 'Quotes', path: '/quotes', icon: RequestQuoteIcon },
   { name: 'Parts', path: '/parts', icon: CategoryIcon },

--- a/supabase/schema.prod.sql
+++ b/supabase/schema.prod.sql
@@ -1,6 +1,6 @@
 -- ============================================================
 -- Jigged Manufacturing Data Platform - Database Schema
--- Generated: 2026-06-22T00:21:11Z
+-- Generated: 2026-06-23T13:00:08Z
 -- Schemas: public, storage
 -- ============================================================
 
@@ -30,10 +30,6 @@ CREATE TABLE IF NOT EXISTS "public"."companies"
     "state" text,
     "postal_code" text,
     "country" text,
-    "packing_slip_number_format" text NOT NULL DEFAULT 'PS-{YYYY}-{seq:0000}'::text,
-    "packing_slip_seq_year" integer,
-    "packing_slip_next_seq" integer NOT NULL DEFAULT 1,
-    "default_coc_text" text,
     CONSTRAINT "companies_pkey" PRIMARY KEY (id),
     CONSTRAINT "companies_slug_key" UNIQUE (slug)
 );
@@ -93,6 +89,14 @@ CREATE TABLE IF NOT EXISTS "public"."company_custom_units"
     CONSTRAINT "company_custom_units_company_id_unit_name_key" UNIQUE (company_id, unit_name)
 );
 
+CREATE TABLE IF NOT EXISTS "public"."company_order_counters"
+(
+    "company_id" uuid NOT NULL,
+    "next_number" integer NOT NULL DEFAULT 1,
+    "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "company_order_counters_pkey" PRIMARY KEY (company_id)
+);
+
 CREATE TABLE IF NOT EXISTS "public"."customers"
 (
     "id" uuid NOT NULL DEFAULT gen_random_uuid(),
@@ -101,12 +105,8 @@ CREATE TABLE IF NOT EXISTS "public"."customers"
     "website" text,
     "created_at" timestamp with time zone DEFAULT now(),
     "updated_at" timestamp with time zone DEFAULT now(),
-    "default_shipping_arrangement" text,
-    "default_carrier" text,
-    "default_coc_text" text,
     CONSTRAINT "customers_pkey" PRIMARY KEY (id),
-    CONSTRAINT "customers_company_name_unique" UNIQUE (company_id, name),
-    CONSTRAINT "customers_default_shipping_arrangement_check" CHECK (((default_shipping_arrangement IS NULL) OR (default_shipping_arrangement = ANY (ARRAY['prepaid_and_add'::text, 'prepaid'::text, 'collect'::text, 'third_party_account'::text, 'customer_pickup'::text, 'customer_arranged_freight'::text, 'other'::text]))))
+    CONSTRAINT "customers_company_name_unique" UNIQUE (company_id, name)
 );
 
 CREATE TABLE IF NOT EXISTS "public"."customer_addresses"
@@ -169,6 +169,21 @@ CREATE TABLE IF NOT EXISTS "public"."feedback"
     CONSTRAINT "feedback_pkey" PRIMARY KEY (id)
 );
 
+CREATE TABLE IF NOT EXISTS "public"."inventory_locations"
+(
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id" uuid NOT NULL,
+    "parent_id" uuid,
+    "name" text NOT NULL,
+    "kind" text,
+    "code" text,
+    "sort_order" integer NOT NULL DEFAULT 0,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "inventory_locations_pkey" PRIMARY KEY (id),
+    CONSTRAINT "inventory_locations_name_not_blank" CHECK ((length(btrim(name)) > 0))
+);
+
 CREATE TABLE IF NOT EXISTS "public"."invitations"
 (
     "id" uuid NOT NULL DEFAULT gen_random_uuid(),
@@ -216,8 +231,16 @@ CREATE TABLE IF NOT EXISTS "public"."quotes"
     "billing_address_id" uuid,
     "shipping_address_id" uuid,
     "contact_id" uuid,
+    "payment_terms" text,
+    "lead_time_value" integer,
+    "lead_time_unit" text DEFAULT 'business_days'::text,
+    "customer_name" text,
+    "bill_to_address" jsonb,
+    "ship_to_address" jsonb,
+    "contact_snapshot" jsonb,
     CONSTRAINT "quotes_pkey" PRIMARY KEY (id),
     CONSTRAINT "quotes_company_id_quote_number_key" UNIQUE (company_id, quote_number),
+    CONSTRAINT "quotes_lead_time_unit_check" CHECK ((lead_time_unit = ANY (ARRAY['business_days'::text, 'calendar_days'::text, 'weeks'::text]))),
     CONSTRAINT "quotes_status_check" CHECK ((status = ANY (ARRAY['active'::text, 'expired'::text])))
 );
 
@@ -242,10 +265,28 @@ CREATE TABLE IF NOT EXISTS "public"."jobs"
     "billing_address_id" uuid,
     "shipping_address_id" uuid,
     "contact_id" uuid,
+    "customer_name" text,
+    "bill_to_address" jsonb,
+    "ship_to_address" jsonb,
+    "contact_snapshot" jsonb,
     CONSTRAINT "jobs_pkey" PRIMARY KEY (id),
     CONSTRAINT "jobs_company_id_job_number_key" UNIQUE (company_id, job_number),
     CONSTRAINT "jobs_fulfillment_status_check" CHECK ((fulfillment_status = ANY (ARRAY['unshipped'::text, 'partially_shipped'::text, 'fully_shipped'::text]))),
     CONSTRAINT "jobs_production_status_check" CHECK ((production_status = ANY (ARRAY['not_started'::text, 'in_progress'::text, 'completed'::text, 'cancelled'::text])))
+);
+
+CREATE TABLE IF NOT EXISTS "public"."job_attachments"
+(
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id" uuid NOT NULL,
+    "job_id" uuid NOT NULL,
+    "storage_path" text NOT NULL,
+    "file_name" text NOT NULL,
+    "mime_type" text,
+    "size_bytes" bigint,
+    "uploaded_by" uuid,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "job_attachments_pkey" PRIMARY KEY (id)
 );
 
 CREATE TABLE IF NOT EXISTS "public"."saved_insights"
@@ -270,23 +311,19 @@ CREATE TABLE IF NOT EXISTS "public"."shipments"
     "packing_slip_number" text NOT NULL,
     "ship_date" date NOT NULL DEFAULT CURRENT_DATE,
     "carrier" text,
-    "tracking_number" text,
-    "shipping_arrangement" text,
-    "shipping_arrangement_other" text,
-    "weight_lbs" numeric(10,2),
-    "package_count" integer,
-    "package_type" text,
     "notes" text,
-    "coc_text" text,
     "created_by" uuid,
     "created_at" timestamp with time zone NOT NULL DEFAULT now(),
     "voided_at" timestamp with time zone,
     "voided_by" uuid,
+    "shipping_method" text,
+    "job_id" uuid NOT NULL,
+    "customer_name" text,
+    "bill_to_address" jsonb,
+    "ship_to_address" jsonb,
     CONSTRAINT "shipments_pkey" PRIMARY KEY (id),
     CONSTRAINT "shipments_packing_slip_company_unique" UNIQUE (company_id, packing_slip_number),
-    CONSTRAINT "shipments_arrangement_other_text" CHECK (((shipping_arrangement IS DISTINCT FROM 'other'::text) OR (shipping_arrangement_other IS NOT NULL))),
-    CONSTRAINT "shipments_one_address_source" CHECK ((((shipping_address_id IS NOT NULL) AND (one_time_address IS NULL)) OR ((shipping_address_id IS NULL) AND (one_time_address IS NOT NULL)))),
-    CONSTRAINT "shipments_shipping_arrangement_check" CHECK (((shipping_arrangement IS NULL) OR (shipping_arrangement = ANY (ARRAY['prepaid_and_add'::text, 'prepaid'::text, 'collect'::text, 'third_party_account'::text, 'customer_pickup'::text, 'customer_arranged_freight'::text, 'other'::text]))))
+    CONSTRAINT "shipments_shipping_method_check" CHECK (((shipping_method IS NULL) OR (shipping_method = ANY (ARRAY['customer_pickup'::text, 'personal_delivery'::text, 'shipment'::text, 'dropship'::text, 'restock'::text]))))
 );
 
 CREATE TABLE IF NOT EXISTS "public"."job_fulfillment_audit"
@@ -325,18 +362,6 @@ CREATE TABLE IF NOT EXISTS "public"."user_company_access"
     CONSTRAINT "user_company_access_pkey" PRIMARY KEY (id),
     CONSTRAINT "user_company_access_user_id_company_id_key" UNIQUE (user_id, company_id),
     CONSTRAINT "user_company_access_role_check" CHECK ((role = ANY (ARRAY['admin'::text, 'user'::text, 'operator'::text])))
-);
-
-CREATE TABLE IF NOT EXISTS "public"."job_notes"
-(
-    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
-    "company_id" uuid NOT NULL,
-    "job_id" uuid NOT NULL,
-    "author_id" uuid,
-    "body" text NOT NULL,
-    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
-    CONSTRAINT "job_notes_pkey" PRIMARY KEY (id),
-    CONSTRAINT "job_notes_body_not_blank" CHECK ((length(btrim(body)) > 0))
 );
 
 CREATE TABLE IF NOT EXISTS "public"."quickbooks_connections"
@@ -381,8 +406,8 @@ CREATE TABLE IF NOT EXISTS "public"."quickbooks_invoice_links"
 (
     "id" uuid NOT NULL DEFAULT gen_random_uuid(),
     "company_id" uuid NOT NULL,
-    "quote_id" uuid NOT NULL,
-    "job_id" uuid,
+    "quote_id" uuid,
+    "job_id" uuid NOT NULL,
     "realm_id" text NOT NULL,
     "qb_request_id" uuid NOT NULL,
     "qb_invoice_id" text,
@@ -394,7 +419,7 @@ CREATE TABLE IF NOT EXISTS "public"."quickbooks_invoice_links"
     "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
     "qb_invoice_url" text,
     CONSTRAINT "quickbooks_invoice_links_pkey" PRIMARY KEY (id),
-    CONSTRAINT "quickbooks_invoice_links_quote_realm_key" UNIQUE (quote_id, realm_id),
+    CONSTRAINT "quickbooks_invoice_links_job_realm_key" UNIQUE (job_id, realm_id),
     CONSTRAINT "quickbooks_invoice_links_status_check" CHECK ((status = ANY (ARRAY['pending'::text, 'created'::text, 'error'::text])))
 );
 
@@ -445,12 +470,42 @@ CREATE TABLE IF NOT EXISTS "public"."parts"
     "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
     "source" text NOT NULL DEFAULT 'made'::text,
     "markup_rate_id" uuid,
+    "is_location_tracked" boolean NOT NULL DEFAULT false,
     CONSTRAINT "parts_pkey" PRIMARY KEY (id),
     CONSTRAINT "parts_legacy_id_unique_per_company" UNIQUE (company_id, legacy_id),
     CONSTRAINT "parts_unique_per_company" UNIQUE (company_id, part_name),
     CONSTRAINT "parts_quantity_non_negative" CHECK ((quantity >= (0)::numeric)),
     CONSTRAINT "parts_requires_unit" CHECK ((primary_unit IS NOT NULL)),
     CONSTRAINT "parts_source_check" CHECK ((source = ANY (ARRAY['made'::text, 'bought'::text])))
+);
+
+CREATE TABLE IF NOT EXISTS "public"."part_attachments"
+(
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id" uuid NOT NULL,
+    "part_id" uuid NOT NULL,
+    "storage_path" text NOT NULL,
+    "file_name" text NOT NULL,
+    "kind" text NOT NULL DEFAULT 'other'::text,
+    "mime_type" text,
+    "size_bytes" bigint,
+    "uploaded_by" uuid,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "part_attachments_pkey" PRIMARY KEY (id),
+    CONSTRAINT "part_attachments_kind_check" CHECK ((kind = ANY (ARRAY['pdf'::text, 'step'::text, 'dwg'::text, 'other'::text])))
+);
+
+CREATE TABLE IF NOT EXISTS "public"."part_location_stock"
+(
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id" uuid NOT NULL,
+    "part_id" uuid NOT NULL,
+    "location_id" uuid NOT NULL,
+    "quantity" numeric NOT NULL DEFAULT 0,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "part_location_stock_pkey" PRIMARY KEY (id),
+    CONSTRAINT "part_location_stock_part_location_unique" UNIQUE (part_id, location_id),
+    CONSTRAINT "part_location_stock_quantity_non_negative" CHECK ((quantity >= (0)::numeric))
 );
 
 CREATE TABLE IF NOT EXISTS "public"."part_notes"
@@ -568,6 +623,8 @@ CREATE TABLE IF NOT EXISTS "public"."job_parts"
     "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
     "production_status" text NOT NULL,
     "fulfillment_status" text NOT NULL,
+    "unit_price" numeric(12,4),
+    "total_price" numeric(12,4),
     CONSTRAINT "job_parts_pkey" PRIMARY KEY (id),
     CONSTRAINT "job_parts_job_part_unique" UNIQUE (job_id, part_id),
     CONSTRAINT "job_parts_job_sequence_unique" UNIQUE (job_id, sequence),
@@ -710,7 +767,6 @@ CREATE TABLE IF NOT EXISTS "public"."routing_operations"
     "cycle_minutes_per_unit" numeric(8,4),
     "labor_rate_override" numeric(10,2),
     "external_unit_price" numeric(12,4),
-    "external_setup_cost" numeric(12,4),
     "instructions" text,
     "metadata" jsonb DEFAULT '{}'::jsonb,
     "created_at" timestamp with time zone DEFAULT now(),
@@ -761,9 +817,47 @@ CREATE TABLE IF NOT EXISTS "public"."inventory_transactions"
     "created_at" timestamp with time zone DEFAULT now(),
     "created_by" uuid,
     "has_discrepancy" boolean NOT NULL DEFAULT false,
+    "location_id" uuid,
+    "transfer_group_id" uuid,
+    "location_name" text,
     CONSTRAINT "inventory_transactions_pkey" PRIMARY KEY (id),
     CONSTRAINT "inventory_transactions_quantity_positive" CHECK ((quantity >= (0)::numeric)),
     CONSTRAINT "inventory_transactions_type_check" CHECK ((type = ANY (ARRAY['addition'::text, 'depletion'::text, 'adjustment'::text])))
+);
+
+CREATE TABLE IF NOT EXISTS "public"."job_notes"
+(
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id" uuid NOT NULL,
+    "job_id" uuid NOT NULL,
+    "author_id" uuid,
+    "body" text,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "job_part_id" uuid,
+    "job_operation_id" uuid,
+    "note_type" text NOT NULL DEFAULT 'user'::text,
+    CONSTRAINT "job_notes_pkey" PRIMARY KEY (id),
+    CONSTRAINT "job_notes_body_blank_or_null" CHECK (((body IS NULL) OR (length(btrim(body)) > 0))),
+    CONSTRAINT "job_notes_note_type_check" CHECK ((note_type = ANY (ARRAY['user'::text, 'event'::text]))),
+    CONSTRAINT "job_notes_operation_requires_part" CHECK (((job_operation_id IS NULL) OR (job_part_id IS NOT NULL)))
+);
+
+CREATE TABLE IF NOT EXISTS "public"."job_note_media"
+(
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id" uuid NOT NULL,
+    "note_id" uuid NOT NULL,
+    "storage_path" text NOT NULL,
+    "thumbnail_path" text,
+    "kind" text NOT NULL DEFAULT 'photo'::text,
+    "mime_type" text,
+    "size_bytes" bigint,
+    "width" integer,
+    "height" integer,
+    "duration_seconds" numeric,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "job_note_media_pkey" PRIMARY KEY (id),
+    CONSTRAINT "job_note_media_kind_check" CHECK ((kind = ANY (ARRAY['photo'::text, 'video'::text])))
 );
 
 -- ============================================================
@@ -774,20 +868,26 @@ ALTER TABLE "public"."ai_config" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."auth_audit_log" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."companies" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."company_custom_units" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."company_order_counters" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."customer_addresses" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."customer_contacts" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."customers" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."demo_data_templates" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."feedback" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."inventory_locations" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."inventory_transactions" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."invitations" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."job_attachments" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."job_fulfillment_audit" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."job_materials" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."job_note_media" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."job_notes" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."job_operations" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."job_parts" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."jobs" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."markup_rates" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."part_attachments" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."part_location_stock" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."part_notes" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."part_pricing_tiers" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."part_procurement_tiers" ENABLE ROW LEVEL SECURITY;
@@ -1021,6 +1121,31 @@ CREATE POLICY "Users can insert feedback for their companies"
    FROM user_company_access uca
   WHERE (uca.user_id = auth.uid()))));
 
+DROP POLICY IF EXISTS "Users can delete inventory_locations" ON "public"."inventory_locations";
+CREATE POLICY "Users can delete inventory_locations"
+    ON "public"."inventory_locations"
+    FOR DELETE
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+DROP POLICY IF EXISTS "Users can insert inventory_locations" ON "public"."inventory_locations";
+CREATE POLICY "Users can insert inventory_locations"
+    ON "public"."inventory_locations"
+    FOR INSERT
+    WITH CHECK ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+DROP POLICY IF EXISTS "Users can update inventory_locations" ON "public"."inventory_locations";
+CREATE POLICY "Users can update inventory_locations"
+    ON "public"."inventory_locations"
+    FOR UPDATE
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)))
+    WITH CHECK ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+DROP POLICY IF EXISTS "Users can view inventory_locations" ON "public"."inventory_locations";
+CREATE POLICY "Users can view inventory_locations"
+    ON "public"."inventory_locations"
+    FOR SELECT
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
 DROP POLICY IF EXISTS "Users can insert inventory_transactions" ON "public"."inventory_transactions";
 CREATE POLICY "Users can insert inventory_transactions"
     ON "public"."inventory_transactions"
@@ -1059,6 +1184,24 @@ CREATE POLICY "Users can read invitations for their email"
     USING (((email)::text = (( SELECT users.email
    FROM auth.users
   WHERE (users.id = auth.uid())))::text));
+
+DROP POLICY IF EXISTS "Users can delete their company's job_attachments" ON "public"."job_attachments";
+CREATE POLICY "Users can delete their company's job_attachments"
+    ON "public"."job_attachments"
+    FOR DELETE
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+DROP POLICY IF EXISTS "Users can insert their company's job_attachments" ON "public"."job_attachments";
+CREATE POLICY "Users can insert their company's job_attachments"
+    ON "public"."job_attachments"
+    FOR INSERT
+    WITH CHECK ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+DROP POLICY IF EXISTS "Users can view their company's job_attachments" ON "public"."job_attachments";
+CREATE POLICY "Users can view their company's job_attachments"
+    ON "public"."job_attachments"
+    FOR SELECT
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
 
 DROP POLICY IF EXISTS "Users can view job_fulfillment_audit" ON "public"."job_fulfillment_audit";
 CREATE POLICY "Users can view job_fulfillment_audit"
@@ -1113,6 +1256,26 @@ CREATE POLICY "ai_readonly_select"
     USING ((EXISTS ( SELECT 1
    FROM jobs
   WHERE ((jobs.id = job_materials.job_id) AND (jobs.company_id = (current_setting('jigged.company_id'::text, true))::uuid)))));
+
+DROP POLICY IF EXISTS "Authors and admins can delete job_note_media" ON "public"."job_note_media";
+CREATE POLICY "Authors and admins can delete job_note_media"
+    ON "public"."job_note_media"
+    FOR DELETE
+    USING ((is_company_admin(company_id) OR (EXISTS ( SELECT 1
+   FROM job_notes n
+  WHERE ((n.id = job_note_media.note_id) AND (n.author_id = get_operator_access_id(n.company_id)))))));
+
+DROP POLICY IF EXISTS "Users can insert job_note_media" ON "public"."job_note_media";
+CREATE POLICY "Users can insert job_note_media"
+    ON "public"."job_note_media"
+    FOR INSERT
+    WITH CHECK (((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)) AND (get_operator_access_id(company_id) IS NOT NULL)));
+
+DROP POLICY IF EXISTS "Users can view job_note_media" ON "public"."job_note_media";
+CREATE POLICY "Users can view job_note_media"
+    ON "public"."job_note_media"
+    FOR SELECT
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
 
 DROP POLICY IF EXISTS "Authors and admins can delete job_notes" ON "public"."job_notes";
 CREATE POLICY "Authors and admins can delete job_notes"
@@ -1283,6 +1446,30 @@ CREATE POLICY "markup_rates_update"
     USING ((company_id IN ( SELECT user_company_access.company_id
    FROM user_company_access
   WHERE (user_company_access.user_id = auth.uid()))));
+
+DROP POLICY IF EXISTS "Uploaders and admins can delete part_attachments" ON "public"."part_attachments";
+CREATE POLICY "Uploaders and admins can delete part_attachments"
+    ON "public"."part_attachments"
+    FOR DELETE
+    USING (((uploaded_by = get_operator_access_id(company_id)) OR is_company_admin(company_id)));
+
+DROP POLICY IF EXISTS "Users can insert own part_attachments" ON "public"."part_attachments";
+CREATE POLICY "Users can insert own part_attachments"
+    ON "public"."part_attachments"
+    FOR INSERT
+    WITH CHECK (((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)) AND (uploaded_by = get_operator_access_id(company_id))));
+
+DROP POLICY IF EXISTS "Users can view part_attachments" ON "public"."part_attachments";
+CREATE POLICY "Users can view part_attachments"
+    ON "public"."part_attachments"
+    FOR SELECT
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+DROP POLICY IF EXISTS "Users can view part_location_stock" ON "public"."part_location_stock";
+CREATE POLICY "Users can view part_location_stock"
+    ON "public"."part_location_stock"
+    FOR SELECT
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
 
 DROP POLICY IF EXISTS "Authors and admins can delete part_notes" ON "public"."part_notes";
 CREATE POLICY "Authors and admins can delete part_notes"
@@ -2090,6 +2277,9 @@ ALTER TABLE "public"."companies"
 ALTER TABLE "public"."company_custom_units"
     ADD CONSTRAINT "company_custom_units_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
 
+ALTER TABLE "public"."company_order_counters"
+    ADD CONSTRAINT "company_order_counters_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
+
 ALTER TABLE "public"."customer_addresses"
     ADD CONSTRAINT "customer_addresses_customer_id_fkey" FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE CASCADE;
 
@@ -2108,6 +2298,12 @@ ALTER TABLE "public"."feedback"
 ALTER TABLE "public"."feedback"
     ADD CONSTRAINT "feedback_user_id_fkey" FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
+ALTER TABLE "public"."inventory_locations"
+    ADD CONSTRAINT "inventory_locations_company_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."inventory_locations"
+    ADD CONSTRAINT "inventory_locations_parent_fkey" FOREIGN KEY (parent_id) REFERENCES inventory_locations(id) ON DELETE RESTRICT;
+
 ALTER TABLE "public"."inventory_transactions"
     ADD CONSTRAINT "inventory_transactions_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
 
@@ -2116,6 +2312,9 @@ ALTER TABLE "public"."inventory_transactions"
 
 ALTER TABLE "public"."inventory_transactions"
     ADD CONSTRAINT "inventory_transactions_job_operation_id_fkey" FOREIGN KEY (job_operation_id) REFERENCES job_operations(id) ON DELETE SET NULL;
+
+ALTER TABLE "public"."inventory_transactions"
+    ADD CONSTRAINT "inventory_transactions_location_fkey" FOREIGN KEY (location_id) REFERENCES inventory_locations(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."inventory_transactions"
     ADD CONSTRAINT "inventory_transactions_part_id_fkey" FOREIGN KEY (part_id) REFERENCES parts(id) ON DELETE SET NULL;
@@ -2128,6 +2327,15 @@ ALTER TABLE "public"."invitations"
 
 ALTER TABLE "public"."invitations"
     ADD CONSTRAINT "invitations_invited_by_fkey" FOREIGN KEY (invited_by) REFERENCES auth.users(id);
+
+ALTER TABLE "public"."job_attachments"
+    ADD CONSTRAINT "job_attachments_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."job_attachments"
+    ADD CONSTRAINT "job_attachments_job_id_fkey" FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."job_attachments"
+    ADD CONSTRAINT "job_attachments_uploaded_by_fkey" FOREIGN KEY (uploaded_by) REFERENCES auth.users(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."job_fulfillment_audit"
     ADD CONSTRAINT "job_fulfillment_audit_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
@@ -2153,6 +2361,12 @@ ALTER TABLE "public"."job_materials"
 ALTER TABLE "public"."job_materials"
     ADD CONSTRAINT "job_materials_parts_bom_id_fkey" FOREIGN KEY (parts_bom_id) REFERENCES parts_bom(id) ON DELETE SET NULL;
 
+ALTER TABLE "public"."job_note_media"
+    ADD CONSTRAINT "job_note_media_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."job_note_media"
+    ADD CONSTRAINT "job_note_media_note_id_fkey" FOREIGN KEY (note_id) REFERENCES job_notes(id) ON DELETE CASCADE;
+
 ALTER TABLE "public"."job_notes"
     ADD CONSTRAINT "job_notes_author_id_fkey" FOREIGN KEY (author_id) REFERENCES user_company_access(id) ON DELETE SET NULL;
 
@@ -2161,6 +2375,12 @@ ALTER TABLE "public"."job_notes"
 
 ALTER TABLE "public"."job_notes"
     ADD CONSTRAINT "job_notes_job_id_fkey" FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."job_notes"
+    ADD CONSTRAINT "job_notes_job_operation_id_fkey" FOREIGN KEY (job_operation_id) REFERENCES job_operations(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."job_notes"
+    ADD CONSTRAINT "job_notes_job_part_id_fkey" FOREIGN KEY (job_part_id) REFERENCES job_parts(id) ON DELETE CASCADE;
 
 ALTER TABLE "public"."job_operations"
     ADD CONSTRAINT "job_operations_assigned_to_fkey" FOREIGN KEY (assigned_to) REFERENCES auth.users(id);
@@ -2215,6 +2435,24 @@ ALTER TABLE "public"."jobs"
 
 ALTER TABLE "public"."markup_rates"
     ADD CONSTRAINT "markup_rates_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."part_attachments"
+    ADD CONSTRAINT "part_attachments_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."part_attachments"
+    ADD CONSTRAINT "part_attachments_part_id_fkey" FOREIGN KEY (part_id) REFERENCES parts(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."part_attachments"
+    ADD CONSTRAINT "part_attachments_uploaded_by_fkey" FOREIGN KEY (uploaded_by) REFERENCES user_company_access(id) ON DELETE SET NULL;
+
+ALTER TABLE "public"."part_location_stock"
+    ADD CONSTRAINT "part_location_stock_company_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."part_location_stock"
+    ADD CONSTRAINT "part_location_stock_location_fkey" FOREIGN KEY (location_id) REFERENCES inventory_locations(id) ON DELETE RESTRICT;
+
+ALTER TABLE "public"."part_location_stock"
+    ADD CONSTRAINT "part_location_stock_part_fkey" FOREIGN KEY (part_id) REFERENCES parts(id) ON DELETE RESTRICT;
 
 ALTER TABLE "public"."part_notes"
     ADD CONSTRAINT "part_notes_author_id_fkey" FOREIGN KEY (author_id) REFERENCES user_company_access(id) ON DELETE SET NULL;
@@ -2274,13 +2512,13 @@ ALTER TABLE "public"."quickbooks_invoice_links"
     ADD CONSTRAINT "quickbooks_invoice_links_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
 
 ALTER TABLE "public"."quickbooks_invoice_links"
-    ADD CONSTRAINT "quickbooks_invoice_links_job_id_fkey" FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE SET NULL;
+    ADD CONSTRAINT "quickbooks_invoice_links_job_id_fkey" FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE;
 
 ALTER TABLE "public"."quickbooks_invoice_links"
     ADD CONSTRAINT "quickbooks_invoice_links_pushed_by_fkey" FOREIGN KEY (pushed_by) REFERENCES user_company_access(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."quickbooks_invoice_links"
-    ADD CONSTRAINT "quickbooks_invoice_links_quote_id_fkey" FOREIGN KEY (quote_id) REFERENCES quotes(id) ON DELETE CASCADE;
+    ADD CONSTRAINT "quickbooks_invoice_links_quote_id_fkey" FOREIGN KEY (quote_id) REFERENCES quotes(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."quote_line_items"
     ADD CONSTRAINT "quote_line_items_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
@@ -2316,7 +2554,7 @@ ALTER TABLE "public"."quote_operations"
     ADD CONSTRAINT "quote_operations_quote_id_fkey" FOREIGN KEY (quote_id) REFERENCES quotes(id) ON DELETE CASCADE;
 
 ALTER TABLE "public"."quotes"
-    ADD CONSTRAINT "quotes_billing_address_id_fkey" FOREIGN KEY (billing_address_id) REFERENCES customer_addresses(id);
+    ADD CONSTRAINT "quotes_billing_address_id_fkey" FOREIGN KEY (billing_address_id) REFERENCES customer_addresses(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."quotes"
     ADD CONSTRAINT "quotes_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
@@ -2331,7 +2569,7 @@ ALTER TABLE "public"."quotes"
     ADD CONSTRAINT "quotes_customer_id_fkey" FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."quotes"
-    ADD CONSTRAINT "quotes_shipping_address_id_fkey" FOREIGN KEY (shipping_address_id) REFERENCES customer_addresses(id);
+    ADD CONSTRAINT "quotes_shipping_address_id_fkey" FOREIGN KEY (shipping_address_id) REFERENCES customer_addresses(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."routing_operations"
     ADD CONSTRAINT "routing_operations_routing_id_fkey" FOREIGN KEY (routing_id) REFERENCES routings(id) ON DELETE CASCADE;
@@ -2370,7 +2608,10 @@ ALTER TABLE "public"."shipments"
     ADD CONSTRAINT "shipments_customer_id_fkey" FOREIGN KEY (customer_id) REFERENCES customers(id);
 
 ALTER TABLE "public"."shipments"
-    ADD CONSTRAINT "shipments_shipping_address_id_fkey" FOREIGN KEY (shipping_address_id) REFERENCES customer_addresses(id);
+    ADD CONSTRAINT "shipments_job_id_fkey" FOREIGN KEY (job_id) REFERENCES jobs(id);
+
+ALTER TABLE "public"."shipments"
+    ADD CONSTRAINT "shipments_shipping_address_id_fkey" FOREIGN KEY (shipping_address_id) REFERENCES customer_addresses(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."shipments"
     ADD CONSTRAINT "shipments_voided_by_fkey" FOREIGN KEY (voided_by) REFERENCES auth.users(id) ON DELETE SET NULL;
@@ -2421,20 +2662,26 @@ CREATE INDEX IF NOT EXISTS idx_customer_contacts_customer ON public.customer_con
 CREATE INDEX IF NOT EXISTS idx_customers_company ON public.customers USING btree (company_id);
 CREATE INDEX IF NOT EXISTS idx_customers_name ON public.customers USING btree (company_id, name);
 CREATE INDEX IF NOT EXISTS idx_customers_name_trgm ON public.customers USING gin (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS inventory_locations_company_parent_idx ON public.inventory_locations USING btree (company_id, parent_id);
+CREATE UNIQUE INDEX IF NOT EXISTS inventory_locations_one_unassigned_per_company ON public.inventory_locations USING btree (company_id) WHERE (name = 'Unassigned'::text);
 CREATE INDEX IF NOT EXISTS inventory_transactions_company_id_created_at_idx ON public.inventory_transactions USING btree (company_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS inventory_transactions_discrepancy_idx ON public.inventory_transactions USING btree (company_id, created_at DESC) WHERE (has_discrepancy = true);
 CREATE INDEX IF NOT EXISTS inventory_transactions_job_id_idx ON public.inventory_transactions USING btree (job_id) WHERE (job_id IS NOT NULL);
 CREATE INDEX IF NOT EXISTS inventory_transactions_job_operation_id_idx ON public.inventory_transactions USING btree (job_operation_id) WHERE (job_operation_id IS NOT NULL);
+CREATE INDEX IF NOT EXISTS inventory_transactions_location_idx ON public.inventory_transactions USING btree (location_id) WHERE (location_id IS NOT NULL);
 CREATE INDEX IF NOT EXISTS inventory_transactions_part_id_created_at_idx ON public.inventory_transactions USING btree (part_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS inventory_transactions_transfer_group_idx ON public.inventory_transactions USING btree (transfer_group_id) WHERE (transfer_group_id IS NOT NULL);
 CREATE INDEX IF NOT EXISTS idx_invitations_company_id ON public.invitations USING btree (company_id);
 CREATE INDEX IF NOT EXISTS idx_invitations_email ON public.invitations USING btree (email);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_invitations_pending_email_company ON public.invitations USING btree (email, company_id) WHERE ((status)::text = 'pending'::text);
+CREATE INDEX IF NOT EXISTS idx_job_attachments_job ON public.job_attachments USING btree (job_id);
 CREATE INDEX IF NOT EXISTS idx_job_fulfillment_audit_company ON public.job_fulfillment_audit USING btree (company_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_job_fulfillment_audit_job ON public.job_fulfillment_audit USING btree (job_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_job_materials_job ON public.job_materials USING btree (job_id);
 CREATE INDEX IF NOT EXISTS idx_job_materials_job_part_id ON public.job_materials USING btree (job_part_id);
 CREATE INDEX IF NOT EXISTS idx_job_materials_material_part ON public.job_materials USING btree (material_part_id);
 CREATE INDEX IF NOT EXISTS idx_job_materials_parts_bom ON public.job_materials USING btree (parts_bom_id);
+CREATE INDEX IF NOT EXISTS idx_job_note_media_note ON public.job_note_media USING btree (note_id);
 CREATE INDEX IF NOT EXISTS idx_job_notes_job_created ON public.job_notes USING btree (job_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_job_operations_job_part_id ON public.job_operations USING btree (job_part_id);
 CREATE INDEX IF NOT EXISTS idx_job_ops_assigned ON public.job_operations USING btree (assigned_to) WHERE (assigned_to IS NOT NULL);
@@ -2456,6 +2703,10 @@ CREATE INDEX IF NOT EXISTS idx_jobs_production_status ON public.jobs USING btree
 CREATE INDEX IF NOT EXISTS idx_jobs_quote ON public.jobs USING btree (quote_id);
 CREATE INDEX IF NOT EXISTS idx_markup_rates_company ON public.markup_rates USING btree (company_id);
 CREATE UNIQUE INDEX IF NOT EXISTS markup_rates_one_default_per_company ON public.markup_rates USING btree (company_id) WHERE is_default;
+CREATE INDEX IF NOT EXISTS idx_part_attachments_part_created ON public.part_attachments USING btree (part_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS part_location_stock_company_idx ON public.part_location_stock USING btree (company_id);
+CREATE INDEX IF NOT EXISTS part_location_stock_location_idx ON public.part_location_stock USING btree (location_id);
+CREATE INDEX IF NOT EXISTS part_location_stock_part_idx ON public.part_location_stock USING btree (part_id);
 CREATE INDEX IF NOT EXISTS idx_part_notes_part_created ON public.part_notes USING btree (part_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_part_pricing_tiers_company ON public.part_pricing_tiers USING btree (company_id);
 CREATE INDEX IF NOT EXISTS idx_part_pricing_tiers_part ON public.part_pricing_tiers USING btree (part_id, sequence);
@@ -2472,6 +2723,7 @@ CREATE INDEX IF NOT EXISTS idx_parts_preferred_vendor ON public.parts USING btre
 CREATE INDEX IF NOT EXISTS idx_parts_bom_child ON public.parts_bom USING btree (child_part_id);
 CREATE INDEX IF NOT EXISTS idx_parts_bom_parent ON public.parts_bom USING btree (parent_part_id);
 CREATE INDEX IF NOT EXISTS idx_parts_unit_conversions_part ON public.parts_unit_conversions USING btree (part_id);
+CREATE INDEX IF NOT EXISTS idx_qb_invoice_links_job ON public.quickbooks_invoice_links USING btree (job_id);
 CREATE INDEX IF NOT EXISTS idx_qb_invoice_links_quote ON public.quickbooks_invoice_links USING btree (quote_id);
 CREATE INDEX IF NOT EXISTS idx_quote_line_items_company ON public.quote_line_items USING btree (company_id);
 CREATE INDEX IF NOT EXISTS idx_quote_line_items_part ON public.quote_line_items USING btree (part_id);
@@ -2495,6 +2747,7 @@ CREATE INDEX IF NOT EXISTS idx_shipment_line_items_job_part ON public.shipment_l
 CREATE INDEX IF NOT EXISTS idx_shipment_line_items_shipment ON public.shipment_line_items USING btree (shipment_id);
 CREATE INDEX IF NOT EXISTS idx_shipments_company ON public.shipments USING btree (company_id);
 CREATE INDEX IF NOT EXISTS idx_shipments_customer ON public.shipments USING btree (customer_id);
+CREATE INDEX IF NOT EXISTS idx_shipments_job_id ON public.shipments USING btree (job_id);
 CREATE INDEX IF NOT EXISTS idx_shipments_packing_slip ON public.shipments USING btree (company_id, packing_slip_number);
 CREATE INDEX IF NOT EXISTS idx_shipments_packing_slip_trgm ON public.shipments USING gin (packing_slip_number gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS idx_shipments_ship_date ON public.shipments USING btree (company_id, ship_date DESC);
@@ -2625,6 +2878,131 @@ BEGIN
     WHERE id = v_inv.id;
 
     RETURN v_inv.company_id;
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.add_stock_at_location(p_part_id uuid, p_location_id uuid, p_quantity numeric, p_unit text, p_converted_quantity numeric, p_notes text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_item_name text; v_tracked boolean;
+    v_new_balance numeric; v_rollup numeric;
+BEGIN
+    IF p_quantity <= 0 OR p_converted_quantity <= 0 THEN
+        RAISE EXCEPTION 'Quantity must be positive' USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT company_id, part_name, is_location_tracked
+      INTO v_company, v_item_name, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF NOT v_tracked THEN
+        RAISE EXCEPTION 'part % is not location-tracked; enable tracking first', p_part_id USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM public.inv_assert_location_in_company(p_location_id, v_company);
+
+    INSERT INTO public.part_location_stock AS pls (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, p_location_id, p_converted_quantity)
+    ON CONFLICT (part_id, location_id)
+        DO UPDATE SET quantity = pls.quantity + EXCLUDED.quantity
+    RETURNING pls.quantity INTO v_new_balance;
+
+    INSERT INTO public.inventory_transactions
+        (company_id, part_id, item_name, type, quantity, unit, converted_quantity,
+         location_id, notes, created_by)
+    VALUES
+        (v_company, p_part_id, v_item_name, 'addition', p_quantity, p_unit, p_converted_quantity,
+         p_location_id, p_notes, auth.uid());
+
+    SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+    RETURN jsonb_build_object('location_balance', v_new_balance, 'part_quantity', v_rollup);
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.address_block_snapshot(p_address_id uuid)
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT jsonb_build_object(
+           'address_line1', a.address_line1,
+           'address_line2', a.address_line2,
+           'city',          a.city,
+           'state',         a.state,
+           'postal_code',   a.postal_code,
+           'country',       a.country,
+           'attention_to',  a.attention_to
+         )
+    FROM public.customer_addresses a
+   WHERE a.id = p_address_id;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.adjust_stock_at_location(p_part_id uuid, p_location_id uuid, p_new_quantity numeric, p_unit text, p_converted_new_quantity numeric, p_notes text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_item_name text; v_primary_unit text; v_tracked boolean;
+    v_current numeric; v_diff numeric; v_rollup numeric; v_notes text;
+BEGIN
+    IF p_converted_new_quantity < 0 THEN
+        RAISE EXCEPTION 'Quantity cannot be negative' USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT company_id, part_name, primary_unit, is_location_tracked
+      INTO v_company, v_item_name, v_primary_unit, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF NOT v_tracked THEN
+        RAISE EXCEPTION 'part % is not location-tracked; enable tracking first', p_part_id USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM public.inv_assert_location_in_company(p_location_id, v_company);
+
+    SELECT quantity INTO v_current
+      FROM public.part_location_stock
+     WHERE part_id = p_part_id AND location_id = p_location_id
+       FOR UPDATE;
+    v_current := COALESCE(v_current, 0);
+    v_diff := p_converted_new_quantity - v_current;
+
+    INSERT INTO public.part_location_stock (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, p_location_id, p_converted_new_quantity)
+    ON CONFLICT (part_id, location_id) DO UPDATE SET quantity = EXCLUDED.quantity;
+
+    v_notes := COALESCE(
+        p_notes,
+        format('Adjusted from %s to %s %s', v_current, p_converted_new_quantity, v_primary_unit));
+
+    INSERT INTO public.inventory_transactions
+        (company_id, part_id, item_name, type, quantity, unit, converted_quantity,
+         location_id, notes, created_by)
+    VALUES
+        (v_company, p_part_id, v_item_name, 'adjustment', abs(v_diff), v_primary_unit, abs(v_diff),
+         p_location_id, v_notes, auth.uid());
+
+    SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+    RETURN jsonb_build_object('location_balance', p_converted_new_quantity, 'part_quantity', v_rollup);
 END;
 $function$
 
@@ -2861,7 +3239,6 @@ BEGIN
                    ro.cycle_minutes_per_unit,
                    ro.labor_rate_override,
                    ro.external_unit_price,
-                   ro.external_setup_cost,
                    wc.kind          AS wc_kind,
                    wc.labor_rate    AS wc_labor_rate
               FROM public.routing_operations ro
@@ -2880,14 +3257,13 @@ BEGIN
                              * COALESCE(v_op.labor_rate_override, v_op.wc_labor_rate)
                              / 60.0;
             ELSE
-                IF v_op.external_unit_price IS NULL AND v_op.external_setup_cost IS NULL THEN
+                IF v_op.external_unit_price IS NULL THEN
                     RAISE EXCEPTION
-                        'Cannot compute cost for part %: external routing op has no pricing (neither external_unit_price nor external_setup_cost)',
+                        'Cannot compute cost for part %: external routing op has no unit price (external_unit_price is required)',
                         v_part_name
                         USING ERRCODE = 'check_violation';
                 END IF;
-                v_op_cost := COALESCE(v_op.external_unit_price, 0)
-                             + COALESCE(v_op.external_setup_cost, 0) / p_qty;
+                v_op_cost := COALESCE(v_op.external_unit_price, 0);
             END IF;
             v_total := v_total + v_op_cost;
         END LOOP;
@@ -3010,6 +3386,22 @@ BEGIN
     missing_leaves := v_missing;
     RETURN NEXT;
 END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.contact_block_snapshot(p_contact_id uuid)
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT jsonb_build_object(
+           'name',  c.name,
+           'email', c.email,
+           'phone', c.phone
+         )
+    FROM public.customer_contacts c
+   WHERE c.id = p_contact_id;
 $function$
 
 ;
@@ -3147,7 +3539,7 @@ $function$
 
 ;
 
-CREATE OR REPLACE FUNCTION public.create_shipment_with_line_items(p_company_id uuid, p_customer_id uuid, p_shipping_address_id uuid, p_one_time_address jsonb, p_ship_date date, p_carrier text, p_tracking_number text, p_shipping_arrangement text, p_shipping_arrangement_other text, p_weight_lbs numeric, p_package_count integer, p_package_type text, p_notes text, p_coc_text text, p_line_items jsonb)
+CREATE OR REPLACE FUNCTION public.create_shipment_with_line_items(p_company_id uuid, p_customer_id uuid, p_shipping_address_id uuid, p_one_time_address jsonb, p_ship_date date, p_carrier text, p_shipping_method text, p_notes text, p_line_items jsonb)
  RETURNS uuid
  LANGUAGE plpgsql
  SECURITY DEFINER
@@ -3159,7 +3551,11 @@ DECLARE
     v_user_id uuid := auth.uid();
     v_item jsonb;
     v_pre_status jsonb := '{}'::jsonb;
+    v_job_ids uuid[];
     v_job_id uuid;
+    v_job_number text;
+    v_base text;
+    v_seq int;
     r record;
 BEGIN
     IF NOT (p_company_id IN (SELECT get_user_company_ids())) THEN
@@ -3168,49 +3564,51 @@ BEGIN
             USING ERRCODE = 'insufficient_privilege';
     END IF;
 
-    -- 1. Acquire per-job advisory locks in sorted order to prevent
-    --    deadlock between concurrent RPCs touching the same job set.
-    --    pg_advisory_xact_lock is released at COMMIT/ROLLBACK.
-    FOR v_job_id IN
-        SELECT DISTINCT jp.job_id
-          FROM public.job_parts jp
-         WHERE jp.id IN (
-            SELECT (item->>'job_part_id')::uuid
-              FROM jsonb_array_elements(p_line_items) AS item
-         )
-         ORDER BY jp.job_id
-    LOOP
-        PERFORM pg_advisory_xact_lock(hashtext('job:' || v_job_id::text));
-    END LOOP;
+    -- 1. Resolve the job(s) behind the line items. A packing slip belongs to
+    --    exactly one job — reject empty or multi-job inputs.
+    SELECT array_agg(DISTINCT jp.job_id)
+      INTO v_job_ids
+      FROM public.job_parts jp
+     WHERE jp.id IN (
+        SELECT (item->>'job_part_id')::uuid
+          FROM jsonb_array_elements(p_line_items) AS item
+     );
 
-    -- 2. Snapshot pre-cascade fulfillment_status.
+    IF v_job_ids IS NULL OR array_length(v_job_ids, 1) IS NULL THEN
+        RAISE EXCEPTION 'create_shipment_with_line_items: no job parts resolved from line items';
+    END IF;
+    IF array_length(v_job_ids, 1) > 1 THEN
+        RAISE EXCEPTION 'create_shipment_with_line_items: a packing slip must belong to a single job (got % jobs)',
+            array_length(v_job_ids, 1);
+    END IF;
+    v_job_id := v_job_ids[1];
+
+    -- 2. Lock the job so the per-job packing-slip sequence is collision-free
+    --    under concurrent callers. Released at COMMIT/ROLLBACK.
+    PERFORM pg_advisory_xact_lock(hashtext('job:' || v_job_id::text));
+
+    -- 3. Snapshot pre-cascade fulfillment_status for the audit row.
     SELECT COALESCE(jsonb_object_agg(j.id::text, j.fulfillment_status), '{}'::jsonb)
       INTO v_pre_status
       FROM public.jobs j
-     WHERE j.id IN (
-        SELECT DISTINCT jp.job_id FROM public.job_parts jp
-         WHERE jp.id IN (
-            SELECT (item->>'job_part_id')::uuid
-              FROM jsonb_array_elements(p_line_items) AS item
-         )
-     );
+     WHERE j.id = v_job_id;
 
-    -- 3. Mint packing slip number.
-    v_packing_slip := public.next_packing_slip_number(p_company_id);
+    -- 4. Mint the job-derived packing-slip number: PS-{jobBase}-{n}, n from 1.
+    --    jobBase strips the alpha prefix off job_number (J-0141 -> 0141).
+    SELECT j.job_number INTO v_job_number FROM public.jobs j WHERE j.id = v_job_id;
+    v_base := regexp_replace(v_job_number, '^[A-Za-z]+-?', '');
+    SELECT count(*) + 1 INTO v_seq FROM public.shipments WHERE job_id = v_job_id;
+    v_packing_slip := 'PS-' || v_base || '-' || v_seq::text;
 
-    -- 4. Insert shipment + line items. Triggers A → C cascade automatically.
+    -- 5. Insert shipment + line items. Triggers cascade fulfillment_status.
     INSERT INTO public.shipments (
         company_id, customer_id, shipping_address_id, one_time_address,
-        packing_slip_number, ship_date, carrier, tracking_number,
-        shipping_arrangement, shipping_arrangement_other,
-        weight_lbs, package_count, package_type, notes, coc_text,
-        created_by
+        packing_slip_number, ship_date, job_id, carrier, shipping_method,
+        notes, created_by
     ) VALUES (
         p_company_id, p_customer_id, p_shipping_address_id, p_one_time_address,
-        v_packing_slip, COALESCE(p_ship_date, current_date), p_carrier, p_tracking_number,
-        p_shipping_arrangement, p_shipping_arrangement_other,
-        p_weight_lbs, p_package_count, p_package_type, p_notes, p_coc_text,
-        v_user_id
+        v_packing_slip, COALESCE(p_ship_date, current_date), v_job_id, p_carrier, p_shipping_method,
+        p_notes, v_user_id
     ) RETURNING id INTO v_shipment_id;
 
     FOR v_item IN SELECT * FROM jsonb_array_elements(p_line_items) LOOP
@@ -3222,9 +3620,7 @@ BEGIN
         );
     END LOOP;
 
-    -- 5. For each touched job, write an audit row IFF it crossed
-    --    forward into fully_shipped. v_pre_status defaults to '{}' so the
-    --    loop no-ops when p_line_items is empty.
+    -- 6. Audit the job iff it crossed forward into fully_shipped.
     FOR r IN
         SELECT j.id AS job_id, j.fulfillment_status AS new_status,
                v_pre_status->>(j.id::text) AS old_status
@@ -3245,6 +3641,257 @@ BEGIN
 
     RETURN v_shipment_id;
 END $function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.delete_location(p_location_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid;
+    v_guard   integer := 0;
+BEGIN
+    SELECT company_id INTO v_company FROM public.inventory_locations WHERE id = p_location_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'location % not found', p_location_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+
+    -- Refuse only if any location in the subtree still holds stock.
+    IF EXISTS (
+        WITH RECURSIVE sub AS (
+            SELECT id FROM public.inventory_locations WHERE id = p_location_id
+            UNION ALL
+            SELECT l.id FROM public.inventory_locations l JOIN sub s ON l.parent_id = s.id
+        )
+        SELECT 1
+          FROM public.part_location_stock pls
+          JOIN sub ON pls.location_id = sub.id
+         WHERE pls.quantity > 0
+    ) THEN
+        RAISE EXCEPTION 'location subtree still holds stock' USING ERRCODE = 'foreign_key_violation';
+    END IF;
+
+    -- Drop leftover zero-qty balance rows across the subtree (clients can't —
+    -- part_location_stock is SELECT-only). part_location_stock.location_id is
+    -- ON DELETE RESTRICT, so these must go before their locations.
+    DELETE FROM public.part_location_stock
+     WHERE location_id IN (
+        WITH RECURSIVE sub AS (
+            SELECT id FROM public.inventory_locations WHERE id = p_location_id
+            UNION ALL
+            SELECT l.id FROM public.inventory_locations l JOIN sub s ON l.parent_id = s.id
+        )
+        SELECT id FROM sub
+     );
+
+    -- Delete the subtree bottom-up. inventory_locations.parent_id is ON DELETE
+    -- RESTRICT, so a parent can't be removed while children exist; repeatedly
+    -- delete the current leaves of the subtree until the target is gone.
+    LOOP
+        v_guard := v_guard + 1;
+        IF v_guard > 1000 THEN
+            RAISE EXCEPTION 'delete_location: subtree too deep or cyclic for %', p_location_id;
+        END IF;
+
+        DELETE FROM public.inventory_locations loc
+         WHERE loc.id IN (
+            WITH RECURSIVE sub AS (
+                SELECT id FROM public.inventory_locations WHERE id = p_location_id
+                UNION ALL
+                SELECT l.id FROM public.inventory_locations l JOIN sub s ON l.parent_id = s.id
+            )
+            SELECT s.id
+              FROM sub s
+             WHERE NOT EXISTS (
+                SELECT 1 FROM public.inventory_locations c WHERE c.parent_id = s.id
+             )
+         );
+
+        EXIT WHEN NOT EXISTS (SELECT 1 FROM public.inventory_locations WHERE id = p_location_id);
+    END LOOP;
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.deplete_stock_at_location(p_part_id uuid, p_location_id uuid, p_quantity numeric, p_unit text, p_converted_quantity numeric, p_graceful boolean DEFAULT false, p_notes text DEFAULT NULL::text, p_job_id uuid DEFAULT NULL::uuid, p_job_operation_id uuid DEFAULT NULL::uuid, p_operator_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_item_name text; v_primary_unit text; v_tracked boolean;
+    v_current numeric; v_new numeric; v_rollup numeric;
+    v_discrepancy boolean := false; v_shortfall numeric := 0;
+    v_notes text; v_disc_note text;
+BEGIN
+    IF p_quantity <= 0 OR p_converted_quantity <= 0 THEN
+        RAISE EXCEPTION 'Quantity must be positive' USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT company_id, part_name, primary_unit, is_location_tracked
+      INTO v_company, v_item_name, v_primary_unit, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF NOT v_tracked THEN
+        RAISE EXCEPTION 'part % is not location-tracked; enable tracking first', p_part_id USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM public.inv_assert_location_in_company(p_location_id, v_company);
+
+    -- Lock the balance row (treat a missing row as 0 on hand).
+    SELECT quantity INTO v_current
+      FROM public.part_location_stock
+     WHERE part_id = p_part_id AND location_id = p_location_id
+       FOR UPDATE;
+    v_current := COALESCE(v_current, 0);
+
+    v_new := v_current - p_converted_quantity;
+    v_notes := p_notes;
+
+    IF v_new < 0 THEN
+        IF p_graceful THEN
+            v_shortfall := p_converted_quantity - v_current;
+            v_new := 0;
+            v_discrepancy := true;
+            v_disc_note := format(
+                '[DISCREPANCY: Confirmed %s %s, but only %s %s was available. Shortfall: %s %s]',
+                p_converted_quantity, v_primary_unit, v_current, v_primary_unit, v_shortfall, v_primary_unit);
+            v_notes := CASE WHEN v_notes IS NULL OR v_notes = '' THEN v_disc_note
+                            ELSE v_notes || ' ' || v_disc_note END;
+        ELSE
+            RAISE EXCEPTION 'Insufficient stock at location (have %, need %)', v_current, p_converted_quantity
+                USING ERRCODE = 'check_violation';
+        END IF;
+    END IF;
+
+    INSERT INTO public.part_location_stock (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, p_location_id, v_new)
+    ON CONFLICT (part_id, location_id) DO UPDATE SET quantity = EXCLUDED.quantity;
+
+    INSERT INTO public.inventory_transactions
+        (company_id, part_id, item_name, type, quantity, unit, converted_quantity,
+         location_id, job_id, job_operation_id, operator_id, notes, has_discrepancy, created_by)
+    VALUES
+        (v_company, p_part_id, v_item_name, 'depletion', p_quantity, p_unit, p_converted_quantity,
+         p_location_id, p_job_id, p_job_operation_id, p_operator_id, v_notes, v_discrepancy, auth.uid());
+
+    SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+    RETURN jsonb_build_object(
+        'location_balance', v_new, 'part_quantity', v_rollup,
+        'has_discrepancy', v_discrepancy, 'shortfall', v_shortfall);
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.disable_location_tracking(p_part_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_tracked boolean; v_total numeric;
+BEGIN
+    SELECT company_id, is_location_tracked
+      INTO v_company, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+
+    IF NOT v_tracked THEN
+        RETURN jsonb_build_object('part_quantity',
+            (SELECT quantity FROM public.parts WHERE id = p_part_id), 'tracked', false, 'noop', true);
+    END IF;
+
+    v_total := COALESCE(
+        (SELECT SUM(quantity) FROM public.part_location_stock WHERE part_id = p_part_id), 0);
+
+    -- Flip the flag FIRST (so the subsequent DELETE's rollup is a no-op) and set
+    -- the collapsed total in the same statement (allowed: tracked is now false).
+    UPDATE public.parts
+       SET is_location_tracked = false, quantity = v_total, updated_at = now()
+     WHERE id = p_part_id;
+
+    DELETE FROM public.part_location_stock WHERE part_id = p_part_id;
+
+    RETURN jsonb_build_object('part_quantity', v_total, 'tracked', false);
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.enable_location_tracking(p_part_id uuid, p_initial_location_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_qty numeric; v_tracked boolean; v_loc uuid; v_rollup numeric;
+BEGIN
+    SELECT company_id, quantity, is_location_tracked
+      INTO v_company, v_qty, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+
+    -- Idempotent: already tracked -> no-op.
+    IF v_tracked THEN
+        SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+        RETURN jsonb_build_object('part_quantity', v_rollup, 'tracked', true, 'noop', true);
+    END IF;
+
+    -- Resolve the backfill location: caller-chosen, else find-or-create "Unassigned".
+    IF p_initial_location_id IS NOT NULL THEN
+        PERFORM public.inv_assert_location_in_company(p_initial_location_id, v_company);
+        v_loc := p_initial_location_id;
+    ELSE
+        PERFORM pg_advisory_xact_lock(hashtext('inv_unassigned:' || v_company::text));
+        SELECT id INTO v_loc
+          FROM public.inventory_locations
+         WHERE company_id = v_company AND name = 'Unassigned';
+        IF v_loc IS NULL THEN
+            INSERT INTO public.inventory_locations (company_id, name, kind)
+            VALUES (v_company, 'Unassigned', 'system')
+            RETURNING id INTO v_loc;
+        END IF;
+    END IF;
+
+    -- Flip the flag FIRST (quantity unchanged -> guard skipped), THEN seed the
+    -- backfill balance equal to the pre-existing quantity so the rollup overwrites
+    -- parts.quantity with the same SUM. Never let a standalone value coexist.
+    UPDATE public.parts SET is_location_tracked = true, updated_at = now() WHERE id = p_part_id;
+
+    INSERT INTO public.part_location_stock AS pls (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, v_loc, v_qty)
+    ON CONFLICT (part_id, location_id)
+        DO UPDATE SET quantity = pls.quantity + EXCLUDED.quantity;
+
+    SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+    RETURN jsonb_build_object('location_id', v_loc, 'part_quantity', v_rollup, 'tracked', true);
+END;
+$function$
 
 ;
 
@@ -3435,27 +4082,41 @@ END $function$
 
 ;
 
-CREATE OR REPLACE FUNCTION public.format_packing_slip_number(p_format text, p_year integer, p_seq integer)
- RETURNS text
+CREATE OR REPLACE FUNCTION public.enforce_tracked_part_quantity()
+ RETURNS trigger
  LANGUAGE plpgsql
- IMMUTABLE
+ SECURITY DEFINER
  SET search_path TO 'public', 'pg_temp'
 AS $function$
 DECLARE
-    v_result text := p_format;
-    v_pad_match text;
-    v_width int;
+    v_expected numeric;
 BEGIN
-    v_result := replace(v_result, '{YYYY}', p_year::text);
-    v_pad_match := substring(v_result FROM '\{seq:(0+)\}');
-    IF v_pad_match IS NOT NULL THEN
-        v_width := length(v_pad_match);
-        v_result := regexp_replace(v_result, '\{seq:0+\}', lpad(p_seq::text, v_width, '0'));
-    ELSE
-        v_result := replace(v_result, '{seq}', p_seq::text);
+    IF NEW.is_location_tracked AND NEW.quantity IS DISTINCT FROM OLD.quantity THEN
+        v_expected := COALESCE(
+            (SELECT SUM(quantity) FROM public.part_location_stock WHERE part_id = NEW.id),
+            0);
+
+        IF NEW.quantity IS DISTINCT FROM v_expected THEN
+            RAISE EXCEPTION 'parts.quantity for location-tracked part % is maintained from part_location_stock; direct quantity writes are not allowed (attempted %, expected %)',
+                NEW.id, NEW.quantity, v_expected
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
     END IF;
-    RETURN v_result;
-END $function$
+
+    RETURN NEW;
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.generate_direct_job_number(company_uuid uuid)
+ RETURNS text
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  RETURN 'J-' || LPAD(public.next_order_number(company_uuid)::text, 4, '0');
+END;
+$function$
 
 ;
 
@@ -3463,18 +4124,8 @@ CREATE OR REPLACE FUNCTION public.generate_quote_number(company_uuid uuid)
  RETURNS text
  LANGUAGE plpgsql
 AS $function$
-DECLARE
-  next_num INTEGER;
 BEGIN
-  SELECT COALESCE(
-    MAX(CAST(SUBSTRING(quote_number FROM 'Q-(\d+)') AS INTEGER)), 0
-  ) + 1
-  INTO next_num
-  FROM quotes
-  WHERE company_id = company_uuid
-    AND quote_number ~ '^Q-\d+$';
-  
-  RETURN 'Q-' || LPAD(next_num::TEXT, 4, '0');
+  RETURN 'Q-' || LPAD(public.next_order_number(company_uuid)::text, 4, '0');
 END;
 $function$
 
@@ -3553,8 +4204,7 @@ BEGIN
                         AND wc.labor_rate IS NULL)
                     OR
                     (wc.kind <> 'internal'
-                        AND ro.external_unit_price IS NULL
-                        AND ro.external_setup_cost IS NULL)
+                        AND ro.external_unit_price IS NULL)
                 )
           )
           -- Every BOM child must already be priceable. A made part with no
@@ -3843,6 +4493,46 @@ AS '$libdir/pg_trgm', $function$gtrgm_union$function$
 
 ;
 
+CREATE OR REPLACE FUNCTION public.inv_assert_location_in_company(p_location_id uuid, p_company_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+    IF p_location_id IS NULL THEN
+        RAISE EXCEPTION 'location_id is required' USING ERRCODE = 'null_value_not_allowed';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM public.inventory_locations
+         WHERE id = p_location_id AND company_id = p_company_id
+    ) THEN
+        RAISE EXCEPTION 'location % is not in company %', p_location_id, p_company_id
+            USING ERRCODE = 'insufficient_privilege';
+    END IF;
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.inv_location_path_label(p_location_id uuid)
+ RETURNS text
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH RECURSIVE chain AS (
+    SELECT id, parent_id, name, 0 AS depth
+      FROM public.inventory_locations WHERE id = p_location_id
+    UNION ALL
+    SELECT l.id, l.parent_id, l.name, c.depth + 1
+      FROM public.inventory_locations l JOIN chain c ON l.id = c.parent_id
+  )
+  SELECT string_agg(name, ' › ' ORDER BY depth DESC) FROM chain;
+$function$
+
+;
+
 CREATE OR REPLACE FUNCTION public.is_company_admin(check_company_id uuid)
  RETURNS boolean
  LANGUAGE sql
@@ -3902,45 +4592,24 @@ $function$
 
 ;
 
-CREATE OR REPLACE FUNCTION public.next_packing_slip_number(p_company_id uuid)
- RETURNS text
+CREATE OR REPLACE FUNCTION public.next_order_number(company_uuid uuid)
+ RETURNS integer
  LANGUAGE plpgsql
  SECURITY DEFINER
- SET search_path TO 'public', 'pg_temp'
+ SET search_path TO 'public'
 AS $function$
 DECLARE
-    v_year int := EXTRACT(year FROM current_date)::int;
-    v_format text;
-    v_current_year int;
-    v_current_seq int;
-    v_seq int;
+  result integer;
 BEGIN
-    -- Defensive: a caller without company access must not be able to
-    -- advance another company's counter, even though SECURITY DEFINER
-    -- bypasses RLS.
-    IF NOT (p_company_id IN (SELECT get_user_company_ids())) THEN
-        RAISE EXCEPTION 'next_packing_slip_number: caller does not have access to company %', p_company_id
-            USING ERRCODE = 'insufficient_privilege';
-    END IF;
-
-    UPDATE public.companies
-       SET packing_slip_next_seq = CASE
-               WHEN packing_slip_seq_year = v_year THEN packing_slip_next_seq + 1
-               ELSE 2  -- next caller gets 2; this caller consumes seq 1
-           END,
-           packing_slip_seq_year = v_year,
-           updated_at = now()
-     WHERE id = p_company_id
-    RETURNING packing_slip_seq_year, packing_slip_next_seq, packing_slip_number_format
-        INTO v_current_year, v_current_seq, v_format;
-
-    IF v_current_year IS NULL THEN
-        RAISE EXCEPTION 'next_packing_slip_number: company % not found', p_company_id;
-    END IF;
-
-    v_seq := v_current_seq - 1;
-    RETURN public.format_packing_slip_number(v_format, v_year, v_seq);
-END $function$
+  INSERT INTO public.company_order_counters (company_id, next_number)
+  VALUES (company_uuid, 2)
+  ON CONFLICT (company_id) DO UPDATE
+    SET next_number = public.company_order_counters.next_number + 1,
+        updated_at = now()
+  RETURNING next_number - 1 INTO result;
+  RETURN result;
+END;
+$function$
 
 ;
 
@@ -3999,6 +4668,33 @@ BEGIN
     END LOOP;
     RETURN NULL;
 END $function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.recompute_part_quantity_from_locations()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_part_id uuid := COALESCE(NEW.part_id, OLD.part_id);
+    v_tracked boolean;
+BEGIN
+    SELECT is_location_tracked INTO v_tracked FROM public.parts WHERE id = v_part_id;
+
+    IF COALESCE(v_tracked, false) THEN
+        UPDATE public.parts
+           SET quantity = COALESCE(
+                   (SELECT SUM(quantity) FROM public.part_location_stock WHERE part_id = v_part_id),
+                   0),
+               updated_at = now()
+         WHERE id = v_part_id;
+    END IF;
+
+    RETURN NULL; -- AFTER trigger: return value is ignored
+END;
+$function$
 
 ;
 
@@ -4076,6 +4772,8 @@ BEGIN
        OR OLD.created_at       IS DISTINCT FROM NEW.created_at
        OR OLD.created_by       IS DISTINCT FROM NEW.created_by
        OR OLD.has_discrepancy  IS DISTINCT FROM NEW.has_discrepancy
+       OR OLD.location_name     IS DISTINCT FROM NEW.location_name
+       OR OLD.transfer_group_id IS DISTINCT FROM NEW.transfer_group_id
     THEN
         RAISE EXCEPTION 'Only the notes field can be updated on inventory transactions';
     END IF;
@@ -4304,7 +5002,7 @@ BEGIN
                         routing_id, work_center_id, sequence,
                         setup_minutes, cycle_minutes_per_unit,
                         labor_rate_override,
-                        external_unit_price, external_setup_cost,
+                        external_unit_price,
                         instructions
                     ) VALUES (
                         v_routing_id,
@@ -4314,7 +5012,6 @@ BEGIN
                         NULLIF(v_inner->>'cycle_minutes_per_unit', '')::numeric,
                         NULLIF(v_inner->>'labor_rate_override', '')::numeric,
                         NULLIF(v_inner->>'external_unit_price', '')::numeric,
-                        NULLIF(v_inner->>'external_setup_cost', '')::numeric,
                         v_inner->>'instructions'
                     );
                 END LOOP;
@@ -4478,6 +5175,88 @@ CREATE OR REPLACE FUNCTION public.similarity_op(text, text)
  LANGUAGE c
  STABLE PARALLEL SAFE STRICT
 AS '$libdir/pg_trgm', $function$similarity_op$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.snapshot_document_party()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+    IF TG_OP = 'INSERT' OR NEW.customer_id IS DISTINCT FROM OLD.customer_id THEN
+        IF NEW.customer_id IS NOT NULL THEN
+            NEW.customer_name := (SELECT name FROM public.customers WHERE id = NEW.customer_id);
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' OR NEW.billing_address_id IS DISTINCT FROM OLD.billing_address_id THEN
+        IF NEW.billing_address_id IS NOT NULL THEN
+            NEW.bill_to_address := public.address_block_snapshot(NEW.billing_address_id);
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' OR NEW.shipping_address_id IS DISTINCT FROM OLD.shipping_address_id THEN
+        IF NEW.shipping_address_id IS NOT NULL THEN
+            NEW.ship_to_address := public.address_block_snapshot(NEW.shipping_address_id);
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' OR NEW.contact_id IS DISTINCT FROM OLD.contact_id THEN
+        IF NEW.contact_id IS NOT NULL THEN
+            NEW.contact_snapshot := public.contact_block_snapshot(NEW.contact_id);
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.snapshot_shipment_party()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+    IF TG_OP = 'INSERT' OR NEW.customer_id IS DISTINCT FROM OLD.customer_id THEN
+        IF NEW.customer_id IS NOT NULL THEN
+            NEW.customer_name := (SELECT name FROM public.customers WHERE id = NEW.customer_id);
+            NEW.bill_to_address := public.address_block_snapshot(
+                (SELECT a.id FROM public.customer_addresses a
+                  WHERE a.customer_id = NEW.customer_id AND a.default_billing
+                  LIMIT 1));
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' OR NEW.shipping_address_id IS DISTINCT FROM OLD.shipping_address_id THEN
+        IF NEW.shipping_address_id IS NOT NULL THEN
+            NEW.ship_to_address := public.address_block_snapshot(NEW.shipping_address_id);
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.snapshot_transaction_location_name()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+    IF NEW.location_id IS NOT NULL AND NEW.location_name IS NULL THEN
+        NEW.location_name := public.inv_location_path_label(NEW.location_id);
+    END IF;
+    RETURN NEW;
+END;
+$function$
 
 ;
 
@@ -4646,6 +5425,86 @@ $function$
 
 ;
 
+CREATE OR REPLACE FUNCTION public.transfer_stock(p_part_id uuid, p_from_location_id uuid, p_to_location_id uuid, p_quantity numeric, p_unit text, p_converted_quantity numeric, p_notes text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_item_name text; v_tracked boolean;
+    v_src numeric; v_from_balance numeric; v_to_balance numeric;
+    v_group uuid; v_from_name text; v_to_name text;
+    v_from_notes text; v_to_notes text; v_base text;
+BEGIN
+    IF p_quantity <= 0 OR p_converted_quantity <= 0 THEN
+        RAISE EXCEPTION 'Quantity must be positive' USING ERRCODE = 'check_violation';
+    END IF;
+    IF p_from_location_id = p_to_location_id THEN
+        RAISE EXCEPTION 'Source and destination locations must differ' USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT company_id, part_name, is_location_tracked
+      INTO v_company, v_item_name, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF NOT v_tracked THEN
+        RAISE EXCEPTION 'part % is not location-tracked; enable tracking first', p_part_id USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM public.inv_assert_location_in_company(p_from_location_id, v_company);
+    PERFORM public.inv_assert_location_in_company(p_to_location_id, v_company);
+
+    -- Lock + verify source has enough (hard fail — you can't move stock you lack).
+    SELECT quantity INTO v_src
+      FROM public.part_location_stock
+     WHERE part_id = p_part_id AND location_id = p_from_location_id
+       FOR UPDATE;
+    IF v_src IS NULL OR v_src < p_converted_quantity THEN
+        RAISE EXCEPTION 'Insufficient stock at source location (have %, need %)',
+            COALESCE(v_src, 0), p_converted_quantity USING ERRCODE = 'check_violation';
+    END IF;
+
+    UPDATE public.part_location_stock
+       SET quantity = v_src - p_converted_quantity
+     WHERE part_id = p_part_id AND location_id = p_from_location_id
+    RETURNING quantity INTO v_from_balance;
+
+    INSERT INTO public.part_location_stock AS pls (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, p_to_location_id, p_converted_quantity)
+    ON CONFLICT (part_id, location_id)
+        DO UPDATE SET quantity = pls.quantity + EXCLUDED.quantity
+    RETURNING pls.quantity INTO v_to_balance;
+
+    v_group := gen_random_uuid();
+    SELECT name INTO v_from_name FROM public.inventory_locations WHERE id = p_from_location_id;
+    SELECT name INTO v_to_name   FROM public.inventory_locations WHERE id = p_to_location_id;
+    v_base := COALESCE(NULLIF(p_notes, ''), '');
+
+    v_from_notes := btrim(v_base || ' ' || format('[Transfer to %s]', v_to_name));
+    v_to_notes   := btrim(v_base || ' ' || format('[Transfer from %s]', v_from_name));
+
+    INSERT INTO public.inventory_transactions
+        (company_id, part_id, item_name, type, quantity, unit, converted_quantity,
+         location_id, transfer_group_id, notes, created_by)
+    VALUES
+        (v_company, p_part_id, v_item_name, 'depletion', p_quantity, p_unit, p_converted_quantity,
+         p_from_location_id, v_group, v_from_notes, auth.uid()),
+        (v_company, p_part_id, v_item_name, 'addition', p_quantity, p_unit, p_converted_quantity,
+         p_to_location_id, v_group, v_to_notes, auth.uid());
+
+    RETURN jsonb_build_object(
+        'transfer_group_id', v_group,
+        'from_balance', v_from_balance, 'to_balance', v_to_balance);
+END;
+$function$
+
+;
+
 CREATE OR REPLACE FUNCTION public.update_inventory_items_updated_at()
  RETURNS trigger
  LANGUAGE plpgsql
@@ -4747,6 +5606,9 @@ CREATE TRIGGER customers_updated_at BEFORE UPDATE ON public.customers FOR EACH R
 DROP TRIGGER IF EXISTS "enforce_transaction_notes_only_update" ON "public"."inventory_transactions";
 CREATE TRIGGER enforce_transaction_notes_only_update BEFORE UPDATE ON public.inventory_transactions FOR EACH ROW EXECUTE FUNCTION restrict_transaction_update_to_notes();
 
+DROP TRIGGER IF EXISTS "trg_snapshot_txn_location" ON "public"."inventory_transactions";
+CREATE TRIGGER trg_snapshot_txn_location BEFORE INSERT ON public.inventory_transactions FOR EACH ROW EXECUTE FUNCTION snapshot_transaction_location_name();
+
 DROP TRIGGER IF EXISTS "job_materials_updated_at" ON "public"."job_materials";
 CREATE TRIGGER job_materials_updated_at BEFORE UPDATE ON public.job_materials FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
@@ -4780,11 +5642,17 @@ CREATE TRIGGER enforce_job_address_contact_customer_trg BEFORE INSERT OR UPDATE 
 DROP TRIGGER IF EXISTS "jobs_updated_at" ON "public"."jobs";
 CREATE TRIGGER jobs_updated_at BEFORE UPDATE ON public.jobs FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS "trg_snapshot_job_party" ON "public"."jobs";
+CREATE TRIGGER trg_snapshot_job_party BEFORE INSERT OR UPDATE OF customer_id, billing_address_id, shipping_address_id, contact_id ON public.jobs FOR EACH ROW EXECUTE FUNCTION snapshot_document_party();
+
 DROP TRIGGER IF EXISTS "trigger_job_production_status_change" ON "public"."jobs";
 CREATE TRIGGER trigger_job_production_status_change BEFORE UPDATE ON public.jobs FOR EACH ROW EXECUTE FUNCTION track_job_production_status_change();
 
 DROP TRIGGER IF EXISTS "markup_rates_updated_at" ON "public"."markup_rates";
 CREATE TRIGGER markup_rates_updated_at BEFORE UPDATE ON public.markup_rates FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+DROP TRIGGER IF EXISTS "trg_recompute_part_quantity" ON "public"."part_location_stock";
+CREATE TRIGGER trg_recompute_part_quantity AFTER INSERT OR DELETE OR UPDATE ON public.part_location_stock FOR EACH ROW EXECUTE FUNCTION recompute_part_quantity_from_locations();
 
 DROP TRIGGER IF EXISTS "part_pricing_tiers_updated_at" ON "public"."part_pricing_tiers";
 CREATE TRIGGER part_pricing_tiers_updated_at BEFORE UPDATE ON public.part_pricing_tiers FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
@@ -4794,6 +5662,9 @@ CREATE TRIGGER part_procurement_tiers_updated_at BEFORE UPDATE ON public.part_pr
 
 DROP TRIGGER IF EXISTS "parts_updated_at" ON "public"."parts";
 CREATE TRIGGER parts_updated_at BEFORE UPDATE ON public.parts FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+DROP TRIGGER IF EXISTS "trg_enforce_tracked_part_quantity" ON "public"."parts";
+CREATE TRIGGER trg_enforce_tracked_part_quantity BEFORE UPDATE ON public.parts FOR EACH ROW EXECUTE FUNCTION enforce_tracked_part_quantity();
 
 DROP TRIGGER IF EXISTS "parts_bom_no_cycles" ON "public"."parts_bom";
 CREATE TRIGGER parts_bom_no_cycles BEFORE INSERT OR UPDATE OF parent_part_id, child_part_id ON public.parts_bom FOR EACH ROW EXECUTE FUNCTION enforce_no_bom_cycles();
@@ -4815,6 +5686,9 @@ CREATE TRIGGER enforce_quote_address_contact_customer_trg BEFORE INSERT OR UPDAT
 
 DROP TRIGGER IF EXISTS "quotes_updated_at" ON "public"."quotes";
 CREATE TRIGGER quotes_updated_at BEFORE UPDATE ON public.quotes FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+DROP TRIGGER IF EXISTS "trg_snapshot_quote_party" ON "public"."quotes";
+CREATE TRIGGER trg_snapshot_quote_party BEFORE INSERT OR UPDATE OF customer_id, billing_address_id, shipping_address_id, contact_id ON public.quotes FOR EACH ROW EXECUTE FUNCTION snapshot_document_party();
 
 DROP TRIGGER IF EXISTS "trigger_quote_status_change" ON "public"."quotes";
 CREATE TRIGGER trigger_quote_status_change BEFORE UPDATE ON public.quotes FOR EACH ROW EXECUTE FUNCTION track_quote_status_change();
@@ -4845,6 +5719,9 @@ CREATE TRIGGER enforce_shipment_address_contact_customer_trg BEFORE INSERT OR UP
 
 DROP TRIGGER IF EXISTS "enforce_shipment_customer_id_immutable_trg" ON "public"."shipments";
 CREATE TRIGGER enforce_shipment_customer_id_immutable_trg BEFORE UPDATE OF customer_id ON public.shipments FOR EACH ROW EXECUTE FUNCTION enforce_shipment_customer_id_immutable();
+
+DROP TRIGGER IF EXISTS "trg_snapshot_shipment_party" ON "public"."shipments";
+CREATE TRIGGER trg_snapshot_shipment_party BEFORE INSERT OR UPDATE OF customer_id, shipping_address_id ON public.shipments FOR EACH ROW EXECUTE FUNCTION snapshot_shipment_party();
 
 DROP TRIGGER IF EXISTS "trigger_recompute_jp_fulfillment_on_void" ON "public"."shipments";
 CREATE TRIGGER trigger_recompute_jp_fulfillment_on_void AFTER UPDATE OF voided_at ON public.shipments FOR EACH ROW EXECUTE FUNCTION recompute_job_part_fulfillment_from_void();
@@ -4895,6 +5772,9 @@ COMMENT ON TABLE "public"."demo_data_templates"
 COMMENT ON TABLE "public"."feedback"
     IS 'In-app user feedback submissions';
 
+COMMENT ON TABLE "public"."inventory_locations"
+    IS 'Company-scoped, arbitrary-depth storage-location tree (cabinet › row › side, etc.). is_qr_anchor marks nodes with a printed QR.';
+
 COMMENT ON TABLE "public"."inventory_transactions"
     IS 'Append-only ledger of inventory changes (addition / depletion / adjustment). Notes are the only mutable column post-insert (enforced by trigger).';
 
@@ -4903,6 +5783,9 @@ COMMENT ON TABLE "public"."job_fulfillment_audit"
 
 COMMENT ON TABLE "public"."markup_rates"
     IS 'Named, reusable markup matrices (qty × markup%) per company. Applied to parts via snapshot — copies breakpoints into part_pricing_tiers, no link.';
+
+COMMENT ON TABLE "public"."part_location_stock"
+    IS 'Per-location stock balances; source of truth for location-tracked parts. SELECT-only via RLS — mutated only through SECURITY DEFINER RPCs that also write inventory_transactions.';
 
 COMMENT ON TABLE "public"."part_procurement_tiers"
     IS 'Vendor-keyed tiered pricing for bought parts. Each row is one (vendor, min_quantity, cost_per_unit) point on a vendor''s tier sheet. vendor_id may be NULL for "internal estimate" rows. Ordering of tiers within a vendor sheet is derived from min_quantity ASC — no separate sequence column. Resolved at read time via get_procurement_cost(part_id, qty), which picks the cheapest non-expired tier where min_quantity <= qty across all vendors.';
@@ -5027,18 +5910,6 @@ COMMENT ON COLUMN "public"."companies"."created_at"
 COMMENT ON COLUMN "public"."companies"."updated_at"
     IS 'Timestamp of last update. Auto-updated via trigger.';
 
-COMMENT ON COLUMN "public"."companies"."packing_slip_number_format"
-    IS 'Template string for generated packing slip numbers. Tokens: {YYYY} = ship year, {seq:0000} = zero-padded sequence (zero count sets width). Default ''PS-{YYYY}-{seq:0000}''. Consumed by public.next_packing_slip_number() (PR 4).';
-
-COMMENT ON COLUMN "public"."companies"."packing_slip_seq_year"
-    IS 'Year of the most recent packing slip number issued. When the current year differs, next_packing_slip_number() resets the sequence to 1. Server-UTC; not customer-local.';
-
-COMMENT ON COLUMN "public"."companies"."packing_slip_next_seq"
-    IS 'Next sequence number to issue for a packing slip. Incremented atomically under a row lock by next_packing_slip_number(). Defaults to 1 for new companies; legacy-data backfill (PR 4) advances this past the synthetic-shipment count.';
-
-COMMENT ON COLUMN "public"."companies"."default_coc_text"
-    IS 'Shop-wide default Certificate of Conformance text. Last step in the cascade (shipment.coc_text → customer.default_coc_text → company.default_coc_text → omit).';
-
 COMMENT ON COLUMN "public"."company_custom_units"."id"
     IS 'Primary key. UUID auto-generated.';
 
@@ -5084,15 +5955,6 @@ COMMENT ON COLUMN "public"."customers"."created_at"
 COMMENT ON COLUMN "public"."customers"."updated_at"
     IS 'Timestamp of last update. Auto-updated via trigger.';
 
-COMMENT ON COLUMN "public"."customers"."default_shipping_arrangement"
-    IS 'Per-customer default shipping arrangement (freight terms). Same enum as shipments.shipping_arrangement. Prefilled onto the Create Shipment form. NULL when no default has been set.';
-
-COMMENT ON COLUMN "public"."customers"."default_carrier"
-    IS 'Per-customer default carrier name (free text — UPS, FedEx, customer''s freight provider, etc.). Prefilled onto the Create Shipment form.';
-
-COMMENT ON COLUMN "public"."customers"."default_coc_text"
-    IS 'Per-customer default Certificate of Conformance text block printed on the packing slip when the shipment does not override it. Cascade order: shipment.coc_text → customer.default_coc_text → company.default_coc_text → omit.';
-
 COMMENT ON COLUMN "public"."demo_data_templates"."id"
     IS 'Primary key. UUID auto-generated.';
 
@@ -5125,6 +5987,9 @@ COMMENT ON COLUMN "public"."inventory_transactions"."part_id"
 
 COMMENT ON COLUMN "public"."inventory_transactions"."item_name"
     IS 'Snapshot of the part name at transaction time. Survives part renames so historical ledger entries stay readable.';
+
+COMMENT ON COLUMN "public"."inventory_transactions"."location_name"
+    IS 'Snapshot of the location''s full path at transaction time, so deleted locations remain referrable in history (mirrors item_name for deleted parts).';
 
 COMMENT ON COLUMN "public"."job_materials"."parts_bom_id"
     IS 'Source parts_bom row this job_material was snapshotted from at job-start (renamed from routing_material_id; BOM is now part-attached, not routing-attached).';
@@ -5183,6 +6048,9 @@ COMMENT ON COLUMN "public"."parts"."legacy_id"
 COMMENT ON COLUMN "public"."parts"."source"
     IS 'How this part is sourced. ''made'' = produced in-shop (will have a routing); ''bought'' = procured from a vendor. Combined with is_stocked, classifies the part into one of four quadrants (Custom Made / Sub-assembly / Raw Material / Service+Drop-ship). Replaces the prior is_manufacturable boolean — see the 20260504 migration header for the (false,false)→''made'' orphan-default rationale.';
 
+COMMENT ON COLUMN "public"."parts"."is_location_tracked"
+    IS 'When true, parts.quantity is a trigger-maintained rollup of part_location_stock and direct quantity writes are rejected.';
+
 COMMENT ON COLUMN "public"."parts_bom"."quantity"
     IS 'Quantity of child consumed per unit of parent, expressed in `unit`. Cost rollups convert to the child part primary_unit via parts_unit_conversions if `unit` differs.';
 
@@ -5219,6 +6087,27 @@ COMMENT ON COLUMN "public"."quotes"."shipping_address_id"
 COMMENT ON COLUMN "public"."quotes"."contact_id"
     IS 'Customer contact the quote is addressed to. Renders as the Customer Contact section on the printed quote (name, role, email, phone). Defaults at quote creation to the customer''s primary contact (is_primary=true in customer_contacts); editable per-quote.';
 
+COMMENT ON COLUMN "public"."quotes"."payment_terms"
+    IS 'Payment terms shown on the quote (preset or custom free text), e.g. Net 30, 2/10 Net 30.';
+
+COMMENT ON COLUMN "public"."quotes"."lead_time_value"
+    IS 'Lead time as stated by the user, in the unit given by lead_time_unit. Normalized into lead_time_days on save.';
+
+COMMENT ON COLUMN "public"."quotes"."lead_time_unit"
+    IS 'Unit for lead_time_value: business_days | calendar_days | weeks.';
+
+COMMENT ON COLUMN "public"."quotes"."customer_name"
+    IS 'Immutable snapshot of the customer name at quote issue time.';
+
+COMMENT ON COLUMN "public"."quotes"."bill_to_address"
+    IS 'Immutable snapshot of the billing address block at quote issue time (Document Snapshot Standard). The rendered quote reads this, not the live billing_address_id row.';
+
+COMMENT ON COLUMN "public"."quotes"."ship_to_address"
+    IS 'Immutable snapshot of the shipping address block at quote issue time.';
+
+COMMENT ON COLUMN "public"."quotes"."contact_snapshot"
+    IS 'Immutable snapshot of the customer contact { name, email, phone } at quote issue time.';
+
 COMMENT ON COLUMN "public"."routing_operations"."sequence"
     IS 'Linear order within the routing. Lower values execute first. Steps of 10 (10, 20, 30...) leave room for inserts.';
 
@@ -5233,9 +6122,6 @@ COMMENT ON COLUMN "public"."routing_operations"."labor_rate_override"
 
 COMMENT ON COLUMN "public"."routing_operations"."external_unit_price"
     IS 'For kind=external only: cost per output unit charged by the vendor.';
-
-COMMENT ON COLUMN "public"."routing_operations"."external_setup_cost"
-    IS 'For kind=external only: one-time per-job setup charge from the vendor; amortizes across batch.';
 
 COMMENT ON COLUMN "public"."saved_insights"."id"
     IS 'Primary key. UUID auto-generated.';
@@ -5261,8 +6147,17 @@ COMMENT ON COLUMN "public"."saved_insights"."created_at"
 COMMENT ON COLUMN "public"."shipments"."one_time_address"
     IS 'Reserved for Phase 3 ad-hoc shipping. Either shipping_address_id OR one_time_address must be set (XOR shipments_one_address_source).';
 
-COMMENT ON COLUMN "public"."shipments"."shipping_arrangement"
-    IS 'Enum-via-CHECK. ''other'' requires shipping_arrangement_other (shipments_arrangement_other_text).';
+COMMENT ON COLUMN "public"."shipments"."shipping_method"
+    IS 'How the goods left: customer_pickup | personal_delivery | shipment | dropship (resale) | restock (to in-store stock). Replaces the retired shipping_arrangement. Enum-via-CHECK.';
+
+COMMENT ON COLUMN "public"."shipments"."job_id"
+    IS 'The single job this packing slip belongs to. All shipment_line_items resolve to job_parts of this job (enforced in create_shipment_with_line_items). Source of the PS-{jobBase}-{n} number.';
+
+COMMENT ON COLUMN "public"."shipments"."bill_to_address"
+    IS 'Immutable snapshot of the bill-to address block at shipment/packing-slip issue time.';
+
+COMMENT ON COLUMN "public"."shipments"."ship_to_address"
+    IS 'Immutable snapshot of the ship-to address block at shipment issue time.';
 
 COMMENT ON COLUMN "public"."system_admins"."id"
     IS 'Primary key. UUID auto-generated.';

--- a/supabase/schema.staging.sql
+++ b/supabase/schema.staging.sql
@@ -1,6 +1,6 @@
 -- ============================================================
 -- Jigged Manufacturing Data Platform - Database Schema
--- Generated: 2026-06-22T00:21:17Z
+-- Generated: 2026-06-23T13:00:20Z
 -- Schemas: public, storage
 -- ============================================================
 
@@ -169,6 +169,21 @@ CREATE TABLE IF NOT EXISTS "public"."feedback"
     CONSTRAINT "feedback_pkey" PRIMARY KEY (id)
 );
 
+CREATE TABLE IF NOT EXISTS "public"."inventory_locations"
+(
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id" uuid NOT NULL,
+    "parent_id" uuid,
+    "name" text NOT NULL,
+    "kind" text,
+    "code" text,
+    "sort_order" integer NOT NULL DEFAULT 0,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "inventory_locations_pkey" PRIMARY KEY (id),
+    CONSTRAINT "inventory_locations_name_not_blank" CHECK ((length(btrim(name)) > 0))
+);
+
 CREATE TABLE IF NOT EXISTS "public"."invitations"
 (
     "id" uuid NOT NULL DEFAULT gen_random_uuid(),
@@ -216,8 +231,16 @@ CREATE TABLE IF NOT EXISTS "public"."quotes"
     "billing_address_id" uuid,
     "shipping_address_id" uuid,
     "contact_id" uuid,
+    "payment_terms" text,
+    "lead_time_value" integer,
+    "lead_time_unit" text DEFAULT 'business_days'::text,
+    "customer_name" text,
+    "bill_to_address" jsonb,
+    "ship_to_address" jsonb,
+    "contact_snapshot" jsonb,
     CONSTRAINT "quotes_pkey" PRIMARY KEY (id),
     CONSTRAINT "quotes_company_id_quote_number_key" UNIQUE (company_id, quote_number),
+    CONSTRAINT "quotes_lead_time_unit_check" CHECK ((lead_time_unit = ANY (ARRAY['business_days'::text, 'calendar_days'::text, 'weeks'::text]))),
     CONSTRAINT "quotes_status_check" CHECK ((status = ANY (ARRAY['active'::text, 'expired'::text])))
 );
 
@@ -242,6 +265,10 @@ CREATE TABLE IF NOT EXISTS "public"."jobs"
     "billing_address_id" uuid,
     "shipping_address_id" uuid,
     "contact_id" uuid,
+    "customer_name" text,
+    "bill_to_address" jsonb,
+    "ship_to_address" jsonb,
+    "contact_snapshot" jsonb,
     CONSTRAINT "jobs_pkey" PRIMARY KEY (id),
     CONSTRAINT "jobs_company_id_job_number_key" UNIQUE (company_id, job_number),
     CONSTRAINT "jobs_fulfillment_status_check" CHECK ((fulfillment_status = ANY (ARRAY['unshipped'::text, 'partially_shipped'::text, 'fully_shipped'::text]))),
@@ -291,9 +318,11 @@ CREATE TABLE IF NOT EXISTS "public"."shipments"
     "voided_by" uuid,
     "shipping_method" text,
     "job_id" uuid NOT NULL,
+    "customer_name" text,
+    "bill_to_address" jsonb,
+    "ship_to_address" jsonb,
     CONSTRAINT "shipments_pkey" PRIMARY KEY (id),
     CONSTRAINT "shipments_packing_slip_company_unique" UNIQUE (company_id, packing_slip_number),
-    CONSTRAINT "shipments_one_address_source" CHECK ((((shipping_address_id IS NOT NULL) AND (one_time_address IS NULL)) OR ((shipping_address_id IS NULL) AND (one_time_address IS NOT NULL)))),
     CONSTRAINT "shipments_shipping_method_check" CHECK (((shipping_method IS NULL) OR (shipping_method = ANY (ARRAY['customer_pickup'::text, 'personal_delivery'::text, 'shipment'::text, 'dropship'::text, 'restock'::text]))))
 );
 
@@ -333,18 +362,6 @@ CREATE TABLE IF NOT EXISTS "public"."user_company_access"
     CONSTRAINT "user_company_access_pkey" PRIMARY KEY (id),
     CONSTRAINT "user_company_access_user_id_company_id_key" UNIQUE (user_id, company_id),
     CONSTRAINT "user_company_access_role_check" CHECK ((role = ANY (ARRAY['admin'::text, 'user'::text, 'operator'::text])))
-);
-
-CREATE TABLE IF NOT EXISTS "public"."job_notes"
-(
-    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
-    "company_id" uuid NOT NULL,
-    "job_id" uuid NOT NULL,
-    "author_id" uuid,
-    "body" text NOT NULL,
-    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
-    CONSTRAINT "job_notes_pkey" PRIMARY KEY (id),
-    CONSTRAINT "job_notes_body_not_blank" CHECK ((length(btrim(body)) > 0))
 );
 
 CREATE TABLE IF NOT EXISTS "public"."quickbooks_connections"
@@ -453,12 +470,42 @@ CREATE TABLE IF NOT EXISTS "public"."parts"
     "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
     "source" text NOT NULL DEFAULT 'made'::text,
     "markup_rate_id" uuid,
+    "is_location_tracked" boolean NOT NULL DEFAULT false,
     CONSTRAINT "parts_pkey" PRIMARY KEY (id),
     CONSTRAINT "parts_legacy_id_unique_per_company" UNIQUE (company_id, legacy_id),
     CONSTRAINT "parts_unique_per_company" UNIQUE (company_id, part_name),
     CONSTRAINT "parts_quantity_non_negative" CHECK ((quantity >= (0)::numeric)),
     CONSTRAINT "parts_requires_unit" CHECK ((primary_unit IS NOT NULL)),
     CONSTRAINT "parts_source_check" CHECK ((source = ANY (ARRAY['made'::text, 'bought'::text])))
+);
+
+CREATE TABLE IF NOT EXISTS "public"."part_attachments"
+(
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id" uuid NOT NULL,
+    "part_id" uuid NOT NULL,
+    "storage_path" text NOT NULL,
+    "file_name" text NOT NULL,
+    "kind" text NOT NULL DEFAULT 'other'::text,
+    "mime_type" text,
+    "size_bytes" bigint,
+    "uploaded_by" uuid,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "part_attachments_pkey" PRIMARY KEY (id),
+    CONSTRAINT "part_attachments_kind_check" CHECK ((kind = ANY (ARRAY['pdf'::text, 'step'::text, 'dwg'::text, 'other'::text])))
+);
+
+CREATE TABLE IF NOT EXISTS "public"."part_location_stock"
+(
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id" uuid NOT NULL,
+    "part_id" uuid NOT NULL,
+    "location_id" uuid NOT NULL,
+    "quantity" numeric NOT NULL DEFAULT 0,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "part_location_stock_pkey" PRIMARY KEY (id),
+    CONSTRAINT "part_location_stock_part_location_unique" UNIQUE (part_id, location_id),
+    CONSTRAINT "part_location_stock_quantity_non_negative" CHECK ((quantity >= (0)::numeric))
 );
 
 CREATE TABLE IF NOT EXISTS "public"."part_notes"
@@ -469,8 +516,10 @@ CREATE TABLE IF NOT EXISTS "public"."part_notes"
     "author_id" uuid,
     "body" text NOT NULL,
     "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "note_type" text NOT NULL DEFAULT 'user'::text,
     CONSTRAINT "part_notes_pkey" PRIMARY KEY (id),
-    CONSTRAINT "part_notes_body_not_blank" CHECK ((length(btrim(body)) > 0))
+    CONSTRAINT "part_notes_body_not_blank" CHECK ((length(btrim(body)) > 0)),
+    CONSTRAINT "part_notes_note_type_check" CHECK ((note_type = ANY (ARRAY['user'::text, 'pricing'::text])))
 );
 
 CREATE TABLE IF NOT EXISTS "public"."part_pricing_tiers"
@@ -718,7 +767,6 @@ CREATE TABLE IF NOT EXISTS "public"."routing_operations"
     "cycle_minutes_per_unit" numeric(8,4),
     "labor_rate_override" numeric(10,2),
     "external_unit_price" numeric(12,4),
-    "external_setup_cost" numeric(12,4),
     "instructions" text,
     "metadata" jsonb DEFAULT '{}'::jsonb,
     "created_at" timestamp with time zone DEFAULT now(),
@@ -769,9 +817,47 @@ CREATE TABLE IF NOT EXISTS "public"."inventory_transactions"
     "created_at" timestamp with time zone DEFAULT now(),
     "created_by" uuid,
     "has_discrepancy" boolean NOT NULL DEFAULT false,
+    "location_id" uuid,
+    "transfer_group_id" uuid,
+    "location_name" text,
     CONSTRAINT "inventory_transactions_pkey" PRIMARY KEY (id),
     CONSTRAINT "inventory_transactions_quantity_positive" CHECK ((quantity >= (0)::numeric)),
     CONSTRAINT "inventory_transactions_type_check" CHECK ((type = ANY (ARRAY['addition'::text, 'depletion'::text, 'adjustment'::text])))
+);
+
+CREATE TABLE IF NOT EXISTS "public"."job_notes"
+(
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id" uuid NOT NULL,
+    "job_id" uuid NOT NULL,
+    "author_id" uuid,
+    "body" text,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "job_part_id" uuid,
+    "job_operation_id" uuid,
+    "note_type" text NOT NULL DEFAULT 'user'::text,
+    CONSTRAINT "job_notes_pkey" PRIMARY KEY (id),
+    CONSTRAINT "job_notes_body_blank_or_null" CHECK (((body IS NULL) OR (length(btrim(body)) > 0))),
+    CONSTRAINT "job_notes_note_type_check" CHECK ((note_type = ANY (ARRAY['user'::text, 'event'::text]))),
+    CONSTRAINT "job_notes_operation_requires_part" CHECK (((job_operation_id IS NULL) OR (job_part_id IS NOT NULL)))
+);
+
+CREATE TABLE IF NOT EXISTS "public"."job_note_media"
+(
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+    "company_id" uuid NOT NULL,
+    "note_id" uuid NOT NULL,
+    "storage_path" text NOT NULL,
+    "thumbnail_path" text,
+    "kind" text NOT NULL DEFAULT 'photo'::text,
+    "mime_type" text,
+    "size_bytes" bigint,
+    "width" integer,
+    "height" integer,
+    "duration_seconds" numeric,
+    "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "job_note_media_pkey" PRIMARY KEY (id),
+    CONSTRAINT "job_note_media_kind_check" CHECK ((kind = ANY (ARRAY['photo'::text, 'video'::text])))
 );
 
 -- ============================================================
@@ -788,16 +874,20 @@ ALTER TABLE "public"."customer_contacts" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."customers" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."demo_data_templates" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."feedback" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."inventory_locations" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."inventory_transactions" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."invitations" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."job_attachments" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."job_fulfillment_audit" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."job_materials" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."job_note_media" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."job_notes" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."job_operations" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."job_parts" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."jobs" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."markup_rates" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."part_attachments" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "public"."part_location_stock" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."part_notes" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."part_pricing_tiers" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."part_procurement_tiers" ENABLE ROW LEVEL SECURITY;
@@ -1031,6 +1121,31 @@ CREATE POLICY "Users can insert feedback for their companies"
    FROM user_company_access uca
   WHERE (uca.user_id = auth.uid()))));
 
+DROP POLICY IF EXISTS "Users can delete inventory_locations" ON "public"."inventory_locations";
+CREATE POLICY "Users can delete inventory_locations"
+    ON "public"."inventory_locations"
+    FOR DELETE
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+DROP POLICY IF EXISTS "Users can insert inventory_locations" ON "public"."inventory_locations";
+CREATE POLICY "Users can insert inventory_locations"
+    ON "public"."inventory_locations"
+    FOR INSERT
+    WITH CHECK ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+DROP POLICY IF EXISTS "Users can update inventory_locations" ON "public"."inventory_locations";
+CREATE POLICY "Users can update inventory_locations"
+    ON "public"."inventory_locations"
+    FOR UPDATE
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)))
+    WITH CHECK ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+DROP POLICY IF EXISTS "Users can view inventory_locations" ON "public"."inventory_locations";
+CREATE POLICY "Users can view inventory_locations"
+    ON "public"."inventory_locations"
+    FOR SELECT
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
 DROP POLICY IF EXISTS "Users can insert inventory_transactions" ON "public"."inventory_transactions";
 CREATE POLICY "Users can insert inventory_transactions"
     ON "public"."inventory_transactions"
@@ -1141,6 +1256,26 @@ CREATE POLICY "ai_readonly_select"
     USING ((EXISTS ( SELECT 1
    FROM jobs
   WHERE ((jobs.id = job_materials.job_id) AND (jobs.company_id = (current_setting('jigged.company_id'::text, true))::uuid)))));
+
+DROP POLICY IF EXISTS "Authors and admins can delete job_note_media" ON "public"."job_note_media";
+CREATE POLICY "Authors and admins can delete job_note_media"
+    ON "public"."job_note_media"
+    FOR DELETE
+    USING ((is_company_admin(company_id) OR (EXISTS ( SELECT 1
+   FROM job_notes n
+  WHERE ((n.id = job_note_media.note_id) AND (n.author_id = get_operator_access_id(n.company_id)))))));
+
+DROP POLICY IF EXISTS "Users can insert job_note_media" ON "public"."job_note_media";
+CREATE POLICY "Users can insert job_note_media"
+    ON "public"."job_note_media"
+    FOR INSERT
+    WITH CHECK (((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)) AND (get_operator_access_id(company_id) IS NOT NULL)));
+
+DROP POLICY IF EXISTS "Users can view job_note_media" ON "public"."job_note_media";
+CREATE POLICY "Users can view job_note_media"
+    ON "public"."job_note_media"
+    FOR SELECT
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
 
 DROP POLICY IF EXISTS "Authors and admins can delete job_notes" ON "public"."job_notes";
 CREATE POLICY "Authors and admins can delete job_notes"
@@ -1311,6 +1446,30 @@ CREATE POLICY "markup_rates_update"
     USING ((company_id IN ( SELECT user_company_access.company_id
    FROM user_company_access
   WHERE (user_company_access.user_id = auth.uid()))));
+
+DROP POLICY IF EXISTS "Uploaders and admins can delete part_attachments" ON "public"."part_attachments";
+CREATE POLICY "Uploaders and admins can delete part_attachments"
+    ON "public"."part_attachments"
+    FOR DELETE
+    USING (((uploaded_by = get_operator_access_id(company_id)) OR is_company_admin(company_id)));
+
+DROP POLICY IF EXISTS "Users can insert own part_attachments" ON "public"."part_attachments";
+CREATE POLICY "Users can insert own part_attachments"
+    ON "public"."part_attachments"
+    FOR INSERT
+    WITH CHECK (((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)) AND (uploaded_by = get_operator_access_id(company_id))));
+
+DROP POLICY IF EXISTS "Users can view part_attachments" ON "public"."part_attachments";
+CREATE POLICY "Users can view part_attachments"
+    ON "public"."part_attachments"
+    FOR SELECT
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
+
+DROP POLICY IF EXISTS "Users can view part_location_stock" ON "public"."part_location_stock";
+CREATE POLICY "Users can view part_location_stock"
+    ON "public"."part_location_stock"
+    FOR SELECT
+    USING ((company_id IN ( SELECT get_user_company_ids() AS get_user_company_ids)));
 
 DROP POLICY IF EXISTS "Authors and admins can delete part_notes" ON "public"."part_notes";
 CREATE POLICY "Authors and admins can delete part_notes"
@@ -2139,6 +2298,12 @@ ALTER TABLE "public"."feedback"
 ALTER TABLE "public"."feedback"
     ADD CONSTRAINT "feedback_user_id_fkey" FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
+ALTER TABLE "public"."inventory_locations"
+    ADD CONSTRAINT "inventory_locations_company_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."inventory_locations"
+    ADD CONSTRAINT "inventory_locations_parent_fkey" FOREIGN KEY (parent_id) REFERENCES inventory_locations(id) ON DELETE RESTRICT;
+
 ALTER TABLE "public"."inventory_transactions"
     ADD CONSTRAINT "inventory_transactions_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
 
@@ -2147,6 +2312,9 @@ ALTER TABLE "public"."inventory_transactions"
 
 ALTER TABLE "public"."inventory_transactions"
     ADD CONSTRAINT "inventory_transactions_job_operation_id_fkey" FOREIGN KEY (job_operation_id) REFERENCES job_operations(id) ON DELETE SET NULL;
+
+ALTER TABLE "public"."inventory_transactions"
+    ADD CONSTRAINT "inventory_transactions_location_fkey" FOREIGN KEY (location_id) REFERENCES inventory_locations(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."inventory_transactions"
     ADD CONSTRAINT "inventory_transactions_part_id_fkey" FOREIGN KEY (part_id) REFERENCES parts(id) ON DELETE SET NULL;
@@ -2193,6 +2361,12 @@ ALTER TABLE "public"."job_materials"
 ALTER TABLE "public"."job_materials"
     ADD CONSTRAINT "job_materials_parts_bom_id_fkey" FOREIGN KEY (parts_bom_id) REFERENCES parts_bom(id) ON DELETE SET NULL;
 
+ALTER TABLE "public"."job_note_media"
+    ADD CONSTRAINT "job_note_media_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."job_note_media"
+    ADD CONSTRAINT "job_note_media_note_id_fkey" FOREIGN KEY (note_id) REFERENCES job_notes(id) ON DELETE CASCADE;
+
 ALTER TABLE "public"."job_notes"
     ADD CONSTRAINT "job_notes_author_id_fkey" FOREIGN KEY (author_id) REFERENCES user_company_access(id) ON DELETE SET NULL;
 
@@ -2201,6 +2375,12 @@ ALTER TABLE "public"."job_notes"
 
 ALTER TABLE "public"."job_notes"
     ADD CONSTRAINT "job_notes_job_id_fkey" FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."job_notes"
+    ADD CONSTRAINT "job_notes_job_operation_id_fkey" FOREIGN KEY (job_operation_id) REFERENCES job_operations(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."job_notes"
+    ADD CONSTRAINT "job_notes_job_part_id_fkey" FOREIGN KEY (job_part_id) REFERENCES job_parts(id) ON DELETE CASCADE;
 
 ALTER TABLE "public"."job_operations"
     ADD CONSTRAINT "job_operations_assigned_to_fkey" FOREIGN KEY (assigned_to) REFERENCES auth.users(id);
@@ -2255,6 +2435,24 @@ ALTER TABLE "public"."jobs"
 
 ALTER TABLE "public"."markup_rates"
     ADD CONSTRAINT "markup_rates_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."part_attachments"
+    ADD CONSTRAINT "part_attachments_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."part_attachments"
+    ADD CONSTRAINT "part_attachments_part_id_fkey" FOREIGN KEY (part_id) REFERENCES parts(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."part_attachments"
+    ADD CONSTRAINT "part_attachments_uploaded_by_fkey" FOREIGN KEY (uploaded_by) REFERENCES user_company_access(id) ON DELETE SET NULL;
+
+ALTER TABLE "public"."part_location_stock"
+    ADD CONSTRAINT "part_location_stock_company_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
+
+ALTER TABLE "public"."part_location_stock"
+    ADD CONSTRAINT "part_location_stock_location_fkey" FOREIGN KEY (location_id) REFERENCES inventory_locations(id) ON DELETE RESTRICT;
+
+ALTER TABLE "public"."part_location_stock"
+    ADD CONSTRAINT "part_location_stock_part_fkey" FOREIGN KEY (part_id) REFERENCES parts(id) ON DELETE RESTRICT;
 
 ALTER TABLE "public"."part_notes"
     ADD CONSTRAINT "part_notes_author_id_fkey" FOREIGN KEY (author_id) REFERENCES user_company_access(id) ON DELETE SET NULL;
@@ -2356,7 +2554,7 @@ ALTER TABLE "public"."quote_operations"
     ADD CONSTRAINT "quote_operations_quote_id_fkey" FOREIGN KEY (quote_id) REFERENCES quotes(id) ON DELETE CASCADE;
 
 ALTER TABLE "public"."quotes"
-    ADD CONSTRAINT "quotes_billing_address_id_fkey" FOREIGN KEY (billing_address_id) REFERENCES customer_addresses(id);
+    ADD CONSTRAINT "quotes_billing_address_id_fkey" FOREIGN KEY (billing_address_id) REFERENCES customer_addresses(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."quotes"
     ADD CONSTRAINT "quotes_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
@@ -2371,7 +2569,7 @@ ALTER TABLE "public"."quotes"
     ADD CONSTRAINT "quotes_customer_id_fkey" FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."quotes"
-    ADD CONSTRAINT "quotes_shipping_address_id_fkey" FOREIGN KEY (shipping_address_id) REFERENCES customer_addresses(id);
+    ADD CONSTRAINT "quotes_shipping_address_id_fkey" FOREIGN KEY (shipping_address_id) REFERENCES customer_addresses(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."routing_operations"
     ADD CONSTRAINT "routing_operations_routing_id_fkey" FOREIGN KEY (routing_id) REFERENCES routings(id) ON DELETE CASCADE;
@@ -2413,7 +2611,7 @@ ALTER TABLE "public"."shipments"
     ADD CONSTRAINT "shipments_job_id_fkey" FOREIGN KEY (job_id) REFERENCES jobs(id);
 
 ALTER TABLE "public"."shipments"
-    ADD CONSTRAINT "shipments_shipping_address_id_fkey" FOREIGN KEY (shipping_address_id) REFERENCES customer_addresses(id);
+    ADD CONSTRAINT "shipments_shipping_address_id_fkey" FOREIGN KEY (shipping_address_id) REFERENCES customer_addresses(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."shipments"
     ADD CONSTRAINT "shipments_voided_by_fkey" FOREIGN KEY (voided_by) REFERENCES auth.users(id) ON DELETE SET NULL;
@@ -2464,11 +2662,15 @@ CREATE INDEX IF NOT EXISTS idx_customer_contacts_customer ON public.customer_con
 CREATE INDEX IF NOT EXISTS idx_customers_company ON public.customers USING btree (company_id);
 CREATE INDEX IF NOT EXISTS idx_customers_name ON public.customers USING btree (company_id, name);
 CREATE INDEX IF NOT EXISTS idx_customers_name_trgm ON public.customers USING gin (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS inventory_locations_company_parent_idx ON public.inventory_locations USING btree (company_id, parent_id);
+CREATE UNIQUE INDEX IF NOT EXISTS inventory_locations_one_unassigned_per_company ON public.inventory_locations USING btree (company_id) WHERE (name = 'Unassigned'::text);
 CREATE INDEX IF NOT EXISTS inventory_transactions_company_id_created_at_idx ON public.inventory_transactions USING btree (company_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS inventory_transactions_discrepancy_idx ON public.inventory_transactions USING btree (company_id, created_at DESC) WHERE (has_discrepancy = true);
 CREATE INDEX IF NOT EXISTS inventory_transactions_job_id_idx ON public.inventory_transactions USING btree (job_id) WHERE (job_id IS NOT NULL);
 CREATE INDEX IF NOT EXISTS inventory_transactions_job_operation_id_idx ON public.inventory_transactions USING btree (job_operation_id) WHERE (job_operation_id IS NOT NULL);
+CREATE INDEX IF NOT EXISTS inventory_transactions_location_idx ON public.inventory_transactions USING btree (location_id) WHERE (location_id IS NOT NULL);
 CREATE INDEX IF NOT EXISTS inventory_transactions_part_id_created_at_idx ON public.inventory_transactions USING btree (part_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS inventory_transactions_transfer_group_idx ON public.inventory_transactions USING btree (transfer_group_id) WHERE (transfer_group_id IS NOT NULL);
 CREATE INDEX IF NOT EXISTS idx_invitations_company_id ON public.invitations USING btree (company_id);
 CREATE INDEX IF NOT EXISTS idx_invitations_email ON public.invitations USING btree (email);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_invitations_pending_email_company ON public.invitations USING btree (email, company_id) WHERE ((status)::text = 'pending'::text);
@@ -2479,6 +2681,7 @@ CREATE INDEX IF NOT EXISTS idx_job_materials_job ON public.job_materials USING b
 CREATE INDEX IF NOT EXISTS idx_job_materials_job_part_id ON public.job_materials USING btree (job_part_id);
 CREATE INDEX IF NOT EXISTS idx_job_materials_material_part ON public.job_materials USING btree (material_part_id);
 CREATE INDEX IF NOT EXISTS idx_job_materials_parts_bom ON public.job_materials USING btree (parts_bom_id);
+CREATE INDEX IF NOT EXISTS idx_job_note_media_note ON public.job_note_media USING btree (note_id);
 CREATE INDEX IF NOT EXISTS idx_job_notes_job_created ON public.job_notes USING btree (job_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_job_operations_job_part_id ON public.job_operations USING btree (job_part_id);
 CREATE INDEX IF NOT EXISTS idx_job_ops_assigned ON public.job_operations USING btree (assigned_to) WHERE (assigned_to IS NOT NULL);
@@ -2500,6 +2703,10 @@ CREATE INDEX IF NOT EXISTS idx_jobs_production_status ON public.jobs USING btree
 CREATE INDEX IF NOT EXISTS idx_jobs_quote ON public.jobs USING btree (quote_id);
 CREATE INDEX IF NOT EXISTS idx_markup_rates_company ON public.markup_rates USING btree (company_id);
 CREATE UNIQUE INDEX IF NOT EXISTS markup_rates_one_default_per_company ON public.markup_rates USING btree (company_id) WHERE is_default;
+CREATE INDEX IF NOT EXISTS idx_part_attachments_part_created ON public.part_attachments USING btree (part_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS part_location_stock_company_idx ON public.part_location_stock USING btree (company_id);
+CREATE INDEX IF NOT EXISTS part_location_stock_location_idx ON public.part_location_stock USING btree (location_id);
+CREATE INDEX IF NOT EXISTS part_location_stock_part_idx ON public.part_location_stock USING btree (part_id);
 CREATE INDEX IF NOT EXISTS idx_part_notes_part_created ON public.part_notes USING btree (part_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_part_pricing_tiers_company ON public.part_pricing_tiers USING btree (company_id);
 CREATE INDEX IF NOT EXISTS idx_part_pricing_tiers_part ON public.part_pricing_tiers USING btree (part_id, sequence);
@@ -2671,6 +2878,131 @@ BEGIN
     WHERE id = v_inv.id;
 
     RETURN v_inv.company_id;
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.add_stock_at_location(p_part_id uuid, p_location_id uuid, p_quantity numeric, p_unit text, p_converted_quantity numeric, p_notes text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_item_name text; v_tracked boolean;
+    v_new_balance numeric; v_rollup numeric;
+BEGIN
+    IF p_quantity <= 0 OR p_converted_quantity <= 0 THEN
+        RAISE EXCEPTION 'Quantity must be positive' USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT company_id, part_name, is_location_tracked
+      INTO v_company, v_item_name, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF NOT v_tracked THEN
+        RAISE EXCEPTION 'part % is not location-tracked; enable tracking first', p_part_id USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM public.inv_assert_location_in_company(p_location_id, v_company);
+
+    INSERT INTO public.part_location_stock AS pls (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, p_location_id, p_converted_quantity)
+    ON CONFLICT (part_id, location_id)
+        DO UPDATE SET quantity = pls.quantity + EXCLUDED.quantity
+    RETURNING pls.quantity INTO v_new_balance;
+
+    INSERT INTO public.inventory_transactions
+        (company_id, part_id, item_name, type, quantity, unit, converted_quantity,
+         location_id, notes, created_by)
+    VALUES
+        (v_company, p_part_id, v_item_name, 'addition', p_quantity, p_unit, p_converted_quantity,
+         p_location_id, p_notes, auth.uid());
+
+    SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+    RETURN jsonb_build_object('location_balance', v_new_balance, 'part_quantity', v_rollup);
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.address_block_snapshot(p_address_id uuid)
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT jsonb_build_object(
+           'address_line1', a.address_line1,
+           'address_line2', a.address_line2,
+           'city',          a.city,
+           'state',         a.state,
+           'postal_code',   a.postal_code,
+           'country',       a.country,
+           'attention_to',  a.attention_to
+         )
+    FROM public.customer_addresses a
+   WHERE a.id = p_address_id;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.adjust_stock_at_location(p_part_id uuid, p_location_id uuid, p_new_quantity numeric, p_unit text, p_converted_new_quantity numeric, p_notes text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_item_name text; v_primary_unit text; v_tracked boolean;
+    v_current numeric; v_diff numeric; v_rollup numeric; v_notes text;
+BEGIN
+    IF p_converted_new_quantity < 0 THEN
+        RAISE EXCEPTION 'Quantity cannot be negative' USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT company_id, part_name, primary_unit, is_location_tracked
+      INTO v_company, v_item_name, v_primary_unit, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF NOT v_tracked THEN
+        RAISE EXCEPTION 'part % is not location-tracked; enable tracking first', p_part_id USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM public.inv_assert_location_in_company(p_location_id, v_company);
+
+    SELECT quantity INTO v_current
+      FROM public.part_location_stock
+     WHERE part_id = p_part_id AND location_id = p_location_id
+       FOR UPDATE;
+    v_current := COALESCE(v_current, 0);
+    v_diff := p_converted_new_quantity - v_current;
+
+    INSERT INTO public.part_location_stock (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, p_location_id, p_converted_new_quantity)
+    ON CONFLICT (part_id, location_id) DO UPDATE SET quantity = EXCLUDED.quantity;
+
+    v_notes := COALESCE(
+        p_notes,
+        format('Adjusted from %s to %s %s', v_current, p_converted_new_quantity, v_primary_unit));
+
+    INSERT INTO public.inventory_transactions
+        (company_id, part_id, item_name, type, quantity, unit, converted_quantity,
+         location_id, notes, created_by)
+    VALUES
+        (v_company, p_part_id, v_item_name, 'adjustment', abs(v_diff), v_primary_unit, abs(v_diff),
+         p_location_id, v_notes, auth.uid());
+
+    SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+    RETURN jsonb_build_object('location_balance', p_converted_new_quantity, 'part_quantity', v_rollup);
 END;
 $function$
 
@@ -2907,7 +3239,6 @@ BEGIN
                    ro.cycle_minutes_per_unit,
                    ro.labor_rate_override,
                    ro.external_unit_price,
-                   ro.external_setup_cost,
                    wc.kind          AS wc_kind,
                    wc.labor_rate    AS wc_labor_rate
               FROM public.routing_operations ro
@@ -2926,14 +3257,13 @@ BEGIN
                              * COALESCE(v_op.labor_rate_override, v_op.wc_labor_rate)
                              / 60.0;
             ELSE
-                IF v_op.external_unit_price IS NULL AND v_op.external_setup_cost IS NULL THEN
+                IF v_op.external_unit_price IS NULL THEN
                     RAISE EXCEPTION
-                        'Cannot compute cost for part %: external routing op has no pricing (neither external_unit_price nor external_setup_cost)',
+                        'Cannot compute cost for part %: external routing op has no unit price (external_unit_price is required)',
                         v_part_name
                         USING ERRCODE = 'check_violation';
                 END IF;
-                v_op_cost := COALESCE(v_op.external_unit_price, 0)
-                             + COALESCE(v_op.external_setup_cost, 0) / p_qty;
+                v_op_cost := COALESCE(v_op.external_unit_price, 0);
             END IF;
             v_total := v_total + v_op_cost;
         END LOOP;
@@ -3056,6 +3386,22 @@ BEGIN
     missing_leaves := v_missing;
     RETURN NEXT;
 END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.contact_block_snapshot(p_contact_id uuid)
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT jsonb_build_object(
+           'name',  c.name,
+           'email', c.email,
+           'phone', c.phone
+         )
+    FROM public.customer_contacts c
+   WHERE c.id = p_contact_id;
 $function$
 
 ;
@@ -3298,6 +3644,257 @@ END $function$
 
 ;
 
+CREATE OR REPLACE FUNCTION public.delete_location(p_location_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid;
+    v_guard   integer := 0;
+BEGIN
+    SELECT company_id INTO v_company FROM public.inventory_locations WHERE id = p_location_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'location % not found', p_location_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+
+    -- Refuse only if any location in the subtree still holds stock.
+    IF EXISTS (
+        WITH RECURSIVE sub AS (
+            SELECT id FROM public.inventory_locations WHERE id = p_location_id
+            UNION ALL
+            SELECT l.id FROM public.inventory_locations l JOIN sub s ON l.parent_id = s.id
+        )
+        SELECT 1
+          FROM public.part_location_stock pls
+          JOIN sub ON pls.location_id = sub.id
+         WHERE pls.quantity > 0
+    ) THEN
+        RAISE EXCEPTION 'location subtree still holds stock' USING ERRCODE = 'foreign_key_violation';
+    END IF;
+
+    -- Drop leftover zero-qty balance rows across the subtree (clients can't —
+    -- part_location_stock is SELECT-only). part_location_stock.location_id is
+    -- ON DELETE RESTRICT, so these must go before their locations.
+    DELETE FROM public.part_location_stock
+     WHERE location_id IN (
+        WITH RECURSIVE sub AS (
+            SELECT id FROM public.inventory_locations WHERE id = p_location_id
+            UNION ALL
+            SELECT l.id FROM public.inventory_locations l JOIN sub s ON l.parent_id = s.id
+        )
+        SELECT id FROM sub
+     );
+
+    -- Delete the subtree bottom-up. inventory_locations.parent_id is ON DELETE
+    -- RESTRICT, so a parent can't be removed while children exist; repeatedly
+    -- delete the current leaves of the subtree until the target is gone.
+    LOOP
+        v_guard := v_guard + 1;
+        IF v_guard > 1000 THEN
+            RAISE EXCEPTION 'delete_location: subtree too deep or cyclic for %', p_location_id;
+        END IF;
+
+        DELETE FROM public.inventory_locations loc
+         WHERE loc.id IN (
+            WITH RECURSIVE sub AS (
+                SELECT id FROM public.inventory_locations WHERE id = p_location_id
+                UNION ALL
+                SELECT l.id FROM public.inventory_locations l JOIN sub s ON l.parent_id = s.id
+            )
+            SELECT s.id
+              FROM sub s
+             WHERE NOT EXISTS (
+                SELECT 1 FROM public.inventory_locations c WHERE c.parent_id = s.id
+             )
+         );
+
+        EXIT WHEN NOT EXISTS (SELECT 1 FROM public.inventory_locations WHERE id = p_location_id);
+    END LOOP;
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.deplete_stock_at_location(p_part_id uuid, p_location_id uuid, p_quantity numeric, p_unit text, p_converted_quantity numeric, p_graceful boolean DEFAULT false, p_notes text DEFAULT NULL::text, p_job_id uuid DEFAULT NULL::uuid, p_job_operation_id uuid DEFAULT NULL::uuid, p_operator_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_item_name text; v_primary_unit text; v_tracked boolean;
+    v_current numeric; v_new numeric; v_rollup numeric;
+    v_discrepancy boolean := false; v_shortfall numeric := 0;
+    v_notes text; v_disc_note text;
+BEGIN
+    IF p_quantity <= 0 OR p_converted_quantity <= 0 THEN
+        RAISE EXCEPTION 'Quantity must be positive' USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT company_id, part_name, primary_unit, is_location_tracked
+      INTO v_company, v_item_name, v_primary_unit, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF NOT v_tracked THEN
+        RAISE EXCEPTION 'part % is not location-tracked; enable tracking first', p_part_id USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM public.inv_assert_location_in_company(p_location_id, v_company);
+
+    -- Lock the balance row (treat a missing row as 0 on hand).
+    SELECT quantity INTO v_current
+      FROM public.part_location_stock
+     WHERE part_id = p_part_id AND location_id = p_location_id
+       FOR UPDATE;
+    v_current := COALESCE(v_current, 0);
+
+    v_new := v_current - p_converted_quantity;
+    v_notes := p_notes;
+
+    IF v_new < 0 THEN
+        IF p_graceful THEN
+            v_shortfall := p_converted_quantity - v_current;
+            v_new := 0;
+            v_discrepancy := true;
+            v_disc_note := format(
+                '[DISCREPANCY: Confirmed %s %s, but only %s %s was available. Shortfall: %s %s]',
+                p_converted_quantity, v_primary_unit, v_current, v_primary_unit, v_shortfall, v_primary_unit);
+            v_notes := CASE WHEN v_notes IS NULL OR v_notes = '' THEN v_disc_note
+                            ELSE v_notes || ' ' || v_disc_note END;
+        ELSE
+            RAISE EXCEPTION 'Insufficient stock at location (have %, need %)', v_current, p_converted_quantity
+                USING ERRCODE = 'check_violation';
+        END IF;
+    END IF;
+
+    INSERT INTO public.part_location_stock (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, p_location_id, v_new)
+    ON CONFLICT (part_id, location_id) DO UPDATE SET quantity = EXCLUDED.quantity;
+
+    INSERT INTO public.inventory_transactions
+        (company_id, part_id, item_name, type, quantity, unit, converted_quantity,
+         location_id, job_id, job_operation_id, operator_id, notes, has_discrepancy, created_by)
+    VALUES
+        (v_company, p_part_id, v_item_name, 'depletion', p_quantity, p_unit, p_converted_quantity,
+         p_location_id, p_job_id, p_job_operation_id, p_operator_id, v_notes, v_discrepancy, auth.uid());
+
+    SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+    RETURN jsonb_build_object(
+        'location_balance', v_new, 'part_quantity', v_rollup,
+        'has_discrepancy', v_discrepancy, 'shortfall', v_shortfall);
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.disable_location_tracking(p_part_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_tracked boolean; v_total numeric;
+BEGIN
+    SELECT company_id, is_location_tracked
+      INTO v_company, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+
+    IF NOT v_tracked THEN
+        RETURN jsonb_build_object('part_quantity',
+            (SELECT quantity FROM public.parts WHERE id = p_part_id), 'tracked', false, 'noop', true);
+    END IF;
+
+    v_total := COALESCE(
+        (SELECT SUM(quantity) FROM public.part_location_stock WHERE part_id = p_part_id), 0);
+
+    -- Flip the flag FIRST (so the subsequent DELETE's rollup is a no-op) and set
+    -- the collapsed total in the same statement (allowed: tracked is now false).
+    UPDATE public.parts
+       SET is_location_tracked = false, quantity = v_total, updated_at = now()
+     WHERE id = p_part_id;
+
+    DELETE FROM public.part_location_stock WHERE part_id = p_part_id;
+
+    RETURN jsonb_build_object('part_quantity', v_total, 'tracked', false);
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.enable_location_tracking(p_part_id uuid, p_initial_location_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_qty numeric; v_tracked boolean; v_loc uuid; v_rollup numeric;
+BEGIN
+    SELECT company_id, quantity, is_location_tracked
+      INTO v_company, v_qty, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+
+    -- Idempotent: already tracked -> no-op.
+    IF v_tracked THEN
+        SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+        RETURN jsonb_build_object('part_quantity', v_rollup, 'tracked', true, 'noop', true);
+    END IF;
+
+    -- Resolve the backfill location: caller-chosen, else find-or-create "Unassigned".
+    IF p_initial_location_id IS NOT NULL THEN
+        PERFORM public.inv_assert_location_in_company(p_initial_location_id, v_company);
+        v_loc := p_initial_location_id;
+    ELSE
+        PERFORM pg_advisory_xact_lock(hashtext('inv_unassigned:' || v_company::text));
+        SELECT id INTO v_loc
+          FROM public.inventory_locations
+         WHERE company_id = v_company AND name = 'Unassigned';
+        IF v_loc IS NULL THEN
+            INSERT INTO public.inventory_locations (company_id, name, kind)
+            VALUES (v_company, 'Unassigned', 'system')
+            RETURNING id INTO v_loc;
+        END IF;
+    END IF;
+
+    -- Flip the flag FIRST (quantity unchanged -> guard skipped), THEN seed the
+    -- backfill balance equal to the pre-existing quantity so the rollup overwrites
+    -- parts.quantity with the same SUM. Never let a standalone value coexist.
+    UPDATE public.parts SET is_location_tracked = true, updated_at = now() WHERE id = p_part_id;
+
+    INSERT INTO public.part_location_stock AS pls (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, v_loc, v_qty)
+    ON CONFLICT (part_id, location_id)
+        DO UPDATE SET quantity = pls.quantity + EXCLUDED.quantity;
+
+    SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
+    RETURN jsonb_build_object('location_id', v_loc, 'part_quantity', v_rollup, 'tracked', true);
+END;
+$function$
+
+;
+
 CREATE OR REPLACE FUNCTION public.enforce_job_address_contact_customer()
  RETURNS trigger
  LANGUAGE plpgsql
@@ -3485,6 +4082,33 @@ END $function$
 
 ;
 
+CREATE OR REPLACE FUNCTION public.enforce_tracked_part_quantity()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_expected numeric;
+BEGIN
+    IF NEW.is_location_tracked AND NEW.quantity IS DISTINCT FROM OLD.quantity THEN
+        v_expected := COALESCE(
+            (SELECT SUM(quantity) FROM public.part_location_stock WHERE part_id = NEW.id),
+            0);
+
+        IF NEW.quantity IS DISTINCT FROM v_expected THEN
+            RAISE EXCEPTION 'parts.quantity for location-tracked part % is maintained from part_location_stock; direct quantity writes are not allowed (attempted %, expected %)',
+                NEW.id, NEW.quantity, v_expected
+                USING ERRCODE = 'integrity_constraint_violation';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$
+
+;
+
 CREATE OR REPLACE FUNCTION public.generate_direct_job_number(company_uuid uuid)
  RETURNS text
  LANGUAGE plpgsql
@@ -3580,8 +4204,7 @@ BEGIN
                         AND wc.labor_rate IS NULL)
                     OR
                     (wc.kind <> 'internal'
-                        AND ro.external_unit_price IS NULL
-                        AND ro.external_setup_cost IS NULL)
+                        AND ro.external_unit_price IS NULL)
                 )
           )
           -- Every BOM child must already be priceable. A made part with no
@@ -3870,6 +4493,46 @@ AS '$libdir/pg_trgm', $function$gtrgm_union$function$
 
 ;
 
+CREATE OR REPLACE FUNCTION public.inv_assert_location_in_company(p_location_id uuid, p_company_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+    IF p_location_id IS NULL THEN
+        RAISE EXCEPTION 'location_id is required' USING ERRCODE = 'null_value_not_allowed';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM public.inventory_locations
+         WHERE id = p_location_id AND company_id = p_company_id
+    ) THEN
+        RAISE EXCEPTION 'location % is not in company %', p_location_id, p_company_id
+            USING ERRCODE = 'insufficient_privilege';
+    END IF;
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.inv_location_path_label(p_location_id uuid)
+ RETURNS text
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH RECURSIVE chain AS (
+    SELECT id, parent_id, name, 0 AS depth
+      FROM public.inventory_locations WHERE id = p_location_id
+    UNION ALL
+    SELECT l.id, l.parent_id, l.name, c.depth + 1
+      FROM public.inventory_locations l JOIN chain c ON l.id = c.parent_id
+  )
+  SELECT string_agg(name, ' › ' ORDER BY depth DESC) FROM chain;
+$function$
+
+;
+
 CREATE OR REPLACE FUNCTION public.is_company_admin(check_company_id uuid)
  RETURNS boolean
  LANGUAGE sql
@@ -4008,6 +4671,33 @@ END $function$
 
 ;
 
+CREATE OR REPLACE FUNCTION public.recompute_part_quantity_from_locations()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_part_id uuid := COALESCE(NEW.part_id, OLD.part_id);
+    v_tracked boolean;
+BEGIN
+    SELECT is_location_tracked INTO v_tracked FROM public.parts WHERE id = v_part_id;
+
+    IF COALESCE(v_tracked, false) THEN
+        UPDATE public.parts
+           SET quantity = COALESCE(
+                   (SELECT SUM(quantity) FROM public.part_location_stock WHERE part_id = v_part_id),
+                   0),
+               updated_at = now()
+         WHERE id = v_part_id;
+    END IF;
+
+    RETURN NULL; -- AFTER trigger: return value is ignored
+END;
+$function$
+
+;
+
 CREATE OR REPLACE FUNCTION public.reset_demo_company(p_source_company_id uuid, p_user_id uuid)
  RETURNS void
  LANGUAGE plpgsql
@@ -4082,6 +4772,8 @@ BEGIN
        OR OLD.created_at       IS DISTINCT FROM NEW.created_at
        OR OLD.created_by       IS DISTINCT FROM NEW.created_by
        OR OLD.has_discrepancy  IS DISTINCT FROM NEW.has_discrepancy
+       OR OLD.location_name     IS DISTINCT FROM NEW.location_name
+       OR OLD.transfer_group_id IS DISTINCT FROM NEW.transfer_group_id
     THEN
         RAISE EXCEPTION 'Only the notes field can be updated on inventory transactions';
     END IF;
@@ -4342,7 +5034,7 @@ BEGIN
                         routing_id, work_center_id, sequence,
                         setup_minutes, cycle_minutes_per_unit,
                         labor_rate_override,
-                        external_unit_price, external_setup_cost,
+                        external_unit_price,
                         instructions
                     ) VALUES (
                         v_routing_id,
@@ -4352,7 +5044,6 @@ BEGIN
                         NULLIF(v_inner->>'cycle_minutes_per_unit', '')::numeric,
                         NULLIF(v_inner->>'labor_rate_override', '')::numeric,
                         NULLIF(v_inner->>'external_unit_price', '')::numeric,
-                        NULLIF(v_inner->>'external_setup_cost', '')::numeric,
                         v_inner->>'instructions'
                     );
                 END LOOP;
@@ -4516,6 +5207,88 @@ CREATE OR REPLACE FUNCTION public.similarity_op(text, text)
  LANGUAGE c
  STABLE PARALLEL SAFE STRICT
 AS '$libdir/pg_trgm', $function$similarity_op$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.snapshot_document_party()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+    IF TG_OP = 'INSERT' OR NEW.customer_id IS DISTINCT FROM OLD.customer_id THEN
+        IF NEW.customer_id IS NOT NULL THEN
+            NEW.customer_name := (SELECT name FROM public.customers WHERE id = NEW.customer_id);
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' OR NEW.billing_address_id IS DISTINCT FROM OLD.billing_address_id THEN
+        IF NEW.billing_address_id IS NOT NULL THEN
+            NEW.bill_to_address := public.address_block_snapshot(NEW.billing_address_id);
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' OR NEW.shipping_address_id IS DISTINCT FROM OLD.shipping_address_id THEN
+        IF NEW.shipping_address_id IS NOT NULL THEN
+            NEW.ship_to_address := public.address_block_snapshot(NEW.shipping_address_id);
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' OR NEW.contact_id IS DISTINCT FROM OLD.contact_id THEN
+        IF NEW.contact_id IS NOT NULL THEN
+            NEW.contact_snapshot := public.contact_block_snapshot(NEW.contact_id);
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.snapshot_shipment_party()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+    IF TG_OP = 'INSERT' OR NEW.customer_id IS DISTINCT FROM OLD.customer_id THEN
+        IF NEW.customer_id IS NOT NULL THEN
+            NEW.customer_name := (SELECT name FROM public.customers WHERE id = NEW.customer_id);
+            NEW.bill_to_address := public.address_block_snapshot(
+                (SELECT a.id FROM public.customer_addresses a
+                  WHERE a.customer_id = NEW.customer_id AND a.default_billing
+                  LIMIT 1));
+        END IF;
+    END IF;
+
+    IF TG_OP = 'INSERT' OR NEW.shipping_address_id IS DISTINCT FROM OLD.shipping_address_id THEN
+        IF NEW.shipping_address_id IS NOT NULL THEN
+            NEW.ship_to_address := public.address_block_snapshot(NEW.shipping_address_id);
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.snapshot_transaction_location_name()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+    IF NEW.location_id IS NOT NULL AND NEW.location_name IS NULL THEN
+        NEW.location_name := public.inv_location_path_label(NEW.location_id);
+    END IF;
+    RETURN NEW;
+END;
+$function$
 
 ;
 
@@ -4684,6 +5457,86 @@ $function$
 
 ;
 
+CREATE OR REPLACE FUNCTION public.transfer_stock(p_part_id uuid, p_from_location_id uuid, p_to_location_id uuid, p_quantity numeric, p_unit text, p_converted_quantity numeric, p_notes text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_company uuid; v_item_name text; v_tracked boolean;
+    v_src numeric; v_from_balance numeric; v_to_balance numeric;
+    v_group uuid; v_from_name text; v_to_name text;
+    v_from_notes text; v_to_notes text; v_base text;
+BEGIN
+    IF p_quantity <= 0 OR p_converted_quantity <= 0 THEN
+        RAISE EXCEPTION 'Quantity must be positive' USING ERRCODE = 'check_violation';
+    END IF;
+    IF p_from_location_id = p_to_location_id THEN
+        RAISE EXCEPTION 'Source and destination locations must differ' USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT company_id, part_name, is_location_tracked
+      INTO v_company, v_item_name, v_tracked
+      FROM public.parts WHERE id = p_part_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'part % not found', p_part_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    IF NOT v_tracked THEN
+        RAISE EXCEPTION 'part % is not location-tracked; enable tracking first', p_part_id USING ERRCODE = 'check_violation';
+    END IF;
+    PERFORM public.inv_assert_location_in_company(p_from_location_id, v_company);
+    PERFORM public.inv_assert_location_in_company(p_to_location_id, v_company);
+
+    -- Lock + verify source has enough (hard fail — you can't move stock you lack).
+    SELECT quantity INTO v_src
+      FROM public.part_location_stock
+     WHERE part_id = p_part_id AND location_id = p_from_location_id
+       FOR UPDATE;
+    IF v_src IS NULL OR v_src < p_converted_quantity THEN
+        RAISE EXCEPTION 'Insufficient stock at source location (have %, need %)',
+            COALESCE(v_src, 0), p_converted_quantity USING ERRCODE = 'check_violation';
+    END IF;
+
+    UPDATE public.part_location_stock
+       SET quantity = v_src - p_converted_quantity
+     WHERE part_id = p_part_id AND location_id = p_from_location_id
+    RETURNING quantity INTO v_from_balance;
+
+    INSERT INTO public.part_location_stock AS pls (company_id, part_id, location_id, quantity)
+    VALUES (v_company, p_part_id, p_to_location_id, p_converted_quantity)
+    ON CONFLICT (part_id, location_id)
+        DO UPDATE SET quantity = pls.quantity + EXCLUDED.quantity
+    RETURNING pls.quantity INTO v_to_balance;
+
+    v_group := gen_random_uuid();
+    SELECT name INTO v_from_name FROM public.inventory_locations WHERE id = p_from_location_id;
+    SELECT name INTO v_to_name   FROM public.inventory_locations WHERE id = p_to_location_id;
+    v_base := COALESCE(NULLIF(p_notes, ''), '');
+
+    v_from_notes := btrim(v_base || ' ' || format('[Transfer to %s]', v_to_name));
+    v_to_notes   := btrim(v_base || ' ' || format('[Transfer from %s]', v_from_name));
+
+    INSERT INTO public.inventory_transactions
+        (company_id, part_id, item_name, type, quantity, unit, converted_quantity,
+         location_id, transfer_group_id, notes, created_by)
+    VALUES
+        (v_company, p_part_id, v_item_name, 'depletion', p_quantity, p_unit, p_converted_quantity,
+         p_from_location_id, v_group, v_from_notes, auth.uid()),
+        (v_company, p_part_id, v_item_name, 'addition', p_quantity, p_unit, p_converted_quantity,
+         p_to_location_id, v_group, v_to_notes, auth.uid());
+
+    RETURN jsonb_build_object(
+        'transfer_group_id', v_group,
+        'from_balance', v_from_balance, 'to_balance', v_to_balance);
+END;
+$function$
+
+;
+
 CREATE OR REPLACE FUNCTION public.update_inventory_items_updated_at()
  RETURNS trigger
  LANGUAGE plpgsql
@@ -4788,6 +5641,9 @@ CREATE TRIGGER feedback AFTER INSERT ON public.feedback FOR EACH ROW EXECUTE FUN
 DROP TRIGGER IF EXISTS "enforce_transaction_notes_only_update" ON "public"."inventory_transactions";
 CREATE TRIGGER enforce_transaction_notes_only_update BEFORE UPDATE ON public.inventory_transactions FOR EACH ROW EXECUTE FUNCTION restrict_transaction_update_to_notes();
 
+DROP TRIGGER IF EXISTS "trg_snapshot_txn_location" ON "public"."inventory_transactions";
+CREATE TRIGGER trg_snapshot_txn_location BEFORE INSERT ON public.inventory_transactions FOR EACH ROW EXECUTE FUNCTION snapshot_transaction_location_name();
+
 DROP TRIGGER IF EXISTS "job_materials_updated_at" ON "public"."job_materials";
 CREATE TRIGGER job_materials_updated_at BEFORE UPDATE ON public.job_materials FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
@@ -4821,11 +5677,17 @@ CREATE TRIGGER enforce_job_address_contact_customer_trg BEFORE INSERT OR UPDATE 
 DROP TRIGGER IF EXISTS "jobs_updated_at" ON "public"."jobs";
 CREATE TRIGGER jobs_updated_at BEFORE UPDATE ON public.jobs FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS "trg_snapshot_job_party" ON "public"."jobs";
+CREATE TRIGGER trg_snapshot_job_party BEFORE INSERT OR UPDATE OF customer_id, billing_address_id, shipping_address_id, contact_id ON public.jobs FOR EACH ROW EXECUTE FUNCTION snapshot_document_party();
+
 DROP TRIGGER IF EXISTS "trigger_job_production_status_change" ON "public"."jobs";
 CREATE TRIGGER trigger_job_production_status_change BEFORE UPDATE ON public.jobs FOR EACH ROW EXECUTE FUNCTION track_job_production_status_change();
 
 DROP TRIGGER IF EXISTS "markup_rates_updated_at" ON "public"."markup_rates";
 CREATE TRIGGER markup_rates_updated_at BEFORE UPDATE ON public.markup_rates FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+DROP TRIGGER IF EXISTS "trg_recompute_part_quantity" ON "public"."part_location_stock";
+CREATE TRIGGER trg_recompute_part_quantity AFTER INSERT OR DELETE OR UPDATE ON public.part_location_stock FOR EACH ROW EXECUTE FUNCTION recompute_part_quantity_from_locations();
 
 DROP TRIGGER IF EXISTS "part_pricing_tiers_updated_at" ON "public"."part_pricing_tiers";
 CREATE TRIGGER part_pricing_tiers_updated_at BEFORE UPDATE ON public.part_pricing_tiers FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
@@ -4835,6 +5697,9 @@ CREATE TRIGGER part_procurement_tiers_updated_at BEFORE UPDATE ON public.part_pr
 
 DROP TRIGGER IF EXISTS "parts_updated_at" ON "public"."parts";
 CREATE TRIGGER parts_updated_at BEFORE UPDATE ON public.parts FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+DROP TRIGGER IF EXISTS "trg_enforce_tracked_part_quantity" ON "public"."parts";
+CREATE TRIGGER trg_enforce_tracked_part_quantity BEFORE UPDATE ON public.parts FOR EACH ROW EXECUTE FUNCTION enforce_tracked_part_quantity();
 
 DROP TRIGGER IF EXISTS "parts_bom_no_cycles" ON "public"."parts_bom";
 CREATE TRIGGER parts_bom_no_cycles BEFORE INSERT OR UPDATE OF parent_part_id, child_part_id ON public.parts_bom FOR EACH ROW EXECUTE FUNCTION enforce_no_bom_cycles();
@@ -4856,6 +5721,9 @@ CREATE TRIGGER enforce_quote_address_contact_customer_trg BEFORE INSERT OR UPDAT
 
 DROP TRIGGER IF EXISTS "quotes_updated_at" ON "public"."quotes";
 CREATE TRIGGER quotes_updated_at BEFORE UPDATE ON public.quotes FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+DROP TRIGGER IF EXISTS "trg_snapshot_quote_party" ON "public"."quotes";
+CREATE TRIGGER trg_snapshot_quote_party BEFORE INSERT OR UPDATE OF customer_id, billing_address_id, shipping_address_id, contact_id ON public.quotes FOR EACH ROW EXECUTE FUNCTION snapshot_document_party();
 
 DROP TRIGGER IF EXISTS "trigger_quote_status_change" ON "public"."quotes";
 CREATE TRIGGER trigger_quote_status_change BEFORE UPDATE ON public.quotes FOR EACH ROW EXECUTE FUNCTION track_quote_status_change();
@@ -4886,6 +5754,9 @@ CREATE TRIGGER enforce_shipment_address_contact_customer_trg BEFORE INSERT OR UP
 
 DROP TRIGGER IF EXISTS "enforce_shipment_customer_id_immutable_trg" ON "public"."shipments";
 CREATE TRIGGER enforce_shipment_customer_id_immutable_trg BEFORE UPDATE OF customer_id ON public.shipments FOR EACH ROW EXECUTE FUNCTION enforce_shipment_customer_id_immutable();
+
+DROP TRIGGER IF EXISTS "trg_snapshot_shipment_party" ON "public"."shipments";
+CREATE TRIGGER trg_snapshot_shipment_party BEFORE INSERT OR UPDATE OF customer_id, shipping_address_id ON public.shipments FOR EACH ROW EXECUTE FUNCTION snapshot_shipment_party();
 
 DROP TRIGGER IF EXISTS "trigger_recompute_jp_fulfillment_on_void" ON "public"."shipments";
 CREATE TRIGGER trigger_recompute_jp_fulfillment_on_void AFTER UPDATE OF voided_at ON public.shipments FOR EACH ROW EXECUTE FUNCTION recompute_job_part_fulfillment_from_void();
@@ -4936,6 +5807,9 @@ COMMENT ON TABLE "public"."demo_data_templates"
 COMMENT ON TABLE "public"."feedback"
     IS 'In-app user feedback submissions';
 
+COMMENT ON TABLE "public"."inventory_locations"
+    IS 'Company-scoped, arbitrary-depth storage-location tree (cabinet › row › side, etc.). is_qr_anchor marks nodes with a printed QR.';
+
 COMMENT ON TABLE "public"."inventory_transactions"
     IS 'Append-only ledger of inventory changes (addition / depletion / adjustment). Notes are the only mutable column post-insert (enforced by trigger).';
 
@@ -4944,6 +5818,9 @@ COMMENT ON TABLE "public"."job_fulfillment_audit"
 
 COMMENT ON TABLE "public"."markup_rates"
     IS 'Named, reusable markup matrices (qty × markup%) per company. Applied to parts via snapshot — copies breakpoints into part_pricing_tiers, no link.';
+
+COMMENT ON TABLE "public"."part_location_stock"
+    IS 'Per-location stock balances; source of truth for location-tracked parts. SELECT-only via RLS — mutated only through SECURITY DEFINER RPCs that also write inventory_transactions.';
 
 COMMENT ON TABLE "public"."part_procurement_tiers"
     IS 'Vendor-keyed tiered pricing for bought parts. Each row is one (vendor, min_quantity, cost_per_unit) point on a vendor''s tier sheet. vendor_id may be NULL for "internal estimate" rows. Ordering of tiers within a vendor sheet is derived from min_quantity ASC — no separate sequence column. Resolved at read time via get_procurement_cost(part_id, qty), which picks the cheapest non-expired tier where min_quantity <= qty across all vendors.';
@@ -5146,6 +6023,9 @@ COMMENT ON COLUMN "public"."inventory_transactions"."part_id"
 COMMENT ON COLUMN "public"."inventory_transactions"."item_name"
     IS 'Snapshot of the part name at transaction time. Survives part renames so historical ledger entries stay readable.';
 
+COMMENT ON COLUMN "public"."inventory_transactions"."location_name"
+    IS 'Snapshot of the location''s full path at transaction time, so deleted locations remain referrable in history (mirrors item_name for deleted parts).';
+
 COMMENT ON COLUMN "public"."job_materials"."parts_bom_id"
     IS 'Source parts_bom row this job_material was snapshotted from at job-start (renamed from routing_material_id; BOM is now part-attached, not routing-attached).';
 
@@ -5203,6 +6083,9 @@ COMMENT ON COLUMN "public"."parts"."legacy_id"
 COMMENT ON COLUMN "public"."parts"."source"
     IS 'How this part is sourced. ''made'' = produced in-shop (will have a routing); ''bought'' = procured from a vendor. Combined with is_stocked, classifies the part into one of four quadrants (Custom Made / Sub-assembly / Raw Material / Service+Drop-ship). Replaces the prior is_manufacturable boolean — see the 20260504 migration header for the (false,false)→''made'' orphan-default rationale.';
 
+COMMENT ON COLUMN "public"."parts"."is_location_tracked"
+    IS 'When true, parts.quantity is a trigger-maintained rollup of part_location_stock and direct quantity writes are rejected.';
+
 COMMENT ON COLUMN "public"."parts_bom"."quantity"
     IS 'Quantity of child consumed per unit of parent, expressed in `unit`. Cost rollups convert to the child part primary_unit via parts_unit_conversions if `unit` differs.';
 
@@ -5239,6 +6122,27 @@ COMMENT ON COLUMN "public"."quotes"."shipping_address_id"
 COMMENT ON COLUMN "public"."quotes"."contact_id"
     IS 'Customer contact the quote is addressed to. Renders as the Customer Contact section on the printed quote (name, role, email, phone). Defaults at quote creation to the customer''s primary contact (is_primary=true in customer_contacts); editable per-quote.';
 
+COMMENT ON COLUMN "public"."quotes"."payment_terms"
+    IS 'Payment terms shown on the quote (preset or custom free text), e.g. Net 30, 2/10 Net 30.';
+
+COMMENT ON COLUMN "public"."quotes"."lead_time_value"
+    IS 'Lead time as stated by the user, in the unit given by lead_time_unit. Normalized into lead_time_days on save.';
+
+COMMENT ON COLUMN "public"."quotes"."lead_time_unit"
+    IS 'Unit for lead_time_value: business_days | calendar_days | weeks.';
+
+COMMENT ON COLUMN "public"."quotes"."customer_name"
+    IS 'Immutable snapshot of the customer name at quote issue time.';
+
+COMMENT ON COLUMN "public"."quotes"."bill_to_address"
+    IS 'Immutable snapshot of the billing address block at quote issue time (Document Snapshot Standard). The rendered quote reads this, not the live billing_address_id row.';
+
+COMMENT ON COLUMN "public"."quotes"."ship_to_address"
+    IS 'Immutable snapshot of the shipping address block at quote issue time.';
+
+COMMENT ON COLUMN "public"."quotes"."contact_snapshot"
+    IS 'Immutable snapshot of the customer contact { name, email, phone } at quote issue time.';
+
 COMMENT ON COLUMN "public"."routing_operations"."sequence"
     IS 'Linear order within the routing. Lower values execute first. Steps of 10 (10, 20, 30...) leave room for inserts.';
 
@@ -5253,9 +6157,6 @@ COMMENT ON COLUMN "public"."routing_operations"."labor_rate_override"
 
 COMMENT ON COLUMN "public"."routing_operations"."external_unit_price"
     IS 'For kind=external only: cost per output unit charged by the vendor.';
-
-COMMENT ON COLUMN "public"."routing_operations"."external_setup_cost"
-    IS 'For kind=external only: one-time per-job setup charge from the vendor; amortizes across batch.';
 
 COMMENT ON COLUMN "public"."saved_insights"."id"
     IS 'Primary key. UUID auto-generated.';
@@ -5286,6 +6187,12 @@ COMMENT ON COLUMN "public"."shipments"."shipping_method"
 
 COMMENT ON COLUMN "public"."shipments"."job_id"
     IS 'The single job this packing slip belongs to. All shipment_line_items resolve to job_parts of this job (enforced in create_shipment_with_line_items). Source of the PS-{jobBase}-{n} number.';
+
+COMMENT ON COLUMN "public"."shipments"."bill_to_address"
+    IS 'Immutable snapshot of the bill-to address block at shipment/packing-slip issue time.';
+
+COMMENT ON COLUMN "public"."shipments"."ship_to_address"
+    IS 'Immutable snapshot of the ship-to address block at shipment issue time.';
 
 COMMENT ON COLUMN "public"."system_admins"."id"
     IS 'Primary key. UUID auto-generated.';

--- a/utils/dashboardAccess.ts
+++ b/utils/dashboardAccess.ts
@@ -5,13 +5,28 @@ import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 
 // ============== Types ==============
 
+export type ActivityType = 'quote' | 'job' | 'shipment' | 'note' | 'photo' | 'operation';
+
+export type ActivityAction =
+  | 'created'
+  | 'started'
+  | 'completed'
+  | 'shipped'
+  | 'noted'
+  | 'photo_added';
+
 export interface ActivityItem {
   id: string;
-  type: 'quote' | 'job';
+  type: ActivityType;
+  /** The job/quote number the event hangs off (the row's bold label). */
   entityNumber: string;
-  action: 'created' | 'started' | 'completed' | 'shipped';
+  action: ActivityAction;
   timestamp: string;
   customerName?: string;
+  /** For note/photo events: who authored it. */
+  authorName?: string;
+  /** Deep link to the underlying record. */
+  href?: string;
 }
 
 // ============== Pinned Metrics ==============
@@ -407,4 +422,310 @@ export async function getPinnedMetricValues(
     })
   );
   return Object.fromEntries(results) as Record<MetricKey, MetricValue>;
+}
+
+// ============== Activity feed ==============
+//
+// A cross-module "what happened" stream, built UNION-on-read over the
+// authoritative tables (jobs, quotes, shipments, job_notes, job_operations) —
+// NOT a materialized/fan-out activity table. Per-tenant volume is tiny and the
+// status/timestamps already live on those rows, so a second source of truth
+// would only invite drift (mirrors the getPartActivity aggregate-on-read).
+// All reads are plain Supabase (no AI on mount). company_id leads every query.
+
+/** Cap pulled per source before the in-memory merge, so one busy source can't starve the feed. */
+const ACTIVITY_PER_SOURCE = 50;
+
+/** Flatten a Supabase joined relation (object | array | null) to a single row. */
+function firstRel<T>(rel: T | T[] | null | undefined): T | null {
+  if (!rel) return null;
+  return Array.isArray(rel) ? rel[0] ?? null : rel;
+}
+
+interface CollectOptions {
+  /** Only items strictly older than this ISO timestamp (pagination cursor). */
+  before?: string;
+  /** Restrict to these activity types. Undefined = all. */
+  types?: ActivityType[];
+  /** Rows to pull per source query. */
+  perSource?: number;
+}
+
+type JobRow = {
+  id: string;
+  job_number: string;
+  created_at: string | null;
+  completed_at: string | null;
+  customer: { name: string | null } | { name: string | null }[] | null;
+};
+
+async function fetchJobActivity(
+  companyId: string,
+  before: string | undefined,
+  perSource: number,
+): Promise<ActivityItem[]> {
+  const supabase = getSupabase();
+
+  let createdQ = supabase
+    .from('jobs')
+    .select('id, job_number, created_at, completed_at, customer:customers(name)')
+    .eq('company_id', companyId)
+    .order('created_at', { ascending: false })
+    .limit(perSource);
+  if (before) createdQ = createdQ.lt('created_at', before);
+
+  let completedQ = supabase
+    .from('jobs')
+    .select('id, job_number, created_at, completed_at, customer:customers(name)')
+    .eq('company_id', companyId)
+    .not('completed_at', 'is', null)
+    .order('completed_at', { ascending: false })
+    .limit(perSource);
+  if (before) completedQ = completedQ.lt('completed_at', before);
+
+  const [created, completed] = await Promise.all([createdQ, completedQ]);
+  const items: ActivityItem[] = [];
+
+  for (const r of (created.data ?? []) as unknown as JobRow[]) {
+    if (!r.created_at) continue;
+    items.push({
+      id: `job-created-${r.id}`,
+      type: 'job',
+      action: 'created',
+      entityNumber: r.job_number,
+      timestamp: r.created_at,
+      customerName: firstRel(r.customer)?.name ?? undefined,
+      href: `/dashboard/${companyId}/jobs/${r.id}`,
+    });
+  }
+  for (const r of (completed.data ?? []) as unknown as JobRow[]) {
+    if (!r.completed_at) continue;
+    items.push({
+      id: `job-completed-${r.id}`,
+      type: 'job',
+      action: 'completed',
+      entityNumber: r.job_number,
+      timestamp: r.completed_at,
+      customerName: firstRel(r.customer)?.name ?? undefined,
+      href: `/dashboard/${companyId}/jobs/${r.id}`,
+    });
+  }
+  return items;
+}
+
+type QuoteRow = {
+  id: string;
+  quote_number: string;
+  created_at: string | null;
+  customer: { name: string | null } | { name: string | null }[] | null;
+};
+
+async function fetchQuoteActivity(
+  companyId: string,
+  before: string | undefined,
+  perSource: number,
+): Promise<ActivityItem[]> {
+  const supabase = getSupabase();
+  let q = supabase
+    .from('quotes')
+    .select('id, quote_number, created_at, customer:customers(name)')
+    .eq('company_id', companyId)
+    .order('created_at', { ascending: false })
+    .limit(perSource);
+  if (before) q = q.lt('created_at', before);
+
+  const { data } = await q;
+  const items: ActivityItem[] = [];
+  for (const r of (data ?? []) as unknown as QuoteRow[]) {
+    if (!r.created_at) continue;
+    items.push({
+      id: `quote-created-${r.id}`,
+      type: 'quote',
+      action: 'created',
+      entityNumber: r.quote_number,
+      timestamp: r.created_at,
+      customerName: firstRel(r.customer)?.name ?? undefined,
+      href: `/dashboard/${companyId}/quotes/${r.id}`,
+    });
+  }
+  return items;
+}
+
+type ShipmentRow = {
+  id: string;
+  created_at: string;
+  job_id: string;
+  job: { job_number: string } | { job_number: string }[] | null;
+  customer: { name: string | null } | { name: string | null }[] | null;
+};
+
+async function fetchShipmentActivity(
+  companyId: string,
+  before: string | undefined,
+  perSource: number,
+): Promise<ActivityItem[]> {
+  const supabase = getSupabase();
+  let q = supabase
+    .from('shipments')
+    .select('id, created_at, job_id, job:jobs(job_number), customer:customers(name)')
+    .eq('company_id', companyId)
+    .order('created_at', { ascending: false })
+    .limit(perSource);
+  if (before) q = q.lt('created_at', before);
+
+  const { data } = await q;
+  const items: ActivityItem[] = [];
+  for (const r of (data ?? []) as unknown as ShipmentRow[]) {
+    if (!r.created_at) continue;
+    items.push({
+      id: `shipment-${r.id}`,
+      type: 'shipment',
+      action: 'shipped',
+      entityNumber: firstRel(r.job)?.job_number ?? '',
+      timestamp: r.created_at,
+      customerName: firstRel(r.customer)?.name ?? undefined,
+      href: `/dashboard/${companyId}/jobs/${r.job_id}`,
+    });
+  }
+  return items;
+}
+
+type NoteActivityRow = {
+  id: string;
+  created_at: string;
+  job_id: string;
+  job: { job_number: string } | { job_number: string }[] | null;
+  author: { name: string | null } | { name: string | null }[] | null;
+  media: { id: string }[] | null;
+};
+
+async function fetchNoteActivity(
+  companyId: string,
+  before: string | undefined,
+  perSource: number,
+): Promise<ActivityItem[]> {
+  const supabase = getSupabase();
+  let q = supabase
+    .from('job_notes')
+    .select('id, created_at, job_id, job:jobs(job_number), author:user_company_access(name), media:job_note_media(id)')
+    .eq('company_id', companyId)
+    .order('created_at', { ascending: false })
+    .limit(perSource);
+  if (before) q = q.lt('created_at', before);
+
+  const { data } = await q;
+  const items: ActivityItem[] = [];
+  for (const r of (data ?? []) as unknown as NoteActivityRow[]) {
+    if (!r.created_at) continue;
+    const hasMedia = (r.media ?? []).length > 0;
+    items.push({
+      id: `note-${r.id}`,
+      // A note carrying photos surfaces as a 'photo' event so the /activity
+      // filter can separate the two; text-only notes are 'note'.
+      type: hasMedia ? 'photo' : 'note',
+      action: hasMedia ? 'photo_added' : 'noted',
+      entityNumber: firstRel(r.job)?.job_number ?? '',
+      timestamp: r.created_at,
+      authorName: firstRel(r.author)?.name ?? undefined,
+      href: `/dashboard/${companyId}/jobs/${r.job_id}`,
+    });
+  }
+  return items;
+}
+
+type OperationActivityRow = {
+  id: string;
+  completed_at: string | null;
+  job_id: string;
+  jobs: { job_number: string } | { job_number: string }[] | null;
+};
+
+async function fetchOperationActivity(
+  companyId: string,
+  before: string | undefined,
+  perSource: number,
+): Promise<ActivityItem[]> {
+  const supabase = getSupabase();
+  // job_operations has no company_id; scope through the inner jobs join.
+  let q = supabase
+    .from('job_operations')
+    .select('id, completed_at, job_id, jobs!inner(job_number, company_id)')
+    .eq('jobs.company_id', companyId)
+    .not('completed_at', 'is', null)
+    .order('completed_at', { ascending: false })
+    .limit(perSource);
+  if (before) q = q.lt('completed_at', before);
+
+  const { data } = await q;
+  const items: ActivityItem[] = [];
+  for (const r of (data ?? []) as unknown as OperationActivityRow[]) {
+    if (!r.completed_at) continue;
+    items.push({
+      id: `op-${r.id}`,
+      type: 'operation',
+      action: 'completed',
+      entityNumber: firstRel(r.jobs)?.job_number ?? '',
+      timestamp: r.completed_at,
+      href: `/dashboard/${companyId}/jobs/${r.job_id}`,
+    });
+  }
+  return items;
+}
+
+async function collectActivity(
+  companyId: string,
+  { before, types, perSource = ACTIVITY_PER_SOURCE }: CollectOptions,
+): Promise<ActivityItem[]> {
+  const want = (t: ActivityType) => !types || types.includes(t);
+
+  const tasks: Promise<ActivityItem[]>[] = [];
+  if (want('job')) tasks.push(fetchJobActivity(companyId, before, perSource));
+  if (want('quote')) tasks.push(fetchQuoteActivity(companyId, before, perSource));
+  if (want('shipment')) tasks.push(fetchShipmentActivity(companyId, before, perSource));
+  // 'note' and 'photo' both come from job_notes (one query yields both kinds).
+  if (want('note') || want('photo')) tasks.push(fetchNoteActivity(companyId, before, perSource));
+  if (want('operation')) tasks.push(fetchOperationActivity(companyId, before, perSource));
+
+  const results = await Promise.all(tasks.map((t) => t.catch(() => [] as ActivityItem[])));
+  let items = results.flat();
+  if (types) items = items.filter((i) => types.includes(i.type));
+  items.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  return items;
+}
+
+/**
+ * Compact dashboard "Recent Activity" card: the latest manager-relevant
+ * business milestones (jobs created/completed, quotes created, shipments) —
+ * deliberately NOT the high-volume per-note/photo floor chatter, which lives on
+ * the dedicated /activity page. Newest first, capped (default 6).
+ */
+export async function getDashboardActivity(
+  companyId: string,
+  opts?: { limit?: number },
+): Promise<ActivityItem[]> {
+  const limit = opts?.limit ?? 6;
+  const items = await collectActivity(companyId, {
+    types: ['job', 'quote', 'shipment'],
+    perSource: Math.max(limit * 3, 12),
+  });
+  return items.slice(0, limit);
+}
+
+/**
+ * The dedicated /activity page stream: the full cross-module feed including
+ * floor activity (notes, photos, operation completions). Optionally filtered by
+ * type and paginated with a `before` cursor (pass the last item's timestamp to
+ * load older). Newest first.
+ */
+export async function getActivityStream(
+  companyId: string,
+  opts?: { types?: ActivityType[]; limit?: number; before?: string },
+): Promise<ActivityItem[]> {
+  const limit = opts?.limit ?? 30;
+  const items = await collectActivity(companyId, {
+    before: opts?.before,
+    types: opts?.types,
+    perSource: Math.max(limit, ACTIVITY_PER_SOURCE),
+  });
+  return items.slice(0, limit);
 }


### PR DESCRIPTION
## Phase 2 of the Activity Feature

Surfaces shop activity beyond a single job: a compact **"Recent Activity" card** on the dashboard (business milestones, glanceable) plus a dedicated **filterable `/activity` page** that exposes the cross-module stream — the floor activity (notes, photos, operation completions) that was previously trapped inside individual jobs.

Builds on P1 (#432). Progressive disclosure: the card stays manager-glanceable; "View all" hops to the full stream.

### Data (no migration — UNION-on-read)
- Extends the already-scaffolded `ActivityItem` / `RecentActivity` with `note`/`photo`/`shipment`/`operation` types.
- `getDashboardActivity()` — compact, capped business milestones (jobs created/completed, quotes, shipments) for the card.
- `getActivityStream()` — full feed incl. notes/photos/operation completions, filter-by-type + `before` cursor pagination.
- Both aggregate-on-read over `jobs`/`quotes`/`shipments`/`job_notes`/`job_operations` (mirrors the existing `getPartActivity`; **no materialized/fan-out table**). `company_id` leads every query.

### UI
- `components/dashboard/activityFormat.tsx` — one shared source for icons/labels/relative+absolute time across surfaces.
- `RecentActivity` wired into the dashboard (fetched in `useEffect`, **no AI on mount**), rows deep-link to the record, "View all" link.
- New `app/dashboard/[companyId]/activity/page.tsx` — filter chips + load-more.
- Sidebar "Activity" entry + header title.

### Notes
- Includes the **refreshed `schema.prod.sql`/`schema.staging.sql` snapshots** (regenerated after P1's prod push).
- Floor "chatter" (every note/photo) stays off the compact dashboard card and lives on `/activity` (keeps the card glanceable).

### Validation
- `tsc` clean · `pnpm lint` within budget · **735/735** unit tests pass (5 new for the activity feed) · embed check passes against the refreshed prod snapshot.

P3 (operator "last time we ran this part" guidance) is the remaining phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)