### PR TITLE
feat(operator): 'last time we ran this part' guidance (Activity P3)

### DIFF
--- a/__tests__/utils/operatorPreviousRun.test.ts
+++ b/__tests__/utils/operatorPreviousRun.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Per-table Supabase mock so the multi-query flow (job_parts → job_notes →
+// job_operations) can return distinct data per source.
+const DATA: {
+  jobParts: unknown[];
+  notes: unknown[];
+  curOp: unknown;
+  priorOps: unknown[];
+  error?: unknown;
+} = { jobParts: [], notes: [], curOp: null, priorOps: [] };
+
+function resolveData(state: { table: string; single: boolean }) {
+  if (DATA.error) return { data: null, error: DATA.error };
+  switch (state.table) {
+    case 'job_parts':
+      return { data: DATA.jobParts, error: null };
+    case 'job_notes':
+      return { data: DATA.notes, error: null };
+    case 'job_operations':
+      return { data: state.single ? DATA.curOp : DATA.priorOps, error: null };
+    default:
+      return { data: [], error: null };
+  }
+}
+
+function makeBuilder(table: string) {
+  const state = { table, single: false };
+  const b: Record<string, unknown> = {};
+  const ret = () => b;
+  b.select = vi.fn(ret);
+  b.eq = vi.fn(ret);
+  b.in = vi.fn(ret);
+  b.not = vi.fn(ret);
+  b.order = vi.fn(ret);
+  b.limit = vi.fn(ret);
+  b.lt = vi.fn(ret);
+  b.single = vi.fn(() => {
+    state.single = true;
+    return b;
+  });
+  b.then = (resolve: (v: unknown) => void) => resolve(resolveData(state));
+  return b;
+}
+
+const mockSupabase = { from: vi.fn((t: string) => makeBuilder(t)) };
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+vi.mock('@/lib/supabaseErrors', () => ({
+  friendlyErrorMessage: (_e: unknown, o?: { fallback?: string }) => o?.fallback ?? 'error',
+}));
+
+import { getPreviousRunForPart } from '@/utils/operatorAccess';
+
+function note(over: Record<string, unknown>) {
+  return {
+    id: 'n',
+    job_id: 'jNew',
+    job_operation_id: null,
+    body: 'x',
+    created_at: '2026-06-10T00:00:00Z',
+    author: null,
+    operation: null,
+    media: [],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  DATA.jobParts = [];
+  DATA.notes = [];
+  DATA.curOp = null;
+  DATA.priorOps = [];
+  delete DATA.error;
+});
+
+describe('getPreviousRunForPart', () => {
+  it('returns the newest completed prior run, excluding the current job', async () => {
+    DATA.jobParts = [
+      { job_id: 'jOld', completed_at: '2026-06-01T00:00:00Z', jobs: { id: 'jOld', job_number: 'J-OLD' } },
+      { job_id: 'jNew', completed_at: '2026-06-10T00:00:00Z', jobs: { id: 'jNew', job_number: 'J-NEW' } },
+      { job_id: 'jCur', completed_at: '2026-06-15T00:00:00Z', jobs: { id: 'jCur', job_number: 'J-CUR' } },
+    ];
+    DATA.notes = [note({ id: 'n1', body: 'setup notes' })];
+
+    const run = await getPreviousRunForPart('part-1', 'c1', { excludeJobId: 'jCur' });
+
+    expect(run).not.toBeNull();
+    expect(run!.jobId).toBe('jNew'); // newest non-excluded
+    expect(run!.jobNumber).toBe('J-NEW');
+    expect(run!.notes).toHaveLength(1);
+    expect(run!.notes[0].body).toBe('setup notes');
+  });
+
+  it('returns null when the only completed run is the current job', async () => {
+    DATA.jobParts = [
+      { job_id: 'jCur', completed_at: '2026-06-15T00:00:00Z', jobs: { id: 'jCur', job_number: 'J-CUR' } },
+    ];
+    const run = await getPreviousRunForPart('part-1', 'c1', { excludeJobId: 'jCur' });
+    expect(run).toBeNull();
+  });
+
+  it('returns null when there are no completed prior runs', async () => {
+    DATA.jobParts = [];
+    expect(await getPreviousRunForPart('part-1', 'c1', {})).toBeNull();
+  });
+
+  it('filters notes to the same step across runs via routing_operation_id', async () => {
+    DATA.jobParts = [
+      { job_id: 'jNew', completed_at: '2026-06-10T00:00:00Z', jobs: { id: 'jNew', job_number: 'J-NEW' } },
+    ];
+    DATA.curOp = { routing_operation_id: 'ro1', operation_name: 'Mill' };
+    DATA.priorOps = [
+      { id: 'opPrior', routing_operation_id: 'ro1', operation_name: 'Mill' },
+      { id: 'opOther', routing_operation_id: 'ro2', operation_name: 'Saw' },
+    ];
+    DATA.notes = [
+      note({ id: 'n1', job_operation_id: 'opPrior', body: 'this step' }),
+      note({ id: 'n2', job_operation_id: 'opOther', body: 'other step' }),
+      note({ id: 'n3', job_operation_id: null, body: 'general' }),
+    ];
+
+    const run = await getPreviousRunForPart('part-1', 'c1', {
+      excludeJobId: 'jCur',
+      jobOperationId: 'opCur',
+    });
+
+    expect(run!.notes).toHaveLength(1);
+    expect(run!.notes[0].body).toBe('this step');
+  });
+
+  it('returns null when the job_parts query errors', async () => {
+    DATA.error = { message: 'boom' };
+    expect(await getPreviousRunForPart('part-1', 'c1', {})).toBeNull();
+  });
+});

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -24,6 +24,7 @@ import {
 import { useStationContext } from '@/components/operator/OperatorStationContext';
 import StationSelector from '@/components/operator/StationSelector';
 import JobFeed from '@/components/operator/JobFeed';
+import PreviousRunCard from '@/components/operator/PreviousRunCard';
 import type { OperatorJobDetail } from '@/types/operator';
 
 /**
@@ -263,6 +264,17 @@ export default function OperatorOperationActionPage() {
           )}
         </CardContent>
       </Card>
+
+      {/* Setup guidance: how THIS step went on the last run of this part. */}
+      <Box sx={{ mb: 3 }}>
+        <PreviousRunCard
+          partId={job.part_id}
+          companyId={companyId}
+          excludeJobId={jobId}
+          jobOperationId={jobOperationId}
+          title="Last time, this step"
+        />
+      </Box>
 
       {isCompleted ? (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
@@ -19,6 +19,7 @@ import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { getJobPartTraveler } from '@/utils/operatorAccess';
 import JobFeed from '@/components/operator/JobFeed';
+import PreviousRunCard from '@/components/operator/PreviousRunCard';
 import type { JobTraveler, JobTravelerOperation } from '@/types/operator';
 
 const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
@@ -191,6 +192,16 @@ export default function OperatorJobTravelerPage() {
           per step on the operation pages. Bumped up top: operators use it a lot. */}
       <Box sx={{ mb: 3 }}>
         <JobFeed readOnly jobId={traveler.job_id} companyId={companyId} />
+      </Box>
+
+      {/* Guidance: how this part went last time (collapsed; part-centric). */}
+      <Box sx={{ mb: 3 }}>
+        <PreviousRunCard
+          partId={traveler.part_id}
+          companyId={companyId}
+          excludeJobId={traveler.job_id}
+          title="Last time we ran this part"
+        />
       </Box>
 
       {/* Operations / steps — tap one to action it */}

--- a/components/operator/PreviousRunCard.tsx
+++ b/components/operator/PreviousRunCard.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { useState } from 'react';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import IconButton from '@mui/material/IconButton';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import HistoryIcon from '@mui/icons-material/History';
+import CloseIcon from '@mui/icons-material/Close';
+import { getPreviousRunForPart } from '@/utils/operatorAccess';
+import { getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
+import type { PreviousRun, JobNoteMedia } from '@/types/operator';
+
+const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
+const THUMB = 72;
+
+interface PreviousRunCardProps {
+  partId: string;
+  companyId: string;
+  /** Exclude the current job so it never shows as its own "last time". */
+  excludeJobId: string;
+  /** When set, scopes the guidance to this step ("last time, this step"). */
+  jobOperationId?: string;
+  title: string;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return '';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function formatTimestamp(value: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+}
+
+/**
+ * "Last time we ran this part" guidance for operators. Collapsed by default;
+ * lazy-loads the most recent completed prior run's notes + setup photos on
+ * expand (fetch in the handler, not an effect). Part-centric, read-only, no
+ * operator time metrics. When `jobOperationId` is set, it's scoped to that step.
+ */
+export default function PreviousRunCard({
+  partId,
+  companyId,
+  excludeJobId,
+  jobOperationId,
+  title,
+}: PreviousRunCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [run, setRun] = useState<PreviousRun | null>(null);
+  const [mediaUrls, setMediaUrls] = useState<Record<string, string>>({});
+  const [viewerUrl, setViewerUrl] = useState<string | null>(null);
+
+  const handleExpand = async (_e: React.SyntheticEvent, isExpanded: boolean) => {
+    setExpanded(isExpanded);
+    if (!isExpanded || loaded) return;
+    setLoading(true);
+    try {
+      const r = await getPreviousRunForPart(partId, companyId, { excludeJobId, jobOperationId });
+      setRun(r);
+      if (r) {
+        const media = r.notes.flatMap((n) => n.media);
+        const pairs = await Promise.all(
+          media.map(async (m) => {
+            try {
+              return [m.id, await getJobNoteMediaUrl(m.thumbnail_path ?? m.storage_path)] as const;
+            } catch {
+              return null;
+            }
+          }),
+        );
+        const urls: Record<string, string> = {};
+        for (const p of pairs) if (p) urls[p[0]] = p[1];
+        setMediaUrls(urls);
+      }
+    } catch {
+      setRun(null);
+    } finally {
+      setLoading(false);
+      setLoaded(true);
+    }
+  };
+
+  const openViewer = async (media: JobNoteMedia) => {
+    try {
+      setViewerUrl(await getJobNoteMediaUrl(media.storage_path));
+    } catch {
+      /* ignore — thumbnail stays */
+    }
+  };
+
+  const emptyMessage = jobOperationId
+    ? 'No notes recorded for this step last time.'
+    : 'The last run had no notes.';
+
+  return (
+    <Accordion
+      expanded={expanded}
+      onChange={handleExpand}
+      elevation={2}
+      disableGutters
+      sx={{ ...cardSx, '&:before': { display: 'none' }, borderRadius: '8px !important' }}
+    >
+      <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 56 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <HistoryIcon fontSize="small" color="action" />
+          <Typography variant="subtitle1" color="text.secondary">
+            {title}
+          </Typography>
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails sx={{ pt: 0 }}>
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+            <CircularProgress size={20} />
+          </Box>
+        ) : !run ? (
+          <Typography variant="body2" color="text.secondary">
+            No previous runs of this part.
+          </Typography>
+        ) : (
+          <Box>
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+              {run.jobNumber}
+              {run.completedAt ? ` · completed ${formatDate(run.completedAt)}` : ''}
+            </Typography>
+
+            {run.notes.length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                {emptyMessage}
+              </Typography>
+            ) : (
+              <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                {run.notes.map((note, idx) => (
+                  <Box key={note.id}>
+                    {idx > 0 && <Divider sx={{ my: 1 }} />}
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.25 }}>
+                      <Typography variant="subtitle2" fontWeight={700} noWrap>
+                        {note.author_name || 'Unknown'}
+                      </Typography>
+                      {note.operation_label && (
+                        <Chip size="small" label={note.operation_label} variant="outlined" />
+                      )}
+                      <Box sx={{ flex: 1 }} />
+                      <Typography variant="caption" color="text.secondary">
+                        {formatTimestamp(note.created_at)}
+                      </Typography>
+                    </Box>
+                    {note.body && (
+                      <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                        {note.body}
+                      </Typography>
+                    )}
+                    {note.media.length > 0 && (
+                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
+                        {note.media.map((m) => {
+                          const url = mediaUrls[m.id];
+                          return (
+                            <Box
+                              key={m.id}
+                              onClick={() => url && openViewer(m)}
+                              sx={{
+                                width: THUMB,
+                                height: THUMB,
+                                borderRadius: 1,
+                                overflow: 'hidden',
+                                cursor: url ? 'pointer' : 'default',
+                                bgcolor: 'rgba(255,255,255,0.06)',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                              }}
+                            >
+                              {url ? (
+                                <Box
+                                  component="img"
+                                  src={url}
+                                  alt="Past run photo"
+                                  sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                                />
+                              ) : (
+                                <CircularProgress size={16} />
+                              )}
+                            </Box>
+                          );
+                        })}
+                      </Box>
+                    )}
+                  </Box>
+                ))}
+              </Box>
+            )}
+          </Box>
+        )}
+      </AccordionDetails>
+
+      <Dialog open={!!viewerUrl} onClose={() => setViewerUrl(null)} fullScreen>
+        <IconButton
+          aria-label="Close"
+          onClick={() => setViewerUrl(null)}
+          sx={{ position: 'absolute', right: 12, top: 12, zIndex: 1, color: 'common.white' }}
+        >
+          <CloseIcon />
+        </IconButton>
+        <DialogContent
+          sx={{ p: 0, bgcolor: 'background.default', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+        >
+          {viewerUrl && (
+            <Box
+              component="img"
+              src={viewerUrl}
+              alt="Past run photo"
+              sx={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </Accordion>
+  );
+}

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -62,6 +62,8 @@ export interface OperatorJobDetail {
   id: string;
   /** Parent job id (for the back-to-parts-hub navigation). */
   job_id: string;
+  /** The made part this job_part produces (for part-scoped guidance). */
+  part_id: string;
   job_number: string;
   customer_name: string | null;
   part_name: string | null;
@@ -174,6 +176,20 @@ export interface JobNote {
   author_name: string | null;
   /** Attached photos/videos, in insertion order. */
   media: JobNoteMedia[];
+}
+
+/**
+ * A prior completed run of the same part, used as operator guidance ("last time
+ * we ran this part"). Part-centric, never operator-comparative. `notes` are that
+ * run's feed entries (with media); when fetched for a specific step they're
+ * filtered to that step's matching operation.
+ */
+export interface PreviousRun {
+  jobId: string;
+  jobNumber: string;
+  /** When the part finished on that run; null if not recorded. */
+  completedAt: string | null;
+  notes: JobNote[];
 }
 
 // ============================================================================

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -33,6 +33,7 @@ import type {
   JobTravelerOperation,
   JobNote,
   JobNoteMedia,
+  PreviousRun,
 } from '@/types/operator';
 
 // Operator type from user_company_access. role and created_at are
@@ -295,6 +296,7 @@ export async function getOperatorJobs(
 interface PartHeaderForDetail {
   id: string;
   job_id: string;
+  part_id: string;
   quantity: number;
   production_status: string;
   job_number: string;
@@ -328,7 +330,7 @@ async function loadPartHeader(
   const { data: part, error } = await supabase
     .from('job_parts')
     .select(`
-      id, job_id, production_status, quantity,
+      id, job_id, part_id, production_status, quantity,
       parts(part_name, description),
       jobs!inner(id, job_number, customers(name))
     `)
@@ -341,6 +343,7 @@ async function loadPartHeader(
   type PartRow = {
     id: string;
     job_id: string;
+    part_id: string;
     production_status: string;
     quantity: number;
     parts: { part_name: string; description: string | null } | { part_name: string; description: string | null }[] | null;
@@ -356,6 +359,7 @@ async function loadPartHeader(
   return {
     id: p.id,
     job_id: p.job_id,
+    part_id: p.part_id,
     quantity: p.quantity,
     production_status: p.production_status,
     job_number: jobJoin?.job_number ?? '',
@@ -398,6 +402,7 @@ async function assembleJobPartDetail(
   return {
     id: header.id,
     job_id: header.job_id,
+    part_id: header.part_id,
     job_number: header.job_number,
     customer_name: header.customer_name,
     part_name: header.part_name,
@@ -880,4 +885,86 @@ export async function addJobNote(
   }
 
   return mapJobNoteRow(data as unknown as JobNoteRow);
+}
+
+/**
+ * "Last time we ran this part" guidance: the most recent COMPLETED prior run of
+ * the same part (excluding the current job), with that run's feed (notes +
+ * photos) for the operator to reference — e.g. the setup photo from last time.
+ *
+ * Part-centric (keyed on part_id), never operator-comparative — no time metrics.
+ * When `jobOperationId` is given, the returned notes are filtered to the SAME
+ * step across runs (matched by routing_operation_id, falling back to
+ * operation_name), so the operation page can show "last time, this step".
+ * Returns null when there's no prior completed run.
+ */
+export async function getPreviousRunForPart(
+  partId: string,
+  companyId: string,
+  opts?: { excludeJobId?: string; jobOperationId?: string },
+): Promise<PreviousRun | null> {
+  const supabase = getSupabase();
+
+  // Completed prior runs of this part (job_parts carries part-level completion
+  // + company_id). Low volume per part, so pick the newest in JS.
+  const { data, error } = await supabase
+    .from('job_parts')
+    .select('job_id, completed_at, jobs!inner(id, job_number)')
+    .eq('part_id', partId)
+    .eq('company_id', companyId)
+    .eq('production_status', 'completed');
+
+  if (error || !data) return null;
+
+  type PriorRow = {
+    job_id: string;
+    completed_at: string | null;
+    jobs: { id: string; job_number: string } | { id: string; job_number: string }[] | null;
+  };
+  const rows = (data as unknown as PriorRow[]).filter(
+    (r) => r.job_id !== opts?.excludeJobId,
+  );
+  if (rows.length === 0) return null;
+
+  // Newest completed first (nulls last).
+  rows.sort((a, b) => (b.completed_at ?? '').localeCompare(a.completed_at ?? ''));
+  const prior = rows[0];
+  const priorJob = Array.isArray(prior.jobs) ? prior.jobs[0] : prior.jobs;
+  if (!priorJob) return null;
+
+  let notes = await getJobNotes(prior.job_id, companyId);
+
+  // Per-step filtering: match the same operation across runs.
+  if (opts?.jobOperationId) {
+    const { data: curOp } = await supabase
+      .from('job_operations')
+      .select('routing_operation_id, operation_name')
+      .eq('id', opts.jobOperationId)
+      .single();
+
+    const { data: priorOps } = await supabase
+      .from('job_operations')
+      .select('id, routing_operation_id, operation_name')
+      .eq('job_id', prior.job_id);
+
+    type OpRow = { id: string; routing_operation_id: string | null; operation_name: string };
+    const cur = curOp as { routing_operation_id: string | null; operation_name: string } | null;
+    const matchIds = new Set(
+      ((priorOps ?? []) as OpRow[])
+        .filter((op) =>
+          cur?.routing_operation_id && op.routing_operation_id
+            ? op.routing_operation_id === cur.routing_operation_id
+            : op.operation_name === cur?.operation_name,
+        )
+        .map((op) => op.id),
+    );
+    notes = notes.filter((n) => n.job_operation_id && matchIds.has(n.job_operation_id));
+  }
+
+  return {
+    jobId: priorJob.id,
+    jobNumber: priorJob.job_number,
+    completedAt: prior.completed_at,
+    notes,
+  };
 }


### PR DESCRIPTION
## Phase 3 of the Activity Feature (final phase)

Gives operators **guidance from prior runs of the same part** — the last completed run's notes and **setup photos** — so they can see "how we did this last time." Part-centric, read-only, **no operator time metrics or comparison** (per the gamification guardrails).

Builds on P1 (job feed + photos) and P2 (activity stream). No migration.

### Access
- `getPreviousRunForPart(partId, companyId, { excludeJobId, jobOperationId? })` — finds the most recent **completed** prior run of the part (via `job_parts → jobs`, excluding the current job), returns that run's feed (notes + media) through the P1 `getJobNotes`. With a `jobOperationId`, it filters to the **same step across runs**, matched by `routing_operation_id` (fallback `operation_name`) — the "last time, this step" setup help.
- Surfaces `part_id` on `OperatorJobDetail` (additive) so the operation page can scope per-step.

### UI — `PreviousRunCard` (collapsed, lazy-loaded on expand; fetch in the handler, not an effect)
- **Traveler:** "Last time we ran this part" — the whole prior run's notes/photos.
- **Operation page:** "Last time, this step" — setup guidance for the exact step, right where operators work (they land here via the per-operation QR).
- Two-tier disclosure, read-only, tap a photo for full-size. Quiet empty states ("No previous runs of this part.").

### Validation
- `tsc` clean · `pnpm lint` within budget (no new warnings — fetch is handler-driven, not an effect) · **740/740** unit tests pass (5 new for `getPreviousRunForPart`) · embed check clean.

This completes the three-phase Activity Feature: P1 capture (#432), P2 dashboard/activity (#433), P3 guidance (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)