### PR TITLE
fix(pricing): part tier unit-price override no longer reverts on save

### DIFF
--- a/__tests__/types/quote.test.ts
+++ b/__tests__/types/quote.test.ts
@@ -86,9 +86,31 @@ describe('calculateMarkupFromUnitPrice', () => {
     expect(calculateMarkupFromUnitPrice(100, 100)).toBe(0);
   });
 
-  it('rounds to 2 decimal places', () => {
-    // $139.39 from $103.25 = ((139.39 - 103.25) / 103.25) * 100 = 35.0024...
-    expect(calculateMarkupFromUnitPrice(103.25, 139.39)).toBeCloseTo(35, 0);
+  it('rounds to 6 decimal places (matches numeric(10,6) markup column)', () => {
+    // $139.39 from $103.25 = ((139.39 - 103.25) / 103.25) * 100 = 35.002421...
+    expect(calculateMarkupFromUnitPrice(103.25, 139.39)).toBe(35.002421);
+  });
+});
+
+describe('unit-price ⇄ markup round-trip', () => {
+  // A unit price the user types must survive the back-solve-to-markup →
+  // store-as-numeric(10,6) → recompute-price path and land back on the exact
+  // cent. The old numeric(5,2) (2-dp markup) quantized achievable prices ~1.4¢
+  // apart near a typical base, so $140.00 on a $139.98 base snapped to $139.99.
+  // numeric(10,6) (6-dp markup) round-trips exactly for any base < $1,000,000.
+  const cases: Array<[base: number, typedPrice: number]> = [
+    [139.98, 140], // the reported bug: base just over the old $100 safe limit
+    [139.98, 140.01],
+    [103.25, 139.39],
+    [100.01, 137.77],
+    [1000.0, 1234.56],
+    [9999.99, 12500.0], // large base — still well under the $1M limit
+  ];
+
+  it.each(cases)('base $%s, typed price $%s round-trips to the cent', (base, typedPrice) => {
+    const markup = calculateMarkupFromUnitPrice(base, typedPrice);
+    expect(markup).not.toBeNull();
+    expect(calculateUnitPriceFromMarkup(base, markup as number)).toBe(typedPrice);
   });
 });
 

--- a/supabase/migrations/20260623134506_widen_part_pricing_markup_precision.sql
+++ b/supabase/migrations/20260623134506_widen_part_pricing_markup_precision.sql
@@ -1,0 +1,16 @@
+-- Widen part_pricing_tiers.markup_percent precision so a user-typed unit price
+-- round-trips to the exact cent.
+--
+-- markup_percent is the single source of truth for a part tier (the unit_price /
+-- base_cost columns were dropped in 20260514 so price always re-derives from cost).
+-- When a user overrides the unit price, the UI back-solves the markup and saves
+-- that. At numeric(5,2) the markup was quantized to 0.01%, which near a typical
+-- base (~$140) spaces achievable prices ~1.4¢ apart — so an exact $140.00 snapped
+-- down to $139.99 on reload.
+--
+-- numeric(10,6): 4 integer digits + 6 decimals (max 9999.999999). This only
+-- widens the type — every existing value (<= 999.99) fits unchanged, so no
+-- backfill is required. 6 decimals of percent gives price resolution base x 1e-8,
+-- far finer than a cent for any realistic base.
+ALTER TABLE public.part_pricing_tiers
+  ALTER COLUMN markup_percent TYPE numeric(10,6);

--- a/supabase/schema.staging.sql
+++ b/supabase/schema.staging.sql
@@ -1,6 +1,6 @@
 -- ============================================================
 -- Jigged Manufacturing Data Platform - Database Schema
--- Generated: 2026-06-23T13:00:20Z
+-- Generated: 2026-06-23T13:49:44Z
 -- Schemas: public, storage
 -- ============================================================
 
@@ -529,7 +529,7 @@ CREATE TABLE IF NOT EXISTS "public"."part_pricing_tiers"
     "company_id" uuid NOT NULL,
     "sequence" integer NOT NULL,
     "quantity" integer NOT NULL,
-    "markup_percent" numeric(5,2),
+    "markup_percent" numeric(10,6),
     "created_at" timestamp with time zone NOT NULL DEFAULT now(),
     "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
     CONSTRAINT "part_pricing_tiers_pkey" PRIMARY KEY (id),

--- a/types/quote.ts
+++ b/types/quote.ts
@@ -436,11 +436,19 @@ export function calculateUnitPriceFromMarkup(baseCost: number, markupPercent: nu
 /**
  * Back-calculate markup percentage from base cost and unit price.
  * markup = ((unit_price - base_cost) / base_cost) × 100
+ *
+ * Rounded to 6 decimals to match `part_pricing_tiers.markup_percent`'s
+ * numeric(10,6) precision. Markup is the stored source of truth for a part
+ * tier, so a unit price the user types is persisted as this markup and
+ * re-expanded on read. Rounding any coarser (the old numeric(5,2) / 2-dp)
+ * quantized achievable prices ~1.4¢ apart near a typical base, so an exact
+ * $140.00 snapped down to $139.99 on reload. 6 decimals lets the typed price
+ * round-trip to the cent.
  */
 export function calculateMarkupFromUnitPrice(baseCost: number, unitPrice: number): number | null {
   if (isNaN(baseCost) || baseCost <= 0) return null;
   if (isNaN(unitPrice) || unitPrice < 0) return null;
-  return Math.round(((unitPrice - baseCost) / baseCost) * 100 * 100) / 100;
+  return Math.round(((unitPrice - baseCost) / baseCost) * 100 * 1e6) / 1e6;
 }
 
 /**


### PR DESCRIPTION
## Problem

On **Part Details → Pricing**, typing a unit price (e.g. `$140`) over the computed value and clicking **Save pricing** reverts it to a lower value (`$139.99`) after save.

## Root cause

`markup_percent` is the single source of truth for a part tier — unit price always re-derives as `base × (1 + markup/100)` (the `unit_price`/`base_cost` columns were deliberately dropped in `20260514`). When a user overrides the price, the UI back-solves the markup and persists *that*. Two layers truncated it:

1. `calculateMarkupFromUnitPrice` rounded the markup to **2 decimals** — `0.014288%` → `0.01%`.
2. The column `part_pricing_tiers.markup_percent` was **`numeric(5,2)`** — physically can't hold more than 2 decimals.

At 2-dp the markup quantizes achievable prices ~1.4¢ apart near a typical base, so `$140.00` collapsed to `0.01%` → `$139.99` on reload.

## Is `numeric(10,6)` enough?

Yes, with large margin. Round-trip error is bounded by `base × 0.5 × 10⁻⁽ᴺ⁺²⁾`; landing on the exact cent requires `base < 10ᴺ`.

- Old N=2 → safe only below **$100** (the `$139.98` base was just over → broke).
- New N=6 → safe below **$1,000,000**.

## Approach

Keep **markup as the single source of truth** (no second column re-added — `20260514` intent preserved), but widen markup precision so a typed unit price round-trips to the exact cent. Trade-off: if the part's cost later changes, the price re-derives from the stored markup (intended cost-plus behavior).

## Changes

- **Migration** `20260623134506_widen_part_pricing_markup_precision.sql` — `ALTER COLUMN markup_percent TYPE numeric(10,6)` (widen-only, no backfill; existing ≤999.99 values fit).
- `types/quote.ts` — `calculateMarkupFromUnitPrice` rounds to 6 decimals to match the column.
- `__tests__/types/quote.test.ts` — multi-base unit-price ⇄ markup round-trip regression test (incl. the reported `$139.98 → $140` case).
- `supabase/schema.staging.sql` — refreshed snapshot (now `numeric(10,6)`).

No UI change needed: `handleUnitPriceChange` already stores `String(back)` and the save/reload path is unchanged — it just no longer loses precision. The Markup % field now shows the precise back-solved value (e.g. `0.014288`) in override cases; ordinary markups (25%, etc.) are unaffected.

## Verification

- ✅ `pnpm test --run __tests__/types/quote.test.ts` — 38 pass (incl. round-trip)
- ✅ `routingCostCalculation` + `partPricingTiersAccess` suites — 25 pass
- ✅ `pnpm exec tsc --noEmit` — clean
- ✅ Migration applied to **Jigged Staging**; column confirmed `numeric(10,6)`

## Prod migration (owner: human)

Not yet pushed to prod. After merge:
```
supabase link --project-ref mayuquvexmqjvwkfasxg   # Jigged (prod)
supabase db push
```
Then `python scripts/export_schema.py` + `pnpm gen:db-types` to refresh both snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)