### PR TITLE
feat(operator): tag an inventory removal to a job (manual pick) — Phase 1

### DIFF
--- a/__tests__/components/operator/OperatorBinView.test.tsx
+++ b/__tests__/components/operator/OperatorBinView.test.tsx
@@ -29,11 +29,14 @@ vi.mock('@/utils/operatorAccess', () => ({
   getCurrentOperator: vi.fn(),
 }));
 
-// The bin view embeds the "Stock a part" receive modal, which imports
-// partsAccess (→ lib/supabase). Mock it so the module graph doesn't eval the
-// real Supabase client. The modal isn't opened in these tests.
+// The bin view embeds modals that import partsAccess + jobsAccess
+// (→ lib/supabase). Mock them so the module graph doesn't eval the real
+// Supabase client. (getAllJobs loads on the deplete modal's onEnter.)
 vi.mock('@/utils/partsAccess', () => ({
   getStockedParts: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/utils/jobsAccess', () => ({
+  getAllJobs: vi.fn().mockResolvedValue([]),
 }));
 
 const loc = (over: { id: string; name: string; code?: string | null; parent_id?: string | null }) => ({

--- a/__tests__/components/operator/OperatorLocationActionModal.test.tsx
+++ b/__tests__/components/operator/OperatorLocationActionModal.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@mui/material/styles';
+import jiggedTheme from '@/lib/theme';
+
+import OperatorLocationActionModal from '@/components/operator/OperatorLocationActionModal';
+import { depleteStockAtLocation } from '@/utils/inventoryLocationsAccess';
+import { getAllJobs } from '@/utils/jobsAccess';
+import type { JobWithRelations } from '@/types/job';
+
+vi.mock('@/utils/inventoryLocationsAccess', () => ({
+  addStockAtLocation: vi.fn(),
+  depleteStockAtLocation: vi.fn(),
+  adjustStockAtLocation: vi.fn(),
+}));
+vi.mock('@/utils/jobsAccess', () => ({ getAllJobs: vi.fn() }));
+
+const job = (over: { id: string; job_number: string; parts: string[] }) =>
+  ({
+    id: over.id,
+    job_number: over.job_number,
+    job_parts: over.parts.map((n) => ({ parts: { part_name: n } })),
+  }) as unknown as JobWithRelations;
+
+const renderModal = (props: Partial<React.ComponentProps<typeof OperatorLocationActionModal>> = {}) =>
+  render(
+    <OperatorLocationActionModal
+      open
+      action="deplete"
+      companyId="co1"
+      partId="p1"
+      partName="Steel Rod"
+      currentQuantity={12}
+      primaryUnit="ea"
+      unitOptions={['ea']}
+      locationId="loc1"
+      locationName="Bin 3"
+      operatorId="op1"
+      onClose={vi.fn()}
+      onDone={vi.fn()}
+      {...props}
+    />,
+    { wrapper: ({ children }) => <ThemeProvider theme={jiggedTheme}>{children}</ThemeProvider> },
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getAllJobs as ReturnType<typeof vi.fn>).mockResolvedValue([
+    job({ id: 'j1', job_number: 'JOB-001', parts: ['Bracket', 'Pin'] }),
+    job({ id: 'j2', job_number: 'JOB-002', parts: ['Flange'] }),
+  ]);
+  (depleteStockAtLocation as ReturnType<typeof vi.fn>).mockResolvedValue({ location_balance: 7, part_quantity: 7 });
+});
+
+describe('OperatorLocationActionModal — deplete job tag', () => {
+  it('lists active jobs with their parts and tags the removal with the chosen job', async () => {
+    renderModal();
+
+    await userEvent.type(screen.getByRole('spinbutton', { name: /quantity/i }), '5');
+
+    await userEvent.click(await screen.findByRole('combobox', { name: /tag to a job/i }));
+    await userEvent.keyboard('{ArrowDown}');
+    const option = await screen.findByRole('option', { name: /JOB-001/ });
+    expect(option).toHaveTextContent('Bracket, Pin'); // the job's parts disambiguate it
+    await userEvent.click(option);
+
+    await userEvent.click(screen.getByRole('button', { name: /^remove$/i }));
+    await waitFor(() =>
+      expect(depleteStockAtLocation).toHaveBeenCalledWith(
+        'p1',
+        'loc1',
+        5,
+        'ea',
+        expect.objectContaining({ jobId: 'j1', graceful: true, operatorId: 'op1' }),
+      ),
+    );
+  });
+
+  it('leaves the removal untagged when no job is picked', async () => {
+    renderModal();
+    await userEvent.type(screen.getByRole('spinbutton', { name: /quantity/i }), '3');
+    await userEvent.click(screen.getByRole('button', { name: /^remove$/i }));
+    await waitFor(() =>
+      expect(depleteStockAtLocation).toHaveBeenCalledWith(
+        'p1',
+        'loc1',
+        3,
+        'ea',
+        expect.objectContaining({ jobId: undefined }),
+      ),
+    );
+  });
+});

--- a/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
+++ b/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
@@ -246,6 +246,7 @@ export default function OperatorBinViewPage() {
         <OperatorLocationActionModal
           open
           action={modal.action}
+          companyId={companyId}
           partId={modal.part.part_id}
           partName={modal.part.part_name}
           currentQuantity={modal.part.quantity}

--- a/components/operator/OperatorLocationActionModal.tsx
+++ b/components/operator/OperatorLocationActionModal.tsx
@@ -9,7 +9,9 @@ import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import Autocomplete from '@mui/material/Autocomplete';
 import Alert from '@mui/material/Alert';
 
 import {
@@ -17,6 +19,18 @@ import {
   depleteStockAtLocation,
   adjustStockAtLocation,
 } from '@/utils/inventoryLocationsAccess';
+import { getAllJobs } from '@/utils/jobsAccess';
+import type { JobWithRelations, ProductionStatus } from '@/types/job';
+
+// Active jobs an operator could be consuming material for.
+const ACTIVE_STATUSES: ProductionStatus[] = ['not_started', 'in_progress'];
+
+/** "Part A, Part B" — the job's parts, to disambiguate look-alike job numbers. */
+const jobPartsLabel = (j: JobWithRelations): string =>
+  (j.job_parts ?? [])
+    .map((jp) => jp.parts?.part_name)
+    .filter((n): n is string => Boolean(n))
+    .join(', ');
 
 export type OperatorLocationAction = 'add' | 'deplete' | 'adjust';
 
@@ -35,6 +49,7 @@ const CONFIRM: Record<OperatorLocationAction, string> = {
 interface OperatorLocationActionModalProps {
   open: boolean;
   action: OperatorLocationAction;
+  companyId: string;
   partId: string;
   partName: string;
   /** Current on-hand at this location, for context. */
@@ -59,6 +74,7 @@ interface OperatorLocationActionModalProps {
 export default function OperatorLocationActionModal({
   open,
   action,
+  companyId,
   partId,
   partName,
   currentQuantity,
@@ -76,11 +92,27 @@ export default function OperatorLocationActionModal({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleEnter = () => {
+  // Optional job tag, deplete only. Loaded on open via onEnter (house
+  // convention — not a useEffect, which would trip set-state-in-effect lint).
+  const [jobs, setJobs] = useState<JobWithRelations[]>([]);
+  const [loadingJobs, setLoadingJobs] = useState(false);
+  const [job, setJob] = useState<JobWithRelations | null>(null);
+
+  const handleEnter = async () => {
     setQuantity('');
     setUnit(primaryUnit);
     setNotes('');
     setError(null);
+    setJob(null);
+    if (action !== 'deplete') return;
+    setLoadingJobs(true);
+    try {
+      setJobs(await getAllJobs(companyId, { productionStatus: ACTIVE_STATUSES }));
+    } catch {
+      setJobs([]); // job tag is optional — never block the removal
+    } finally {
+      setLoadingJobs(false);
+    }
   };
 
   const qtyLabel = action === 'adjust' ? 'New quantity here' : 'Quantity';
@@ -101,6 +133,7 @@ export default function OperatorLocationActionModal({
           graceful: true,
           notes: notes || undefined,
           operatorId: operatorId || undefined,
+          jobId: job?.id || undefined, // tie to the job, not an operation
         });
       } else {
         await adjustStockAtLocation(partId, locationId, qty, unit, notes || undefined);
@@ -158,6 +191,34 @@ export default function OperatorLocationActionModal({
               Removing more than is here records the shortfall and sets the count to zero — it
               won&apos;t block you.
             </Typography>
+          )}
+          {action === 'deplete' && (
+            <Autocomplete
+              options={jobs}
+              loading={loadingJobs}
+              value={job}
+              onChange={(_, v) => setJob(v)}
+              getOptionLabel={(j) => j.job_number}
+              isOptionEqualToValue={(a, b) => a.id === b.id}
+              renderOption={(props, j) => {
+                const { key, ...rest } = props;
+                return (
+                  <Box component="li" key={key} {...rest}>
+                    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                      <Typography variant="body2">{j.job_number}</Typography>
+                      {jobPartsLabel(j) && (
+                        <Typography variant="caption" color="text.secondary">
+                          {jobPartsLabel(j)}
+                        </Typography>
+                      )}
+                    </Box>
+                  </Box>
+                );
+              }}
+              renderInput={(params) => <TextField {...params} label="Tag to a job (optional)" />}
+              noOptionsText="No active jobs"
+              loadingText="Loading jobs…"
+            />
           )}
           <TextField
             label="Notes (optional)"


### PR DESCRIPTION
## What & why

When an operator **Removes** stock at a location (bin view), they can now optionally **tag the removal to a JOB** — giving per-job material traceability/costing from the shop floor. Today a removal is ad-hoc.

This is **Phase 1 (manual pick)** of a phased plan; **scanning a job traveler QR is a fast-follow** (it needs an in-app camera/QR-decode lib + on-device validation).

## Changes
- **`OperatorLocationActionModal`** (deplete action only): a **"Tag to a job (optional)"** Autocomplete of **active jobs** (`not_started` / `in_progress`), each option rendered with the job's **part names** so look-alike job numbers are easy to disambiguate. Loaded on the Dialog `onEnter` (house convention — not a `useEffect`, which would trip the `set-state-in-effect` lint budget). The removal carries **`jobId` only** (not `job_operation_id`) — tie to the **job**, not an operation.
- Bin view passes `companyId` to the modal.

## No DB change
The deplete RPC (`deplete_stock_at_location`) and the `inventory_transactions` ledger already store `job_id`/`job_operation_id` (both nullable), and `DepleteOptions.jobId` is already forwarded. Reuses `getAllJobs(companyId, { productionStatus })` — returns jobs **with their parts in one query** and isn't station-gated.

## Industry alignment
Matches how **JobBOSS² / ProShop / Fulcrum** cost material **to the work order (job)** while floor scans are operation/traveler-level for labor — material rolls up to the job. Manual scan-to-issue (vs. backflush) is the right default for high-mix precision shops.

## Validation
`tsc` clean; full **Vitest 748** (2 new: lists active jobs with parts + tags `jobId`; untagged removal omits `jobId`); `lint` exit 0 (modal adds 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)