### PR TITLE
feat(pricing): fractional order quantities for non-count parts

### DIFF
--- a/__tests__/components/quotes/QuoteForm.test.tsx
+++ b/__tests__/components/quotes/QuoteForm.test.tsx
@@ -213,6 +213,26 @@ describe('QuoteForm', () => {
     });
   });
 
+  it('accepts a fractional order quantity (parts sold by length/weight) and forwards it', async () => {
+    render(<QuoteForm mode="create" initialData={initialPopulated} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create quote/i })).toBeEnabled();
+    });
+
+    const user = userEvent.setup();
+    const qtyInput = screen.getByLabelText('Order quantity');
+    await user.clear(qtyInput);
+    await user.type(qtyInput, '0.32');
+    await user.click(screen.getByRole('button', { name: /create quote/i }));
+
+    await waitFor(() => {
+      expect(createQuote).toHaveBeenCalledTimes(1);
+    });
+    const [, payload] = createQuote.mock.calls[0];
+    expect(payload.parts).toEqual([{ part_id: 'part-1', order_quantity: 0.32 }]);
+  });
+
   it('calls updateQuote with the payload and navigates on success', async () => {
     render(
       <QuoteForm mode="edit" quoteId="q-existing" initialData={initialPopulated} />,

--- a/__tests__/lib/quantityInput.test.ts
+++ b/__tests__/lib/quantityInput.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MAX_QUANTITY_DECIMALS,
+  isValidQuantityInput,
+  isValidQuantityValue,
+} from '@/lib/quantityInput';
+
+describe('quantityInput: isValidQuantityInput', () => {
+  it('accepts whole numbers and the empty (cleared) field', () => {
+    expect(isValidQuantityInput('')).toBe(true);
+    expect(isValidQuantityInput('0')).toBe(true);
+    expect(isValidQuantityInput('12')).toBe(true);
+  });
+
+  it('accepts decimals up to 4 places — the fractional-unit cases', () => {
+    expect(isValidQuantityInput('0.32')).toBe(true); // the reported customer case
+    expect(isValidQuantityInput('12.5')).toBe(true);
+    expect(isValidQuantityInput('0.1875')).toBe(true); // 3/16" — exactly 4 dp
+    expect(isValidQuantityInput('.')).toBe(true); // transient input state
+    expect(isValidQuantityInput('0.')).toBe(true);
+  });
+
+  it('rejects more than 4 decimal places', () => {
+    expect(isValidQuantityInput('0.32567')).toBe(false);
+    expect(isValidQuantityInput('1.00001')).toBe(false);
+  });
+
+  it('rejects signs, separators, and non-numeric junk', () => {
+    expect(isValidQuantityInput('-1')).toBe(false);
+    expect(isValidQuantityInput('1.2.3')).toBe(false);
+    expect(isValidQuantityInput('1,000')).toBe(false);
+    expect(isValidQuantityInput('1e3')).toBe(false);
+    expect(isValidQuantityInput('abc')).toBe(false);
+  });
+});
+
+describe('quantityInput: isValidQuantityValue (save guard)', () => {
+  it('accepts finite, positive, <=4-dp values', () => {
+    expect(isValidQuantityValue(0.32)).toBe(true);
+    expect(isValidQuantityValue(12)).toBe(true);
+    expect(isValidQuantityValue(0.1875)).toBe(true);
+  });
+
+  it('rejects zero, negatives, and non-finite values', () => {
+    expect(isValidQuantityValue(0)).toBe(false);
+    expect(isValidQuantityValue(-1)).toBe(false);
+    expect(isValidQuantityValue(NaN)).toBe(false);
+    expect(isValidQuantityValue(Infinity)).toBe(false);
+  });
+
+  it('rejects values finer than the precision cap (paste / programmatic paths)', () => {
+    expect(isValidQuantityValue(0.00001)).toBe(false); // 5 dp
+    expect(isValidQuantityValue(0.123456)).toBe(false);
+  });
+});
+
+describe('quantityInput: MAX_QUANTITY_DECIMALS', () => {
+  it('is 4 — the manufacturing-practical ceiling (machining tenths)', () => {
+    expect(MAX_QUANTITY_DECIMALS).toBe(4);
+  });
+});

--- a/__tests__/lib/standardUnits.test.ts
+++ b/__tests__/lib/standardUnits.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { unitShortLabel, quantityUnitSuffix } from '@/lib/standardUnits';
+
+describe('standardUnits: unitShortLabel', () => {
+  it('maps a standard unit key to its short symbol', () => {
+    expect(unitShortLabel('inches')).toBe('in');
+    expect(unitShortLabel('pounds')).toBe('lb');
+    expect(unitShortLabel('each')).toBe('ea');
+  });
+
+  it('falls back to the raw value for custom/company units', () => {
+    expect(unitShortLabel('barrel')).toBe('barrel');
+  });
+
+  it('returns null for a null/empty unit', () => {
+    expect(unitShortLabel(null)).toBeNull();
+    expect(unitShortLabel(undefined)).toBeNull();
+    expect(unitShortLabel('')).toBeNull();
+  });
+});
+
+describe('standardUnits: quantityUnitSuffix', () => {
+  it('labels non-count units so a fractional quantity is unambiguous', () => {
+    expect(quantityUnitSuffix('inches')).toBe('in');
+    expect(quantityUnitSuffix('pounds')).toBe('lb');
+    expect(quantityUnitSuffix('gallons')).toBe('gal');
+  });
+
+  it('suppresses the suffix for count units (a bare number is conventional)', () => {
+    expect(quantityUnitSuffix('each')).toBeNull();
+    expect(quantityUnitSuffix('pieces')).toBeNull();
+    expect(quantityUnitSuffix('dozen')).toBeNull();
+  });
+
+  it('labels custom units (treated as non-count)', () => {
+    expect(quantityUnitSuffix('barrel')).toBe('barrel');
+  });
+
+  it('returns null for a null/empty unit', () => {
+    expect(quantityUnitSuffix(null)).toBeNull();
+    expect(quantityUnitSuffix(undefined)).toBeNull();
+  });
+});

--- a/__tests__/utils/quotePdf.test.ts
+++ b/__tests__/utils/quotePdf.test.ts
@@ -151,6 +151,7 @@ const baseQuote: QuoteWithRelations = {
         id: 'part-1',
         part_name: 'BRKT-001',
         description: 'Steel bracket, 3/16"',
+        primary_unit: 'each',
       },
     },
   ],
@@ -203,6 +204,29 @@ describe('generateQuotePdf', () => {
     expect(qty).toBe('10');
     expect(unitPrice).toContain('$70');
     expect(total).toContain('$700');
+  });
+
+  it('labels a fractional quantity with the part unit (e.g. "0.32 in") for non-count parts', async () => {
+    const lengthQuote: QuoteWithRelations = {
+      ...baseQuote,
+      line_items: [
+        {
+          ...baseQuote.line_items![0],
+          quantity: 0.32,
+          parts: {
+            ...baseQuote.line_items![0].parts!,
+            part_name: 'BAR-STOCK',
+            primary_unit: 'inches',
+          },
+        },
+      ],
+    };
+
+    await generateQuotePdf(lengthQuote, baseCompany);
+
+    const config = autoTableFn.mock.calls[0][1];
+    const [, , qty] = config.body[0];
+    expect(qty).toBe('0.32 in');
   });
 
   it('leaves the description cell blank when parts.description is null', async () => {

--- a/__tests__/utils/quotesAccess.test.ts
+++ b/__tests__/utils/quotesAccess.test.ts
@@ -438,6 +438,36 @@ describe('quotesAccess utilities', () => {
       expect(insertLineItemForPartMock.mock.calls[1][3]).toBe(10);
     });
 
+    it('forwards a fractional order_quantity unchanged (parts sold by length/weight)', async () => {
+      (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) => {
+        if (table === 'quotes') {
+          return {
+            insert: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { id: 'quote-new', company_id: 'company-1' },
+                  error: null,
+                }),
+              }),
+            }),
+          };
+        }
+        return mockQueryBuilder;
+      });
+      getTiersWithComputedPricesMock.mockResolvedValue([]);
+      insertLineItemForPartMock.mockResolvedValue({});
+
+      await expect(
+        createQuote('company-1', {
+          ...baseForm,
+          parts: [{ part_id: 'part-1', order_quantity: 0.32 }],
+        }),
+      ).resolves.toBeDefined();
+
+      // 0.32 reaches the line-item insert intact — no integer coercion.
+      expect(insertLineItemForPartMock.mock.calls[0][3]).toBe(0.32);
+    });
+
     it('rejects order_quantity <= 0', async () => {
       await expect(
         createQuote('company-1', { ...baseForm, parts: [{ part_id: 'part-1', order_quantity: 0 }] }),

--- a/components/parts/PartPricing.tsx
+++ b/components/parts/PartPricing.tsx
@@ -48,6 +48,8 @@ import {
 import { calculateMarkupFromUnitPrice } from '@/types/quote';
 import type { Part } from '@/types/part';
 import { buildPartHref, pushPartToChain } from '@/lib/partNavStack';
+import { isValidQuantityInput, isValidQuantityValue } from '@/lib/quantityInput';
+import { quantityUnitSuffix } from '@/lib/standardUnits';
 import SaveStatus, { type SaveState } from '@/components/common/SaveStatus';
 
 interface PartPricingProps {
@@ -144,6 +146,10 @@ export default function PartPricing({
 }: PartPricingProps) {
   const partId = part.id;
   const isBought = part.source === 'bought';
+  // Label the Min qty column with the part's unit (e.g. "Min qty (in)") so a
+  // fractional break reads unambiguously. null unit -> plain "Min qty".
+  const qtyUnitLabel = quantityUnitSuffix(part.primary_unit);
+  const qtyColumnHeader = qtyUnitLabel ? `Min qty (${qtyUnitLabel})` : 'Min qty';
 
   const [rows, setRows] = useState<EditRow[]>([]);
   const [breakdown, setBreakdown] = useState<RoutingCostBreakdown | null>(null);
@@ -238,10 +244,10 @@ export default function PartPricing({
   const handleSave = async (): Promise<void> => {
     const allValid = rows.every((r) => {
       const q = parseNumber(r.quantity);
-      return q !== null && q > 0;
+      return q !== null && isValidQuantityValue(q);
     });
     if (!allValid) {
-      setError('Every tier needs a quantity of at least 1.');
+      setError('Every tier needs a quantity greater than 0.');
       return;
     }
     setSaveState('saving');
@@ -302,7 +308,9 @@ export default function PartPricing({
   };
 
   const handleQuantityChange = (idx: number, value: string): void => {
-    if (!/^\d*$/.test(value)) return;
+    // Tier minimum quantities are decimal-capable (universal, up to 4 dp) so a
+    // part sold by length/weight/volume can set a fractional break like 0.32.
+    if (!isValidQuantityInput(value)) return;
     updateRows((prev) => {
       const next = [...prev];
       next[idx] = recomputeRow({ ...next[idx], quantity: value }, breakdown);
@@ -611,7 +619,7 @@ export default function PartPricing({
                 <Table size="small">
                   <TableHead>
                     <TableRow>
-                      <TableCell>Min qty</TableCell>
+                      <TableCell>{qtyColumnHeader}</TableCell>
                       {!isBought && <TableCell align="right">Base / unit</TableCell>}
                       <TableCell align="right">Markup %</TableCell>
                       {!isBought && <TableCell align="right">Unit price</TableCell>}
@@ -664,7 +672,7 @@ export default function PartPricing({
                 <Table size="small">
                   <TableHead>
                     <TableRow>
-                      <TableCell>Min qty</TableCell>
+                      <TableCell>{qtyColumnHeader}</TableCell>
                       {!isBought && <TableCell align="right">Base / unit</TableCell>}
                       <TableCell align="right">Markup %</TableCell>
                       {!isBought && <TableCell align="right">Unit price</TableCell>}
@@ -680,7 +688,7 @@ export default function PartPricing({
                               size="small"
                               value={row.quantity}
                               onChange={(e) => handleQuantityChange(idx, e.target.value)}
-                              inputMode="numeric"
+                              inputMode="decimal"
                             />
                           </TableCell>
                           {!isBought && (

--- a/components/quotes/ConvertToJobModal.tsx
+++ b/components/quotes/ConvertToJobModal.tsx
@@ -20,6 +20,7 @@ import FormLabel from '@mui/material/FormLabel';
 import type { QuoteLineItem, QuoteWithRelations } from '@/types/quote';
 import { isQuoteExpired, formatLeadTime } from '@/types/quote';
 import { convertQuoteToJob } from '@/utils/quotesAccess';
+import { unitShortLabel } from '@/lib/standardUnits';
 import { uploadJobAttachment } from '@/utils/jobAttachmentsAccess';
 import AttachmentUploadField from '@/components/jobs/AttachmentUploadField';
 
@@ -87,14 +88,22 @@ export default function ConvertToJobModal({
   // quantity converts as-is; a part with several quantities (price options)
   // needs the salesperson to pick the accepted quantity before converting.
   const partGroups = useMemo(() => {
-    const groups: { part_id: string; part_name: string; items: QuoteLineItem[] }[] = [];
+    const groups: { part_id: string; part_name: string; unit: string; items: QuoteLineItem[] }[] =
+      [];
     const index = new Map<string, number>();
     for (const li of lineItems) {
       let gi = index.get(li.part_id);
       if (gi === undefined) {
         gi = groups.length;
         index.set(li.part_id, gi);
-        groups.push({ part_id: li.part_id, part_name: li.parts?.part_name ?? 'Part', items: [] });
+        groups.push({
+          part_id: li.part_id,
+          part_name: li.parts?.part_name ?? 'Part',
+          // Real unit so a fractional order reads "0.32 in" not "0.32 ea";
+          // count parts still show "ea". Falls back to "ea" for a unitless part.
+          unit: unitShortLabel(li.parts?.primary_unit) ?? 'ea',
+          items: [],
+        });
       }
       groups[gi].items.push(li);
     }
@@ -220,7 +229,8 @@ export default function ConvertToJobModal({
                       {group.part_name}
                     </Typography>
                     <Typography variant="body2" color="text.secondary">
-                      {group.items[0].quantity} ea @ {formatCurrency(group.items[0].unit_price)} ={' '}
+                      {group.items[0].quantity} {group.unit} @{' '}
+                      {formatCurrency(group.items[0].unit_price)} ={' '}
                       {formatCurrency(
                         group.items[0].total_price ??
                           group.items[0].unit_price * group.items[0].quantity,
@@ -248,7 +258,7 @@ export default function ConvertToJobModal({
                             key={li.id}
                             value={li.id}
                             control={<Radio size="small" />}
-                            label={`${li.quantity} ea @ ${formatCurrency(
+                            label={`${li.quantity} ${group.unit} @ ${formatCurrency(
                               li.unit_price,
                             )} = ${formatCurrency(li.total_price ?? li.unit_price * li.quantity)}`}
                           />

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -24,6 +24,7 @@ import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
+import InputAdornment from '@mui/material/InputAdornment';
 import Collapse from '@mui/material/Collapse';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
@@ -45,6 +46,8 @@ import {
 } from '@/utils/customerAccess';
 import { getTiersWithComputedPrices } from '@/utils/partPricingTiersAccess';
 import { resolveTier } from '@/utils/quotePricingResolver';
+import { isValidQuantityInput } from '@/lib/quantityInput';
+import { quantityUnitSuffix, unitShortLabel } from '@/lib/standardUnits';
 import type { ComputedPartPricingTier } from '@/types/partPricing';
 import CustomerFormModal from '@/components/customers/CustomerFormModal';
 import CustomerAddressForm from '@/components/customers/CustomerAddressForm';
@@ -816,7 +819,6 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
         if (!Number.isFinite(orderQty) || orderQty <= 0) {
           return 'Every quantity must be greater than zero.';
         }
-        if (!Number.isInteger(orderQty)) return 'Quantity must be a whole number.';
         if (seenQty.has(orderQty)) return 'Each quantity can appear only once per part.';
         seenQty.add(orderQty);
         if (!block.override_open) {
@@ -1156,6 +1158,12 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
             // Part-level custom price — when active it overrides every row.
             const blockOverrideActive =
               block.override_open && block.override_unit_price.trim() !== '';
+            // Unit symbol for the order-qty field (e.g. "in") so a fractional
+            // quantity isn't ambiguous. null for count/unitless parts.
+            const orderQtyUnitLabel = quantityUnitSuffix(block.part?.primary_unit);
+            // Tier caption reads "Tier 0.5 in" / "Tier 1 ea" — always show a
+            // unit here (full label, fallback "ea") so counts stay unchanged.
+            const tierUnitLabel = unitShortLabel(block.part?.primary_unit) ?? 'ea';
 
             return (
               <Box key={idx} sx={{ mb: idx === partBlocks.length - 1 ? 0 : 3 }}>
@@ -1273,10 +1281,24 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                               value={row.quantity}
                               onChange={(e) => {
                                 const v = e.target.value;
-                                if (v !== '' && !/^\d+$/.test(v)) return;
+                                // Order quantities are decimal-capable (up to 4 dp)
+                                // so a part sold by length/weight can be quoted as
+                                // 0.32. isValidQuantityInput allows the empty string.
+                                if (!isValidQuantityInput(v)) return;
                                 updateRow(idx, rowIdx, { quantity: v });
                               }}
-                              inputProps={{ 'aria-label': 'Order quantity', inputMode: 'numeric' }}
+                              inputProps={{ 'aria-label': 'Order quantity', inputMode: 'decimal' }}
+                              InputProps={
+                                orderQtyUnitLabel
+                                  ? {
+                                      endAdornment: (
+                                        <InputAdornment position="end">
+                                          {orderQtyUnitLabel}
+                                        </InputAdornment>
+                                      ),
+                                    }
+                                  : undefined
+                              }
                               sx={{ width: 110 }}
                               error={hasOrderQty && !isOverride && matched?.below_min === true}
                             />
@@ -1305,8 +1327,8 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                                     color={matched.below_min ? 'warning.main' : 'text.secondary'}
                                   >
                                     {matched.below_min
-                                      ? `Below min · Tier ${matched.matched_tier_quantity} ea`
-                                      : `Tier ${matched.matched_tier_quantity} ea`}
+                                      ? `Below min · Tier ${matched.matched_tier_quantity} ${tierUnitLabel}`
+                                      : `Tier ${matched.matched_tier_quantity} ${tierUnitLabel}`}
                                   </Typography>
                                 </>
                               ) : (

--- a/e2e/fractional-quote-to-job.spec.ts
+++ b/e2e/fractional-quote-to-job.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+import { navigateTo } from './helpers/navigation';
+
+/**
+ * E2E: fractional order quantity, quote → job.
+ *
+ * Proves the end-to-end numeric path that integer columns used to block:
+ * a part measured in a non-count unit (inches) can be quoted at a fractional
+ * quantity, the tier resolves, the quote persists (quote_line_items.quantity
+ * is numeric), and conversion succeeds (job_parts.quantity is numeric and the
+ * shop-floor RPC returns it without truncation).
+ *
+ * Seeded prerequisites (e2e/global-setup.ts):
+ *   - E2E Test Customer
+ *   - E2E-LENGTH-001 (made part, primary_unit 'inches', one-op routing,
+ *     one fractional pricing tier at qty 0.5 in)
+ *
+ * Mirrors quote-to-job.spec.ts; kept separate per that spec's guidance to
+ * not expand it.
+ */
+test.describe('Fractional quote to job workflow', () => {
+  test('quote a fractional quantity of a length-measured part and convert to job', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/dashboard\//, { timeout: 30_000 });
+
+    await navigateTo(page, 'Quotes');
+    await expect(page).toHaveURL(/\/quotes/);
+
+    await page.getByRole('button', { name: /New Quote/i }).click();
+    await expect(page).toHaveURL(/\/quotes\/new/);
+
+    const customerField = page.getByRole('combobox', { name: /^Customer$/i });
+    await customerField.click();
+    await customerField.fill('E2E Test Customer');
+    await page
+      .getByRole('listbox')
+      .getByRole('option')
+      .filter({ hasText: /E2E Test Customer/i })
+      .first()
+      .click();
+
+    await page.getByRole('button', { name: /Add part/i }).click();
+
+    const partField = page.getByRole('combobox', { name: /^Part 1$/i });
+    await partField.click();
+    await partField.fill('E2E-LENGTH-001');
+    await page
+      .getByRole('listbox')
+      .getByRole('option')
+      .filter({ hasText: /E2E-LENGTH-001/i })
+      .first()
+      .click();
+
+    // The reported customer case: a fractional order quantity. The seed's only
+    // tier is qty 0.5 in, so ordering 0.5 resolves to it deterministically.
+    const orderQty = page.getByRole('textbox', { name: /Order quantity/i });
+    await orderQty.fill('0.5');
+    // Tier caption carries the part's unit now (not a hardcoded "ea") — "Tier 0.5 in".
+    await expect(page.getByText(/Tier 0\.5 in/i).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByRole('spinbutton', { name: /Lead time/i }).fill('14');
+    await page.getByRole('combobox', { name: 'Unit' }).click();
+    await page.getByRole('option', { name: 'Weeks' }).click();
+
+    await page.getByRole('combobox', { name: /Payment terms/i }).click();
+    await page.getByRole('option', { name: 'Net 30', exact: true }).click();
+
+    await page.getByRole('button', { name: /Create Quote/i }).click();
+
+    // Quote persisted with a fractional quantity (quote_line_items.quantity numeric).
+    await expect(page).toHaveURL(/\/quotes\/[^/]+$/, { timeout: 15_000 });
+    await expect(page.getByText(/Q-\d+/)).toBeVisible();
+
+    // Convert to job — exercises convertQuoteToJob copying 0.5 into
+    // job_parts.quantity (numeric) and the job read path.
+    await page.getByRole('button', { name: /Convert to Job/i }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(/Convert .* to/i)).toBeVisible();
+    await dialog.getByRole('textbox', { name: /Customer PO/i }).fill('PO-E2E-FRAC-001');
+    await dialog.getByRole('button', { name: /^Create J-\d+/i }).click();
+
+    await expect(page).toHaveURL(/\/jobs\/[^/]+$/, { timeout: 15_000 });
+    await expect(page.getByText(/J-\d+/).first()).toBeVisible();
+  });
+});

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -46,6 +46,9 @@ const CUSTOMER_NAME = 'E2E Test Customer';
 const PART_MFG_NAME = 'E2E-MFG-001';
 const PART_RAW_NAME = 'E2E-RAW-001';
 const PART_SUB_NAME = 'E2E-SUB-001';
+// Made part measured in a non-count unit (inches), with a fractional pricing
+// tier — exercises fractional order quantities end-to-end (quote -> job).
+const PART_LENGTH_NAME = 'E2E-LENGTH-001';
 
 interface SetupEnv {
   url: string;
@@ -446,11 +449,25 @@ export default async function globalSetup(): Promise<void> {
     cost_per_unit: 12.0,
   });
 
+  const lengthPartId = await ensurePart(supabase, companyId, {
+    part_name: PART_LENGTH_NAME,
+    description: 'E2E made part sold by length (inches)',
+    source: 'made',
+    is_stocked: false,
+    primary_unit: 'inches',
+    quantity: 0,
+    cost_per_unit: null,
+  });
+
   await ensureRouting(supabase, companyId, mfgPartId, wcInternalId);
+  await ensureRouting(supabase, companyId, lengthPartId, wcInternalId);
   await ensureBomEdge(supabase, mfgPartId, subPartId);
   // Two pricing tiers so QuoteForm can resolve a tier on the seeded MFG part.
   await ensurePricingTier(supabase, companyId, mfgPartId, 1, 1, 50);
   await ensurePricingTier(supabase, companyId, mfgPartId, 2, 10, 40);
+  // Fractional minimum-quantity tier on the length part (0.5 in) — only valid
+  // once part_pricing_tiers.quantity is numeric. Seeds the fractional path.
+  await ensurePricingTier(supabase, companyId, lengthPartId, 1, 0.5, 30);
 
   // eslint-disable-next-line no-console
   console.log(`[e2e/global-setup] Done. user=${TEST_EMAIL} company=${companyId}`);

--- a/lib/quantityInput.ts
+++ b/lib/quantityInput.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared validation for user-typed order / pricing-tier quantities.
+ *
+ * Quantities are universally decimal-capable. The whole-number assumption only
+ * ever held for count units ("you can't sell 2.5 widgets"); parts measured by
+ * length / weight / volume / area are legitimately fractional (e.g. 0.32 inches
+ * of material). Rather than gate on the part's unit category — a blunt rule that
+ * mishandles half-dozens and 1.5-hour billing — we allow decimals everywhere and
+ * cap precision uniformly.
+ *
+ * 4 decimal places is the manufacturing-practical ceiling: it covers machining
+ * "tenths" (0.0001") and fractional-inch conversions (3/16" = 0.1875, itself 4
+ * dp), without inviting noise like 0.333333. The DB quantity columns are
+ * unbounded `numeric`, so this module — not the schema — is the precision
+ * authority. Used by PartPricing tier rows and the QuoteForm order-qty input.
+ */
+export const MAX_QUANTITY_DECIMALS = 4;
+
+const QUANTITY_INPUT_REGEX = new RegExp(`^\\d*\\.?\\d{0,${MAX_QUANTITY_DECIMALS}}$`);
+
+/**
+ * True when `value` is an acceptable in-progress quantity input string: digits
+ * with an optional decimal point and up to {@link MAX_QUANTITY_DECIMALS}
+ * fractional digits. The empty string is allowed (a cleared field). No sign, no
+ * thousands separators. Use in an onChange handler to reject keystrokes that
+ * would push the value past the precision cap.
+ */
+export function isValidQuantityInput(value: string): boolean {
+  return QUANTITY_INPUT_REGEX.test(value);
+}
+
+/**
+ * Save-time guard: a parsed quantity is valid when it is finite, strictly
+ * positive, and within the precision cap. Defends the persisted value against
+ * paste / programmatic paths that bypass the per-keystroke {@link
+ * isValidQuantityInput} check.
+ */
+export function isValidQuantityValue(n: number): boolean {
+  if (!Number.isFinite(n) || n <= 0) return false;
+  const scaled = n * 10 ** MAX_QUANTITY_DECIMALS;
+  return Math.abs(scaled - Math.round(scaled)) < 1e-9;
+}

--- a/lib/standardUnits.ts
+++ b/lib/standardUnits.ts
@@ -83,3 +83,28 @@ export const STANDARD_UNITS_BY_KEY: Record<string, StandardUnit> =
     acc[u.key] = u;
     return acc;
   }, {});
+
+/**
+ * Short display symbol for a unit key (e.g. `inches` -> `in`), used to label a
+ * quantity so a fractional value isn't ambiguous ("0.32 in" not "0.32"). Falls
+ * back to the raw value for custom/company units not in the standard set, and
+ * returns `null` for a null/empty unit so callers can drop the suffix entirely.
+ */
+export function unitShortLabel(unit: string | null | undefined): string | null {
+  if (!unit) return null;
+  return STANDARD_UNITS_BY_KEY[unit]?.short ?? unit;
+}
+
+/**
+ * Unit symbol to render alongside a quantity, or `null` when a suffix would be
+ * noise. Non-count units (length / weight / volume / area / time) and custom
+ * company units get labelled so a fractional value is unambiguous ("0.32 in",
+ * "0.5 barrel"); count units return `null` because a bare number is the
+ * convention there ("10 brackets", not "10 ea"). Keeps existing count-based
+ * quotes visually unchanged while disambiguating the fractional cases.
+ */
+export function quantityUnitSuffix(unit: string | null | undefined): string | null {
+  if (!unit) return null;
+  if (STANDARD_UNITS_BY_KEY[unit]?.category === 'count') return null;
+  return unitShortLabel(unit);
+}

--- a/supabase/migrations/20260623143220_widen_quantity_precision_for_fractional_units.sql
+++ b/supabase/migrations/20260623143220_widen_quantity_precision_for_fractional_units.sql
@@ -1,0 +1,92 @@
+-- Allow fractional order quantities end-to-end for parts measured in non-count
+-- units (length / weight / volume / area / time) — e.g. selling 0.32 inches of
+-- material. The whole-number assumption only holds for count units; the app now
+-- accepts up to 4 decimal places uniformly (the UI is the precision authority).
+--
+-- Every column below holds a quantity that flows along the pricing -> quote ->
+-- job -> shipment chain. Widening to unbounded `numeric` mirrors the existing
+-- part_procurement_tiers.min_quantity column and is lossless: every current
+-- integer / numeric(12,2) value fits unchanged, so no backfill is required. The
+-- existing `quantity > 0` CHECK constraints survive ALTER COLUMN ... TYPE and
+-- need no drop/recreate.
+
+ALTER TABLE public.part_pricing_tiers
+  ALTER COLUMN quantity TYPE numeric USING quantity::numeric;
+
+ALTER TABLE public.quote_line_items
+  ALTER COLUMN quantity TYPE numeric USING quantity::numeric;
+
+ALTER TABLE public.job_parts
+  ALTER COLUMN quantity TYPE numeric USING quantity::numeric;
+
+-- Shipment qty was numeric(12,2). Widen so a 4-dp job_part quantity (e.g. a
+-- fractional-inch order like 0.1875") can be shipped exactly — otherwise the
+-- fulfillment status could never reach 'fully_shipped' for sub-cent fractions.
+--
+-- trigger_recompute_jp_fulfillment_on_line_upd fires AFTER UPDATE OF "quantity"
+-- on this table, so Postgres refuses to alter the column type while it exists
+-- (SQLSTATE 0A000). Drop it, alter, then recreate it verbatim from the baseline.
+DROP TRIGGER IF EXISTS "trigger_recompute_jp_fulfillment_on_line_upd"
+  ON public.shipment_line_items;
+
+ALTER TABLE public.shipment_line_items
+  ALTER COLUMN quantity TYPE numeric USING quantity::numeric;
+
+CREATE TRIGGER "trigger_recompute_jp_fulfillment_on_line_upd"
+  AFTER UPDATE OF "quantity", "job_part_id", "shipment_id" ON "public"."shipment_line_items"
+  FOR EACH ROW EXECUTE FUNCTION "public"."recompute_job_part_fulfillment_from_line"();
+
+-- get_ready_operations_for_station returns part_quantity as the job_part order
+-- quantity (jp.quantity). Its RETURNS TABLE column was typed `integer`, which
+-- would truncate a fractional quantity in the shop-floor station view. Re-type
+-- it to `numeric`. Changing an OUT/TABLE column type is not allowed via
+-- CREATE OR REPLACE, so drop and recreate (no SQL object depends on it — the
+-- only callers are app-side RPCs). Body is unchanged from the baseline.
+DROP FUNCTION IF EXISTS "public"."get_ready_operations_for_station"("uuid", "uuid");
+
+CREATE OR REPLACE FUNCTION "public"."get_ready_operations_for_station"("p_company_id" "uuid", "p_work_center_id" "uuid") RETURNS TABLE("job_id" "uuid", "job_part_id" "uuid", "job_operation_id" "uuid", "operation_name" "text", "op_status" "text", "job_number" "text", "part_id" "uuid", "part_name" "text", "part_description" "text", "part_quantity" numeric)
+    LANGUAGE "plpgsql" STABLE
+    AS $$
+BEGIN
+    RETURN QUERY
+    WITH eligible_jobs AS (
+        SELECT j.id, j.job_number FROM jobs j
+        WHERE j.company_id = p_company_id
+          AND j.status IN ('not_started', 'in_progress')
+    ),
+    station_ops AS (
+        SELECT jo.id, jo.job_id, jo.job_part_id, jo.operation_name, jo.status, jo.sequence, ej.job_number
+        FROM job_operations jo
+        JOIN eligible_jobs ej ON ej.id = jo.job_id
+        WHERE jo.work_center_id = p_work_center_id
+          AND jo.status IN ('pending', 'in_progress')
+    ),
+    ready_or_active AS (
+        SELECT so.id, so.job_id, so.job_part_id, so.operation_name, so.status, so.job_number
+        FROM station_ops so
+        WHERE so.status = 'in_progress'
+           OR NOT EXISTS (
+               SELECT 1 FROM job_operations prev
+               WHERE prev.job_part_id = so.job_part_id
+                 AND prev.sequence < so.sequence
+                 AND prev.status <> 'completed'
+           )
+    )
+    SELECT
+        ra.job_id,
+        ra.job_part_id,
+        ra.id AS job_operation_id,
+        ra.operation_name,
+        ra.status AS op_status,
+        ra.job_number,
+        jp.part_id,
+        p.part_name,
+        p.description AS part_description,
+        jp.quantity AS part_quantity
+    FROM ready_or_active ra
+    JOIN job_parts jp ON jp.id = ra.job_part_id
+    JOIN parts p ON p.id = jp.part_id;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_ready_operations_for_station"("p_company_id" "uuid", "p_work_center_id" "uuid") OWNER TO "postgres";

--- a/supabase/schema.staging.sql
+++ b/supabase/schema.staging.sql
@@ -1,6 +1,6 @@
 -- ============================================================
 -- Jigged Manufacturing Data Platform - Database Schema
--- Generated: 2026-06-23T13:49:44Z
+-- Generated: 2026-06-23T15:02:27Z
 -- Schemas: public, storage
 -- ============================================================
 
@@ -528,13 +528,13 @@ CREATE TABLE IF NOT EXISTS "public"."part_pricing_tiers"
     "part_id" uuid NOT NULL,
     "company_id" uuid NOT NULL,
     "sequence" integer NOT NULL,
-    "quantity" integer NOT NULL,
+    "quantity" numeric NOT NULL,
     "markup_percent" numeric(10,6),
     "created_at" timestamp with time zone NOT NULL DEFAULT now(),
     "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
     CONSTRAINT "part_pricing_tiers_pkey" PRIMARY KEY (id),
     CONSTRAINT "part_pricing_tiers_unique_seq" UNIQUE (part_id, sequence),
-    CONSTRAINT "part_pricing_tiers_quantity_check" CHECK ((quantity > 0))
+    CONSTRAINT "part_pricing_tiers_quantity_check" CHECK ((quantity > (0)::numeric))
 );
 
 CREATE TABLE IF NOT EXISTS "public"."part_procurement_tiers"
@@ -592,7 +592,7 @@ CREATE TABLE IF NOT EXISTS "public"."quote_line_items"
     "part_id" uuid NOT NULL,
     "source_tier_id" uuid,
     "sequence" integer NOT NULL,
-    "quantity" integer NOT NULL,
+    "quantity" numeric NOT NULL,
     "unit_price" numeric(12,4) NOT NULL,
     "total_price" numeric(12,4),
     "markup_percent" numeric(5,2),
@@ -603,7 +603,7 @@ CREATE TABLE IF NOT EXISTS "public"."quote_line_items"
     "basis_unknown" boolean NOT NULL DEFAULT false,
     CONSTRAINT "quote_line_items_pkey" PRIMARY KEY (id),
     CONSTRAINT "quote_line_items_unique_seq" UNIQUE (quote_id, sequence),
-    CONSTRAINT "quote_line_items_quantity_check" CHECK ((quantity > 0))
+    CONSTRAINT "quote_line_items_quantity_check" CHECK ((quantity > (0)::numeric))
 );
 
 CREATE TABLE IF NOT EXISTS "public"."job_parts"
@@ -614,7 +614,7 @@ CREATE TABLE IF NOT EXISTS "public"."job_parts"
     "part_id" uuid NOT NULL,
     "source_quote_line_item_id" uuid,
     "sequence" integer NOT NULL,
-    "quantity" integer NOT NULL,
+    "quantity" numeric NOT NULL,
     "status_changed_at" timestamp with time zone,
     "started_at" timestamp with time zone,
     "completed_at" timestamp with time zone,
@@ -630,7 +630,7 @@ CREATE TABLE IF NOT EXISTS "public"."job_parts"
     CONSTRAINT "job_parts_job_sequence_unique" UNIQUE (job_id, sequence),
     CONSTRAINT "job_parts_fulfillment_status_check" CHECK ((fulfillment_status = ANY (ARRAY['unshipped'::text, 'partially_shipped'::text, 'fully_shipped'::text]))),
     CONSTRAINT "job_parts_production_status_check" CHECK ((production_status = ANY (ARRAY['not_started'::text, 'in_progress'::text, 'completed'::text, 'cancelled'::text]))),
-    CONSTRAINT "job_parts_quantity_check" CHECK ((quantity > 0))
+    CONSTRAINT "job_parts_quantity_check" CHECK ((quantity > (0)::numeric))
 );
 
 CREATE TABLE IF NOT EXISTS "public"."job_materials"
@@ -701,7 +701,7 @@ CREATE TABLE IF NOT EXISTS "public"."shipment_line_items"
     "id" uuid NOT NULL DEFAULT gen_random_uuid(),
     "shipment_id" uuid NOT NULL,
     "job_part_id" uuid NOT NULL,
-    "quantity" numeric(12,2) NOT NULL,
+    "quantity" numeric NOT NULL,
     "created_at" timestamp with time zone NOT NULL DEFAULT now(),
     CONSTRAINT "shipment_line_items_pkey" PRIMARY KEY (id),
     CONSTRAINT "shipment_line_items_quantity_positive" CHECK ((quantity > (0)::numeric))
@@ -4315,7 +4315,7 @@ $function$
 ;
 
 CREATE OR REPLACE FUNCTION public.get_ready_operations_for_station(p_company_id uuid, p_work_center_id uuid)
- RETURNS TABLE(job_id uuid, job_part_id uuid, job_operation_id uuid, operation_name text, op_status text, job_number text, part_id uuid, part_name text, part_description text, part_quantity integer)
+ RETURNS TABLE(job_id uuid, job_part_id uuid, job_operation_id uuid, operation_name text, op_status text, job_number text, part_id uuid, part_name text, part_description text, part_quantity numeric)
  LANGUAGE plpgsql
  STABLE
 AS $function$

--- a/types/database.ts
+++ b/types/database.ts
@@ -7,6 +7,11 @@ export type Json =
   | Json[]
 
 export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.4"
+  }
   graphql_public: {
     Tables: {
       [_ in never]: never
@@ -3215,4 +3220,3 @@ export const Constants = {
     Enums: {},
   },
 } as const
-

--- a/types/quote.ts
+++ b/types/quote.ts
@@ -218,6 +218,10 @@ export interface QuoteLineItem {
     id: string;
     part_name: string;
     description: string | null;
+    // Part's unit of measure — labels a fractional quantity ("0.32 in") so it
+    // isn't ambiguous on the quote / PDF. Inherited from the part (single source
+    // of truth), not snapshotted onto the line.
+    primary_unit: string | null;
   } | null;
 }
 

--- a/utils/quotePdf.ts
+++ b/utils/quotePdf.ts
@@ -11,6 +11,7 @@ import type { QuoteWithRelations } from '@/types/quote';
 import type { AddressSnapshot } from '@/types/documentSnapshot';
 import type { Company } from '@/utils/companyAccess';
 import { isQuoteExpired, daysUntilExpiration, formatLeadTime } from '@/types/quote';
+import { quantityUnitSuffix } from '@/lib/standardUnits';
 
 const MARGIN = 40;
 
@@ -290,7 +291,12 @@ export async function generateQuotePdf(
   // render as ONE table; a part with 2+ quantities spans its name/description
   // across its quantity rows. Firm quotes (every part one quantity) add a grand
   // total; price-options quotes omit it (the customer picks a quantity).
-  const partGroups: { part_name: string; description: string; items: typeof lineItems }[] = [];
+  const partGroups: {
+    part_name: string;
+    description: string;
+    unit: string | null;
+    items: typeof lineItems;
+  }[] = [];
   const groupIndex = new Map<string, number>();
   for (const li of lineItems) {
     let gi = groupIndex.get(li.part_id);
@@ -300,6 +306,8 @@ export async function generateQuotePdf(
       partGroups.push({
         part_name: li.parts?.part_name ?? 'Part',
         description: li.parts?.description?.trim() ?? '',
+        // Labels a fractional quantity ("0.32 in"); null for count parts.
+        unit: quantityUnitSuffix(li.parts?.primary_unit),
         items: [],
       });
     }
@@ -316,7 +324,7 @@ export async function generateQuotePdf(
       const rows = [...group.items].sort((a, b) => a.quantity - b.quantity);
       rows.forEach((li, i) => {
         const qtyCells = [
-          String(li.quantity),
+          group.unit ? `${li.quantity} ${group.unit}` : String(li.quantity),
           formatCurrency(li.unit_price),
           formatCurrency(li.total_price ?? li.unit_price * li.quantity),
         ];

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -117,7 +117,7 @@ const QUOTE_LINE_ITEM_FIELDS = `
   id, quote_id, company_id, part_id, source_tier_id, sequence,
   quantity, unit_price, total_price, markup_percent, base_cost_per_unit,
   is_quote_override, pricing_basis_snapshot, basis_unknown, created_at,
-  parts(id, part_name, description)
+  parts(id, part_name, description, primary_unit)
 `;
 
 const QUOTE_LIST_SELECT = `


### PR DESCRIPTION
## Problem

A customer sells a part measured in inches (0.32") and was blocked from entering a fractional minimum-quantity **pricing tier** — and even past that, couldn't **quote** 0.32 because `quote_line_items` / `job_parts` quantity were integer-locked too. Whole-number quantities only make sense for *count* units, not weight/length/volume/area.

## Approach

Full-chain numeric quantities, universal decimals capped at 4 dp.

- **Migration** (`20260623143220_widen_quantity_precision_for_fractional_units`): widen `quantity` → `numeric` on `part_pricing_tiers`, `quote_line_items`, `job_parts`, and `shipment_line_items` (so fractional jobs can fully ship); re-type `get_ready_operations_for_station.part_quantity` `integer` → `numeric` (drop/recreate — Postgres won't change an OUT-column type via `CREATE OR REPLACE`). Drops + recreates the `shipment_line_items` `UPDATE OF quantity` trigger around its alter. Lossless widening; the `quantity > 0` CHECK constraints survive.
- **Validation**: shared `lib/quantityInput.ts` (4-dp input regex + save guard) replaces the integer gates in `PartPricing` and `QuoteForm`. Universal — no unit/category branching.
- **Display**: `quantityUnitSuffix` labels non-count quantities ("0.32 in") on the tier header, quote form, **customer PDF**, `ConvertToJobModal`, and the tier caption (which previously hardcoded "ea"). Count parts render unchanged.

### Decisions (research-backed)

- **Universal decimals, not category-gated** — matches the prevailing ERP default ([ERPNext](https://docs.erpnext.com/docs/user/manual/en/managing-fractions-in-uom)/Odoo/Dynamics allow decimals on all UOMs by default; whole-number is an opt-in *per-unit* flag, never a hardcoded category gate). A hardcoded "count → whole" rule also mishandles half-dozens and 1.5-hour billing. A per-unit "must be whole number" toggle is a clean future enhancement if needed.
- **4 dp** — the cited "practical manufacturing ceiling"; covers machining tenths (0.0001") and fractional-inch conversions (3/16" = 0.1875). DB columns are unbounded `numeric`; precision is a UI cap.
- **Markup-rate breakpoints stay whole-number** — a company-wide rate spans parts of differing units, so fractional breakpoints are semantically muddy; fractional-unit parts use Custom tiers.

## Testing

- **99 scoped unit/integration tests pass**, `tsc` clean, 0 lint errors. New: `quantityInput` + `standardUnits` helper tests; fractional cases added to `QuoteForm` / `quotesAccess` / `quotePdf`.
- e2e: new seed part `E2E-LENGTH-001` (inches, fractional tier) + `fractional-quote-to-job.spec.ts`.
- **Migration applied to staging and verified** — column + function type changes confirmed in the `schema.staging.sql` diff.

## ⚠️ Prod push owed

The migration is on **staging only**. Prod push is human-owned: relink to prod, `supabase db push`, then `python scripts/export_schema.py` to refresh `schema.prod.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
