### PR TITLE
Readable secondary text + customer PO in QuickBooks push

### DIFF
--- a/api/routes/quickbooks_routes.py
+++ b/api/routes/quickbooks_routes.py
@@ -233,7 +233,10 @@ async def _load_gated_job(db: Client, company_id: str, job_id: str) -> dict:
     quote_id provenance, billing_address_id)."""
     job = (
         db.table("jobs")
-        .select("id, company_id, customer_id, job_number, quote_id, billing_address_id")
+        .select(
+            "id, company_id, customer_id, job_number, customer_po_number, "
+            "quote_id, billing_address_id"
+        )
         .eq("id", job_id)
         .eq("company_id", company_id)
         .limit(1)
@@ -445,6 +448,7 @@ async def push_invoice(company_id: str, job_id: str, request: Request, body: Com
             customer_ref=customer_ref,
             item_ref=item_ref,
             job_number=job.get("job_number"),
+            customer_po_number=job.get("customer_po_number"),
             bill_addr=bill_addr,
             lines=lines,
         )

--- a/api/services/quickbooks.py
+++ b/api/services/quickbooks.py
@@ -597,6 +597,7 @@ def quote_to_invoice_payload(
     customer_ref: str,
     item_ref: str,
     job_number: str | None,
+    customer_po_number: str | None = None,
     bill_addr: dict | None,
     lines: list[dict],
 ) -> dict:
@@ -606,7 +607,9 @@ def quote_to_invoice_payload(
 
     DocNumber is intentionally omitted -> QBO auto-assigns the next invoice number, so
     Jigged never collides with the shop's existing/manual/previous-system numbering. The
-    Jigged job number is stamped into PrivateNote for traceability + QBO-side search."""
+    Jigged job number is stamped into PrivateNote for traceability + QBO-side search, along
+    with the customer's PO number (also appended to each line Description) when present."""
+    po_suffix = f" (PO Number: {customer_po_number})" if customer_po_number else ""
     qb_lines: list[dict] = []
     for ln in lines:
         unit_price = ln.get("unit_price")
@@ -619,6 +622,7 @@ def quote_to_invoice_payload(
         description = ln.get("part_name") or "Part"
         if ln.get("description"):
             description = f"{description} — {ln['description']}"
+        description = f"{description}{po_suffix}"
         qb_lines.append(
             {
                 "DetailType": "SalesItemLineDetail",
@@ -633,8 +637,13 @@ def quote_to_invoice_payload(
             }
         )
     payload: dict = {"CustomerRef": {"value": customer_ref}, "Line": qb_lines}
+    note_parts: list[str] = []
     if job_number:
-        payload["PrivateNote"] = f"Jigged job {job_number}"
+        note_parts.append(f"Jigged job {job_number}")
+    if customer_po_number:
+        note_parts.append(f"PO Number: {customer_po_number}")
+    if note_parts:
+        payload["PrivateNote"] = " · ".join(note_parts)
     if bill_addr:
         payload["BillAddr"] = bill_addr
     return payload

--- a/api/tests/unit/test_quickbooks_service.py
+++ b/api/tests/unit/test_quickbooks_service.py
@@ -236,6 +236,51 @@ def test_payload_basic_taxcode_and_item():
     assert payload["Line"][1]["Description"] == "Shaft"
 
 
+def test_payload_includes_customer_po_in_memo_and_lines():
+    payload = qb.quote_to_invoice_payload(
+        customer_ref="42",
+        item_ref="7",
+        job_number="J-2026-0001",
+        customer_po_number="PO-789",
+        bill_addr=None,
+        lines=[
+            {"quantity": 1, "unit_price": 5.0, "part_name": "Bracket", "description": "Rev C"},
+            {"quantity": 2, "unit_price": 3.0, "part_name": "Shaft", "description": None},
+        ],
+    )
+    # PO number is appended to the memo alongside the job number.
+    assert payload["PrivateNote"] == "Jigged job J-2026-0001 · PO Number: PO-789"
+    # ...and to every line Description, after the part identity.
+    assert payload["Line"][0]["Description"] == "Bracket — Rev C (PO Number: PO-789)"
+    assert payload["Line"][1]["Description"] == "Shaft (PO Number: PO-789)"
+
+
+def test_payload_po_only_memo_without_job_number():
+    payload = qb.quote_to_invoice_payload(
+        customer_ref="1",
+        item_ref="1",
+        job_number=None,
+        customer_po_number="PO-12",
+        bill_addr=None,
+        lines=[{"quantity": 1, "unit_price": 5.0, "part_name": "P", "description": None}],
+    )
+    assert payload["PrivateNote"] == "PO Number: PO-12"
+    assert payload["Line"][0]["Description"] == "P (PO Number: PO-12)"
+
+
+def test_payload_no_po_leaves_lines_and_memo_unchanged():
+    payload = qb.quote_to_invoice_payload(
+        customer_ref="1",
+        item_ref="1",
+        job_number="J-0007",
+        customer_po_number=None,
+        bill_addr=None,
+        lines=[{"quantity": 1, "unit_price": 5.0, "part_name": "P", "description": None}],
+    )
+    assert payload["PrivateNote"] == "Jigged job J-0007"
+    assert payload["Line"][0]["Description"] == "P"
+
+
 def test_payload_rounding_reconciles_to_total():
     lines = [
         {"quantity": 3, "unit_price": 12.3456, "part_name": "A", "description": None},

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -73,7 +73,8 @@ See `lib/theme.ts` for exact values. Primary colors:
 
 - **Deep Indigo:** `#111439` - Foundation color, background base
 
-- **Neutral Gray:** `#B0B3B8` - Secondary text, disabled states
+- **Neutral Gray:** `#B0B3B8` - Disabled states, subtle UI elements
+- **Muted Label Gray:** `#C8CCD4` - Secondary text (`text.secondary` / `body2`); lightened from Neutral Gray so labels stay legible across the lighter end of the card gradient
 
 ### Glass Morphism Cards (Critical Styling)
 
@@ -373,7 +374,8 @@ See `lib/theme.ts` for exact values:
 
 - **Deep Indigo:** `#111439` - Background base, gradient foundation
 
-- **Neutral Gray:** `#B0B3B8` - Secondary text
+- **Neutral Gray:** `#B0B3B8` - Disabled states, subtle UI elements
+- **Muted Label Gray:** `#C8CCD4` - Secondary text (`text.secondary` / `body2`)
 
 ### Status Colors
 
@@ -443,7 +445,7 @@ MUI provides elevation levels from 0-24:
 
 - All status colors tested for sufficient contrast
 
-- Secondary text (#B0B3B8) meets minimum 4.5:1 ratio
+- Secondary text (#C8CCD4) meets minimum 4.5:1 ratio across the card gradient
 
 **Keyboard Navigation:**
 

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -54,7 +54,10 @@ const jiggedTheme = createTheme({
     },
     text: {
       primary: '#ffffff',
-      secondary: '#B0B3B8',
+      // Lightened from #B0B3B8: the old grey lost contrast on the lighter end of
+      // the card gradient (labels like "Customer PO" were hard to read). This value
+      // keeps a muted label feel while staying legible across the whole gradient.
+      secondary: '#C8CCD4',
     },
     success: { main: '#10b981' },
     warning: { main: '#f59e0b' },
@@ -70,7 +73,7 @@ const jiggedTheme = createTheme({
     h5: { fontSize: '1.25rem', fontWeight: 600, lineHeight: 1.4, color: '#ffffff' },
     h6: { fontSize: '1rem', fontWeight: 600, lineHeight: 1.5, color: '#ffffff' },
     body1: { fontSize: '1rem', lineHeight: 1.6, color: '#ffffff' },
-    body2: { fontSize: '0.875rem', lineHeight: 1.5, color: '#B0B3B8' },
+    body2: { fontSize: '0.875rem', lineHeight: 1.5, color: '#C8CCD4' },
     button: { textTransform: 'none', fontWeight: 500 },
   },
   shape: {


### PR DESCRIPTION
## What

Three small fixes that started from "the Customer PO label is hard to read on the job page":

### 1. Readability — grey secondary text (Jigged-wide)
Secondary text was `#B0B3B8`, which lost contrast on the lighter end of the glassmorphic card gradient (the "Customer PO" label was hard to read). Lightened the **global** secondary text color to `#C8CCD4` (`palette.text.secondary` + `typography.body2.color`), so every grey label/caption gets the same legibility bump. Docs updated to match.

### 2. QuickBooks memo includes the customer PO
`PrivateNote` now joins job number and PO:
- Before: `Jigged job J-0015`
- After: `Jigged job J-0015 · PO Number: <po>`

### 3. QuickBooks line-item descriptions include the PO
Each line's `Description`:
- Before: `Bracket — Rev C`
- After: `Bracket — Rev C (PO Number: <po>)`

Plumbing: the push route now selects `customer_po_number` on the job and passes it into `quote_to_invoice_payload` (new param defaults to `None`, so no-PO behavior is unchanged).

## Notes
- QB changes apply to **future** pushes only; existing QuickBooks invoices aren't rewritten.
- The theme color change is intentionally broad (all secondary-text labels), per the request that this was a Jigged-wide readability issue.

## Tests
Added 3 unit cases (PO in memo/lines, PO-only memo, no-PO unchanged). All 32 QuickBooks unit tests pass locally. Integration tests need a live Supabase — left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)