### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jigged",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Aligns `package.json` `version` with the `v0.3.0` release tag (**First Customer Go-Live**).

The `version` field had drifted — it sat at `0.1.0` through both the `v0.2.0` and `v0.3.0` releases. This bumps it to `0.3.0` and starts the practice of keeping it in lockstep with release tags going forward.

No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)