### PR TITLE
fix(ai): replace retired Sonnet 4 model id + add model deprecation early-warning

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -11,7 +11,9 @@ PyJWT>=2.8.0
 bcrypt>=4.0.0
 
 # AI providers (for CSV import mapping)
-anthropic>=0.18.0
+# >=0.40.0 guarantees client.models.list() for the model deprecation check
+# (services/ai/model_config.py). Installed in prod/staging is newer (0.86.0).
+anthropic>=0.40.0
 openai>=1.0.0
 google-genai>=0.3.0
 

--- a/api/routes/admin_routes.py
+++ b/api/routes/admin_routes.py
@@ -88,6 +88,25 @@ def generate_slug(company_name: str) -> str:
 
 
 # ============================================================================
+# AI MODEL HEALTH
+# ============================================================================
+
+@router.get("/ai/model-health")
+async def ai_model_health(request: Request):
+    """Report whether the pinned Anthropic model is still active.
+
+    Uses the free Models API metadata endpoint (no billed inference) so an admin
+    can verify the live model on demand and get advance warning before a model
+    retirement breaks chat/chart (as claude-sonnet-4-20250514 did). Requires
+    system admin access.
+    """
+    await verify_system_admin(request)
+
+    from services.ai.model_config import check_model_health
+    return check_model_health()
+
+
+# ============================================================================
 # LIST COMPANIES
 # ============================================================================
 

--- a/api/services/ai/claude_provider.py
+++ b/api/services/ai/claude_provider.py
@@ -9,6 +9,7 @@ from typing import Optional
 import anthropic
 
 from .base_provider import AIProvider, MappingSuggestion
+from .model_config import DEFAULT_ANTHROPIC_MODEL
 
 logger = logging.getLogger(__name__)
 
@@ -56,14 +57,14 @@ class ClaudeProvider(AIProvider):
 
         Args:
             api_key: Anthropic API key. If not provided, uses ANTHROPIC_API_KEY env var.
-            model: Model to use. Defaults to claude-sonnet-4-20250514.
+            model: Model to use. Defaults to DEFAULT_ANTHROPIC_MODEL (model_config.py).
         """
         self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
         if not self.api_key:
             raise ValueError("ANTHROPIC_API_KEY is required")
 
         self.client = anthropic.Anthropic(api_key=self.api_key)
-        self.model = model or "claude-sonnet-4-20250514"
+        self.model = model or DEFAULT_ANTHROPIC_MODEL
 
     @property
     def provider_name(self) -> str:

--- a/api/services/ai/factory.py
+++ b/api/services/ai/factory.py
@@ -9,6 +9,7 @@ from .base_provider import AIProvider
 from .claude_provider import ClaudeProvider
 from .openai_provider import OpenAIProvider
 from .gemini_provider import GeminiProvider
+from .model_config import DEFAULT_ANTHROPIC_MODEL
 
 
 def create_provider(provider_name: str, model: Optional[str] = None) -> AIProvider:
@@ -55,10 +56,13 @@ async def get_provider(
         Configured AIProvider instance
     """
     try:
-        # Query ai_config table for this company and feature
+        # Query ai_config table for the configured provider. The model is NOT
+        # read from here — model selection is centralized in model_config.py
+        # (DEFAULT_ANTHROPIC_MODEL) so a single source of truth governs which
+        # Claude model is used and a retired id can't linger in a stale row.
         response = (
             supabase.table("ai_config")
-            .select("provider, model, settings")
+            .select("provider, settings")
             .eq("company_id", company_id)
             .eq("feature", feature)
             .maybe_single()
@@ -67,8 +71,7 @@ async def get_provider(
 
         if response.data:
             provider_name = response.data.get("provider", "anthropic")
-            model = response.data.get("model")
-            return create_provider(provider_name, model)
+            return create_provider(provider_name)
 
     except Exception:
         # If DB lookup fails, fall back to default
@@ -91,7 +94,7 @@ def get_available_providers() -> list[dict]:
         "name": "anthropic",
         "display_name": "Claude (Anthropic)",
         "available": bool(os.getenv("ANTHROPIC_API_KEY")),
-        "default_model": "claude-sonnet-4-20250514",
+        "default_model": DEFAULT_ANTHROPIC_MODEL,
     })
 
     # Check OpenAI

--- a/api/services/ai/model_config.py
+++ b/api/services/ai/model_config.py
@@ -1,0 +1,88 @@
+"""Central Anthropic model selection + a free deprecation early-warning.
+
+Single source of truth for which Claude model the backend uses, plus a helper
+that checks — using the **free Models API metadata endpoint, never billed
+inference** — whether the pinned model is still active. The check powers an
+on-demand admin diagnostic and a test, so a future model retirement surfaces as
+an advance warning instead of a production 404 (which is exactly how
+``claude-sonnet-4-20250514`` broke chat/chart after its 2026-06-15 retirement).
+
+Why a pinned constant rather than auto-resolving the newest model at runtime:
+the resolved model has to actually be callable by this org's key, and the
+dashboard chat path constructs ``ClaudeProvider()`` directly (no factory), so a
+runtime resolver added latency + a 24h-stale-cache footgun without covering the
+broken feature. Pinning here keeps a human in the loop on cost/quality drift;
+the check below provides the missing "this model is going away" signal.
+"""
+
+import logging
+import os
+from typing import Optional
+
+import anthropic
+
+logger = logging.getLogger(__name__)
+
+# The model every backend AI path uses. Update this one line (after the
+# deprecation check below flags it) when migrating to a newer Sonnet.
+# claude-sonnet-4-6 is the documented drop-in replacement for retired Sonnet 4.
+DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6"
+
+
+def list_active_anthropic_model_ids(api_key: Optional[str] = None) -> list[str]:
+    """Return the IDs of all currently-active Anthropic models.
+
+    Uses the Models API (``GET /v1/models``) — free metadata, NOT billed
+    inference. Retired models do not appear in this list, which is what makes it
+    a usable deprecation signal. The SDK auto-paginates on iteration.
+    """
+    api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise ValueError("ANTHROPIC_API_KEY is required")
+
+    client = anthropic.Anthropic(api_key=api_key)
+    return [model.id for model in client.models.list()]
+
+
+def check_model_health(
+    model: str = DEFAULT_ANTHROPIC_MODEL,
+    api_key: Optional[str] = None,
+) -> dict:
+    """Report whether ``model`` is still active per the Models API.
+
+    Never raises — designed to back an admin diagnostic endpoint and a test.
+
+    Returns a dict with:
+        model:            the model id that was checked
+        active:           True/False if the check ran, None if it could not
+        active_model_ids: the active id list (empty if the check failed)
+        checked:          whether the Models API call succeeded
+        error:            error string when checked is False, else None
+    """
+    try:
+        active_ids = list_active_anthropic_model_ids(api_key=api_key)
+    except Exception as e:  # noqa: BLE001 — diagnostic must not raise
+        logger.warning(f"Model health check failed for {model}: {e}")
+        return {
+            "model": model,
+            "active": None,
+            "active_model_ids": [],
+            "checked": False,
+            "error": str(e),
+        }
+
+    is_active = model in active_ids
+    if not is_active:
+        logger.warning(
+            f"Anthropic model '{model}' is NOT in the active model list — "
+            f"it may be deprecated or retired. Update DEFAULT_ANTHROPIC_MODEL. "
+            f"Active ids: {active_ids}"
+        )
+
+    return {
+        "model": model,
+        "active": is_active,
+        "active_model_ids": active_ids,
+        "checked": True,
+        "error": None,
+    }

--- a/api/services/uom_normalizer.py
+++ b/api/services/uom_normalizer.py
@@ -23,6 +23,8 @@ from typing import Optional
 
 import anthropic
 
+from services.ai.model_config import DEFAULT_ANTHROPIC_MODEL
+
 logger = logging.getLogger(__name__)
 
 
@@ -149,7 +151,7 @@ def infer_uom_with_ai(
         return {item["key"]: None for item in items}
 
     client = anthropic.Anthropic(api_key=api_key)
-    model_name = model or "claude-sonnet-4-20250514"
+    model_name = model or DEFAULT_ANTHROPIC_MODEL
 
     prompt = _AI_PROMPT_TEMPLATE.format(
         canonical_units=json.dumps(sorted(CANONICAL_UNITS)),

--- a/api/tests/integration/test_model_active.py
+++ b/api/tests/integration/test_model_active.py
@@ -1,0 +1,29 @@
+"""Live early-warning: the pinned Anthropic model is still active.
+
+Hits the real Anthropic Models API (`GET /v1/models`) — free metadata, NOT
+billed inference. Skips when ANTHROPIC_API_KEY is unset. When this test FAILS,
+the pinned model is being retired: update DEFAULT_ANTHROPIC_MODEL in
+api/services/ai/model_config.py to a current model from the printed active list.
+"""
+
+import os
+
+import pytest
+
+from services.ai.model_config import DEFAULT_ANTHROPIC_MODEL, check_model_health
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set; skipping live model-deprecation check",
+)
+def test_pinned_model_is_active():
+    result = check_model_health()
+    assert result["checked"] is True, f"Models API call failed: {result['error']}"
+    assert result["active"] is True, (
+        f"Pinned model '{DEFAULT_ANTHROPIC_MODEL}' is not in the active model "
+        f"list — it is likely being retired. Update DEFAULT_ANTHROPIC_MODEL. "
+        f"Active: {result['active_model_ids']}"
+    )

--- a/api/tests/unit/test_model_config.py
+++ b/api/tests/unit/test_model_config.py
@@ -1,0 +1,72 @@
+"""Unit tests for centralized Anthropic model config + the deprecation check.
+
+These mock the Anthropic client so no network call or API key is needed. The
+live early-warning test lives in tests/integration/test_model_active.py.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.ai.model_config import DEFAULT_ANTHROPIC_MODEL, check_model_health
+
+pytestmark = pytest.mark.unit
+
+RETIRED_MODEL = "claude-sonnet-4-20250514"  # the id that broke chat/chart
+
+
+def _fake_client(model_ids):
+    client = MagicMock()
+    client.models.list.return_value = [SimpleNamespace(id=mid) for mid in model_ids]
+    return client
+
+
+def test_default_model_is_a_nonretired_sonnet():
+    assert DEFAULT_ANTHROPIC_MODEL.startswith("claude-sonnet-")
+    assert DEFAULT_ANTHROPIC_MODEL != RETIRED_MODEL
+
+
+def test_claude_provider_uses_default_model():
+    # Regression guard: the chat/chart route builds ClaudeProvider() with no
+    # model, so the default must be the pinned model — never the retired id.
+    from services.ai.claude_provider import ClaudeProvider
+
+    provider = ClaudeProvider(api_key="test-key")
+    assert provider.model == DEFAULT_ANTHROPIC_MODEL
+    assert provider.model != RETIRED_MODEL
+
+
+@patch("services.ai.model_config.anthropic.Anthropic")
+def test_check_model_health_active(mock_anthropic):
+    mock_anthropic.return_value = _fake_client(
+        ["claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5"]
+    )
+    result = check_model_health(model="claude-sonnet-4-6", api_key="test-key")
+    assert result["checked"] is True
+    assert result["active"] is True
+    assert result["error"] is None
+    assert "claude-sonnet-4-6" in result["active_model_ids"]
+
+
+@patch("services.ai.model_config.anthropic.Anthropic")
+def test_check_model_health_flags_retired_model(mock_anthropic):
+    # Reproduce the incident: the pinned model is no longer in the active list.
+    mock_anthropic.return_value = _fake_client(["claude-sonnet-4-6", "claude-opus-4-8"])
+    result = check_model_health(model=RETIRED_MODEL, api_key="test-key")
+    assert result["checked"] is True
+    assert result["active"] is False
+    assert result["error"] is None
+
+
+@patch("services.ai.model_config.anthropic.Anthropic")
+def test_check_model_health_never_raises_on_api_error(mock_anthropic):
+    client = MagicMock()
+    client.models.list.side_effect = RuntimeError("network down")
+    mock_anthropic.return_value = client
+
+    result = check_model_health(model="claude-sonnet-4-6", api_key="test-key")
+    assert result["checked"] is False
+    assert result["active"] is None
+    assert "network down" in result["error"]
+    assert result["active_model_ids"] == []


### PR DESCRIPTION
## Problem

Dashboard **chat** and **chart** AI features were returning `404 not_found_error` for `model: claude-sonnet-4-20250514`. Claude Sonnet 4 was retired by Anthropic on **2026-06-15**, so every request using that hardcoded id fails. We get no practical signal when Anthropic retires a model, so this surfaced as a prod outage.

## Fix

- **Single source of truth:** new [`api/services/ai/model_config.py`](api/services/ai/model_config.py) defines `DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6"` (the documented drop-in for retired Sonnet 4). Every backend AI path now uses it:
  - `claude_provider.py` — fixes chat/chart, since `insights_routes.py:97` constructs `ClaudeProvider()` with no model.
  - `uom_normalizer.py` and `factory.py` (also stops reading the never-written `ai_config.model` column; provider selection unchanged).
- **Self-maintaining early-warning** (free Models API metadata — **no billed inference**):
  - `check_model_health()` flags when the pinned model leaves the active list.
  - `GET /api/admin/ai/model-health` — system admins can verify the live model on demand.
  - An integration test that **fails with an actionable message** when the pinned model is being retired — advance warning instead of a prod 404.

## Why not runtime auto-resolution?

An earlier draft auto-resolved the newest Sonnet via the Models API, cached in a new `app_config` table. An adversarial review (claims verified in code) found it: (1) wouldn't cover the broken chat path, which bypasses the factory; (2) relied on neutralizing `ai_config.model` rows that are never written; (3) risked caching an unvalidated/unentitled model for 24h (sticky outage) and a cold-start stampede on serverless. Pinned constant + deprecation check delivers the resilience with none of that, keeping a human in the loop on cost/quality drift. No migration, no new table.

## Testing

- `cd api && pytest tests/unit/test_model_config.py` — 5 new unit tests (mocked); includes a regression guard that `ClaudeProvider().model` is the pinned model, never the retired id.
- `cd api && pytest -m unit` — 72 passing; all touched modules import cleanly; no retired-model id remains in code.
- **Staging (where `ANTHROPIC_API_KEY` is set):** run `pytest -m integration` (the live model-active check), exercise dashboard chat/chart (expect 200s; `ai_chat_queries.model` records `claude-sonnet-4-6`), and hit `GET /api/admin/ai/model-health` (expect `active: true`). These could not run locally — the key isn't in the local shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)