### PR TITLE
feat(inventory): smart Move source/qty + location-track stocked parts by default

### DIFF
--- a/__tests__/components/parts/PartLocationActionModal.test.tsx
+++ b/__tests__/components/parts/PartLocationActionModal.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@mui/material/styles';
+import jiggedTheme from '@/lib/theme';
+
+import PartLocationActionModal, {
+  type LocationBalanceOption,
+  type LocationOption,
+} from '@/components/parts/PartLocationActionModal';
+import { transferStock } from '@/utils/inventoryLocationsAccess';
+
+vi.mock('@/utils/inventoryLocationsAccess', () => ({
+  addStockAtLocation: vi.fn(),
+  depleteStockAtLocation: vi.fn(),
+  adjustStockAtLocation: vi.fn(),
+  transferStock: vi.fn(),
+}));
+
+const ALL: LocationOption[] = [
+  { id: 'l1', label: 'Left' },
+  { id: 'l2', label: 'Right' },
+  { id: 'l3', label: 'Bin' },
+];
+
+const renderMove = (sourceBalances: LocationBalanceOption[]) =>
+  render(
+    <PartLocationActionModal
+      open
+      action="move"
+      partId="p1"
+      primaryUnit="ea"
+      unitOptions={['ea']}
+      locations={ALL}
+      sourceBalances={sourceBalances}
+      onClose={vi.fn()}
+      onDone={vi.fn()}
+    />,
+    { wrapper: ({ children }) => <ThemeProvider theme={jiggedTheme}>{children}</ThemeProvider> },
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (transferStock as ReturnType<typeof vi.fn>).mockResolvedValue({ transfer_group_id: 'g', from_balance: 0, to_balance: 0 });
+});
+
+describe('PartLocationActionModal — Move', () => {
+  it('auto-selects the source when the part is in one place (no From picker)', async () => {
+    renderMove([{ id: 'l1', label: 'Left', quantity: 2 }]);
+    // Single source → no "From location" picker; the source is implied (proven
+    // by transferStock receiving 'l1' below without us choosing it).
+    const toCombo = await screen.findByRole('combobox', { name: /to location/i });
+    expect(screen.queryByRole('combobox', { name: /from location/i })).not.toBeInTheDocument();
+
+    await userEvent.click(toCombo);
+    await userEvent.click(await screen.findByRole('option', { name: 'Right' }));
+    await userEvent.type(screen.getByRole('spinbutton', { name: /quantity/i }), '1');
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() =>
+      expect(transferStock).toHaveBeenCalledWith('p1', 'l1', 'l2', 1, 'ea', undefined),
+    );
+  });
+
+  it('blocks moving more than the source holds, upfront (no DB call)', async () => {
+    renderMove([{ id: 'l1', label: 'Left', quantity: 2 }]);
+    await userEvent.click(await screen.findByRole('combobox', { name: /to location/i }));
+    await userEvent.click(await screen.findByRole('option', { name: 'Right' }));
+    await userEvent.type(screen.getByRole('spinbutton', { name: /quantity/i }), '5');
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(await screen.findByText(/only 2 ea at the source/i)).toBeInTheDocument();
+    expect(transferStock).not.toHaveBeenCalled();
+  });
+
+  it('offers only locations with stock as the source when there are several', async () => {
+    renderMove([
+      { id: 'l1', label: 'Left', quantity: 2 },
+      { id: 'l2', label: 'Right', quantity: 3 },
+    ]);
+    await userEvent.click(await screen.findByRole('combobox', { name: /from location/i }));
+    expect(await screen.findByRole('option', { name: /Left — 2 ea/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Right — 3 ea/ })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /^Bin/ })).not.toBeInTheDocument(); // empty location not a source
+    await userEvent.click(screen.getByRole('option', { name: /Left — 2 ea/ }));
+
+    await userEvent.click(screen.getByRole('combobox', { name: /to location/i }));
+    await userEvent.click(await screen.findByRole('option', { name: 'Bin' }));
+    await userEvent.type(screen.getByRole('spinbutton', { name: /quantity/i }), '1');
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() =>
+      expect(transferStock).toHaveBeenCalledWith('p1', 'l1', 'l3', 1, 'ea', undefined),
+    );
+  });
+});

--- a/api/routes/admin_routes.py
+++ b/api/routes/admin_routes.py
@@ -463,6 +463,30 @@ async def update_company_features(
             f"Updated company {company_id} features: {new_settings['features']}"
         )
 
+        # When inventory locations is newly turned ON, location-track all of the
+        # company's existing stocked parts (the per-part "enable tracking" opt-in
+        # was removed — every stocked part is tracked at "Unassigned" by default).
+        # New parts are auto-tracked by a DB trigger; this catches existing ones.
+        old_features = _normalize_features(current_settings.get("features", {}))
+        if not old_features.get("inventory_locations", False) and new_settings[
+            "features"
+        ].get("inventory_locations", False):
+            try:
+                backfill = service_client.rpc(
+                    "enable_location_tracking_for_company",
+                    {"p_company_id": company_id},
+                ).execute()
+                logger.info(
+                    f"Backfilled location tracking for {company_id}: {backfill.data}"
+                )
+            except Exception as backfill_err:
+                # Non-fatal: the flag write succeeded and the RPC is idempotent,
+                # so it can be retried. Surface for visibility.
+                logger.error(
+                    f"Location-tracking backfill failed for {company_id}: {backfill_err}"
+                )
+                sentry_sdk.capture_exception(backfill_err)
+
         return CompanyFeaturesUpdateResponse(
             success=True,
             company_id=company_id,

--- a/components/parts/PartLocationActionModal.tsx
+++ b/components/parts/PartLocationActionModal.tsx
@@ -9,6 +9,7 @@ import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import Autocomplete from '@mui/material/Autocomplete';
 import Alert from '@mui/material/Alert';
 
@@ -26,6 +27,11 @@ export interface LocationOption {
   label: string;
 }
 
+/** A location where the part currently HAS stock — a valid Move source. */
+export interface LocationBalanceOption extends LocationOption {
+  quantity: number;
+}
+
 const TITLES: Record<LocationAction, string> = {
   add: 'Add stock at a location',
   deplete: 'Remove stock from a location',
@@ -33,13 +39,18 @@ const TITLES: Record<LocationAction, string> = {
   move: 'Move stock between locations',
 };
 
+const num = (n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 4 });
+
 interface PartLocationActionModalProps {
   open: boolean;
   action: LocationAction;
   partId: string;
   primaryUnit: string;
   unitOptions: string[];
+  /** All company locations (Add/Remove/Adjust target + Move destination). */
   locations: LocationOption[];
+  /** Locations where the part has stock — the Move sources (with quantities). */
+  sourceBalances?: LocationBalanceOption[];
   onClose: () => void;
   onDone: () => void | Promise<void>;
 }
@@ -51,11 +62,14 @@ export default function PartLocationActionModal({
   primaryUnit,
   unitOptions,
   locations,
+  sourceBalances = [],
   onClose,
   onDone,
 }: PartLocationActionModalProps) {
-  const [location, setLocation] = useState<LocationOption | null>(null);
-  const [toLocation, setToLocation] = useState<LocationOption | null>(null);
+  const isMove = action === 'move';
+  const [location, setLocation] = useState<LocationOption | null>(null); // Add/Remove/Adjust
+  const [sourceLoc, setSourceLoc] = useState<LocationBalanceOption | null>(null); // Move from
+  const [toLocation, setToLocation] = useState<LocationOption | null>(null); // Move to
   const [quantity, setQuantity] = useState('');
   const [unit, setUnit] = useState(primaryUnit);
   const [notes, setNotes] = useState('');
@@ -64,6 +78,8 @@ export default function PartLocationActionModal({
 
   const handleEnter = () => {
     setLocation(null);
+    // Only one place to move from → pick it; no source picker needed.
+    setSourceLoc(action === 'move' && sourceBalances.length === 1 ? sourceBalances[0] : null);
     setToLocation(null);
     setQuantity('');
     setUnit(primaryUnit);
@@ -71,25 +87,36 @@ export default function PartLocationActionModal({
     setError(null);
   };
 
-  const isMove = action === 'move';
   const qtyLabel = action === 'adjust' ? 'New quantity at location' : 'Quantity';
+  // Cap a Move to what's actually at the source (only meaningful in the part's
+  // primary unit — a different unit can't be capped client-side).
+  const available = isMove && sourceLoc && unit === primaryUnit ? sourceLoc.quantity : null;
 
   const handleSubmit = async () => {
     const qty = parseFloat(quantity);
-    if (!location) {
-      setError(isMove ? 'Choose a source location.' : 'Choose a location.');
-      return;
-    }
-    if (isMove && !toLocation) {
-      setError('Choose a destination location.');
-      return;
-    }
-    if (isMove && toLocation?.id === location.id) {
-      setError('Source and destination must differ.');
+    if (isMove) {
+      if (!sourceLoc) {
+        setError('Choose a source location.');
+        return;
+      }
+      if (!toLocation) {
+        setError('Choose a destination location.');
+        return;
+      }
+      if (toLocation.id === sourceLoc.id) {
+        setError('Source and destination must differ.');
+        return;
+      }
+    } else if (!location) {
+      setError('Choose a location.');
       return;
     }
     if (!Number.isFinite(qty) || (action === 'adjust' ? qty < 0 : qty <= 0)) {
       setError(action === 'adjust' ? 'Quantity cannot be negative.' : 'Quantity must be positive.');
+      return;
+    }
+    if (available != null && qty > available) {
+      setError(`Only ${num(available)} ${primaryUnit} at the source — can't move ${num(qty)}.`);
       return;
     }
 
@@ -97,13 +124,13 @@ export default function PartLocationActionModal({
     setError(null);
     try {
       if (action === 'add') {
-        await addStockAtLocation(partId, location.id, qty, unit, notes || undefined);
+        await addStockAtLocation(partId, location!.id, qty, unit, notes || undefined);
       } else if (action === 'deplete') {
-        await depleteStockAtLocation(partId, location.id, qty, unit, { notes: notes || undefined });
+        await depleteStockAtLocation(partId, location!.id, qty, unit, { notes: notes || undefined });
       } else if (action === 'adjust') {
-        await adjustStockAtLocation(partId, location.id, qty, unit, notes || undefined);
+        await adjustStockAtLocation(partId, location!.id, qty, unit, notes || undefined);
       } else {
-        await transferStock(partId, location.id, toLocation!.id, qty, unit, notes || undefined);
+        await transferStock(partId, sourceLoc!.id, toLocation!.id, qty, unit, notes || undefined);
       }
       await onDone();
       onClose();
@@ -125,24 +152,42 @@ export default function PartLocationActionModal({
       <DialogTitle>{TITLES[action]}</DialogTitle>
       <DialogContent>
         <Stack spacing={2} sx={{ mt: 1 }}>
-          <Autocomplete
-            options={locations}
-            value={location}
-            onChange={(_, v) => setLocation(v)}
-            getOptionLabel={(o) => o.label}
-            isOptionEqualToValue={(o, v) => o.id === v.id}
-            renderInput={(params) => (
-              <TextField {...params} label={isMove ? 'From location' : 'Location'} required />
-            )}
-          />
-          {isMove && (
+          {isMove ? (
+            <>
+              {sourceBalances.length === 0 ? (
+                <Alert severity="info">This part isn&apos;t stored anywhere yet — add stock first.</Alert>
+              ) : sourceBalances.length === 1 ? (
+                <Typography variant="body2" color="text.secondary">
+                  From <strong>{sourceBalances[0].label}</strong> ({num(sourceBalances[0].quantity)}{' '}
+                  {primaryUnit})
+                </Typography>
+              ) : (
+                <Autocomplete
+                  options={sourceBalances}
+                  value={sourceLoc}
+                  onChange={(_, v) => setSourceLoc(v)}
+                  getOptionLabel={(o) => `${o.label} — ${num(o.quantity)} ${primaryUnit}`}
+                  isOptionEqualToValue={(o, v) => o.id === v.id}
+                  renderInput={(params) => <TextField {...params} label="From location" required />}
+                />
+              )}
+              <Autocomplete
+                options={locations}
+                value={toLocation}
+                onChange={(_, v) => setToLocation(v)}
+                getOptionLabel={(o) => o.label}
+                isOptionEqualToValue={(o, v) => o.id === v.id}
+                renderInput={(params) => <TextField {...params} label="To location" required />}
+              />
+            </>
+          ) : (
             <Autocomplete
               options={locations}
-              value={toLocation}
-              onChange={(_, v) => setToLocation(v)}
+              value={location}
+              onChange={(_, v) => setLocation(v)}
               getOptionLabel={(o) => o.label}
               isOptionEqualToValue={(o, v) => o.id === v.id}
-              renderInput={(params) => <TextField {...params} label="To location" required />}
+              renderInput={(params) => <TextField {...params} label="Location" required />}
             />
           )}
           <Stack direction="row" spacing={1}>
@@ -151,7 +196,8 @@ export default function PartLocationActionModal({
               type="number"
               value={quantity}
               onChange={(e) => setQuantity(e.target.value)}
-              inputProps={{ min: 0, step: 'any' }}
+              inputProps={{ min: 0, step: 'any', ...(available != null ? { max: available } : {}) }}
+              helperText={available != null ? `Available: ${num(available)} ${primaryUnit}` : undefined}
               fullWidth
               autoFocus
             />

--- a/components/parts/PartLocationInventory.tsx
+++ b/components/parts/PartLocationInventory.tsx
@@ -6,25 +6,24 @@ import Button from '@mui/material/Button';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import TuneIcon from '@mui/icons-material/Tune';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
-import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined';
 
 import type { Part } from '@/types/part';
 import type {
   InventoryLocation,
   PartLocationBalanceWithLocation,
 } from '@/types/inventoryLocations';
-import { getBalancesForPart, getLocations, disableLocationTracking } from '@/utils/inventoryLocationsAccess';
+import { getBalancesForPart, getLocations } from '@/utils/inventoryLocationsAccess';
 import { getStandardUnitsForUnit } from '@/lib/unitPresets';
 import PartLocationActionModal, {
   type LocationAction,
   type LocationOption,
+  type LocationBalanceOption,
 } from './PartLocationActionModal';
 
 function pathLabel(id: string, byId: Map<string, InventoryLocation>): string {
@@ -59,7 +58,6 @@ export default function PartLocationInventory({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [action, setAction] = useState<LocationAction | null>(null);
-  const [disabling, setDisabling] = useState(false);
 
   const primaryUnit = part.primary_unit ?? '';
 
@@ -91,22 +89,19 @@ export default function PartLocationInventory({
     [locations, byId],
   );
 
+  // Move sources: only the locations where this part actually has stock.
+  const sourceBalances = useMemo<LocationBalanceOption[]>(
+    () =>
+      balances
+        .map((b) => ({ id: b.location_id, label: b.path.join(' › ') || b.location_name, quantity: b.quantity }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [balances],
+  );
+
   const unitOptions = useMemo(
     () => Array.from(new Set([primaryUnit, ...getStandardUnitsForUnit(primaryUnit)])).filter(Boolean),
     [primaryUnit],
   );
-
-  const handleDisable = async () => {
-    setDisabling(true);
-    try {
-      await disableLocationTracking(partId);
-      await onStockChanged();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to disable tracking.');
-    } finally {
-      setDisabling(false);
-    }
-  };
 
   const onActionDone = async () => {
     await reload();
@@ -115,14 +110,6 @@ export default function PartLocationInventory({
 
   return (
     <Box sx={{ textAlign: 'left' }}>
-      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
-        <Chip icon={<LocationOnOutlinedIcon />} label="Location-tracked" color="info" size="small" />
-        <Box sx={{ flex: 1 }} />
-        <Button size="small" color="inherit" onClick={handleDisable} disabled={disabling}>
-          Disable tracking
-        </Button>
-      </Stack>
-
       <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: 'wrap', gap: 1 }}>
         <Button variant="contained" color="success" startIcon={<AddIcon />} onClick={() => setAction('add')}>
           Add
@@ -176,6 +163,7 @@ export default function PartLocationInventory({
           primaryUnit={primaryUnit}
           unitOptions={unitOptions}
           locations={locationOptions}
+          sourceBalances={sourceBalances}
           onClose={() => setAction(null)}
           onDone={onActionDone}
         />

--- a/components/parts/workspace/tabs/InventoryTab.tsx
+++ b/components/parts/workspace/tabs/InventoryTab.tsx
@@ -1,25 +1,20 @@
 'use client';
 
-import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
-import Alert from '@mui/material/Alert';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
 import TuneIcon from '@mui/icons-material/Tune';
-import LocationOnOutlinedIcon from '@mui/icons-material/LocationOnOutlined';
 
 import type { Part, PartUnitConversion } from '@/types/part';
 import type { InventoryTransactionType } from '@/types/partTransaction';
 import PartTransactionHistoryTable from '@/components/parts/PartTransactionHistoryTable';
 import PartUnitConversionsEditor from '@/components/parts/PartUnitConversionsEditor';
 import PartLocationInventory from '@/components/parts/PartLocationInventory';
-import { enableLocationTracking } from '@/utils/inventoryLocationsAccess';
-import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 
 interface InventoryTabProps {
   part: Part;
@@ -49,23 +44,6 @@ export default function InventoryTab({
 }: InventoryTabProps) {
   const belowReorder =
     part.reorder_point !== null && part.quantity <= part.reorder_point;
-  const { features } = useCompanyFeatures();
-
-  const [enabling, setEnabling] = useState(false);
-  const [enableError, setEnableError] = useState<string | null>(null);
-
-  const handleEnableTracking = async () => {
-    setEnabling(true);
-    setEnableError(null);
-    try {
-      await enableLocationTracking(partId);
-      await onStockChanged();
-    } catch (e) {
-      setEnableError(e instanceof Error ? e.message : 'Failed to enable location tracking.');
-    } finally {
-      setEnabling(false);
-    }
-  };
 
   return (
     <Card elevation={2}>
@@ -135,28 +113,6 @@ export default function InventoryTab({
                 Adjust
               </Button>
             </Box>
-
-            {part.primary_unit && features.inventory_locations && (
-              <Box sx={{ mt: 2 }}>
-                <Button
-                  variant="text"
-                  startIcon={<LocationOnOutlinedIcon />}
-                  onClick={handleEnableTracking}
-                  disabled={enabling}
-                >
-                  Enable location tracking
-                </Button>
-                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                  Track where this part is stored across cabinets and bins. Current stock moves to an
-                  “Unassigned” location you can distribute from.
-                </Typography>
-                {enableError && (
-                  <Alert severity="error" sx={{ mt: 1 }}>
-                    {enableError}
-                  </Alert>
-                )}
-              </Box>
-            )}
           </>
         )}
 

--- a/supabase/migrations/20260625140636_track_stocked_parts_by_default.sql
+++ b/supabase/migrations/20260625140636_track_stocked_parts_by_default.sql
@@ -1,0 +1,142 @@
+-- Location-track every stocked part by default, for companies that use
+-- inventory locations (the `inventory_locations` feature flag). Removes the
+-- per-part "Enable location tracking" opt-in: a stocked part just lands at the
+-- system "Unassigned" location and is moved from there. The "Unassigned" bucket
+-- is the implicit "not bin-tracked" state — a part left entirely there behaves
+-- exactly like a global-quantity item.
+--
+-- Flag-OFF companies are untouched: their parts stay is_location_tracked=false
+-- and keep the global Add/Remove/Adjust path on parts.quantity (the
+-- enforce_tracked_part_quantity guard would otherwise block their direct writes).
+--
+-- Pattern mirrors enable_location_tracking (migration 20260622023407 / 20260623031347):
+-- advisory-lock find-or-create "Unassigned" -> flip the flag (quantity unchanged
+-- so the guard skips) -> seed the Unassigned balance = parts.quantity (the rollup
+-- trigger then keeps parts.quantity = SUM(balances) = the same value).
+
+-- ---------------------------------------------------------------------------
+-- Helper: find-or-create a company's system "Unassigned" location.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.inv_get_or_create_unassigned(p_company_id uuid)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_loc uuid;
+BEGIN
+    PERFORM pg_advisory_xact_lock(hashtext('inv_unassigned:' || p_company_id::text));
+    SELECT id INTO v_loc
+      FROM public.inventory_locations
+     WHERE company_id = p_company_id AND name = 'Unassigned';
+    IF v_loc IS NULL THEN
+        INSERT INTO public.inventory_locations (company_id, name, kind)
+        VALUES (p_company_id, 'Unassigned', 'system')
+        RETURNING id INTO v_loc;
+    END IF;
+    RETURN v_loc;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.inv_get_or_create_unassigned(uuid) FROM PUBLIC;
+
+-- ---------------------------------------------------------------------------
+-- Auto-track trigger: a newly-inserted (or newly-stocked) part at a flag-on
+-- company is location-tracked at "Unassigned" with its whole quantity. Fires
+-- ONLY on INSERT or an is_stocked change, so explicit is_location_tracked flips
+-- (this RPC, enable_location_tracking) never re-enter it and the self-UPDATE of
+-- is_location_tracked below doesn't recurse.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.auto_track_stocked_part()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_loc  uuid;
+    v_flag boolean;
+BEGIN
+    -- Cheap exits first (no DB read): only stocked, not-yet-tracked parts.
+    IF NEW.is_stocked IS NOT TRUE OR NEW.is_location_tracked IS TRUE THEN
+        RETURN NULL;
+    END IF;
+    -- Only companies that use inventory locations.
+    SELECT (settings->'features'->>'inventory_locations')::boolean INTO v_flag
+      FROM public.companies WHERE id = NEW.company_id;
+    IF COALESCE(v_flag, false) IS NOT TRUE THEN
+        RETURN NULL;
+    END IF;
+
+    v_loc := public.inv_get_or_create_unassigned(NEW.company_id);
+
+    UPDATE public.parts SET is_location_tracked = true WHERE id = NEW.id;
+
+    INSERT INTO public.part_location_stock (company_id, part_id, location_id, quantity)
+    VALUES (NEW.company_id, NEW.id, v_loc, NEW.quantity)
+    ON CONFLICT (part_id, location_id) DO NOTHING;
+
+    RETURN NULL; -- AFTER trigger
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS trg_auto_track_stocked_part ON public.parts;
+CREATE TRIGGER trg_auto_track_stocked_part
+    AFTER INSERT OR UPDATE OF is_stocked ON public.parts
+    FOR EACH ROW EXECUTE FUNCTION public.auto_track_stocked_part();
+
+-- ---------------------------------------------------------------------------
+-- Bulk backfill: track every stocked, untracked part in a company. Service-role
+-- only (admin flag-toggle) + the migration body below. The is_location_tracked
+-- flip does NOT fire the trigger above (it's keyed on is_stocked), so the CTE
+-- seeds the balances itself with no double-counting.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.enable_location_tracking_for_company(p_company_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_loc   uuid;
+    v_count integer;
+BEGIN
+    v_loc := public.inv_get_or_create_unassigned(p_company_id);
+
+    -- Flip stocked+untracked parts to tracked (quantity unchanged -> guard skips)
+    -- and seed each one's whole quantity at "Unassigned" in the same statement,
+    -- scoped to ONLY the parts just flipped (so already-tracked parts are untouched).
+    WITH flipped AS (
+        UPDATE public.parts
+           SET is_location_tracked = true, updated_at = now()
+         WHERE company_id = p_company_id AND is_stocked AND NOT is_location_tracked
+        RETURNING id, company_id, quantity
+    )
+    INSERT INTO public.part_location_stock (company_id, part_id, location_id, quantity)
+    SELECT company_id, id, v_loc, quantity FROM flipped
+    ON CONFLICT (part_id, location_id) DO NOTHING;
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+
+    RETURN jsonb_build_object('location_id', v_loc, 'parts_tracked', v_count);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.enable_location_tracking_for_company(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.enable_location_tracking_for_company(uuid) TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- Backfill every company that already has the inventory_locations flag on.
+-- ---------------------------------------------------------------------------
+DO $backfill$
+DECLARE
+    c record;
+BEGIN
+    FOR c IN
+        SELECT id FROM public.companies
+         WHERE (settings->'features'->>'inventory_locations')::boolean IS TRUE
+    LOOP
+        PERFORM public.enable_location_tracking_for_company(c.id);
+    END LOOP;
+END
+$backfill$;


### PR DESCRIPTION
Three shop-floor fixes to the part-detail **Inventory** tab + the location model.

## 1 & 2 — Move modal (frontend)
The Move modal showed a "From" picker of **all** locations and only rejected over-moves at the DB. Now:
- **From** lists only the locations where the part **actually has stock**, each with its quantity, and **auto-selects** it (no picker) when the part is in **one** place. The **To** picker still offers all locations.
- The move quantity is **capped to the source balance client-side** ("Available: N", inline error) — no more "failed to update stock" after the `transfer_stock` source check.

`PartLocationInventory` already loads the per-location balances; it now threads them to the modal.

## 3 — Tracking-by-default (drop the per-part opt-in)
For companies with the `inventory_locations` flag, **every stocked part is location-tracked at "Unassigned" by default** — the "Enable location tracking" button is gone, and so is the per-part "Disable tracking".

**Why no per-part opt-out:** bin tracking is the WMS accuracy standard, applied as a *hybrid* (bin what matters, general-area the rest). Jigged's **"Unassigned" bucket already gives that hybrid in one model** — a part left entirely at Unassigned behaves exactly like a global-quantity item — so there's no need for a per-part mode toggle. The real opt-out stays at the **company** level (the flag).

### How it's enforced (one migration, no column change)
- `auto_track_stocked_part` trigger (`AFTER INSERT OR UPDATE OF is_stocked`) tracks new/newly-stocked parts at flag-on companies → flip + seed an "Unassigned" balance = quantity. Scoped to `is_stocked` so explicit `is_location_tracked` flips never re-enter it.
- `enable_location_tracking_for_company(uuid)` (SECURITY DEFINER, **service-role only**) bulk-backfills a company's existing stocked parts.
- The migration backfills every company currently flag-on.
- **Admin flag toggle** (`api/routes/admin_routes.py`): OFF→ON calls the backfill RPC.
- **Flag-OFF companies are untouched** — parts stay `is_location_tracked=false` and keep the global Add/Remove/Adjust path (the tracking guard would otherwise block their direct `parts.quantity` writes).

## Validation
- Migration **applied to staging** + rolled-back smoke: a new flag-on stocked part auto-tracks at Unassigned with `parts.quantity == balance`; a flag-off part is untouched; backfill leaves **0** untracked / **0** quantity mismatches.
- `tsc` clean; **Vitest 767** (3 new Move tests: auto-select single source, upfront over-move block, source = stocked-only); `lint` clean; **api unit 72**.

## Notes
- ⚠️ New migration → adds to the still-owed inventory **prod migration push** (human-owned). *(Staging had a pre-existing migration-drift on `20260624153218`, so I applied + recorded `20260625140636` directly; the formal `db push` will pick it up once that resolves.)*
- Skipped the optional admin "disabling will hide tracked parts" warning — flag-off-after-tracking is harmless (tracked parts keep using the location UI; no data deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)