### PR TITLE
fix(team): bulk delete now removes pending invites, not just members

### DIFF
--- a/app/dashboard/[companyId]/team/page.tsx
+++ b/app/dashboard/[companyId]/team/page.tsx
@@ -336,24 +336,35 @@ export default function TeamPage() {
     }
   }, [companyId]);
 
-  // Revoke an invitation
-  const handleRevokeInvitation = async (invitationId: string) => {
+  // Low-level: revoke a single invitation via the team-invites Edge Function.
+  // Returns true on success. No UI side effects — callers own messaging/refresh,
+  // so this is reusable by both the per-row Revoke button and bulk delete.
+  const revokeInvitationRequest = async (
+    invitationId: string,
+    accessToken: string
+  ): Promise<boolean> => {
     try {
-      const supabase = getSupabase();
-      const { data: { session } } = await supabase.auth.getSession();
-      if (!session) return;
-
       const response = await fetch(`${getInvitesUrl()}/${invitationId}`, {
         method: 'DELETE',
-        headers: { 'Authorization': `Bearer ${session.access_token}` },
+        headers: { 'Authorization': `Bearer ${accessToken}` },
       });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  };
 
-      if (!response.ok) throw new Error('Failed to revoke invitation');
+  // Revoke an invitation
+  const handleRevokeInvitation = async (invitationId: string) => {
+    const supabase = getSupabase();
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session) return;
 
+    const ok = await revokeInvitationRequest(invitationId, session.access_token);
+    if (ok) {
       setSnackbar({ open: true, message: 'Invitation revoked', severity: 'success' });
       loadInvitations();
-    } catch (err) {
-      console.error('Error revoking invitation:', err);
+    } else {
       setSnackbar({ open: true, message: 'Failed to revoke invitation', severity: 'error' });
     }
   };
@@ -420,53 +431,93 @@ export default function TeamPage() {
     return Math.max(headerHeight + rowHeight * displayedRows + paginationHeight, 400);
   }, [loading, currentData.length]);
 
-  // Delete item(s) - all roles now use user_company_access
+  // Delete selected row(s). A row is either an active member (a
+  // user_company_access row) or a pending invitation (id prefixed `inv-`,
+  // backed by the invitations table). These live in different places and must
+  // be removed differently — members via Supabase, invitations via the
+  // team-invites Edge Function — so we split the selection and route each kind.
   const handleDelete = async () => {
     setDeleting(true);
     try {
       const supabase = getSupabase();
       const itemName = activeTab === 0 ? 'admin' : activeTab === 1 ? 'user' : 'operator';
 
-      if (deleteDialog.type === 'single' && deleteDialog.id) {
-        const { error } = await supabase
-          .from('user_company_access')
-          .delete()
-          .eq('id', deleteDialog.id);
+      // Unify single + bulk into one target list.
+      const targetIds =
+        deleteDialog.type === 'single'
+          ? deleteDialog.id
+            ? [deleteDialog.id]
+            : []
+          : selectedIds;
 
-        if (error) throw error;
+      const inviteIds = targetIds
+        .filter((id) => id.startsWith('inv-'))
+        .map((id) => id.slice('inv-'.length));
+      const memberIds = targetIds.filter((id) => !id.startsWith('inv-'));
 
-        setSnackbar({
-          open: true,
-          message: `${itemName.charAt(0).toUpperCase() + itemName.slice(1)} deleted`,
-          severity: 'success',
-        });
-      } else if (deleteDialog.type === 'bulk') {
-        // Only delete actual members, not pending invitations
-        const memberIds = selectedIds.filter(id => !id.startsWith('inv-'));
-        if (memberIds.length === 0) {
-          setDeleteDialog({ open: false, type: 'single' });
-          return;
-        }
-        const { error } = await supabase
+      if (targetIds.length === 0) {
+        setDeleteDialog({ open: false, type: 'single' });
+        return;
+      }
+
+      let removedMembers = 0;
+      let revokedInvites = 0;
+      let failedInvites = 0;
+
+      // Remove active members. count: 'exact' verifies the DB actually deleted
+      // the rows rather than silently matching zero (e.g. RLS), so the toast
+      // reflects reality instead of assuming success.
+      if (memberIds.length > 0) {
+        const { error, count } = await supabase
           .from('user_company_access')
-          .delete()
+          .delete({ count: 'exact' })
           .in('id', memberIds);
 
         if (error) throw error;
-
-        setSnackbar({
-          open: true,
-          message: `${selectedIds.length} ${itemName}${selectedIds.length > 1 ? 's' : ''} deleted`,
-          severity: 'success',
-        });
-        setSelectedIds([]);
-        if (gridRef.current?.api) {
-          gridRef.current.api.deselectAll();
-        }
+        removedMembers = count ?? 0;
       }
 
+      // Revoke pending invitations via the team-invites Edge Function.
+      if (inviteIds.length > 0) {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session) throw new Error('Not authenticated');
+
+        const results = await Promise.all(
+          inviteIds.map((invId) => revokeInvitationRequest(invId, session.access_token))
+        );
+        revokedInvites = results.filter(Boolean).length;
+        failedInvites = results.length - revokedInvites;
+      }
+
+      const totalRemoved = removedMembers + revokedInvites;
+
+      if (failedInvites > 0) {
+        // Partial or total failure on the invitation side — surface it.
+        setSnackbar({
+          open: true,
+          message:
+            totalRemoved > 0
+              ? `Removed ${totalRemoved}, but ${failedInvites} invitation${failedInvites > 1 ? 's' : ''} could not be revoked`
+              : 'Failed to delete',
+          severity: 'error',
+        });
+      } else {
+        setSnackbar({
+          open: true,
+          message: `${totalRemoved} ${itemName}${totalRemoved > 1 ? 's' : ''} removed`,
+          severity: 'success',
+        });
+      }
+
+      setSelectedIds([]);
+      if (gridRef.current?.api) {
+        gridRef.current.api.deselectAll();
+      }
       setDeleteDialog({ open: false, type: 'single' });
-      // Reload the appropriate data
+
+      // Refresh data: invitations state feeds the role grids, so reload it
+      // whenever invites were touched, then reload the active member list.
+      if (inviteIds.length > 0) loadInvitations();
       if (activeTab === 0) loadAdmins();
       else if (activeTab === 1) loadUsers();
       else loadOperators();


### PR DESCRIPTION
## What

Fixes the Team page bulk delete, which silently no-op'd on pending invitations.

Closes #447.

## Root cause

The role grids (Admins / Users / Operators) merge two kinds of rows:

- **Active members** → `user_company_access` rows (real UUID ids)
- **Pending invitations** → `invitations` rows, rendered with ids prefixed `inv-`

`handleDelete` only knew how to delete `user_company_access` rows and filtered every `inv-` id out of the selection, producing three bugs:

1. **Select only invite(s) → total no-op.** `memberIds` was empty, so the handler early-returned: dialog closed, nothing deleted, no toast.
2. **Mixed selection → silent partial delete + wrong count.** Only members were deleted, but the toast reported `selectedIds.length` ("5 admins deleted" when 3 were).
3. **No verification.** Only `error` was checked; an RLS-blocked delete returns `{ error: null }` and still showed success.

## Fix

- Unify single + bulk into one handler that splits the selection by id prefix.
- Members → `user_company_access.delete({ count: 'exact' })` (count verifies rows were actually removed).
- Invitations → `DELETE /team-invites/:id` via the Edge Function (the same path the per-row Revoke button uses).
- Report the **actual combined count**, surface a message even when only invites were selected, and flag partial invite-revoke failures.
- Refresh `invitations` state after revoking so revoked rows leave the grid.
- Extract a low-level `revokeInvitationRequest()` shared by the per-row Revoke button and bulk delete.

The previously-dead single-delete path is now correct too (it would have mis-routed an invite id to `user_company_access`).

## Testing

- `pnpm exec tsc --noEmit` — clean.
- No existing unit/e2e coverage for the Team page; verified the logic by tracing the data flow (invite ids → revoke endpoint, member ids → Supabase, grid refresh via `loadInvitations()` + active loader).

### Manual QA checklist
- [ ] Select only a pending invite → Delete → invite is revoked and leaves the list.
- [ ] Select a mix of members + invites → both removed, toast count is accurate.
- [ ] Select only members → deleted as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
