### PR TITLE
feat(insights): text-first answers + intelligible charts (constrained renderer)

### DIFF
--- a/__tests__/components/insights/InsightChart.test.tsx
+++ b/__tests__/components/insights/InsightChart.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * InsightChart renders an @mui/x-charts chart from a chart_config. These tests
+ * assert the Phase-3 "fail-loud" guards: a blank or key-mismatched config must
+ * show an explicit empty state, never silently render blank labels / zero bars
+ * (the original "empty chart" bug). The x-charts components are stubbed so the
+ * tests are deterministic and don't depend on jsdom layout / ResizeObserver.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '../../test-utils';
+import InsightChart from '@/components/insights/InsightChart';
+import type { ChartConfig } from '@/utils/insightsAccess';
+
+vi.mock('@mui/x-charts/BarChart', () => ({ BarChart: () => <div data-testid="bar-chart" /> }));
+vi.mock('@mui/x-charts/LineChart', () => ({ LineChart: () => <div data-testid="line-chart" /> }));
+vi.mock('@mui/x-charts/PieChart', () => ({ PieChart: () => <div data-testid="pie-chart" /> }));
+vi.mock('@mui/x-charts/SparkLineChart', () => ({
+  SparkLineChart: () => <div data-testid="spark-chart" />,
+}));
+
+function makeConfig(over: Partial<ChartConfig> = {}): ChartConfig {
+  return {
+    chart_type: 'bar',
+    x_key: 'customer',
+    y_key: 'revenue',
+    data: [
+      { customer: 'A', revenue: 100 },
+      { customer: 'B', revenue: 80 },
+      { customer: 'C', revenue: 60 },
+    ],
+    x_label: 'Customer',
+    y_label: 'Revenue ($)',
+    ...over,
+  };
+}
+
+describe('InsightChart', () => {
+  it('shows an empty state when there is no data', () => {
+    render(<InsightChart chartConfig={makeConfig({ data: [] })} />);
+    expect(screen.getByText('No data available for chart')).toBeInTheDocument();
+    expect(screen.queryByTestId('bar-chart')).toBeNull();
+  });
+
+  it('fails loud (no blank chart) when x_key/y_key are missing from the rows', () => {
+    render(
+      <InsightChart
+        chartConfig={makeConfig({
+          data: [
+            { name: 'A', value: 100 },
+            { name: 'B', value: 80 },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText('No chartable data')).toBeInTheDocument();
+    expect(screen.queryByTestId('bar-chart')).toBeNull();
+  });
+
+  it('renders the chart (no fallback text) for a valid config', () => {
+    render(<InsightChart chartConfig={makeConfig()} />);
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    expect(screen.queryByText('No chartable data')).toBeNull();
+    expect(screen.queryByText('No data available for chart')).toBeNull();
+  });
+
+  it('renders an area chart for a temporal config', () => {
+    render(
+      <InsightChart
+        chartConfig={makeConfig({
+          chart_type: 'area',
+          x_key: 'week',
+          data: [
+            { week: '2026-01-01', revenue: 100 },
+            { week: '2026-02-01', revenue: 120 },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+  });
+});

--- a/api/routes/insights_routes.py
+++ b/api/routes/insights_routes.py
@@ -12,6 +12,7 @@ via direct Supabase queries with RLS policies. Per-company alerts
 
 import json
 import logging
+import math
 import os
 import re
 import time
@@ -118,14 +119,22 @@ async def chat(company_id: str, request: ChatRequest):
 
         duration_ms = int((time.time() - start_time) * 1000)
 
-        # Try to extract chart_config from the response
-        # The AI may include it as a JSON block in its response
+        # Extract the chart_config the model proposed, then let deterministic
+        # code decide whether it's worth charting (validate + downgrade to text
+        # for degenerate/invalid data) and pick the chart type from the data
+        # shape. The prose answer is always kept; a dropped chart is never a
+        # blank card.
         raw_content = result["content"]
-        chart_config = _extract_chart_config(raw_content)
+        chart_config = _select_chart_type(
+            _validate_chart_config(_extract_chart_config(raw_content)),
+            request.question,
+        )
 
-        # Strip code blocks (raw JSON) and flatten any markdown tables so the
-        # plain-text UI never shows raw `|---|` column formatting.
-        clean_answer = _flatten_markdown_tables(_strip_code_blocks(raw_content))
+        # Clean the answer for the plain-text UI: drop fenced JSON, flatten any
+        # markdown tables, and neutralize inline markdown (**bold**, etc.).
+        clean_answer = _strip_inline_markdown(
+            _flatten_markdown_tables(_strip_code_blocks(raw_content))
+        )
 
         # Log to ai_chat_queries
         try:
@@ -239,6 +248,167 @@ def _flatten_markdown_tables(content: str) -> str:
             continue
         out.append(line)
     return "\n".join(out).strip()
+
+
+# Inline markdown patterns to neutralize in the plain-text answer. We only touch
+# clearly-paired/anchored markup so shop data like a part number "PART_101" or an
+# expression "a * b" survives untouched. Underscore emphasis is intentionally NOT
+# handled (snake_case identifiers are common in shop data).
+_MD_LINK = re.compile(r"\[([^\]]+)\]\([^)]*\)")              # [label](url) -> label
+_MD_BOLD = re.compile(r"\*\*(\S(?:.*?\S)?)\*\*")            # **bold** -> bold
+_MD_ITALIC = re.compile(r"(?<![\w*])\*(\S(?:.*?\S)?)\*(?![\w*])")  # *italic* -> italic
+_MD_CODE = re.compile(r"`([^`]+)`")                         # `code` -> code
+_MD_HEADING = re.compile(r"(?m)^\s{0,3}#{1,6}\s+")          # leading ### -> remove
+
+
+def _strip_inline_markdown(content: str) -> str:
+    """Neutralize inline markdown so the plain-text UI shows clean prose.
+
+    Unwraps **bold**, *italic*, `code`, [label](url) -> label, and drops leading
+    `#` headings. Only paired/anchored asterisk/backtick patterns are touched, so
+    "PART_101" or a literal "a * b" is left intact. Defensive backstop to the
+    system prompt (which forbids markdown); runs after table flattening.
+    """
+    content = _MD_LINK.sub(r"\1", content)
+    content = _MD_BOLD.sub(r"\1", content)
+    content = _MD_ITALIC.sub(r"\1", content)
+    content = _MD_CODE.sub(r"\1", content)
+    content = _MD_HEADING.sub("", content)
+    return content.strip()
+
+
+# ---- chart_config validation + deterministic chart-type selection -----------
+
+_ALLOWED_CHART_TYPES = frozenset({"area", "pie", "bar", "bar_horizontal", "sparkline"})
+# A chart needs enough points to beat a one-line sentence; below this we downgrade
+# to the prose answer (single fact / 1-2 values -> text).
+_MIN_CHART_POINTS = 3
+# For an exactly-2-point chart, keep it only when the two values are a genuine
+# comparison — the smaller is at least this fraction of the larger. A dominant
+# top-1 (e.g. 7749 vs 36 -> 0.5%) is a single-fact answer, not a comparison.
+_COMPARABLE_RATIO = 0.05
+
+
+def _coerce_number(value) -> float | None:
+    """Best-effort parse of a numeric value; handles '1,234.5' / '$1234'."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value) if math.isfinite(value) else None
+    if isinstance(value, str):
+        try:
+            return float(value.replace(",", "").replace("$", "").strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _comparable(values: list[float]) -> bool:
+    """True when two values are close enough in magnitude to be a real comparison."""
+    a, b = abs(values[0]), abs(values[1])
+    hi = max(a, b)
+    if hi == 0:
+        return False
+    return (min(a, b) / hi) >= _COMPARABLE_RATIO
+
+
+def _validate_chart_config(config: dict | None) -> dict | None:
+    """Return the chart_config only if it will render an intelligible chart.
+
+    Otherwise return None so the chat answers in prose. The prose answer is
+    always kept — a dropped chart is an explicit downgrade, never a blank card
+    (honors the repo's "no silent fallbacks" rule). Validated against the
+    config's own embedded data:
+      - chart_type is supported; data is a non-empty list of objects
+      - every row contains x_key AND y_key; y parses as a finite number
+      - non-degenerate: >=2 distinct categories, not all-equal/all-zero, and
+        enough points (>=3, or exactly 2 only when the values are comparable)
+    """
+    if not isinstance(config, dict):
+        return None
+
+    chart_type = config.get("chart_type")
+    x_key = config.get("x_key")
+    y_key = config.get("y_key")
+    data = config.get("data")
+
+    if chart_type not in _ALLOWED_CHART_TYPES:
+        return None
+    if not isinstance(data, list) or not data:
+        return None
+    if not isinstance(x_key, str) or not isinstance(y_key, str):
+        return None
+
+    categories: list[str] = []
+    y_values: list[float] = []
+    for row in data:
+        if not isinstance(row, dict) or x_key not in row or y_key not in row:
+            return None  # key mismatch — the empty-render class
+        y = _coerce_number(row.get(y_key))
+        if y is None:
+            return None  # non-numeric y
+        categories.append(str(row.get(x_key)))
+        y_values.append(y)
+
+    if len(set(categories)) < 2:
+        return None  # single category — nothing to compare
+    if len(set(y_values)) == 1:
+        return None  # all-equal (covers all-zero) — flat, uninformative
+    if len(y_values) < _MIN_CHART_POINTS:
+        # 1 point -> text; 2 points only if a genuine comparison.
+        if len(y_values) != 2 or not _comparable(y_values):
+            return None
+
+    return config
+
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}")  # ISO-ish date detection for temporal x
+_CHART_TYPE_KEYWORDS = (
+    ("horizontal", "bar_horizontal"),
+    ("donut", "pie"),
+    ("doughnut", "pie"),
+    ("pie", "pie"),
+    ("column", "bar"),
+    ("bar", "bar"),
+    ("line", "area"),
+    ("area", "area"),
+    ("trend", "area"),
+)
+
+
+def _select_chart_type(config: dict | None, question: str = "") -> dict | None:
+    """Pick chart_type deterministically from the data shape, overriding the
+    model's choice — unless the user explicitly named a type in the question.
+
+    temporal x + numeric y          -> area
+    nominal x (few categories)      -> bar (bar_horizontal when labels are long
+                                       or there are many categories)
+    model-chosen pie with few slices -> kept as pie (part-of-whole)
+    """
+    if config is None:
+        return None
+
+    q = (question or "").lower()
+    for kw, ctype in _CHART_TYPE_KEYWORDS:
+        # Word-boundary match so "pipeline" doesn't trigger "line", etc.
+        if re.search(rf"\b{kw}\b", q):
+            return {**config, "chart_type": ctype}
+
+    data = config.get("data") or []
+    x_key = config.get("x_key")
+    cats = [str(r.get(x_key, "")) for r in data if isinstance(r, dict)]
+    n = len(cats)
+    is_temporal = bool(cats) and all(_DATE_RE.match(c) for c in cats)
+
+    if is_temporal:
+        chosen = "area"
+    elif config.get("chart_type") == "pie" and n <= 6:
+        chosen = "pie"  # plausible part-of-whole
+    else:
+        longest = max((len(c) for c in cats), default=0)
+        chosen = "bar_horizontal" if (longest > 14 or n > 8) else "bar"
+
+    return {**config, "chart_type": chosen}
 
 
 @router.get("/{company_id}/chat/history", response_model=ChatHistoryResponse)

--- a/api/services/insights_service.py
+++ b/api/services/insights_service.py
@@ -34,9 +34,13 @@ def _build_chat_system_prompt() -> str:
         "formatting — they render as raw text in the UI. For multiple values, rely on the "
         "chart_config plus a one-line summary, or a short inline list "
         "(e.g. 'Customer A: $50k, B: $35k, C: $28k').\n"
-        "- ALWAYS include a chart_config JSON block when the data has multiple values, trends, comparisons, or distributions.\n"
-        "- Use area for trends over time, bar for comparisons, bar_horizontal for ranked lists, pie for distributions.\n"
-        "- Only omit charts for yes/no answers or single-number lookups.\n"
+        "- Default to a one-line prose answer. Only add a chart_config when there are at least "
+        "3 data points AND a chart genuinely helps: a trend over time, a comparison across several "
+        "categories, or a part-of-whole breakdown. For a single fact, a ranked top-N where one "
+        "value dominates, or only 1-2 values, answer in prose only — no chart.\n"
+        "- When you do chart: area for trends over time, bar for comparisons across categories, "
+        "bar_horizontal for ranked lists with long labels, pie for part-of-whole. Never use bold "
+        "(**) or any markdown formatting in the answer.\n"
         "- Answer with facts and numbers only. Do not add advice, opinions, or recommendations unless the user asks.\n"
         "- Include comparisons to previous periods when the data supports it (e.g., 'up 12% vs last week').\n"
         "- Flag risks prominently (at-risk jobs, low inventory, revenue decline).\n"
@@ -46,12 +50,14 @@ def _build_chat_system_prompt() -> str:
         "chart_config format (include as a ```json code block when applicable):\n"
         "{\n"
         '  "chart_type": "area" | "pie" | "bar" | "bar_horizontal" | "sparkline",\n'
-        '  "data": [{"x_key_value": ..., "y_key_value": ...}, ...],\n'
-        '  "x_key": "field_name",\n'
-        '  "y_key": "field_name",\n'
+        '  "data": [{"customer": "Acme", "revenue": 7749.24}, {"customer": "Globex", "revenue": 5210}],\n'
+        '  "x_key": "customer",\n'
+        '  "y_key": "revenue",\n'
         '  "x_label": "Axis Label",\n'
         '  "y_label": "Axis Label"\n'
-        "}"
+        "}\n\n"
+        "Every key inside the data row objects MUST be exactly the x_key and y_key strings "
+        "(here 'customer' and 'revenue'). Emit valid JSON only — no comments or trailing commas."
     )
 
 

--- a/api/tests/unit/test_chart_config.py
+++ b/api/tests/unit/test_chart_config.py
@@ -1,0 +1,233 @@
+"""Unit tests for chart_config validation + deterministic chart-type selection.
+
+The chat lets the model PROPOSE a chart_config; deterministic code then decides
+whether it's worth charting (validate + downgrade to text) and picks the chart
+type from the data shape. These tests cover that gate with no model in the loop.
+"""
+
+import pytest
+
+from routes.insights_routes import (
+    _extract_chart_config,
+    _flatten_markdown_tables,
+    _select_chart_type,
+    _strip_code_blocks,
+    _strip_inline_markdown,
+    _validate_chart_config,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def cfg(chart_type="bar", x_key="customer", y_key="revenue", data=None):
+    return {
+        "chart_type": chart_type,
+        "x_key": x_key,
+        "y_key": y_key,
+        "data": data if data is not None else [],
+    }
+
+
+class TestValidateChartConfig:
+    def test_none_returns_none(self):
+        assert _validate_chart_config(None) is None
+
+    def test_valid_multi_category_kept(self):
+        c = cfg(data=[
+            {"customer": "A", "revenue": 100},
+            {"customer": "B", "revenue": 80},
+            {"customer": "C", "revenue": 60},
+        ])
+        assert _validate_chart_config(c) is c
+
+    def test_single_dominant_two_points_downgraded(self):
+        # The reported incident: top customer 7749 vs 36 -> text, not a chart.
+        c = cfg(data=[
+            {"customer": "Customer 101", "revenue": 7749.24},
+            {"customer": "Other", "revenue": 36.46},
+        ])
+        assert _validate_chart_config(c) is None
+
+    def test_two_comparable_points_kept(self):
+        # A genuine 2-period comparison stays a chart.
+        c = cfg(x_key="week", y_key="revenue", data=[
+            {"week": "W1", "revenue": 100},
+            {"week": "W2", "revenue": 120},
+        ])
+        assert _validate_chart_config(c) is c
+
+    def test_single_point_downgraded(self):
+        assert _validate_chart_config(cfg(data=[{"customer": "A", "revenue": 100}])) is None
+
+    def test_key_mismatch_downgraded(self):
+        # Rows keyed name/value but config declares customer/revenue.
+        c = cfg(data=[
+            {"name": "A", "value": 100},
+            {"name": "B", "value": 80},
+            {"name": "C", "value": 60},
+        ])
+        assert _validate_chart_config(c) is None
+
+    def test_non_numeric_y_downgraded(self):
+        c = cfg(data=[
+            {"customer": "A", "revenue": "n/a"},
+            {"customer": "B", "revenue": 80},
+            {"customer": "C", "revenue": 60},
+        ])
+        assert _validate_chart_config(c) is None
+
+    def test_numeric_string_y_coerced_and_kept(self):
+        c = cfg(data=[
+            {"customer": "A", "revenue": "1,200.50"},
+            {"customer": "B", "revenue": "$800"},
+            {"customer": "C", "revenue": 600},
+        ])
+        assert _validate_chart_config(c) is c
+
+    def test_all_equal_downgraded(self):
+        c = cfg(data=[
+            {"customer": "A", "revenue": 50},
+            {"customer": "B", "revenue": 50},
+            {"customer": "C", "revenue": 50},
+        ])
+        assert _validate_chart_config(c) is None
+
+    def test_all_zero_downgraded(self):
+        c = cfg(data=[
+            {"customer": "A", "revenue": 0},
+            {"customer": "B", "revenue": 0},
+            {"customer": "C", "revenue": 0},
+        ])
+        assert _validate_chart_config(c) is None
+
+    def test_single_category_downgraded(self):
+        c = cfg(data=[
+            {"customer": "A", "revenue": 10},
+            {"customer": "A", "revenue": 20},
+            {"customer": "A", "revenue": 30},
+        ])
+        assert _validate_chart_config(c) is None
+
+    def test_unsupported_chart_type_downgraded(self):
+        c = cfg(chart_type="radar", data=[
+            {"customer": "A", "revenue": 100},
+            {"customer": "B", "revenue": 80},
+            {"customer": "C", "revenue": 60},
+        ])
+        assert _validate_chart_config(c) is None
+
+    def test_empty_data_downgraded(self):
+        assert _validate_chart_config(cfg(data=[])) is None
+
+
+class TestSelectChartType:
+    def test_none_passthrough(self):
+        assert _select_chart_type(None) is None
+
+    def test_temporal_x_becomes_area(self):
+        c = cfg(chart_type="bar", x_key="week", y_key="revenue", data=[
+            {"week": "2026-01-01", "revenue": 100},
+            {"week": "2026-02-01", "revenue": 120},
+            {"week": "2026-03-01", "revenue": 90},
+        ])
+        assert _select_chart_type(c, "revenue over time")["chart_type"] == "area"
+
+    def test_nominal_short_labels_become_bar(self):
+        c = cfg(chart_type="bar", data=[
+            {"customer": "A", "revenue": 100},
+            {"customer": "B", "revenue": 80},
+            {"customer": "C", "revenue": 60},
+        ])
+        assert _select_chart_type(c, "top customers")["chart_type"] == "bar"
+
+    def test_long_labels_become_horizontal(self):
+        c = cfg(chart_type="bar", data=[
+            {"customer": "Acme Manufacturing Co", "revenue": 100},
+            {"customer": "Globex International Ltd", "revenue": 80},
+            {"customer": "Initech Industrial Group", "revenue": 60},
+        ])
+        assert _select_chart_type(c, "top customers")["chart_type"] == "bar_horizontal"
+
+    def test_explicit_user_request_overrides(self):
+        c = cfg(chart_type="bar", data=[
+            {"customer": "A", "revenue": 100},
+            {"customer": "B", "revenue": 80},
+            {"customer": "C", "revenue": 60},
+        ])
+        assert _select_chart_type(c, "show me a pie chart of revenue")["chart_type"] == "pie"
+
+    def test_pipeline_does_not_trigger_line_keyword(self):
+        # "pipeline" must NOT match the "line" keyword (word-boundary).
+        c = cfg(chart_type="bar", data=[
+            {"customer": "A", "revenue": 100},
+            {"customer": "B", "revenue": 80},
+            {"customer": "C", "revenue": 60},
+        ])
+        assert _select_chart_type(c, "what is my quote pipeline worth?")["chart_type"] == "bar"
+
+    def test_model_pie_with_few_slices_kept(self):
+        c = cfg(chart_type="pie", data=[
+            {"customer": "A", "revenue": 50},
+            {"customer": "B", "revenue": 30},
+            {"customer": "C", "revenue": 20},
+        ])
+        assert _select_chart_type(c, "revenue split by customer")["chart_type"] == "pie"
+
+    def test_does_not_mutate_input(self):
+        c = cfg(chart_type="pie", data=[
+            {"customer": "A", "revenue": 100},
+            {"customer": "B", "revenue": 80},
+            {"customer": "C", "revenue": 60},
+        ])
+        _select_chart_type(c, "top customers")
+        assert c["chart_type"] == "pie"  # original object unchanged
+
+
+def _process(raw: str, question: str = ""):
+    """Mirror exactly what the chat route does to a raw model response."""
+    clean = _strip_inline_markdown(_flatten_markdown_tables(_strip_code_blocks(raw)))
+    chart = _select_chart_type(_validate_chart_config(_extract_chart_config(raw)), question)
+    return clean, chart
+
+
+class TestChatPipelineComposition:
+    """End-to-end of the route's text-cleanup + chart-decision chain (no model)."""
+
+    def test_top_customer_incident_downgrades_and_strips_bold(self):
+        # The reported incident, end to end: bold stripped, degenerate 2-bar
+        # (one dominant value) chart downgraded to a text-only answer.
+        raw = (
+            "**Customer 101** is your top customer by a wide margin — $7,749.24.\n"
+            "```json\n"
+            '{"chart_type": "bar", "x_key": "customer", "y_key": "revenue", '
+            '"data": [{"customer": "Customer 101", "revenue": 7749.24}, '
+            '{"customer": "Other", "revenue": 36.46}]}\n'
+            "```"
+        )
+        clean, chart = _process(raw, "who is my top customer by revenue?")
+        assert "**" not in clean
+        assert "Customer 101 is your top customer" in clean
+        assert chart is None  # degenerate -> text only
+
+    def test_key_mismatch_downgrades(self):
+        raw = (
+            "Here is revenue by customer.\n```json\n"
+            '{"chart_type": "bar", "x_key": "customer", "y_key": "revenue", '
+            '"data": [{"name": "A", "value": 5}, {"name": "B", "value": 3}, '
+            '{"name": "C", "value": 2}]}\n```'
+        )
+        _, chart = _process(raw)
+        assert chart is None
+
+    def test_valid_trend_kept_and_typed_area(self):
+        raw = (
+            "Revenue is trending up.\n```json\n"
+            '{"chart_type": "bar", "x_key": "week", "y_key": "revenue", '
+            '"data": [{"week": "2026-01-01", "revenue": 100}, '
+            '{"week": "2026-02-01", "revenue": 140}, '
+            '{"week": "2026-03-01", "revenue": 120}]}\n```'
+        )
+        clean, chart = _process(raw, "revenue over time")
+        assert chart is not None
+        assert chart["chart_type"] == "area"  # temporal -> area
+        assert "```" not in clean

--- a/api/tests/unit/test_chat_formatting.py
+++ b/api/tests/unit/test_chat_formatting.py
@@ -7,7 +7,11 @@ is the backstop that converts those to readable plain text.
 
 import pytest
 
-from routes.insights_routes import _flatten_markdown_tables, _strip_code_blocks
+from routes.insights_routes import (
+    _flatten_markdown_tables,
+    _strip_code_blocks,
+    _strip_inline_markdown,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -65,3 +69,27 @@ class TestStripCodeBlocks:
         out = _strip_code_blocks(text)
         assert "chart_type" not in out
         assert "Revenue up." in out
+
+
+class TestStripInlineMarkdown:
+    def test_bold_unwrapped(self):
+        # The exact reported defect.
+        assert _strip_inline_markdown("**Customer 101** is your top customer") == (
+            "Customer 101 is your top customer"
+        )
+
+    def test_italic_and_code_and_heading_and_link(self):
+        assert _strip_inline_markdown("an *italic* word") == "an italic word"
+        assert _strip_inline_markdown("the `job_id` field") == "the job_id field"
+        assert _strip_inline_markdown("# Heading\nbody") == "Heading\nbody"
+        assert _strip_inline_markdown("see [the docs](https://x.io/y)") == "see the docs"
+
+    def test_plain_prose_untouched(self):
+        text = "Revenue is up 12% vs last week."
+        assert _strip_inline_markdown(text) == text
+
+    def test_part_numbers_and_multiplication_preserved(self):
+        # Underscores in identifiers and a literal "a * b" must NOT be mangled.
+        assert _strip_inline_markdown("Part PART_101 ships today") == "Part PART_101 ships today"
+        assert _strip_inline_markdown("cost is a * b per unit") == "cost is a * b per unit"
+        assert _strip_inline_markdown("col revenue_total is high") == "col revenue_total is high"

--- a/components/insights/InsightChart.tsx
+++ b/components/insights/InsightChart.tsx
@@ -28,6 +28,15 @@ function formatLabel(value: string): string {
   return value.length > 12 ? value.slice(0, 12) + '...' : value;
 }
 
+/** Abbreviate large numbers for axis ticks: 7749 -> "7.7K", 1.2e6 -> "1.2M". */
+function formatCompact(value: number): string {
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000_000) return (value / 1_000_000_000).toFixed(1).replace(/\.0$/, '') + 'B';
+  if (abs >= 1_000_000) return (value / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M';
+  if (abs >= 1_000) return (value / 1_000).toFixed(1).replace(/\.0$/, '') + 'K';
+  return String(value);
+}
+
 /**
  * Wrapper component that renders MUI X Charts based on chart_config.
  * Supports: area, pie, bar, bar_horizontal, sparkline chart types.
@@ -54,6 +63,20 @@ export default function InsightChart({ chartConfig, height = 250 }: InsightChart
     );
   }
 
+  // Fail loud if the model's x_key/y_key aren't present on the rows. The server
+  // validator should already have dropped such configs, but never silently
+  // render blank labels / zero bars (the original "empty chart" bug).
+  const hasKeys = data.every((d) => x_key in d && y_key in d);
+  if (!hasKeys) {
+    return (
+      <Box sx={{ height, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Typography variant="body2" color="text.secondary">
+          No chartable data
+        </Typography>
+      </Box>
+    );
+  }
+
   const chartColors = [
     theme.palette.primary.main,
     theme.palette.secondary.main,
@@ -63,9 +86,16 @@ export default function InsightChart({ chartConfig, height = 250 }: InsightChart
     theme.palette.info.main,
   ];
 
+  // Sort nominal bars by value (descending) for readability; preserve the
+  // original order for time series (area) and pie.
+  const sortForBars = chart_type === 'bar' || chart_type === 'bar_horizontal';
+  const rows = sortForBars
+    ? [...data].sort((a, b) => Number(b[y_key] ?? 0) - Number(a[y_key] ?? 0))
+    : data;
+
   // Extract x-axis labels and y-axis values
-  const xLabels = data.map((d) => formatLabel(String(d[x_key] ?? '')));
-  const yValues = data.map((d) => Number(d[y_key] ?? 0));
+  const xLabels = rows.map((d) => formatLabel(String(d[x_key] ?? '')));
+  const yValues = rows.map((d) => Number(d[y_key] ?? 0));
 
   if (chart_type === 'area') {
     return (
@@ -82,6 +112,8 @@ export default function InsightChart({ chartConfig, height = 250 }: InsightChart
           yAxis={[
             {
               label: y_label,
+              min: 0,
+              valueFormatter: (value: number) => formatCompact(value),
               tickLabelStyle: { fill: theme.palette.text.secondary, fontSize: 11 },
             },
           ]}
@@ -157,6 +189,8 @@ export default function InsightChart({ chartConfig, height = 250 }: InsightChart
           yAxis={[
             {
               label: y_label,
+              min: 0,
+              valueFormatter: (value: number) => formatCompact(value),
               tickLabelStyle: { fill: theme.palette.text.secondary, fontSize: 11 },
             },
           ]}
@@ -192,6 +226,8 @@ export default function InsightChart({ chartConfig, height = 250 }: InsightChart
           xAxis={[
             {
               label: y_label,
+              min: 0,
+              valueFormatter: (value: number) => formatCompact(value),
               tickLabelStyle: { fill: theme.palette.text.secondary, fontSize: 11 },
             },
           ]}

--- a/docs/modules/ai-insights.md
+++ b/docs/modules/ai-insights.md
@@ -84,13 +84,45 @@ The dashboard page is user-driven: the ask bar is the only way to generate insig
        |
        v
 6. AI interprets results -> returns:
-   - Natural language summary
-   - Optional chart_config (chart type + formatted data)
+   - Natural language summary (inline markdown + tables stripped for the plain-text UI)
+   - Optional *proposed* chart_config (chart type + formatted data)
        |
        v
-7. Frontend renders text + optional MUI X Chart
-   - Save button only shown when chart_config exists
+7. Backend decides the modality deterministically (constrained renderer):
+   - validate chart_config against its data; downgrade to text when invalid or
+     degenerate (missing keys, non-numeric y, 1-2 dominant values, single category)
+   - pick the chart type from the data shape (temporal -> area, nominal -> bar)
+       |
+       v
+8. Frontend renders text + optional MUI X Chart
+   - InsightChart fails loud ("No chartable data") instead of blank bars
+   - Save button only shown when a chart survived validation
 ```
+
+### Chart decisioning & validation
+
+Text-first, **constrained-renderer** pattern (industry norm: ThoughtSpot, Power BI
+Copilot, Tableau "Show Me", Amazon QuickSight Q): the model *proposes* a chart, but
+deterministic code decides whether and how to render it.
+
+- **Modality (prompt):** default to a one-line prose answer; ask for a `chart_config`
+  only when there are >=3 data points and a chart genuinely helps (trend over time,
+  comparison across categories, part-of-whole). Single facts, dominant top-N, and
+  1-2 values stay text.
+- **Validation + downgrade** (`_validate_chart_config`, `api/routes/insights_routes.py`):
+  drops the chart (keeping the prose answer) when `chart_type` is unsupported, data is
+  empty, the declared `x_key`/`y_key` aren't on every row, `y` isn't numeric, or the
+  result is degenerate (<2 distinct categories, all-equal/all-zero, a single point, or
+  a 2-point chart where one value dominates). A dropped chart is an explicit downgrade —
+  never a blank card.
+- **Deterministic chart type** (`_select_chart_type`): the rendered type is derived from
+  the data shape (temporal x -> `area`; nominal x -> `bar`, or `bar_horizontal` for
+  long/many labels; a model-chosen `pie` is kept only for a few slices). An explicit type
+  named in the question ("as a pie") wins.
+- **Renderer guards** (`components/insights/InsightChart.tsx`): missing `x_key`/`y_key`
+  shows an explicit "No chartable data" state (never blank labels / zero bars); bar/area
+  use a zero baseline; axis ticks are abbreviated (`7749` -> `7.7K`); nominal bars are
+  value-sorted.
 
 ### Hybrid Tool Architecture
 
@@ -492,7 +524,7 @@ The chat system prompt includes:
 2. **Database schema** — All 17 tables with column names, types, enum values, foreign key relationships, and important notes (imported from `schema_context.py`)
 3. **SQL guidelines** — Use `$1` for company_id, join patterns for tables without company_id
 4. **Example queries** — 4 common patterns for reference
-5. **Response guidelines** — Keep summaries concise, include chart_config when appropriate, plain prose only (no markdown tables — they render as raw text in the UI), highlight actionable insights
+5. **Response guidelines** — Text-first: a one-line prose answer by default, with a chart_config only when there are >=3 points and a chart helps. Plain prose only — no markdown tables, bold, or other markdown (the UI renders plain text). Highlight actionable insights
 
 ```
 You are a business analyst for a small precision manufacturing shop.
@@ -505,12 +537,12 @@ Guidelines:
 - Always use execute_sql to get real data. Never make up numbers.
 - Use $1 as a placeholder for company_id in all queries.
 - Keep summaries to 1-3 sentences. Shop owners are busy.
-- When data supports it, include a chart_config JSON block.
+- Default to a one-line prose answer; include a chart_config only when there are >=3 data points and a chart helps (trend, comparison, part-of-whole). Single facts and 1-2 values stay text.
 - Highlight actionable insights: what should the owner DO about this data?
 - Compare to previous periods when relevant.
 - Flag risks prominently (at-risk jobs, low inventory, revenue decline).
 - Use plain language. Avoid jargon. These are machinists, not MBAs.
-- Write plain prose. Never use markdown tables or pipe/--- columns; for multiple values use chart_config plus a one-line summary or a short inline list.
+- Write plain prose. Never use markdown tables, bold (**), or any markdown; for multiple values use chart_config plus a one-line summary or a short inline list.
 - Only query tables in the schema above; never reference user/auth/access tables.
 ```
 


### PR DESCRIPTION
## Problem

From the dashboard AI chat: "Who is my top customer by revenue?" returned a **chart** (a 2-bar vertical chart that rendered nearly empty — overlapping y-axis numbers, no visible bars, no category labels) when it should have been a one-line **text** answer, and the text showed literal `**Customer 101**` (raw markdown bold).

A multi-agent research pass (codebase diagnosis + industry practice + adversarial synthesis) confirmed the root causes:
- **Modality was 100% model-driven** via a loose prompt ("ALWAYS chart multiple values") with zero code-side gating.
- The prompt's chart_config **example was self-contradictory** (`x_key_value`/`y_key_value` keys ≠ the declared `x_key`/`y_key`), training the model to emit data whose keys don't match — the exact mismatch that renders empty.
- **No validation** of chart_config against its data anywhere; `InsightChart` silently coerced missing keys to `''`/`0`.
- Inline markdown (`**bold**`) leaked into the plain-text UI.

## Approach — constrained renderer, text-first

Industry consensus (ThoughtSpot, Power BI Copilot, Tableau "Show Me", Amazon QuickSight Q) plus NL2VIS/perception research (LIDA, ChartGPT, VisEval, Mackinlay, Cleveland–McGill): the model **proposes**, but **deterministic code decides whether and how to chart** from the data's shape, defaulting to text.

### Phase 1 — quick wins
- `_strip_inline_markdown` added to the answer cleanup chain (unwraps `**bold**`/`*italic*`/`` `code` ``/links/headings; only paired/anchored patterns, so `PART_101` and `a * b` survive).
- Prompt: **text-first** modality (chart only for ≥3 points where a chart helps); fixed the contradictory example (row keys now match `x_key`/`y_key`); forbid markdown/bold.

### Phase 2 — validate + downgrade (the load-bearing fix)
- `_validate_chart_config`: returns the config or `None` (drop chart, **keep prose** — never a blank card) when `chart_type` is unsupported, data is empty, `x_key`/`y_key` aren't on every row, `y` isn't numeric, or the result is degenerate (<2 distinct categories, all-equal/all-zero, single point, or a 2-point chart where one value dominates — the incident).

### Phase 3 — quality hardening
- `_select_chart_type`: chart type from the data shape (temporal→`area`; nominal→`bar`/`bar_horizontal`; model `pie` kept for few slices); an explicit type in the question ("as a pie") wins. Word-boundary keyword match so "pipeline" doesn't trigger "line".
- `InsightChart`: fail loud ("No chartable data") on missing keys instead of blank bars; `yAxis min=0`; abbreviated axis ticks (`7749`→`7.7K`); value-sorted nominal bars.

## Testing (credit-free, per-PR)

- **pytest** (36): `_strip_inline_markdown` (incl. `PART_101` / `a * b` preserved); `_validate_chart_config` table (single value, 2-point dominant spread, key-mismatch, non-numeric y, all-zero/equal, valid trend → kept vs downgraded); `_select_chart_type`; and a **route-composition test** that runs the exact incident response through the real cleanup→validate→select chain.
- **Vitest** (4): `InsightChart` fail-loud states (empty data, missing keys) + valid render (x-charts stubbed for determinism).
- `tsc --noEmit` clean.

> Note: I implemented the "full pipeline" coverage as the pytest route-composition test rather than a Playwright spec — a Playwright insights spec would be CI-skipped (needs the FastAPI backend + AI mock, like `csv-import`), so the composition test gives the same per-PR confidence credit-free. A Playwright spec + request-aware Anthropic mock remains an easy follow-up if wanted.

No migration. No new dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)