### PR TITLE
refactor(customers): drop unused id field from CustomerAddressFormData (#373)

### DIFF
--- a/components/customers/CustomerAddressForm.tsx
+++ b/components/customers/CustomerAddressForm.tsx
@@ -41,7 +41,6 @@ interface CustomerAddressFormProps {
 
 function addressToFormData(addr: CustomerAddress): CustomerAddressFormData {
   return {
-    id: addr.id,
     address_line1: addr.address_line1 ?? '',
     address_line2: addr.address_line2 ?? '',
     city: addr.city ?? '',

--- a/types/customer.ts
+++ b/types/customer.ts
@@ -41,12 +41,11 @@ export interface CustomerAddress {
 }
 
 /**
- * Address fields the form/modal edits. Excludes server-managed identity and
- * timestamps so create and update can use the same shape.
+ * Address fields the form/modal edits. Excludes server-managed identity (the
+ * row id — passed separately to updateCustomerAddress) and timestamps so
+ * create and update can use the same shape.
  */
 export interface CustomerAddressFormData {
-  /** Present for existing addresses, absent for newly-added rows. */
-  id?: string;
   address_line1: string;
   address_line2: string;
   city: string;


### PR DESCRIPTION
Closes #373.

## Problem

`CustomerAddressFormData.id` was a cosmetic shape mismatch: the field was only ever **written** (in `addressToFormData`), never **read**. `updateCustomerAddress` takes the row id as a separate `addressId` argument, and `formDataToRow` never references `id` — so the form type advertised an `id` that round-trips when it shouldn't.

(The modal named in the issue, `CustomerAddressModal.tsx`, has since been refactored into the inline `CustomerAddressForm.tsx` — same save path, same finding.)

## Change

- `types/customer.ts` — removed `id?: string` from `CustomerAddressFormData`; updated the doc comment to note the id is passed separately to `updateCustomerAddress`.
- `components/customers/CustomerAddressForm.tsx` — removed the orphaned `id: addr.id` assignment in `addressToFormData`.

No behavior change — `id` was never on the save path.

## Verification

- ✅ `pnpm exec tsc --noEmit -p tsconfig.json` passes.
- ✅ `pnpm test --run __tests__/components/quotes/QuoteForm.test.tsx` — 23/23 pass (only test touching this component).

## Acceptance criteria

- [x] `CustomerAddressFormData` no longer exposes `id`; shape matches what `updateCustomerAddress` writes.
- [x] `tsc --noEmit` passes.
- [x] No behavior change in the address form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)