### PR TITLE
refactor(lint): migrate 6 component loaders to useLoad (#442, PR 3b)

### DIFF
--- a/components/dashboard/InsightsSection.tsx
+++ b/components/dashboard/InsightsSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useState } from 'react';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
@@ -14,6 +15,9 @@ import {
 import type { SavedInsight } from '@/utils/insightsAccess';
 
 const MAX_SAVED = 5;
+
+// Stable empty fallback so derived data doesn't churn while the first load runs.
+const EMPTY_INSIGHTS: SavedInsight[] = [];
 
 interface InsightsSectionProps {
   companyId: string;
@@ -33,39 +37,39 @@ export default function InsightsSection({
   savedVersion = 0,
   onSavedCountChange,
 }: InsightsSectionProps) {
-  const [savedInsights, setSavedInsights] = useState<SavedInsight[]>([]);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchSavedInsights = useCallback(async () => {
-    if (!companyId) return;
-
-    try {
-      setLoading(true);
-      setError(null);
+  const {
+    data: savedData,
+    loading,
+    reload: fetchSavedInsights,
+  } = useLoad(
+    async () => {
+      // No company yet → nothing to fetch (and report a zero count so the
+      // parent's chat affordance stays in sync).
+      if (!companyId) {
+        onSavedCountChange?.(0);
+        return [] as SavedInsight[];
+      }
       const saved = await getSavedInsights(companyId);
-      setSavedInsights(saved);
       onSavedCountChange?.(saved.length);
-    } catch (err) {
-      console.error('Error fetching saved insights:', err);
-      setError('Failed to load saved charts.');
-    } finally {
-      setLoading(false);
-    }
-  }, [companyId, onSavedCountChange]);
-
-  useEffect(() => {
-    fetchSavedInsights();
-  }, [fetchSavedInsights, savedVersion]);
+      return saved;
+    },
+    [companyId, savedVersion],
+    {
+      onError: (err) => {
+        console.error('Error fetching saved insights:', err);
+        setError('Failed to load saved charts.');
+      },
+    },
+  );
+  const savedInsights = savedData ?? EMPTY_INSIGHTS;
 
   const handleRemoveSaved = async (insightId: string) => {
     try {
       await deleteSavedInsight(companyId, insightId);
-      setSavedInsights((prev) => {
-        const next = prev.filter((s) => s.id !== insightId);
-        onSavedCountChange?.(next.length);
-        return next;
-      });
+      // Re-pull so the list + reported count come from one source of truth.
+      await fetchSavedInsights();
     } catch (err) {
       console.error('Error deleting saved insight:', err);
     }

--- a/components/inventory/locations/LocationsManager.tsx
+++ b/components/inventory/locations/LocationsManager.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
@@ -65,14 +66,15 @@ function collectLabels(node: InventoryLocationNode, byId: Map<string, InventoryL
   return out;
 }
 
+// Stable empty fallback so the tree/labels memos don't churn while loading.
+const EMPTY_LOCATIONS: InventoryLocation[] = [];
+
 interface LocationsManagerProps {
   companyId: string;
   companyName?: string;
 }
 
 export default function LocationsManager({ companyId, companyName }: LocationsManagerProps) {
-  const [locations, setLocations] = useState<InventoryLocation[]>([]);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const [builderOpen, setBuilderOpen] = useState(false);
@@ -102,25 +104,20 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
     node: null,
   });
 
+  const {
+    data: locationsData,
+    loading,
+    reload,
+  } = useLoad(() => getLocations(companyId), [companyId], {
+    onError: (e) => {
+      setError(e instanceof Error ? e.message : 'Failed to load locations.');
+    },
+  });
+  const locations = locationsData ?? EMPTY_LOCATIONS;
+
   const byId = useMemo(() => new Map(locations.map((l) => [l.id, l] as const)), [locations]);
   const tree = useMemo(() => buildLocationTree(locations), [locations]);
   const allLabels = useMemo(() => tree.flatMap((n) => collectLabels(n, byId)), [tree, byId]);
-
-  const reload = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      setLocations(await getLocations(companyId));
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load locations.');
-    } finally {
-      setLoading(false);
-    }
-  }, [companyId]);
-
-  useEffect(() => {
-    void reload();
-  }, [reload]);
 
   const callbacks = {
     onAddChild: (node: InventoryLocationNode) =>

--- a/components/jobs/JobAttachmentsCard.tsx
+++ b/components/jobs/JobAttachmentsCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useRef, useState } from 'react';
+import { useLoad } from '@/hooks/useLoad';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Box from '@mui/material/Box';
@@ -30,6 +31,9 @@ import {
   validateAttachmentFile,
 } from '@/utils/jobAttachmentsAccess';
 import type { JobAttachment } from '@/types/job';
+
+// Stable empty fallback so derived data doesn't churn while the first load runs.
+const EMPTY_ATTACHMENTS: JobAttachment[] = [];
 
 interface JobAttachmentsCardProps {
   jobId: string;
@@ -62,8 +66,6 @@ function isViewable(att: JobAttachment): boolean {
  * immediate; download opens a fresh signed URL.
  */
 export default function JobAttachmentsCard({ jobId, companyId }: JobAttachmentsCardProps) {
-  const [attachments, setAttachments] = useState<JobAttachment[]>([]);
-  const [loading, setLoading] = useState(true);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -72,20 +74,17 @@ export default function JobAttachmentsCard({ jobId, companyId }: JobAttachmentsC
   const [viewUrl, setViewUrl] = useState<string | null>(null);
   const [viewLoading, setViewLoading] = useState(false);
 
-  const refresh = useCallback(async () => {
-    try {
-      setAttachments(await listJobAttachments(jobId));
-    } catch (err) {
+  const {
+    data: attachmentsData,
+    loading,
+    reload: refresh,
+  } = useLoad(() => listJobAttachments(jobId), [jobId], {
+    onError: (err) => {
       console.error('Error loading attachments:', err);
       setError('Could not load attachments.');
-    } finally {
-      setLoading(false);
-    }
-  }, [jobId]);
-
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
+    },
+  });
+  const attachments = attachmentsData ?? EMPTY_ATTACHMENTS;
 
   const handleSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] ?? null;

--- a/components/jobs/ShipmentHistoryCard.tsx
+++ b/components/jobs/ShipmentHistoryCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { useLoad } from '@/hooks/useLoad';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -28,6 +29,9 @@ import type { ShipmentWithRelations } from '@/types/shipment';
 import { SHIPPING_METHOD_LABELS } from '@/types/shipment';
 import PackingSlipPreviewDialog from '@/components/shipments/PackingSlipPreviewDialog';
 
+// Stable empty fallback so derived data doesn't churn while the first load runs.
+const EMPTY_SHIPMENTS: ShipmentWithRelations[] = [];
+
 interface ShipmentHistoryCardProps {
   jobId: string;
   /** Set to a new value (e.g., Date.now()) when a fresh shipment has been created so the card refetches. */
@@ -52,18 +56,18 @@ export default function ShipmentHistoryCard({
   initialPreviewShipmentId = null,
   onShipmentVoided,
 }: ShipmentHistoryCardProps) {
-  const [shipments, setShipments] = useState<ShipmentWithRelations[]>([]);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [previewId, setPreviewId] = useState<string | null>(initialPreviewShipmentId);
   const [voidTarget, setVoidTarget] = useState<ShipmentWithRelations | null>(null);
   const [voiding, setVoiding] = useState(false);
   const [voidError, setVoidError] = useState<string | null>(null);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
+  const {
+    data: shipmentsData,
+    loading,
+    reload: load,
+  } = useLoad(
+    async () => {
       const rows = await getShipmentsForJob(jobId);
       // The PostgREST inner-join produces one row per matching
       // shipment_line_item. Roll up to one row per shipment so the
@@ -80,24 +84,22 @@ export default function ShipmentHistoryCard({
           ];
         }
       }
-      const merged = Array.from(byId.values()).sort((a, b) => {
+      return Array.from(byId.values()).sort((a, b) => {
         const ad = a.ship_date;
         const bd = b.ship_date;
         if (ad !== bd) return ad < bd ? 1 : -1;
         return a.created_at < b.created_at ? 1 : -1;
       });
-      setShipments(merged);
-    } catch (err) {
-      console.error('Failed to load shipment history:', err);
-      setError(err instanceof Error ? err.message : 'Failed to load shipments.');
-    } finally {
-      setLoading(false);
-    }
-  }, [jobId]);
-
-  useEffect(() => {
-    load();
-  }, [load, refreshKey]);
+    },
+    [jobId, refreshKey],
+    {
+      onError: (err) => {
+        console.error('Failed to load shipment history:', err);
+        setError(err instanceof Error ? err.message : 'Failed to load shipments.');
+      },
+    },
+  );
+  const shipments = shipmentsData ?? EMPTY_SHIPMENTS;
 
   // When a parent passes an initial preview id (post-create flow),
   // open the dialog on first mount. Don't reopen on refresh.

--- a/components/operator/JobFeed.tsx
+++ b/components/operator/JobFeed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useLoad } from '@/hooks/useLoad';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Box from '@mui/material/Box';
@@ -24,6 +25,9 @@ import type { JobNote, JobNoteMedia } from '@/types/operator';
 
 const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
 const THUMB = 76;
+
+// Stable empty fallback so the merge memo doesn't churn while the first load runs.
+const EMPTY_NOTES: JobNote[] = [];
 
 /**
  * Context the operation page passes so the composer auto-tags every capture to
@@ -71,9 +75,10 @@ interface PendingPhoto {
  * Listing is a plain Supabase read (no AI on mount).
  */
 export default function JobFeed({ jobId, companyId, readOnly, operationContext }: JobFeedProps) {
-  const [notes, setNotes] = useState<JobNote[]>([]);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Notes posted optimistically (prepended before the next full load). Deduped
+  // out of the merged list once they show up in a fresh load by id.
+  const [pendingNotes, setPendingNotes] = useState<JobNote[]>([]);
 
   const [operatorId, setOperatorId] = useState<string | null>(null);
   const [noteDraft, setNoteDraft] = useState('');
@@ -90,21 +95,25 @@ export default function JobFeed({ jobId, companyId, readOnly, operationContext }
 
   const showComposer = !readOnly && !!operationContext;
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      setNotes(await getJobNotes(jobId, companyId));
-    } catch (err) {
+  const {
+    data: loadedNotesData,
+    loading,
+    reload: load,
+  } = useLoad(() => getJobNotes(jobId, companyId), [jobId, companyId], {
+    onError: (err) => {
       setError(err instanceof Error ? err.message : 'Could not load the feed.');
-    } finally {
-      setLoading(false);
-    }
-  }, [jobId, companyId]);
+    },
+  });
+  const loadedNotes = loadedNotesData ?? EMPTY_NOTES;
 
-  useEffect(() => {
-    load();
-  }, [load]);
+  // Merge optimistic posts ahead of the loaded feed, dropping any that the
+  // latest load already includes (matched by id) so there are no duplicates.
+  const notes = useMemo(() => {
+    if (pendingNotes.length === 0) return loadedNotes;
+    const loadedIds = new Set(loadedNotes.map((n) => n.id));
+    const stillPending = pendingNotes.filter((n) => !loadedIds.has(n.id));
+    return [...stillPending, ...loadedNotes];
+  }, [loadedNotes, pendingNotes]);
 
   useEffect(() => {
     if (!showComposer) return;
@@ -202,7 +211,7 @@ export default function JobFeed({ jobId, companyId, readOnly, operationContext }
         );
       }
 
-      setNotes((prev) => [{ ...note, media }, ...prev]);
+      setPendingNotes((prev) => [{ ...note, media }, ...prev]);
       pending.forEach((p) => URL.revokeObjectURL(p.previewUrl));
       setPending([]);
       setNoteDraft('');

--- a/components/parts/workspace/PartWorkspace.tsx
+++ b/components/parts/workspace/PartWorkspace.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useParams, useRouter, usePathname, useSearchParams } from 'next/navigation';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -38,6 +39,8 @@ import UsageTab from './tabs/UsageTab';
 import HistoryTab from './tabs/HistoryTab';
 import FilesTab from './tabs/FilesTab';
 
+// Stable empty fallback so derived data doesn't churn while the first load runs.
+const EMPTY_CONVERSIONS: PartUnitConversion[] = [];
 
 /**
  * The part workspace: a maturity-adaptive record that leads with the
@@ -96,10 +99,6 @@ export default function PartWorkspace({
     };
   }, [currentChain]);
 
-  const [part, setPart] = useState<Part | null>(null);
-  const [unitConversions, setUnitConversions] = useState<PartUnitConversion[]>([]);
-
-  const [loading, setLoading] = useState(mode === 'existing');
   const [actionLoading, setActionLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -110,6 +109,11 @@ export default function PartWorkspace({
   // Bumped after each stock transaction so the history table reloads.
   const [transactionsRefreshKey, setTransactionsRefreshKey] = useState(0);
 
+  // Inline conversion edits from the Inventory tab take precedence over the
+  // seed fetched on load (the editor owns the live list once it mounts). Reset
+  // to null on a fresh part (partId-change remounts this component anyway).
+  const [conversionsOverride, setConversionsOverride] = useState<PartUnitConversion[] | null>(null);
+
   const [txnModalOpen, setTxnModalOpen] = useState(false);
   const [txnModalType, setTxnModalType] = useState<InventoryTransactionType>('addition');
 
@@ -118,40 +122,39 @@ export default function PartWorkspace({
   // while loading. Recomputed when refreshKey bumps (routing/pricing changed).
   const [isPriceable, setIsPriceable] = useState<boolean | null>(null);
 
-  /**
-   * Fetch the part + its side-loads. `silent` skips the loading flag so a
-   * post-mutation refetch swaps data in place without spinnering the page.
-   */
-  const fetchPart = useCallback(
-    async (silent = false) => {
-      if (!partId) return;
-      try {
-        if (!silent) setLoading(true);
-        const data = await getPartWithRelations(partId);
-        setPart(data);
-        setError(null);
-
-        if (data) {
-          try {
-            const conversions = await getPartUnitConversions(partId);
-            setUnitConversions(conversions);
-          } catch (err) {
-            console.warn('Failed to load unit conversions:', err);
-            setUnitConversions([]);
-          }
+  // Fetch the part + its side-loads. The mount load (and a partId change)
+  // shows the spinner; a post-mutation refetch comes through a deps bump
+  // (refreshKey / transactionsRefreshKey) so useLoad swaps data in place
+  // without spinnering the page (stale-while-revalidate). Conversions are a
+  // non-fatal side-load — failure degrades to an empty list, not a page error.
+  const {
+    data: loadData,
+    loading: partLoading,
+  } = useLoad(
+    async () => {
+      if (!partId) return { part: null, conversions: [] as PartUnitConversion[] };
+      const part = await getPartWithRelations(partId);
+      let conversions: PartUnitConversion[] = [];
+      if (part) {
+        try {
+          conversions = await getPartUnitConversions(partId);
+        } catch (err) {
+          console.warn('Failed to load unit conversions:', err);
         }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load part');
-      } finally {
-        if (!silent) setLoading(false);
       }
+      return { part, conversions };
     },
-    [partId],
+    [partId, refreshKey, transactionsRefreshKey],
+    {
+      onError: (err) => {
+        setError(err instanceof Error ? err.message : 'Failed to load part');
+      },
+    },
   );
-
-  useEffect(() => {
-    fetchPart();
-  }, [fetchPart]);
+  const part = loadData?.part ?? null;
+  const unitConversions = conversionsOverride ?? loadData?.conversions ?? EMPTY_CONVERSIONS;
+  // Create mode never fetches (no partId); only existing mode shows the spinner.
+  const loading = mode === 'existing' && partLoading;
 
   useEffect(() => {
     if (!partId) return;
@@ -181,10 +184,11 @@ export default function PartWorkspace({
     return () => setTitle(null);
   }, [mode, part, setTitle]);
 
-  const refreshAfterMutation = useCallback(async () => {
-    await fetchPart(true);
+  // Bumping refreshKey re-runs the part fetch (a useLoad dep) in place plus the
+  // cost/priceability reload — replaces the old explicit silent fetchPart call.
+  const refreshAfterMutation = useCallback(() => {
     setRefreshKey((k) => k + 1);
-  }, [fetchPart]);
+  }, []);
 
   const handleDelete = async () => {
     if (!partId) return;
@@ -204,8 +208,9 @@ export default function PartWorkspace({
     setTxnModalOpen(true);
   }, []);
 
-  const handleTxnSuccess = async () => {
-    await fetchPart(true);
+  const handleTxnSuccess = () => {
+    // Bumping transactionsRefreshKey re-runs the part fetch (a useLoad dep) in
+    // place and reloads the transaction history table.
     setTransactionsRefreshKey((k) => k + 1);
   };
 
@@ -374,7 +379,7 @@ export default function PartWorkspace({
           companyId={companyId}
           transactionsRefreshKey={transactionsRefreshKey}
           openTxnModal={openTxnModal}
-          onConversionsChanged={setUnitConversions}
+          onConversionsChanged={setConversionsOverride}
           onStockChanged={handleTxnSuccess}
         />
       )}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint --max-warnings 56",
+    "lint": "eslint --max-warnings 50",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
Continues the `useLoad` migration (#442) into component-level data-fetch loaders, ratcheting `eslint --max-warnings` **56 → 50** (0 errors). Follows #458 (PR 3, merged).

> Supersedes #459, which GitHub auto-closed when PR 3's base branch was deleted on merge. Same branch/commits, now based on `main`.

## Migrated (6 components)
- **ShipmentHistoryCard** — `load` (keeps `refreshKey` in deps; `handleVoidConfirm`'s `await load()` via `reload`).
- **JobAttachmentsCard** — `refresh`; upload/delete handlers refetch via `reload`.
- **PartWorkspace** — `fetchPart` (multi-value `{ part, conversions }`); post-mutation refetch via a refresh-key bump (stale-while-revalidate); inline conversion edits preserved via a local override.
- **InsightsSection** — `fetchSavedInsights` (a saved-insights DB read, not an AI call); refetches the canonical list after delete.
- **LocationsManager** — `reload` (alias keeps all 5 mutation call sites working).
- **JobFeed** — `load`; optimistic post-prepend preserved via a `pendingNotes` merge deduped by id.

Each preserves the component's error-UX (`onError`) and refetch-after-mutation.

## Out of scope (left intentionally)
ShipmentHistoryCard's `setPreviewId(initialPreviewShipmentId)` derive effect is a **PR 4** derived-state item, not a loader (1 remaining warning there).

## Validation
- `pnpm lint` ✅ green at `--max-warnings 50`
- `pnpm exec tsc --noEmit` ✅ clean
- `pnpm test --run __tests__/{components,hooks}` ✅ **208 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)