### PR TITLE
refactor(lint): migrate 10 more loaders to useLoad (#442, PR 3b-2)

### DIFF
--- a/app/dashboard/[companyId]/jobs/page.tsx
+++ b/app/dashboard/[companyId]/jobs/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useRouter, useParams, useSearchParams } from 'next/navigation';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -106,14 +107,15 @@ function parseFulfillmentParam(v: string | null): FulfillmentStatus[] | 'all' | 
   return parts.length > 0 ? (parts as FulfillmentStatus[]) : undefined;
 }
 
+// Stable empty fallback so derived data doesn't churn while the first load runs.
+const EMPTY_JOBS: JobWithRelations[] = [];
+
 export default function JobsPage() {
   const router = useRouter();
   const params = useParams();
   const searchParams = useSearchParams();
   const companyId = params.companyId as string;
 
-  const [jobs, setJobs] = useState<JobWithRelations[]>([]);
-  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [searchDebounced, setSearchDebounced] = useState('');
   const [productionFilter, setProductionFilter] = useState<
@@ -168,13 +170,15 @@ export default function JobsPage() {
     fetchCustomers();
   }, [companyId]);
 
-  // Fetch jobs
-  const fetchJobs = useCallback(async () => {
-    setLoading(true);
-    try {
-      // FR-19: hide done jobs by default — unless the user has explicitly
-      // filtered Fulfillment to include "Fully Shipped", in which case
-      // they've asked to see those rows.
+  // Fetch jobs. FR-19: hide done jobs by default — unless the user has
+  // explicitly filtered Fulfillment to include "Fully Shipped", in which case
+  // they've asked to see those rows.
+  const {
+    data: jobsData,
+    loading,
+    reload: fetchJobs,
+  } = useLoad(
+    () => {
       const fulfillmentIncludesShipped =
         Array.isArray(fulfillmentFilter) && fulfillmentFilter.includes('fully_shipped');
       const filters: JobFilters = {
@@ -185,26 +189,24 @@ export default function JobsPage() {
         overdue: overdueOnly || undefined,
         excludeDone: !fulfillmentIncludesShipped,
       };
-      const data = await getAllJobs(companyId, filters, sortModel.field, sortModel.sort);
-      setJobs(data);
-    } catch (error) {
-      console.error('Error fetching jobs:', error);
-    } finally {
-      setLoading(false);
-    }
-  }, [
-    companyId,
-    productionFilter,
-    fulfillmentFilter,
-    customerFilter,
-    searchDebounced,
-    sortModel,
-    overdueOnly,
-  ]);
-
-  useEffect(() => {
-    fetchJobs();
-  }, [fetchJobs]);
+      return getAllJobs(companyId, filters, sortModel.field, sortModel.sort);
+    },
+    [
+      companyId,
+      productionFilter,
+      fulfillmentFilter,
+      customerFilter,
+      searchDebounced,
+      sortModel,
+      overdueOnly,
+    ],
+    {
+      onError: (error) => {
+        console.error('Error fetching jobs:', error);
+      },
+    },
+  );
+  const jobs = jobsData ?? EMPTY_JOBS;
 
   // Clear selection when filters change
   useEffect(() => {

--- a/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
+++ b/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
@@ -24,7 +25,7 @@ import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
 import { resolveScan } from '@/utils/inventoryLocationsAccess';
 import { getCurrentOperator } from '@/utils/operatorAccess';
 import { getStandardUnitsForUnit } from '@/lib/unitPresets';
-import type { ResolvedScan, LocationContent } from '@/types/inventoryLocations';
+import type { LocationContent } from '@/types/inventoryLocations';
 import OperatorLocationActionModal, {
   type OperatorLocationAction,
 } from '@/components/operator/OperatorLocationActionModal';
@@ -38,9 +39,7 @@ export default function OperatorBinViewPage() {
   const companyId = params.companyId as string;
   const locationId = params.locationId as string;
 
-  const [scan, setScan] = useState<ResolvedScan | null>(null);
   const [operatorId, setOperatorId] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const [modal, setModal] = useState<{ action: OperatorLocationAction; part: LocationContent } | null>(
@@ -48,21 +47,15 @@ export default function OperatorBinViewPage() {
   );
   const [receiveOpen, setReceiveOpen] = useState(false);
 
-  const reload = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      setScan(await resolveScan(locationId));
-    } catch (e) {
+  const {
+    data: scan,
+    loading,
+    reload,
+  } = useLoad(() => resolveScan(locationId), [locationId], {
+    onError: (e) => {
       setError(e instanceof Error ? e.message : 'Could not open this location.');
-    } finally {
-      setLoading(false);
-    }
-  }, [locationId]);
-
-  useEffect(() => {
-    void reload();
-  }, [reload]);
+    },
+  });
 
   // Operator id stamps the ledger; best-effort, never blocks the view.
   useEffect(() => {

--- a/app/operator/[companyId]/inventory/page.tsx
+++ b/app/operator/[companyId]/inventory/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
@@ -18,6 +19,9 @@ import WarehouseOutlinedIcon from '@mui/icons-material/WarehouseOutlined';
 import { getLocations } from '@/utils/inventoryLocationsAccess';
 import type { InventoryLocation } from '@/types/inventoryLocations';
 
+// Stable empty fallback so the roots memo doesn't churn while the first load runs.
+const EMPTY_LOCATIONS: InventoryLocation[] = [];
+
 /**
  * Operator "warehouse home" — the root of the Inventory tab. Lists the
  * top-level storage locations to browse (drill down into the bin view), so the
@@ -29,25 +33,18 @@ export default function OperatorWarehouseHomePage() {
   const router = useRouter();
   const companyId = params.companyId as string;
 
-  const [locations, setLocations] = useState<InventoryLocation[]>([]);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const reload = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      setLocations(await getLocations(companyId));
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Could not load the warehouse.');
-    } finally {
-      setLoading(false);
-    }
-  }, [companyId]);
-
-  useEffect(() => {
-    void reload();
-  }, [reload]);
+  const { data: locationsData, loading } = useLoad(
+    () => getLocations(companyId),
+    [companyId],
+    {
+      onError: (e) => {
+        setError(e instanceof Error ? e.message : 'Could not load the warehouse.');
+      },
+    },
+  );
+  const locations = locationsData ?? EMPTY_LOCATIONS;
 
   // Top-level locations are the warehouse roots to browse from.
   const roots = useMemo(() => locations.filter((l) => l.parent_id === null), [locations]);

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -25,7 +26,6 @@ import { useStationContext } from '@/components/operator/OperatorStationContext'
 import StationSelector from '@/components/operator/StationSelector';
 import JobFeed from '@/components/operator/JobFeed';
 import PreviousRunCard from '@/components/operator/PreviousRunCard';
-import type { OperatorJobDetail } from '@/types/operator';
 
 /**
  * Action view for ONE specific operation on a job_part. Reached by tapping a
@@ -56,9 +56,7 @@ export default function OperatorOperationActionPage() {
 
   const { stationId, stationName, setStation } = useStationContext();
 
-  const [job, setJob] = useState<OperatorJobDetail | null>(null);
   const [currentOperatorId, setCurrentOperatorId] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -70,22 +68,19 @@ export default function OperatorOperationActionPage() {
     loadOperator();
   }, [companyId]);
 
-  const loadJob = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await getOperatorOperationDetail(jobOperationId, companyId);
-      setJob(data);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load operation');
-    } finally {
-      setLoading(false);
-    }
-  }, [jobOperationId, companyId]);
-
-  useEffect(() => {
-    loadJob();
-  }, [loadJob]);
+  const {
+    data: job,
+    loading,
+    reload: loadJob,
+  } = useLoad(
+    () => getOperatorOperationDetail(jobOperationId, companyId),
+    [jobOperationId, companyId],
+    {
+      onError: (err) => {
+        setError(err instanceof Error ? err.message : 'Failed to load operation');
+      },
+    },
+  );
 
   // Completion is a direct, single-tap action — no confirmation. We stay on the
   // page and re-load into the completed state so a mistaken completion can be

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -20,7 +21,7 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { getJobPartTraveler } from '@/utils/operatorAccess';
 import JobFeed from '@/components/operator/JobFeed';
 import PreviousRunCard from '@/components/operator/PreviousRunCard';
-import type { JobTraveler, JobTravelerOperation } from '@/types/operator';
+import type { JobTravelerOperation } from '@/types/operator';
 
 const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
 
@@ -59,30 +60,23 @@ export default function OperatorJobTravelerPage() {
   const jobId = params.jobId as string;
   const jobPartId = params.jobPartId as string;
 
-  const [traveler, setTraveler] = useState<JobTraveler | null>(null);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
+  const { data: traveler, loading } = useLoad(
+    async () => {
       const data = await getJobPartTraveler(jobPartId, companyId);
-      if (!data) {
-        setError('Job not found.');
-        return;
-      }
-      setTraveler(data);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load job');
-    } finally {
-      setLoading(false);
-    }
-  }, [jobPartId, companyId]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+      // A missing traveler is surfaced as a "Job not found." error (routed
+      // through onError below) rather than a silent null.
+      if (!data) throw new Error('Job not found.');
+      return data;
+    },
+    [jobPartId, companyId],
+    {
+      onError: (err) => {
+        setError(err instanceof Error ? err.message : 'Failed to load job');
+      },
+    },
+  );
 
   const openStep = (op: JobTravelerOperation) => {
     router.push(`/operator/${companyId}/jobs/${jobId}/parts/${jobPartId}/operations/${op.id}`);

--- a/components/dashboard/PinnedMetrics.tsx
+++ b/components/dashboard/PinnedMetrics.tsx
@@ -2,6 +2,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
@@ -63,7 +64,6 @@ export default function PinnedMetrics({ companyId }: PinnedMetricsProps) {
   const [pinnedKeys, setPinnedKeys] = useState<MetricKey[]>([]);
   const [values, setValues] = useState<Partial<Record<MetricKey, MetricValue>>>({});
   const [globalPeriod, setGlobalPeriod] = useState<MetricTimePeriod>('this_week');
-  const [loading, setLoading] = useState(true);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [page, setPage] = useState(0);
 
@@ -97,10 +97,14 @@ export default function PinnedMetrics({ companyId }: PinnedMetricsProps) {
     return periods;
   }, []);
 
-  const loadMetrics = useCallback(async () => {
-    if (!companyId) return;
-    try {
-      setLoading(true);
+  // pinnedKeys / globalPeriod / values are also mutated by the picker and the
+  // period toggle, so they stay as independent state. useLoad owns only the
+  // mount fetch + loading flag; every setState below runs inside the async
+  // callback (never synchronously in an effect), so this stays clear of
+  // set-state-in-effect.
+  const { loading } = useLoad(
+    async () => {
+      if (!companyId) return;
       const [keys, storedPeriods] = await Promise.all([
         getPinnedMetricKeys(),
         getMetricTimePeriods(),
@@ -112,17 +116,15 @@ export default function PinnedMetrics({ companyId }: PinnedMetricsProps) {
       const allMetricKeys = AVAILABLE_METRICS.map((m) => m.key);
       const vals = await getPinnedMetricValues(companyId, allMetricKeys, buildTimePeriods(period));
       setValues(vals);
-    } catch (err) {
-      console.error('Error loading pinned metrics:', err);
-      Sentry.captureException(err);
-    } finally {
-      setLoading(false);
-    }
-  }, [companyId, buildTimePeriods]);
-
-  useEffect(() => {
-    loadMetrics();
-  }, [loadMetrics]);
+    },
+    [companyId, buildTimePeriods],
+    {
+      onError: (err) => {
+        console.error('Error loading pinned metrics:', err);
+        Sentry.captureException(err);
+      },
+    },
+  );
 
   const handleSave = async (keys: MetricKey[]) => {
     setPinnedKeys(keys);

--- a/components/parts/PartBomPanel.tsx
+++ b/components/parts/PartBomPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
@@ -108,6 +109,10 @@ interface ChildCostTier {
   costPerUnit: number | null;
 }
 
+// Stable empty fallback so the tier-ladder effect + render don't churn while
+// the first load runs.
+const EMPTY_ROWS: BomLineWithChildPart[] = [];
+
 export default function PartBomPanel({
   partId,
   companyId,
@@ -116,8 +121,6 @@ export default function PartBomPanel({
   description,
   onChanged,
 }: PartBomPanelProps) {
-  const [rows, setRows] = useState<BomLineWithChildPart[]>([]);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // Per-row tier ladder (one entry per qty break point on the child).
   // Loaded after rows arrive. Each entry's costPerUnit comes from
@@ -139,23 +142,17 @@ export default function PartBomPanel({
   const [pendingDelete, setPendingDelete] = useState<BomLineWithChildPart | null>(null);
   const [deleting, setDeleting] = useState(false);
 
-  const fetchRows = useCallback(async () => {
-    try {
-      setLoading(true);
-      const data = await getBomForPart(partId);
-      setRows(data);
-      setError(null);
-    } catch (err) {
+  const {
+    data: rowsData,
+    loading,
+    reload: fetchRows,
+  } = useLoad(() => getBomForPart(partId), [partId], {
+    onError: (err) => {
       console.error('Failed to load BOM:', err);
       setError(err instanceof Error ? err.message : 'Failed to load BOM.');
-    } finally {
-      setLoading(false);
-    }
-  }, [partId]);
-
-  useEffect(() => {
-    fetchRows();
-  }, [fetchRows]);
+    },
+  });
+  const rows = rowsData ?? EMPTY_ROWS;
 
   // Load each BOM row's tier ladder — the qty break points defined on the
   // child + the cost at each (via compute_part_cost_at_qty). These are the

--- a/components/parts/PartLocationInventory.tsx
+++ b/components/parts/PartLocationInventory.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Paper from '@mui/material/Paper';
@@ -25,6 +26,10 @@ import PartLocationActionModal, {
   type LocationOption,
   type LocationBalanceOption,
 } from './PartLocationActionModal';
+
+// Stable empty fallbacks so derived memos don't churn while the first load runs.
+const EMPTY_BALANCES: PartLocationBalanceWithLocation[] = [];
+const EMPTY_LOCATIONS: InventoryLocation[] = [];
 
 function pathLabel(id: string, byId: Map<string, InventoryLocation>): string {
   const names: string[] = [];
@@ -53,31 +58,26 @@ export default function PartLocationInventory({
   companyId,
   onStockChanged,
 }: PartLocationInventoryProps) {
-  const [balances, setBalances] = useState<PartLocationBalanceWithLocation[]>([]);
-  const [locations, setLocations] = useState<InventoryLocation[]>([]);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [action, setAction] = useState<LocationAction | null>(null);
 
   const primaryUnit = part.primary_unit ?? '';
 
-  const reload = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const [b, locs] = await Promise.all([getBalancesForPart(partId), getLocations(companyId)]);
-      setBalances(b);
-      setLocations(locs);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load location balances.');
-    } finally {
-      setLoading(false);
-    }
-  }, [partId, companyId]);
-
-  useEffect(() => {
-    void reload();
-  }, [reload]);
+  const {
+    data: inventoryData,
+    loading,
+    reload,
+  } = useLoad(
+    () => Promise.all([getBalancesForPart(partId), getLocations(companyId)]),
+    [partId, companyId],
+    {
+      onError: (e) => {
+        setError(e instanceof Error ? e.message : 'Failed to load location balances.');
+      },
+    },
+  );
+  const balances = inventoryData?.[0] ?? EMPTY_BALANCES;
+  const locations = inventoryData?.[1] ?? EMPTY_LOCATIONS;
 
   const byId = useMemo(() => new Map(locations.map((l) => [l.id, l] as const)), [locations]);
 

--- a/components/parts/PartUnitConversionsEditor.tsx
+++ b/components/parts/PartUnitConversionsEditor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -48,6 +49,10 @@ interface DraftConversion {
 
 const emptyDraft: DraftConversion = { from_unit: '', to_primary_factor: '' };
 
+// Stable empty fallback so the derived list doesn't churn while the first
+// load runs.
+const EMPTY_CONVERSIONS: PartUnitConversion[] = [];
+
 /**
  * Inline editor for part unit conversions. Lives in the Inventory panel of
  * the part detail page (chunk 14 moved unit-conversion editing out of the
@@ -66,8 +71,6 @@ export default function PartUnitConversionsEditor({
   primaryUnit,
   onChanged,
 }: PartUnitConversionsEditorProps) {
-  const [conversions, setConversions] = useState<PartUnitConversion[]>([]);
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -87,28 +90,36 @@ export default function PartUnitConversionsEditor({
     onChangedRef.current = onChanged;
   }, [onChanged]);
 
-  const reload = useCallback(
-    async (notifyParent = false) => {
-      setLoading(true);
-      try {
-        const data = await getPartUnitConversions(partId);
-        setConversions(data);
-        setError(null);
-        if (notifyParent && onChangedRef.current) onChangedRef.current(data);
-      } catch (err) {
+  // When a persist/delete triggers a reload, the next successful load notifies
+  // the parent with the fresh conversions (the old `reload(true)` path). The
+  // initial mount load and partId-change loads leave it unset, so they don't
+  // notify — matching the previous `notifyParent` default of false.
+  const notifyParentRef = useRef(false);
+
+  const {
+    data: conversionsData,
+    loading,
+    reload,
+  } = useLoad(
+    async () => {
+      const data = await getPartUnitConversions(partId);
+      setError(null);
+      if (notifyParentRef.current) {
+        notifyParentRef.current = false;
+        onChangedRef.current?.(data);
+      }
+      return data;
+    },
+    [partId],
+    {
+      onError: (err) => {
         setError(
           err instanceof Error ? err.message : 'Failed to load unit conversions',
         );
-      } finally {
-        setLoading(false);
-      }
+      },
     },
-    [partId],
   );
-
-  useEffect(() => {
-    reload();
-  }, [reload]);
+  const conversions = conversionsData ?? EMPTY_CONVERSIONS;
 
   const openAdd = () => {
     setDraft(emptyDraft);
@@ -170,7 +181,8 @@ export default function PartUnitConversionsEditor({
     setSaving(true);
     try {
       await replacePartUnitConversions(partId, next);
-      await reload(true);
+      notifyParentRef.current = true;
+      await reload();
       setDraftOpen(false);
       setDraft(emptyDraft);
       setEditingId(undefined);
@@ -220,7 +232,8 @@ export default function PartUnitConversionsEditor({
     setError(null);
     try {
       await replacePartUnitConversions(partId, next);
-      await reload(true);
+      notifyParentRef.current = true;
+      await reload();
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to delete conversion',

--- a/components/parts/workspace/tabs/FilesTab.tsx
+++ b/components/parts/workspace/tabs/FilesTab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -49,6 +50,10 @@ function formatBytes(bytes: number | null): string {
 
 const fmtWhen = (s: string): string => new Date(s).toLocaleDateString();
 
+// Stable empty fallback so the derived list doesn't churn while the first
+// load runs.
+const EMPTY_ATTACHMENTS: PartAttachment[] = [];
+
 /**
  * Files tab — engineering attachments for a part (PDF drawings, STEP models,
  * DWG drawings). Office/admin surface (not the operator view). Listing and
@@ -57,7 +62,6 @@ const fmtWhen = (s: string): string => new Date(s).toLocaleDateString();
  * enforces the same rule — this just hides the affordance).
  */
 export default function FilesTab({ partId, companyId }: FilesTabProps) {
-  const [attachments, setAttachments] = useState<PartAttachment[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
   const [operatorId, setOperatorId] = useState<string | null>(null);
@@ -65,18 +69,17 @@ export default function FilesTab({ partId, companyId }: FilesTabProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const { isAdmin } = useUserRole();
 
-  const refresh = useCallback(async () => {
-    try {
-      setAttachments(await listPartAttachments(partId));
-    } catch (err) {
+  const {
+    data: attachmentsData,
+    loading,
+    reload: refresh,
+  } = useLoad(() => listPartAttachments(partId), [partId], {
+    onError: (err) => {
       console.error('Error loading part attachments:', err);
       setError('Could not load files.');
-    }
-  }, [partId]);
-
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
+    },
+  });
+  const attachments = attachmentsData ?? EMPTY_ATTACHMENTS;
 
   useEffect(() => {
     let cancelled = false;
@@ -145,8 +148,6 @@ export default function FilesTab({ partId, companyId }: FilesTabProps) {
 
   const canDelete = (att: PartAttachment): boolean =>
     isAdmin || (!!operatorId && att.uploaded_by === operatorId);
-
-  const loading = attachments === null;
 
   return (
     <Card elevation={2}>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,10 @@ const eslintConfig = defineConfig([
     // but keeps local `pnpm lint` clean after a coverage run so the
     // --max-warnings 0 cap stays honest.
     "coverage/**",
+    // Local Claude Code state — notably .claude/worktrees/* holds checkouts of
+    // OTHER branches whose (older) source would otherwise be linted and inflate
+    // the warning count vs CI (which never has this dir). Gitignored.
+    ".claude/**",
   ]),
   {
     // ESLint 9 flat config: rules from a plugin need the plugin registered

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint --max-warnings 50",
+    "lint": "eslint --max-warnings 40",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
Continues the `useLoad` migration (#442) into 10 more single-loader pages/components, ratcheting `eslint --max-warnings` **50 → 40** (0 errors).

## Migrated (10 loaders)
- **Components**: `PartLocationInventory` (multi-value), `PartUnitConversionsEditor` (notify-parent flag preserves `reload(notifyParent)` semantics), `FilesTab` (`refresh`), `PinnedMetrics` (`loadMetrics` — multi-state set inside the async callback), `PartBomPanel` (`fetchRows`).
- **Pages**: dashboard jobs list (`fetchJobs`), and 4 operator pages (inventory, inventory location detail, job-part detail, job-operation detail).

Each preserves the `reload` alias for post-mutation refetch, routes load errors through `onError`, and uses stable empty fallbacks. Not-found cases now `throw` inside the loader → `onError` (same UI).

## Out of scope (left intentionally — PR 4 items)
The sibling derived/selection effects in three of these files: `jobs/page` `setSelectedIds([])`, `PartBomPanel` `setTierLadders`, `PinnedMetrics` `setPage` page-clamp.

## Also: `.claude/**` eslint ignore
`.claude/worktrees/*` holds checkouts of other branches whose older source was being linted locally (inflating the count vs CI, which never has that dir). Added to `globalIgnores` — same hygiene as the earlier `coverage/**` ignore. The true count is now **40**.

## Validation
- `pnpm lint` ✅ green at `--max-warnings 40`
- `pnpm exec tsc --noEmit` ✅ clean
- `pnpm test --run __tests__/{components,hooks}` ✅ **208 tests pass**

Remaining for #442: the complex loaders (`jobs/[jobId]`, `team`, `PartPricing`, `PartProcurementPricingPanel`, `accept-invite`, `AlertBadge`) + 7 `setLoading` components, then **PR 4** drives selection/derived/long-tail → **0** and restores the rule to `error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)