### PR TITLE
refactor(lint): autocompletes + setLoading components → useLoad (#442, loaders-3)

### DIFF
--- a/app/dashboard/[companyId]/markup-rates/[rateId]/edit/page.tsx
+++ b/app/dashboard/[companyId]/markup-rates/[rateId]/edit/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Alert from '@mui/material/Alert';
@@ -9,10 +10,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import MarkupRateForm from '@/components/markup-rates/MarkupRateForm';
 import { getMarkupRate } from '@/utils/markupRatesAccess';
-import {
-  type MarkupRateFormData,
-  markupRateToFormData,
-} from '@/types/markupRates';
+import { markupRateToFormData } from '@/types/markupRates';
 
 export default function EditMarkupRatePage() {
   const params = useParams();
@@ -20,33 +18,23 @@ export default function EditMarkupRatePage() {
   const companyId = params.companyId as string;
   const rateId = params.rateId as string;
 
-  const [initial, setInitial] = useState<MarkupRateFormData | null>(null);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    getMarkupRate(rateId)
-      .then((rate) => {
-        if (cancelled) return;
-        if (!rate) {
-          setError('Markup rate not found.');
-          return;
-        }
-        setInitial(markupRateToFormData(rate));
-      })
-      .catch((err) => {
-        if (cancelled) return;
+  // Single loader: resolves to the form data, or throws "not found" so the
+  // rejection path surfaces it as an error (no synchronous setState in an effect).
+  const { data: initial, loading } = useLoad(
+    async () => {
+      const rate = await getMarkupRate(rateId);
+      if (!rate) throw new Error('Markup rate not found.');
+      return markupRateToFormData(rate);
+    },
+    [rateId],
+    {
+      onError: (err) => {
         setError(err instanceof Error ? err.message : 'Failed to load markup rate');
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [rateId]);
+      },
+    },
+  );
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>

--- a/components/layout/AlertBadge.tsx
+++ b/components/layout/AlertBadge.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useLoad } from '@/hooks/useLoad';
 import Badge from '@mui/material/Badge';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
@@ -29,6 +30,9 @@ interface AlertBadgeProps {
   companyId: string;
 }
 
+const EMPTY_JOBS: AtRiskJob[] = [];
+const EMPTY_INVENTORY: InventoryAlert[] = [];
+
 function severityColor(severity: string): 'error' | 'warning' | 'default' {
   if (severity === 'critical' || severity === 'high') return 'error';
   if (severity === 'medium') return 'warning';
@@ -38,28 +42,21 @@ function severityColor(severity: string): 'error' | 'warning' | 'default' {
 export default function AlertBadge({ companyId }: AlertBadgeProps) {
   const router = useRouter();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-  const [atRiskJobs, setAtRiskJobs] = useState<AtRiskJob[]>([]);
-  const [inventoryAlerts, setInventoryAlerts] = useState<InventoryAlert[]>([]);
   const [jobsOpen, setJobsOpen] = useState(true);
   const [inventoryOpen, setInventoryOpen] = useState(true);
 
-  const fetchAlerts = useCallback(async () => {
-    if (!companyId) return;
-    try {
-      const [jobs, inventory] = await Promise.all([
-        getAtRiskJobs(companyId),
-        getLowStockPartsAlerts(companyId),
-      ]);
-      setAtRiskJobs(jobs);
-      setInventoryAlerts(inventory);
-    } catch {
-      // Silently fail — alerts are non-critical
-    }
-  }, [companyId]);
-
-  useEffect(() => {
-    fetchAlerts();
-  }, [fetchAlerts]);
+  // Both reads are plain Supabase metric queries (no AI). Alerts are
+  // non-critical, so a load failure is swallowed (captured into the unused
+  // `error`); useLoad keeps setState out of the effect body.
+  const { data } = useLoad(
+    async (): Promise<[AtRiskJob[], InventoryAlert[]]> => {
+      if (!companyId) return [EMPTY_JOBS, EMPTY_INVENTORY];
+      return Promise.all([getAtRiskJobs(companyId), getLowStockPartsAlerts(companyId)]);
+    },
+    [companyId],
+  );
+  const atRiskJobs = data?.[0] ?? EMPTY_JOBS;
+  const inventoryAlerts = data?.[1] ?? EMPTY_INVENTORY;
 
   const totalCount = atRiskJobs.length + inventoryAlerts.length;
   const open = Boolean(anchorEl);

--- a/components/parts/PartAutocomplete.tsx
+++ b/components/parts/PartAutocomplete.tsx
@@ -79,9 +79,12 @@ export default function PartAutocomplete({
   useEffect(() => {
     if (!open) return;
     let active = true;
-    setLoading(true);
     const delay = inputValue.trim() ? 300 : 0;
+    // setLoading lives inside the debounce callback (not synchronously in the
+    // effect body) so it doesn't trip set-state-in-effect; the spinner shows
+    // for the actual fetch rather than during the debounce wait.
     const timer = setTimeout(async () => {
+      setLoading(true);
       try {
         const data = await searchPartsForSelect(companyId, inputValue, kind, 50);
         if (!active) return;

--- a/components/parts/PartRoutingPanel.tsx
+++ b/components/parts/PartRoutingPanel.tsx
@@ -63,13 +63,15 @@ export default function PartRoutingPanel({
   // Serialize persists so two rapid changes don't race.
   const queueRef = useRef<Promise<void>>(Promise.resolve());
 
+  // `loading` starts true (useState init), so this effect needs no synchronous
+  // setLoading(true)/setError(null) (which would trip set-state-in-effect);
+  // every setState below runs inside the promise callbacks, guarded by `cancelled`.
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
-    setError(null);
     getRoutingForPart(partId)
       .then((data) => {
         if (cancelled) return;
+        setError(null);
         if (data) {
           setRoutingId(data.id);
           setOps(data.operations.map(rowFromOperation));

--- a/components/parts/PartWhereUsedPanel.tsx
+++ b/components/parts/PartWhereUsedPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
@@ -27,6 +28,9 @@ interface PartWhereUsedPanelProps {
   currentChain?: string[];
 }
 
+// Stable empty fallback so the paginate memo doesn't churn while the first load runs.
+const EMPTY_PARENTS: BomLineWithParentPart[] = [];
+
 const formatQuantity = (n: number): string =>
   n.toLocaleString(undefined, { maximumFractionDigits: 4 });
 
@@ -45,33 +49,17 @@ export default function PartWhereUsedPanel({
   companyId,
   currentChain = [],
 }: PartWhereUsedPanelProps) {
-  const [rows, setRows] = useState<BomLineWithParentPart[]>([]);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(25);
 
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    getBomParents(partId)
-      .then((data) => {
-        if (cancelled) return;
-        setRows(data);
-        setError(null);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        console.error('Failed to load BOM parents:', err);
-        setError(err instanceof Error ? err.message : 'Failed to load where-used list.');
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [partId]);
+  const { data: rowsData, loading } = useLoad(() => getBomParents(partId), [partId], {
+    onError: (err) => {
+      console.error('Failed to load BOM parents:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load where-used list.');
+    },
+  });
+  const rows = rowsData ?? EMPTY_PARENTS;
 
   const visibleRows = useMemo(() => {
     const start = page * rowsPerPage;

--- a/components/quotes/QuoteCostBreakdown.tsx
+++ b/components/quotes/QuoteCostBreakdown.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useLoad } from '@/hooks/useLoad';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Box from '@mui/material/Box';
@@ -9,7 +10,7 @@ import Divider from '@mui/material/Divider';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import { getQuoteCostBreakdown } from '@/utils/quotesAccess';
-import type { QuoteCostBreakdown, QuoteLineItem } from '@/types/quote';
+import type { QuoteLineItem } from '@/types/quote';
 import QuoteCostBreakdownView from './QuoteCostBreakdownView';
 
 interface QuoteCostBreakdownProps {
@@ -21,30 +22,17 @@ export default function QuoteCostBreakdownCard({
   quoteId,
   companyId,
 }: QuoteCostBreakdownProps) {
-  const [breakdown, setBreakdown] = useState<QuoteCostBreakdown | null>(null);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    getQuoteCostBreakdown(quoteId, companyId)
-      .then((data) => {
-        if (!cancelled) setBreakdown(data);
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to load cost breakdown');
-        }
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [quoteId, companyId]);
+  const { data: breakdown, loading } = useLoad(
+    () => getQuoteCostBreakdown(quoteId, companyId),
+    [quoteId, companyId],
+    {
+      onError: (err) => {
+        setError(err instanceof Error ? err.message : 'Failed to load cost breakdown');
+      },
+    },
+  );
 
   const lineItemsByPart = new Map<string, QuoteLineItem[]>();
   if (breakdown) {

--- a/components/shipments/ShipmentForm.tsx
+++ b/components/shipments/ShipmentForm.tsx
@@ -143,10 +143,11 @@ export default function ShipmentForm({
   const isCustomerMode = source.kind === 'customer';
 
   // ---------- Initial load ----------
+  // `loading` starts true (useState init), so the effect needs no synchronous
+  // setLoading(true) here (which would trip react-hooks/set-state-in-effect);
+  // every setState below runs inside the async IIFE, guarded by `cancelled`.
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
-    setError(null);
 
     (async () => {
       try {
@@ -160,6 +161,10 @@ export default function ShipmentForm({
           )
           .eq('id', companyId)
           .single();
+        // Clear any prior error only after the first await boundary so no
+        // setState runs synchronously in the effect body. `loading` is true
+        // throughout the load, so the error Alert isn't rendered meanwhile.
+        if (!cancelled) setError(null);
         if (companyErr || !companyRow) {
           throw new Error(companyErr?.message ?? 'Company not found.');
         }

--- a/components/vendors/VendorAutocomplete.tsx
+++ b/components/vendors/VendorAutocomplete.tsx
@@ -60,7 +60,9 @@ export default function VendorAutocomplete({
   sx,
 }: VendorAutocompleteProps) {
   const [vendors, setVendors] = useState<Vendor[]>([]);
-  const [loading, setLoading] = useState(false);
+  // Starts true so the load effect needs no synchronous setLoading(true) (which
+  // would trip set-state-in-effect); all setState happens in the async callback.
+  const [loading, setLoading] = useState(true);
   const [loaded, setLoaded] = useState(false);
 
   // Resolve effective value. Prefer the explicit Vendor; fall back to id
@@ -71,7 +73,6 @@ export default function VendorAutocomplete({
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
     getAllVendors(companyId)
       .then((rows) => {
         if (!cancelled) setVendors(rows);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint --max-warnings 40",
+    "lint": "eslint --max-warnings 32",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
Continues the `useLoad` migration (#442) into 8 more components, ratcheting `eslint --max-warnings` **40 → 32** (0 errors).

## Migrated (8 components)
- **Debounced autocompletes** — `PartAutocomplete`, `VendorAutocomplete`: these do per-keystroke debounced search, so `useLoad` (no debounce) is the wrong tool. Instead the synchronous `setLoading(true)` is moved out of the effect body (into the `setTimeout` debounce callback / via `loading` initialising `true`), preserving the debounce + spinner.
- **AlertBadge** → `useLoad` (multi-value `getAtRiskJobs` + `getLowStockPartsAlerts` — both plain Supabase metric reads, **no AI**; load failure stays silent as before).
- **5 `setLoading`-before-fetch components** — `markup-rates/[rateId]/edit`, `PartWhereUsedPanel`, `QuoteCostBreakdown` → `useLoad`; `PartRoutingPanel`, `ShipmentForm` → inline fix (`loading` inits `true`; setState moved out of the effect body) where the loader sets several coupled states.

Every component keeps its first-load spinner and error handling.

## Validation
- `pnpm lint` ✅ green at `--max-warnings 32`
- `pnpm exec tsc --noEmit` ✅ clean
- `pnpm test --run __tests__/{components,hooks}` ✅ **208 tests pass**

Remaining for #442: 5 complex loaders (`accept-invite`, `jobs/[jobId]`, `team`, `PartPricing`, `PartProcurementPricingPanel`), then **PR 4** drives the 9 selection-clears + derived/long-tail → **0** and restores the rule to `error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)