### PR TITLE
refactor(lint): resolve the 5 complex data-fetch loaders (#442, loaders-final)

### DIFF
--- a/app/accept-invite/[invitationId]/page.tsx
+++ b/app/accept-invite/[invitationId]/page.tsx
@@ -175,6 +175,11 @@ export default function AcceptInvitePage() {
   }, [invitationId, router]);
 
   useEffect(() => {
+    // False positive: checkSessionAndLoadInvitation is an async auth
+    // orchestration (token exchange → session → invitation fetch) and every
+    // setState inside it runs AFTER an await, never synchronously in this
+    // effect body — so it can't cause the cascading-render the rule guards.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     checkSessionAndLoadInvitation();
   }, [checkSessionAndLoadInvitation]);
 

--- a/app/dashboard/[companyId]/jobs/[jobId]/page.tsx
+++ b/app/dashboard/[companyId]/jobs/[jobId]/page.tsx
@@ -108,6 +108,11 @@ export default function JobDetailPage() {
   }, [jobId, companyId]);
 
   useEffect(() => {
+    // Data-fetch-on-mount false positive: fetchJob's setState all runs after
+    // its await, not synchronously in this effect body (the documented class
+    // the eslint.config.mjs note describes). Large page with many refetch
+    // callers — kept as-is rather than restructured to the .then() shape.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchJob();
     (async () => {
       try {

--- a/app/dashboard/[companyId]/team/page.tsx
+++ b/app/dashboard/[companyId]/team/page.tsx
@@ -392,13 +392,17 @@ export default function TeamPage() {
     }
   }, [loadInvitations]);
 
-  // Load invitations on mount
+  // Load invitations on mount. Data-fetch-on-mount false positive: the loader's
+  // setState all runs post-await (the documented class in eslint.config.mjs);
+  // the tab loaders chain getSession→fetch, awkward to restructure cleanly.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     loadInvitations();
   }, [loadInvitations]);
 
-  // Load data based on active tab
+  // Load data based on active tab.
   useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect -- data-fetch-on-mount: each loader's setState runs post-await */
     if (activeTab === 0) {
       loadAdmins();
     } else if (activeTab === 1) {
@@ -406,6 +410,7 @@ export default function TeamPage() {
     } else {
       loadOperators();
     }
+    /* eslint-enable react-hooks/set-state-in-effect */
   }, [activeTab, loadAdmins, loadUsers, loadOperators]);
 
   // Clear selection when search or tab changes

--- a/components/parts/PartPricing.tsx
+++ b/components/parts/PartPricing.tsx
@@ -215,6 +215,10 @@ export default function PartPricing({
   }, [partId, isBought]);
 
   useEffect(() => {
+    // Data-fetch-on-mount false positive: loadAll's setState all runs post-await
+    // (documented class in eslint.config.mjs). loadAll seeds the EDITABLE tier
+    // rows, so useLoad (immutable data) doesn't fit — kept as-is.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     loadAll();
   }, [loadAll, refreshKey]);
 

--- a/components/parts/PartProcurementPricingPanel.tsx
+++ b/components/parts/PartProcurementPricingPanel.tsx
@@ -143,6 +143,10 @@ export default function PartProcurementPricingPanel({
   }, [partId, companyId]);
 
   useEffect(() => {
+    // Data-fetch-on-mount false positive: initialLoad's setState all runs
+    // post-await (documented class in eslint.config.mjs). It seeds the EDITABLE
+    // tier rows, so useLoad (immutable data) doesn't fit — kept as-is.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     initialLoad();
   }, [initialLoad]);
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint --max-warnings 32",
+    "lint": "eslint --max-warnings 26",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
Completes the data-fetch loader work for #442, ratcheting `eslint --max-warnings` **32 → 26** (0 errors). **Comment-only** — zero behavior change.

## Why disables (not useLoad) for these 5
This rule version flags **every** `setState` reachable from an effect — including post-`await` setState in an async loader (the data-fetch-on-mount class the repo's `eslint.config.mjs` was downgraded for). The `.then()`-callback / `useLoad` shape silences it, and ~30 loaders were genuinely migrated that way across the earlier PRs. These 5 are the ones where that refactor is awkward or risky, so each gets a **justified `eslint-disable-next-line`** with a comment:

- **accept-invite** — async auth orchestration (token exchange → session → invitation fetch); every setState is post-await.
- **jobs/[jobId]** — large central page with ~6 refetch callers; restructuring `fetchJob` to `.then()` is high-risk for low value.
- **team** — conditional per-tab loaders that chain `getSession → fetch`; `useLoad` doesn't fit conditional-tab loading.
- **PartPricing / PartProcurementPricingPanel** — the loaders seed **editable** tier rows, so `useLoad`'s immutable `data` doesn't fit.

These are the documented false-positive class, verified to set state only after an await — they cannot cause the cascading render the rule guards.

## Validation
- `pnpm lint` ✅ green at `--max-warnings 26`
- `pnpm exec tsc --noEmit` ✅ clean
- Diff is comment-only (+ the cap), so no test surface changed.

Final step — **PR 4**: the 9 selection-clears (→ move to search/tab handlers) + the ~17 derived/legitimate setters (`useMemo`/derive-during-render) → **0**, then restore `set-state-in-effect` to `error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)