### PR TITLE
refactor(lint): move bulk-selection clears to handlers — final #442 PR (cap 17)

### DIFF
--- a/app/dashboard/[companyId]/customers/page.tsx
+++ b/app/dashboard/[companyId]/customers/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
@@ -104,13 +104,13 @@ export default function CustomersPage() {
   );
   const customers = customersData ?? EMPTY_CUSTOMERS;
 
-  // Clear selection when search changes
-  useEffect(() => {
+  // Clear selection when the search query changes — the rows on screen change,
+  // so any ids selected before may no longer be visible. Called from the
+  // control's onChange (not an effect) to avoid set-state-in-effect.
+  const clearSelection = useCallback(() => {
     setSelectedIds([]);
-    if (gridRef.current?.api) {
-      gridRef.current.api.deselectAll();
-    }
-  }, [searchDebounced]);
+    gridRef.current?.api?.deselectAll();
+  }, []);
 
   // Calculate grid height dynamically
   const gridHeight = useMemo(() => {
@@ -267,7 +267,10 @@ export default function CustomersPage() {
         <TextField
           placeholder="Search customers..."
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            clearSelection();
+          }}
           size="small"
           sx={{ width: { xs: '100%', sm: 300 } }}
           slotProps={{

--- a/app/dashboard/[companyId]/inventory/page.tsx
+++ b/app/dashboard/[companyId]/inventory/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
@@ -128,12 +128,14 @@ export default function InventoryPage() {
   );
   const rows = inventoryData ?? EMPTY_INVENTORY;
 
-  useEffect(() => {
+  // Clear selection when the search query or status filter changes — the rows
+  // on screen change, so any ids selected before may no longer be visible.
+  // Called from each control's onChange (not an effect) to avoid
+  // set-state-in-effect.
+  const clearSelection = useCallback(() => {
     setSelectedIds([]);
-    if (gridRef.current?.api) {
-      gridRef.current.api.deselectAll();
-    }
-  }, [searchDebounced, statusFilter]);
+    gridRef.current?.api?.deselectAll();
+  }, []);
 
   // Apply the status filter client-side so the grid (and the gridHeight /
   // empty-state checks below) all see the same row set. Status is derived
@@ -340,7 +342,10 @@ export default function InventoryPage() {
         <TextField
           placeholder="Search inventory..."
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            clearSelection();
+          }}
           size="small"
           sx={{ width: { xs: '100%', sm: 300 } }}
           slotProps={{
@@ -360,7 +365,10 @@ export default function InventoryPage() {
             labelId="inventory-status-label"
             value={statusFilter}
             label="Status"
-            onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+            onChange={(e) => {
+              setStatusFilter(e.target.value as StatusFilter);
+              clearSelection();
+            }}
           >
             <MenuItem value="all">All</MenuItem>
             <MenuItem value="in_stock">In stock</MenuItem>

--- a/app/dashboard/[companyId]/jobs/page.tsx
+++ b/app/dashboard/[companyId]/jobs/page.tsx
@@ -208,13 +208,13 @@ export default function JobsPage() {
   );
   const jobs = jobsData ?? EMPTY_JOBS;
 
-  // Clear selection when filters change
-  useEffect(() => {
+  // Clear selection when search or any filter changes — the rows on screen
+  // change, so any ids selected before may no longer be visible. Called from
+  // each control's onChange (not an effect) to avoid set-state-in-effect.
+  const clearSelection = useCallback(() => {
     setSelectedIds([]);
-    if (gridRef.current?.api) {
-      gridRef.current.api.deselectAll();
-    }
-  }, [searchDebounced, productionFilter, fulfillmentFilter, customerFilter, overdueOnly]);
+    gridRef.current?.api?.deselectAll();
+  }, []);
 
   const gridHeight = useMemo(() => {
     if (loading || jobs.length === 0) return 600;
@@ -487,7 +487,10 @@ export default function JobsPage() {
           inputRef={searchInputRef}
           placeholder="Job #, PO, customer, part, packing slip…"
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            clearSelection();
+          }}
           onKeyDown={handleSearchKeyDown}
           size="small"
           sx={{ width: { xs: '100%', sm: 320 } }}
@@ -506,9 +509,10 @@ export default function JobsPage() {
           <SearchableSelect
             options={productionStatusOptions}
             value={productionFilterValue}
-            onChange={(value) =>
-              setProductionFilter(value ? ([value] as ProductionStatus[]) : undefined)
-            }
+            onChange={(value) => {
+              setProductionFilter(value ? ([value] as ProductionStatus[]) : undefined);
+              clearSelection();
+            }}
             label="Production Status"
             allowNone
             noneLabel="Any"
@@ -520,9 +524,10 @@ export default function JobsPage() {
           <SearchableSelect
             options={fulfillmentStatusOptions}
             value={fulfillmentFilterValue}
-            onChange={(value) =>
-              setFulfillmentFilter(value ? ([value] as FulfillmentStatus[]) : undefined)
-            }
+            onChange={(value) => {
+              setFulfillmentFilter(value ? ([value] as FulfillmentStatus[]) : undefined);
+              clearSelection();
+            }}
             label="Fulfillment Status"
             allowNone
             noneLabel="Any"
@@ -534,7 +539,10 @@ export default function JobsPage() {
           <SearchableSelect
             options={customerOptions}
             value={customerFilter}
-            onChange={setCustomerFilter}
+            onChange={(value) => {
+              setCustomerFilter(value);
+              clearSelection();
+            }}
             label="Customer"
             allowNone
             noneLabel="All Customers"
@@ -546,7 +554,10 @@ export default function JobsPage() {
           control={
             <Checkbox
               checked={overdueOnly}
-              onChange={(e) => setOverdueOnly(e.target.checked)}
+              onChange={(e) => {
+                setOverdueOnly(e.target.checked);
+                clearSelection();
+              }}
               size="small"
               sx={{
                 // Theme primary is Steel Blue (#4682B4), which blends into

--- a/app/dashboard/[companyId]/markup-rates/page.tsx
+++ b/app/dashboard/[companyId]/markup-rates/page.tsx
@@ -148,12 +148,13 @@ export default function MarkupRatesListPage() {
     return () => clearTimeout(t);
   }, [search]);
 
-  // Clear selection when search changes — the rows on screen change, so any
-  // ids selected before may not be visible anymore.
-  useEffect(() => {
+  // Clear selection when the search query changes — the rows on screen change,
+  // so any ids selected before may not be visible anymore. Called from the
+  // search input's onChange (not an effect) to avoid set-state-in-effect.
+  const clearSelection = useCallback(() => {
     setSelectedIds([]);
-    if (gridRef.current?.api) gridRef.current.api.deselectAll();
-  }, [searchDebounced]);
+    gridRef.current?.api?.deselectAll();
+  }, []);
 
   // The default rate is pinned to the top of the grid (immune to sort + search)
   // and tagged via the `is_default` flag, not by a magic name.
@@ -339,7 +340,10 @@ export default function MarkupRatesListPage() {
         <TextField
           placeholder="Search rates..."
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            clearSelection();
+          }}
           size="small"
           sx={{ width: { xs: '100%', sm: 300 } }}
           slotProps={{

--- a/app/dashboard/[companyId]/parts/page.tsx
+++ b/app/dashboard/[companyId]/parts/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
@@ -144,12 +144,14 @@ export default function PartsPage() {
   // warning can't disagree.
   const priceableIds = partsData?.[1] ?? EMPTY_PRICEABLE;
 
-  useEffect(() => {
+  // Clear selection when the search query or source filter changes — the rows
+  // on screen change, so any ids selected before may no longer be visible.
+  // Called from each control's onChange (not an effect) to avoid
+  // set-state-in-effect.
+  const clearSelection = useCallback(() => {
     setSelectedIds([]);
-    if (gridRef.current?.api) {
-      gridRef.current.api.deselectAll();
-    }
-  }, [searchDebounced, sourceFilter]);
+    gridRef.current?.api?.deselectAll();
+  }, []);
 
   // Apply source filter client-side and stamp each row with is_priceable
   // from the RPC set so the grid, gridHeight, and empty-state checks all
@@ -388,7 +390,10 @@ export default function PartsPage() {
         <TextField
           placeholder="Search parts..."
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            clearSelection();
+          }}
           size="small"
           sx={{ width: { xs: '100%', sm: 300 } }}
           slotProps={{
@@ -408,7 +413,10 @@ export default function PartsPage() {
             labelId="parts-source-label"
             value={sourceFilter}
             label="Source"
-            onChange={(e) => setSourceFilter(e.target.value as SourceFilter)}
+            onChange={(e) => {
+              setSourceFilter(e.target.value as SourceFilter);
+              clearSelection();
+            }}
           >
             <MenuItem value="all">All</MenuItem>
             <MenuItem value="made">Made</MenuItem>

--- a/app/dashboard/[companyId]/quotes/page.tsx
+++ b/app/dashboard/[companyId]/quotes/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useRouter, useParams, useSearchParams } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Link from 'next/link';
@@ -151,13 +151,13 @@ export default function QuotesPage() {
   );
   const quotes = quotesData ?? EMPTY_QUOTES;
 
-  // Clear selection on filter change
-  useEffect(() => {
+  // Clear selection when search or any filter changes — the rows on screen
+  // change, so any ids selected before may no longer be visible. Called from
+  // each control's onChange (not an effect) to avoid set-state-in-effect.
+  const clearSelection = useCallback(() => {
     setSelectedIds([]);
-    if (gridRef.current?.api) {
-      gridRef.current.api.deselectAll();
-    }
-  }, [searchDebounced, statusFilter, customerFilter, createdByFilter]);
+    gridRef.current?.api?.deselectAll();
+  }, []);
 
   // Grid height calculation
   const gridHeight = useMemo(() => {
@@ -337,7 +337,10 @@ export default function QuotesPage() {
         <TextField
           placeholder="Search quotes..."
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            clearSelection();
+          }}
           size="small"
           sx={{ width: { xs: '100%', sm: 250 } }}
           slotProps={{
@@ -358,7 +361,10 @@ export default function QuotesPage() {
               { id: 'expired', label: 'Expired' },
             ]}
             value={statusFilter === 'all' ? '' : statusFilter}
-            onChange={(value) => setStatusFilter((value || 'all') as QuoteStatus | 'all')}
+            onChange={(value) => {
+              setStatusFilter((value || 'all') as QuoteStatus | 'all');
+              clearSelection();
+            }}
             label="Status"
             allowNone
             noneLabel="All Statuses"
@@ -373,7 +379,10 @@ export default function QuotesPage() {
               label: c.name,
             }))}
             value={customerFilter}
-            onChange={setCustomerFilter}
+            onChange={(value) => {
+              setCustomerFilter(value);
+              clearSelection();
+            }}
             label="Customer"
             allowNone
             noneLabel="All Customers"
@@ -390,7 +399,10 @@ export default function QuotesPage() {
                 label: m.name || m.email || 'Unknown',
               }))}
             value={createdByFilter}
-            onChange={setCreatedByFilter}
+            onChange={(value) => {
+              setCreatedByFilter(value);
+              clearSelection();
+            }}
             label="Created By"
             allowNone
             noneLabel="All Users"

--- a/app/dashboard/[companyId]/team/page.tsx
+++ b/app/dashboard/[companyId]/team/page.tsx
@@ -413,17 +413,17 @@ export default function TeamPage() {
     /* eslint-enable react-hooks/set-state-in-effect */
   }, [activeTab, loadAdmins, loadUsers, loadOperators]);
 
-  // Clear selection when search or tab changes
-  useEffect(() => {
+  // Clear selection when search or tab changes — the rows on screen change, so
+  // any ids selected before may no longer be visible. Deselects all three
+  // per-tab grids (the refs are stable, so the empty dep list is correct);
+  // doing all of them keeps this independent of which tab is active. Called
+  // from each control's onChange (not an effect) to avoid set-state-in-effect.
+  const clearSelection = useCallback(() => {
     setSelectedIds([]);
-    if (activeTab === 0 && adminsGridRef.current?.api) {
-      adminsGridRef.current.api.deselectAll();
-    } else if (activeTab === 1 && usersGridRef.current?.api) {
-      usersGridRef.current.api.deselectAll();
-    } else if (activeTab === 2 && operatorsGridRef.current?.api) {
-      operatorsGridRef.current.api.deselectAll();
-    }
-  }, [searchDebounced, activeTab]);
+    adminsGridRef.current?.api?.deselectAll();
+    usersGridRef.current?.api?.deselectAll();
+    operatorsGridRef.current?.api?.deselectAll();
+  }, []);
 
   // Calculate grid height dynamically based on active tab data
   const currentData = activeTab === 0 ? admins : activeTab === 1 ? users : operators;
@@ -725,7 +725,13 @@ export default function TeamPage() {
     <Box>
       {/* Tabs */}
       <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 0, mt: -2 }}>
-        <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)}>
+        <Tabs
+          value={activeTab}
+          onChange={(_, v) => {
+            setActiveTab(v);
+            clearSelection();
+          }}
+        >
           <Tab label="Admins" icon={<AdminPanelSettingsIcon />} iconPosition="start" />
           <Tab label="Users" icon={<PersonIcon />} iconPosition="start" />
           <Tab label="Operators" icon={<BadgeIcon />} iconPosition="start" />
@@ -748,7 +754,10 @@ export default function TeamPage() {
             placeholder="Search admins..."
             size="small"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              clearSelection();
+            }}
             sx={{ width: { xs: '100%', sm: 300 } }}
             slotProps={{
               input: {
@@ -884,7 +893,10 @@ export default function TeamPage() {
             placeholder="Search users..."
             size="small"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              clearSelection();
+            }}
             sx={{ width: { xs: '100%', sm: 300 } }}
             slotProps={{
               input: {
@@ -1020,7 +1032,10 @@ export default function TeamPage() {
             placeholder="Search operators..."
             size="small"
             value={search}
-            onChange={(e) => setSearch(e.target.value)}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              clearSelection();
+            }}
             sx={{ width: { xs: '100%', sm: 300 } }}
             slotProps={{
               input: {

--- a/app/dashboard/[companyId]/vendors/page.tsx
+++ b/app/dashboard/[companyId]/vendors/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
@@ -103,12 +103,13 @@ export default function VendorsPage() {
   );
   const rows = vendorsData ?? EMPTY_VENDORS;
 
-  useEffect(() => {
+  // Clear selection when the search query changes — the rows on screen change,
+  // so any ids selected before may no longer be visible. Called from the
+  // control's onChange (not an effect) to avoid set-state-in-effect.
+  const clearSelection = useCallback(() => {
     setSelectedIds([]);
-    if (gridRef.current?.api) {
-      gridRef.current.api.deselectAll();
-    }
-  }, [searchDebounced]);
+    gridRef.current?.api?.deselectAll();
+  }, []);
 
   const gridHeight = useMemo(() => {
     if (loading || rows.length === 0) return 600;
@@ -255,7 +256,10 @@ export default function VendorsPage() {
         <TextField
           placeholder="Search vendors..."
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            clearSelection();
+          }}
           size="small"
           sx={{ width: { xs: '100%', sm: 300 } }}
           slotProps={{

--- a/app/dashboard/[companyId]/work-centers/page.tsx
+++ b/app/dashboard/[companyId]/work-centers/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
@@ -134,12 +134,14 @@ export default function WorkCentersPage() {
   );
   const rows = workCentersData ?? EMPTY_WORK_CENTERS;
 
-  useEffect(() => {
+  // Clear selection when the search query or the active kind tab changes — the
+  // rows on screen change, so any ids selected before may no longer be visible.
+  // Called from each control's onChange (not an effect) to avoid
+  // set-state-in-effect.
+  const clearSelection = useCallback(() => {
     setSelectedIds([]);
-    if (gridRef.current?.api) {
-      gridRef.current.api.deselectAll();
-    }
-  }, [searchDebounced, activeKind]);
+    gridRef.current?.api?.deselectAll();
+  }, []);
 
   const gridHeight = useMemo(() => {
     if (loading || rows.length === 0) return 600;
@@ -275,6 +277,7 @@ export default function WorkCentersPage() {
         onChange={(_e, value) => {
           setActiveKind(value as WorkCenterKind);
           setSearch('');
+          clearSelection();
         }}
         sx={{ mb: 3, borderBottom: 1, borderColor: 'divider' }}
       >
@@ -294,7 +297,10 @@ export default function WorkCentersPage() {
         <TextField
           placeholder="Search work centers..."
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            clearSelection();
+          }}
           size="small"
           sx={{ width: { xs: '100%', sm: 300 } }}
           slotProps={{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,16 +43,18 @@ const eslintConfig = defineConfig([
           destructuredArrayIgnorePattern: "^_",
         },
       ],
-      // Downgraded from `error` to `warn`. The rule (new in
-      // eslint-plugin-react-hooks v6 / Next.js 16) statically flags every
-      // setState call reached from inside a useEffect — including the
-      // standard data-fetch-on-mount pattern where the setState only
-      // happens after an await. ~78 of these in the codebase, almost all
-      // false positives (the actual cascading-render anti-pattern is rare).
-      // Keep as a warning so new instances are still surfaced in review,
-      // but don't block CI on existing call sites. Refactor surfaces that
-      // genuinely loop (where the rule is right) in the same PR that
-      // touches the affected component.
+      // Kept at `warn` (not `error`). The rule (eslint-plugin-react-hooks v6+ /
+      // Next.js 16) flags EVERY setState reachable from a useEffect — including
+      // the idiomatic data-fetch-on-mount pattern where setState only runs
+      // after an await. Issue #442 drove the count from 109 down to a small
+      // honest budget via genuine refactors: the `useLoad` hook for data
+      // loaders, `onEnter`/key-remount for reset-on-open modals, and moving
+      // bulk-selection clears into the search/tab handlers. The residual is the
+      // rule's documented false-positive / legitimate-effect class — prop
+      // mirrors, guards, localStorage reads, timers, derived-from-loaded-data —
+      // deliberately LEFT as warnings under the ratcheting `--max-warnings` cap
+      // (package.json) rather than mass-suppressed with inline-disables. New
+      // instances still surface in review; the cap only ratchets down.
       "react-hooks/set-state-in-effect": "warn",
     },
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint --max-warnings 26",
+    "lint": "eslint --max-warnings 17",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
The final PR for #442. Moves the "clear bulk-selection on search/filter/tab change" logic on all 9 list pages out of a `useEffect` and into the `onChange` handlers of the controls that trigger it, ratcheting `eslint --max-warnings` **26 → 17** (0 errors).

## What
Each list page gets a stable `clearSelection()` helper, called from the `onChange` of every control the old effect depended on (search field, each filter dropdown, tabs). The selection-clear `useEffect` is deleted. Clearing on the event instead of in an effect is the React-idiomatic shape and clears `set-state-in-effect`.

**Behaviorally safe** (confirmed in the earlier adversarial review): every page already self-clears selection in its bulk-action/delete handlers before refetch, so nothing relied on the effect. Full dependency coverage per page (e.g. jobs covers all 5 filters; team covers all 3 per-tab searches + the Tabs onChange).

## Why we stop at 17 (not 0)
The remaining **17** warnings are the rule's **documented false-positive / legitimate-effect class** — data-fetch-on-mount loaders whose setState only runs post-`await` (and resist the `useLoad`/`.then` shape: auth orchestration, editable-tier pricing/procurement panels, conditional-tab team loaders), plus prop-mirrors, guards, localStorage reads, a rotating-message timer, and derived-from-loaded-data. 

Per a deliberate decision, these are **left as warnings under the ratcheting cap** (the rule stays `warn`) rather than mass-suppressed with ~17 inline-disables. A small honest budget on a rule with a real FP rate beats trading signal for suppression churn (see the `eslint.config.mjs` note). New instances still surface in review; the cap only ratchets down.

## Issue #442 result
**109 → 17 warnings (84%), 0 errors, across 8 PRs, zero regressions.** `useLoad` is now the house client-data-loading pattern (~36 loaders migrated); reset-on-open modals use `onEnter`/key-remount (with tests); config hygiene added (`coverage/**`, `.claude/**` ignores).

## Validation
- `pnpm lint` ✅ green at `--max-warnings 17`
- `pnpm exec tsc --noEmit` ✅ clean
- `pnpm test --run __tests__/{components,utils}` ✅ **673 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)