### PR TITLE
Operator paperless follow-ups: doc cleanups, whole-plant view, multi-part hub

### DIFF
--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -11,7 +11,10 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
   builder.error = null;
   return {
     mockQueryBuilder: builder,
-    mockSupabase: { from: vi.fn().mockImplementation(() => builder) },
+    mockSupabase: {
+      from: vi.fn().mockImplementation(() => builder),
+      rpc: vi.fn().mockResolvedValue({ data: [], error: null }),
+    },
   };
 });
 
@@ -26,12 +29,33 @@ vi.mock('@/lib/supabaseErrors', () => ({
     opts?.fallback ?? 'error',
 }));
 
-import { getJobNotes, addJobNote } from '@/utils/operatorAccess';
+import { getJobNotes, addJobNote, getAllStationsOperatorJobs } from '@/utils/operatorAccess';
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockQueryBuilder.data = null;
   mockQueryBuilder.error = null;
+});
+
+describe('getAllStationsOperatorJobs', () => {
+  it('queries readiness once per station (parallel) and returns [] when nothing is ready', async () => {
+    // The hoisted rpc mock resolves to no ready ops for every station, so the
+    // function short-circuits before any enrichment queries.
+    const stations = [
+      { id: 'wc1', name: 'Lathe' },
+      { id: 'wc2', name: 'Mill' },
+      { id: 'wc3', name: 'Deburr' },
+    ];
+
+    const result = await getAllStationsOperatorJobs('c1', stations);
+
+    expect(mockSupabase.rpc).toHaveBeenCalledTimes(3);
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('get_ready_operations_for_station', {
+      p_company_id: 'c1',
+      p_work_center_id: 'wc2',
+    });
+    expect(result).toEqual([]);
+  });
 });
 
 describe('getJobNotes', () => {

--- a/app/operator/[companyId]/jobs/[jobId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/page.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardActionArea from '@mui/material/CardActionArea';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import LinearProgress from '@mui/material/LinearProgress';
+import Alert from '@mui/material/Alert';
+import IconButton from '@mui/material/IconButton';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { getJobPartsOverview } from '@/utils/operatorAccess';
+import type { JobPartsOverview, JobPartSummary } from '@/types/operator';
+
+const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
+
+function statusColor(status: string): 'default' | 'primary' | 'success' {
+  if (status === 'completed') return 'success';
+  if (status === 'in_progress') return 'primary';
+  return 'default';
+}
+
+/**
+ * Operator job parts hub. A multi-part job lands here so the operator can see
+ * all of the job's parts and jump into any one. A single-part job adds nothing,
+ * so it redirects straight to that part's traveler.
+ */
+export default function OperatorJobPartsHubPage() {
+  const params = useParams();
+  const router = useRouter();
+  const companyId = params.companyId as string;
+  const jobId = params.jobId as string;
+
+  const [overview, setOverview] = useState<JobPartsOverview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let redirecting = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await getJobPartsOverview(jobId, companyId);
+        if (cancelled) return;
+        if (!data) {
+          setError('Job not found.');
+          return;
+        }
+        // Single-part job: the hub adds nothing — go straight to the traveler.
+        if (data.parts.length === 1) {
+          redirecting = true;
+          router.replace(`/operator/${companyId}/jobs/${jobId}/parts/${data.parts[0].job_part_id}`);
+          return;
+        }
+        setOverview(data);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load job');
+      } finally {
+        if (!cancelled && !redirecting) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [companyId, jobId, router]);
+
+  const openPart = (part: JobPartSummary) => {
+    router.push(`/operator/${companyId}/jobs/${jobId}/parts/${part.job_part_id}`);
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error || !overview) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error || 'Job not found.'}
+        </Alert>
+        <Button variant="outlined" onClick={() => router.push(`/operator/${companyId}/jobs`)}>
+          Back to jobs
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ pb: 4 }}>
+      <IconButton
+        onClick={() => router.push(`/operator/${companyId}/jobs`)}
+        sx={{ mb: 2 }}
+        aria-label="Back to jobs"
+      >
+        <ArrowBackIcon />
+      </IconButton>
+
+      {/* Job header */}
+      <Card elevation={2} sx={{ ...cardSx, mb: 3 }}>
+        <CardContent>
+          <Typography variant="h5" component="h1" fontWeight={700}>
+            {overview.job_number}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {overview.customer_name || 'No customer'}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            {overview.parts.length} parts
+          </Typography>
+        </CardContent>
+      </Card>
+
+      <Typography variant="overline" color="text.secondary" sx={{ px: 0.5 }}>
+        Parts
+      </Typography>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, mt: 0.5 }}>
+        {overview.parts.map((part) => (
+          <Card key={part.job_part_id} elevation={2} sx={cardSx}>
+            <CardActionArea onClick={() => openPart(part)}>
+              <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'flex-start',
+                      gap: 1,
+                    }}
+                  >
+                    <Typography variant="body1" fontWeight={600}>
+                      {part.part_name || 'Part'}
+                    </Typography>
+                    <Chip
+                      size="small"
+                      label={part.production_status}
+                      color={statusColor(part.production_status)}
+                    />
+                  </Box>
+                  <Typography variant="caption" color="text.secondary">
+                    Order qty {part.quantity}
+                  </Typography>
+                  {part.operations_total > 0 && (
+                    <Box sx={{ mt: 1 }}>
+                      <Typography variant="caption" color="text.secondary">
+                        {part.operations_completed}/{part.operations_total} operations
+                      </Typography>
+                      <LinearProgress
+                        variant="determinate"
+                        value={(part.operations_completed / part.operations_total) * 100}
+                        sx={{ height: 4, borderRadius: 1, mt: 0.5 }}
+                      />
+                    </Box>
+                  )}
+                </Box>
+                <ChevronRightIcon color="action" />
+              </CardContent>
+            </CardActionArea>
+          </Card>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
@@ -14,6 +14,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import IconButton from '@mui/material/IconButton';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import LayersIcon from '@mui/icons-material/Layers';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import PlayCircleFilledIcon from '@mui/icons-material/PlayCircleFilled';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
@@ -107,15 +108,26 @@ export default function OperatorJobTravelerPage() {
 
   return (
     <Box sx={{ pb: 4 }}>
-      {/* Back to the operator's station jobs list (not the parts hub, which
-          auto-redirects single-part jobs straight back to this traveler). */}
-      <IconButton
-        onClick={() => router.push(`/operator/${companyId}/jobs`)}
-        sx={{ mb: 2 }}
-        aria-label="Back to jobs"
-      >
-        <ArrowBackIcon />
-      </IconButton>
+      {/* Back to the station jobs list, plus an "all parts" jump for multi-part
+          jobs. Single-part jobs have job_part_count = 1, so the link is hidden
+          (their hub would just redirect back here). */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <IconButton
+          onClick={() => router.push(`/operator/${companyId}/jobs`)}
+          aria-label="Back to jobs"
+        >
+          <ArrowBackIcon />
+        </IconButton>
+        {traveler.job_part_count > 1 && (
+          <Button
+            size="small"
+            startIcon={<LayersIcon />}
+            onClick={() => router.push(`/operator/${companyId}/jobs/${jobId}`)}
+          >
+            All {traveler.job_part_count} parts
+          </Button>
+        )}
+      </Box>
 
       {/* Header — mirrors the printed traveler's job block */}
       <Card elevation={2} sx={{ ...cardSx, mb: 3 }}>

--- a/app/operator/[companyId]/jobs/page.tsx
+++ b/app/operator/[companyId]/jobs/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -11,78 +11,95 @@ import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import LinearProgress from '@mui/material/LinearProgress';
 import Alert from '@mui/material/Alert';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import IconButton from '@mui/material/IconButton';
-import { getOperatorJobs } from '@/utils/operatorAccess';
+import { getOperatorJobs, getAllStationsOperatorJobs } from '@/utils/operatorAccess';
 import { useStationContext } from '@/components/operator/OperatorStationContext';
 import StationSelector from '@/components/operator/StationSelector';
-import type { OperatorJob } from '@/types/operator';
+import type { OperatorJob, OperatorPlantJob } from '@/types/operator';
 
 /**
  * Operator Jobs List Page.
  *
- * Shows jobs available for the operator to work on.
- * Filtered by station operation_type_id from station context.
+ * Two lenses:
+ *  - "My Station" — work ready/in-progress at the selected station (the
+ *    dispatch list). Prompts for a station if none is selected.
+ *  - "All Stations" — the whole plant: every active job grouped by station, so
+ *    a roaming operator or lead can find work / see floor status without
+ *    picking one station.
  */
+type Lens = 'station' | 'plant';
+
 export default function OperatorJobsPage() {
   const params = useParams();
   const router = useRouter();
   const companyId = params.companyId as string;
-  const { stationId } = useStationContext();
+  const { stationId, stations } = useStationContext();
 
+  const [lens, setLens] = useState<Lens>('station');
   const [jobs, setJobs] = useState<OperatorJob[]>([]);
+  const [plantJobs, setPlantJobs] = useState<OperatorPlantJob[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const loadJobs = useCallback(async () => {
-    if (!stationId) return;
+    if (lens === 'station' && !stationId) {
+      setJobs([]);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     setError(null);
-
     try {
-      const jobsData = await getOperatorJobs(companyId, stationId);
-      setJobs(jobsData);
+      if (lens === 'plant') {
+        setPlantJobs(await getAllStationsOperatorJobs(companyId, stations));
+      } else {
+        setJobs(await getOperatorJobs(companyId, stationId as string));
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load jobs');
     } finally {
       setLoading(false);
     }
-  }, [companyId, stationId]);
+  }, [companyId, stationId, lens, stations]);
 
   useEffect(() => {
-    // Wait for station to resolve before fetching — otherwise a fetch with
-    // stationId=undefined returns ALL company jobs, and if it lands after the
-    // station-filtered fetch it pollutes the list with wrong-station jobs.
-    if (!stationId) {
-      setJobs([]);
-      setLoading(false);
-      return;
-    }
-
+    // Re-run on lens / station / stations change. Cancellation guards against a
+    // slow fetch landing after the inputs changed (e.g. station just resolved).
     let cancelled = false;
     (async () => {
+      if (lens === 'station' && !stationId) {
+        setJobs([]);
+        setLoading(false);
+        return;
+      }
       setLoading(true);
       setError(null);
       try {
-        const jobsData = await getOperatorJobs(companyId, stationId);
-        if (cancelled) return;
-        setJobs(jobsData);
+        if (lens === 'plant') {
+          const data = await getAllStationsOperatorJobs(companyId, stations);
+          if (!cancelled) setPlantJobs(data);
+        } else {
+          const data = await getOperatorJobs(companyId, stationId as string);
+          if (!cancelled) setJobs(data);
+        }
       } catch (err) {
-        if (cancelled) return;
-        setError(err instanceof Error ? err.message : 'Failed to load jobs');
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load jobs');
       } finally {
         if (!cancelled) setLoading(false);
       }
     })();
-
     return () => {
       cancelled = true;
     };
-  }, [companyId, stationId]);
+  }, [companyId, stationId, lens, stations]);
 
-  // From the station-scoped list the operator is already at a station, so jump
-  // straight to that station's operation (skip the traveler). Fall back to the
-  // traveler if the row has no resolved operation.
+  // Tapping a row opens the ready operation (skipping the traveler). When the
+  // row is at a different station than the operator's current selection, the
+  // operation page's station-match guard handles the mismatch ("switch &
+  // complete") — so the All-Stations lens reuses the same safe path.
   const handlePartClick = (row: OperatorJob) => {
     const base = `/operator/${companyId}/jobs/${row.job_id}/parts/${row.id}`;
     router.push(row.operation_id ? `${base}/operations/${row.operation_id}` : base);
@@ -101,135 +118,170 @@ export default function OperatorJobsPage() {
     }
   };
 
-  // Prompt operator to select a station before showing jobs
-  if (!stationId) {
-    return <StationSelector />;
-  }
+  // Group whole-plant rows by station for the "All Stations" lens.
+  const plantGroups = useMemo(() => {
+    const map = new Map<string, OperatorPlantJob[]>();
+    for (const row of plantJobs) {
+      const key = row.work_center_name ?? 'Unassigned';
+      const list = map.get(key);
+      if (list) list.push(row);
+      else map.set(key, [row]);
+    }
+    return Array.from(map.entries());
+  }, [plantJobs]);
 
-  if (loading) {
-    return (
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          minHeight: '50vh',
-        }}
-      >
-        <CircularProgress />
-      </Box>
-    );
-  }
+  const renderJobCard = (row: OperatorJob, key: string) => (
+    <Card
+      key={key}
+      elevation={2}
+      sx={{ bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' }}
+    >
+      <CardActionArea onClick={() => handlePartClick(row)} sx={{ minHeight: 100 }}>
+        <CardContent>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
+              mb: 1,
+            }}
+          >
+            <Box sx={{ minWidth: 0 }}>
+              <Typography variant="h6" component="div" fontWeight={600}>
+                {row.job_number} · {row.part_name ?? 'Part'}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                Order qty {row.part_quantity}
+              </Typography>
+            </Box>
+            <Chip
+              label={row.operation_status || row.production_status}
+              size="small"
+              color={getStatusColor(row.operation_status || row.production_status)}
+            />
+          </Box>
+
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+            {row.customer_name || 'No customer'}
+          </Typography>
+
+          {row.operation_name && (
+            <Typography variant="body1" sx={{ mb: 1 }}>
+              Op: {row.operation_name}
+            </Typography>
+          )}
+
+          {row.operations_total > 1 && (
+            <Box sx={{ mt: 1 }}>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+                <Typography variant="caption" color="text.secondary">
+                  Part progress: {row.operations_completed}/{row.operations_total}
+                </Typography>
+              </Box>
+              <LinearProgress
+                variant="determinate"
+                value={(row.operations_completed / row.operations_total) * 100}
+                sx={{ height: 4, borderRadius: 1 }}
+              />
+            </Box>
+          )}
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+
+  const showStationSelector = lens === 'station' && !stationId;
 
   return (
     <Box>
-      {/* Header */}
+      {/* Header: lens toggle + refresh */}
       <Box
         sx={{
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
           mb: 2,
+          gap: 1,
         }}
       >
-        <Typography variant="h6" component="h1" fontWeight={600}>
-          Available Jobs
-        </Typography>
-        <IconButton onClick={loadJobs} disabled={loading}>
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          value={lens}
+          onChange={(_e, value) => {
+            if (value) setLens(value as Lens);
+          }}
+          aria-label="Job list scope"
+        >
+          <ToggleButton value="station">My Station</ToggleButton>
+          <ToggleButton value="plant">All Stations</ToggleButton>
+        </ToggleButtonGroup>
+        <IconButton onClick={loadJobs} disabled={loading} aria-label="Refresh">
           <RefreshIcon />
         </IconButton>
       </Box>
 
-      {/* Error State */}
       {error && (
         <Alert severity="error" sx={{ mb: 2 }}>
           {error}
         </Alert>
       )}
 
-      {/* Empty State */}
-      {!error && jobs.length === 0 && (
+      {showStationSelector ? (
+        <StationSelector />
+      ) : loading ? (
         <Box
           sx={{
-            textAlign: 'center',
-            py: 8,
-            px: 2,
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: '40vh',
           }}
         >
+          <CircularProgress />
+        </Box>
+      ) : lens === 'station' ? (
+        jobs.length === 0 ? (
+          <Box sx={{ textAlign: 'center', py: 8, px: 2 }}>
+            <Typography variant="h6" color="text.secondary" gutterBottom>
+              No jobs available
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              There are no pending jobs for your station at this time.
+            </Typography>
+          </Box>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {jobs.map((row) => renderJobCard(row, row.id))}
+          </Box>
+        )
+      ) : plantJobs.length === 0 ? (
+        <Box sx={{ textAlign: 'center', py: 8, px: 2 }}>
           <Typography variant="h6" color="text.secondary" gutterBottom>
-            No jobs available
+            No active jobs
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            There are no pending jobs for your station at this time.
+            There is no ready or in-progress work across the plant right now.
           </Typography>
         </Box>
+      ) : (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          {plantGroups.map(([station, rows]) => (
+            <Box key={station}>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{ display: 'block', mb: 1 }}
+              >
+                {station} · {rows.length}
+              </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                {rows.map((row) => renderJobCard(row, row.operation_id ?? row.id))}
+              </Box>
+            </Box>
+          ))}
+        </Box>
       )}
-
-      {/* Job/Part Cards — one row per (job, part) ready at this station. */}
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-        {jobs.map((row) => (
-          <Card
-            key={row.id}
-            elevation={2}
-            sx={{ bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' }}
-          >
-            <CardActionArea
-              onClick={() => handlePartClick(row)}
-              sx={{ minHeight: 100 }}
-            >
-              <CardContent>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'flex-start',
-                    mb: 1,
-                  }}
-                >
-                  <Box sx={{ minWidth: 0 }}>
-                    <Typography variant="h6" component="div" fontWeight={600}>
-                      {row.job_number} · {row.part_name ?? 'Part'}
-                    </Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      Order qty {row.part_quantity}
-                    </Typography>
-                  </Box>
-                  <Chip
-                    label={row.operation_status || row.production_status}
-                    size="small"
-                    color={getStatusColor(row.operation_status || row.production_status)}
-                  />
-                </Box>
-
-                <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
-                  {row.customer_name || 'No customer'}
-                </Typography>
-
-                {row.operation_name && (
-                  <Typography variant="body1" sx={{ mb: 1 }}>
-                    Op: {row.operation_name}
-                  </Typography>
-                )}
-
-                {row.operations_total > 1 && (
-                  <Box sx={{ mt: 1 }}>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
-                      <Typography variant="caption" color="text.secondary">
-                        Part progress: {row.operations_completed}/{row.operations_total}
-                      </Typography>
-                    </Box>
-                    <LinearProgress
-                      variant="determinate"
-                      value={(row.operations_completed / row.operations_total) * 100}
-                      sx={{ height: 4, borderRadius: 1 }}
-                    />
-                  </Box>
-                )}
-              </CardContent>
-            </CardActionArea>
-          </Card>
-        ))}
-      </Box>
     </Box>
   );
 }

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -2,541 +2,99 @@
 
 ## Overview
 
-The Operator View module provides a mobile-first interface for shop floor operators to log in with email/password, scan station QR codes to identify their workstation, view their assigned jobs, track time on operations, and mark work complete. This is the primary touchpoint for operators using Jigged on the shop floor.
+The Operator View is a mobile-first interface for shop-floor operators, used on their own
+phones. Operators sign in, select the station they're working at (by scanning a posted
+station-QR placard or tapping it from a list), see the work ready at that station, open a
+step, and record progress with a single **Mark Complete**.
 
-**Priority:** Must Have (Build after Jobs module)
+> This spec covers the **data model and screens**. For the end-to-end operator journeys
+> and the paperless-preferred model, see [operator-paperless-flow.md](../operator-paperless-flow.md).
 
-**Dependencies:**
+**Route:** `/operator/{companyId}` (dedicated mobile interface)
 
-- Jobs module (operators work on jobs)
-
-- Authentication system (operator login)
-
-- Operations module (for operation types)
-
-**Database Tables:** `user_company_access` (with role='operator'), `operator_sessions`
-
-**Route:** `/operator/{companyId}` (dedicated mobile-first interface)
+> **Supersedes** an earlier draft that described `operation_type` stations, a routing **DAG**
+> with parallel branches, `operator_sessions` time tracking, and PIN/badge login. The shipped
+> module uses **work centers**, **linear** routings, **complete-only** capture (no
+> sessions/timers), and **email/password** login. Don't trust older revisions.
 
 ---
 
-## User Stories
+## Authentication
 
-| As a... | I want to... | So that... |
+- **Email/password via Supabase Auth.** Operators authenticate the same way as office staff
+  but land on the operator interface. Role = `operator` in `user_company_access`.
+- Operators use **their own phones**; the Supabase session persists, so sign-in is
+  effectively one-time per device. Shared-kiosk PIN/badge is intentionally **not** used.
+- `getPostLoginRoute()` routes `operator`-role users to `/operator/{companyId}`, others to
+  `/dashboard/{companyId}`.
+
+## Stations (work centers)
+
+- A "station" is a row in **`work_centers`**; each `job_operations` row carries `work_center_id`.
+- The operator selects a station **per session** — there is **no permanent operator↔station
+  assignment**. Selection persists in `sessionStorage` (`jigged_operator_station`) and can be
+  changed any time (scan a different placard, or pick from the header).
+- **Station QR placards** are generated per work center (`components/operations/StationQRCode.tsx`)
+  and bulk-printable from the work-centers list. The QR encodes
+  `…/operator/{companyId}/login?station={workCenterId}`.
+
+## Data model
+
+**Operators** — `user_company_access` with `role='operator'` (the legacy `operators` table is deprecated).
+
+**Operations** — `job_operations`: one row per routing step on a `job_part`.
+- `sequence`, `operation_name`, `instructions`, `work_center_id`.
+- `status`: **`pending` → `completed`** (single tap). `completed_at` / `completed_by` record who and when.
+- `estimated_setup_minutes`, `estimated_run_minutes_per_unit` — estimates only, used for costing/quoting.
+- **No actual-time columns and no `operator_sessions` table** — both were removed. There is no
+  start/stop, no timer, no shift/clock-in. See [prd.md](../prd.md) §4.3 (Complete-Only).
+
+**Job feed** — `job_notes` (+ `job_note_media`): one append-only stream per job; a note may be
+tagged to a step via `job_operation_id`. Captured on the operation page (text + photo/video).
+
+## Routing & readiness
+
+- Routings are a **linear sequence** of operations — no DAG, no parallel branches.
+- An operation is **ready** when all lower-`sequence` operations on the **same part** are
+  completed. Out-of-order work is **warned, not blocked** (`predecessors_incomplete`).
+- Completing the last incomplete operation on a part completes the part; the job's
+  `production_status` is derived (`not_started` / `in_progress` / `completed`). There is no
+  separate operation-level "in progress" concept beyond the operation row's status.
+
+---
+
+## Screens & routes
+
+| Screen | Route | Purpose |
 |---|---|---|
-| Operator | Scan a station QR code to identify my workstation | The system knows which station I am working at |
-| Operator | Log in with my email and password | I can access my work using credentials I already have |
-| Operator | See my current station displayed in the header | I always know which station I am working at |
-| Operator | Switch to a different station via dropdown or QR scan | I can move between workstations without logging out |
-| Operator | View a list of pending jobs filtered to my station | I know what work is available at my current station |
-| Operator | Start work on a job | Time tracking begins and others see Im working on it |
-| Operator | Scan a job QR code to navigate to a specific job | I can quickly find the job I need to work on without scrolling through a list |
-| Operator | Stop work on a job | I can take a break or switch to another job |
-| Operator | Mark a job operation as complete | The job moves to the next operation or completion |
-| Operator | View my work session history | I can review past jobs, durations, and dates |
-| Operator | Change my password from my profile | I can update my credentials without admin help |
-| Owner | See which operators are currently active | I have real-time visibility into shop floor activity |
-| Owner | Create and manage operator accounts | I control who can access the operator view |
+| Login | `/operator/{companyId}/login` | Email/password; captures `?station=`, `?job=&part=&operation=`, or `?location=` from a scanned QR and routes accordingly. |
+| Station job list (dispatch) | `/operator/{companyId}/jobs` | Work ready/in-progress at the selected station — one row per (job, part), sorted by due date. An **All Stations** lens shows the whole plant grouped by station. |
+| Job parts hub | `/operator/{companyId}/jobs/{jobId}` | For multi-part jobs, lists the job's parts with progress; single-part jobs redirect straight to the traveler. |
+| Part traveler | `…/jobs/{jobId}/parts/{jobPartId}` | All steps for one part (read-only), with a back-link to the parts hub on multi-part jobs. |
+| Operation action | `…/parts/{jobPartId}/operations/{jobOperationId}` | **Mark Complete** / **Undo**, notes + photos, "last time we ran this part" guidance, and a station-mismatch guard. |
+| Inventory (optional) | `/operator/{companyId}/inventory[/locations/{id}]` | Feature-gated bin browse + add/remove/adjust stock. |
+| Profile | `/operator/{companyId}/profile` | Name, email, current station, sign out. |
+
+## QR codes
+
+- **Station placard** (per work center): selects the station and opens its job list. Posted at
+  the machine, printed once; bulk-print all from the work-centers list.
+- **Per-operation traveler QR** (`utils/jobTravelerPdf.ts`): deep-links to a specific step's
+  action view. An **optional accelerator** for shops mid-transition — not required under the
+  paperless-preferred model.
+
+## Admin
+
+- **Operator creation** uses the backend (`POST /api/operators`) with the Supabase service-role
+  key — the only operator operation that needs the backend. Everything else uses the Supabase
+  client directly with RLS.
+- Operator management lives under `/dashboard/{companyId}/team`.
 
 ---
 
-## Data Model
-
-### Team Members (Operators)
-
-Operators are managed through the unified `user_company_access` table with `role='operator'`. This approach provides consistent team member management across all roles.
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| id | uuid | Yes | Primary key |
-| user_id | uuid | Yes | FK to auth.users (Supabase user) |
-| company_id | uuid | Yes | FK to companies |
-| role | text | Yes | Role type - 'operator' for shop floor users |
-| name | text | No | Display name (from user profile or auth metadata) |
-| created_at | timestamptz | Yes | Record creation timestamp |
-
-> **Note:** The legacy `operators` table is deprecated. New implementations should use `user_company_access` with `role='operator'`. See `types/operator.ts` for the `TeamMember` interface.
-
-### Operator Sessions Table
-
-| Column | Type | Required | Description |
-|---|---|---|---|
-| id | uuid | Yes | Primary key |
-| company_id | uuid | Yes | FK to companies |
-| operator_id | uuid | Yes | FK to user_company_access (the operator's team member record) |
-| job_id | uuid | Yes | FK to jobs (current job being worked) |
-| operation_type_id | uuid | Yes | FK to operation_types (from station QR code) |
-| job_operation_id | uuid | No | FK to job_operations (the specific operation step being worked) |
-| started_at | timestamptz | Yes | When work session started |
-| ended_at | timestamptz | No | When work session ended (null if in progress) |
-
----
-
-## Routing & Session Tracking
-
-Operators work on specific routing nodes (operation steps) within a job. The session tracking system must capture which exact step was worked.
-
-### Key Relationships
-
-`Job → Routing → Routing Nodes (each node is an operation_type)`
-
-- Station QR codes encode `operation_type_id` (station = operation_type)
-
-- When starting work, the system finds the matching uncompleted job_operation for that operation_type
-
-- Sessions track both the operation_type_id (from QR) and job_operation_id (specific step)
-
-### Data Model Update
-
-**operator_sessions table changes:**
-
-- Rename `station_id` (text) → `operation_type_id` (uuid FK to operation_types)
-
-- Add job_operation_id (uuid FK to job_operations) - which specific operation step was worked
-
----
-
-## Job List Filtering Logic
-
-When an operator scans a station QR code (encoding an operation_type_id), the job list is filtered to show only relevant jobs:
-
-1. Job status is `PENDING` or `IN_PROGRESS`
-
-2. Job has an uncompleted job_operation matching the operator's operation_type
-
-3. All predecessor nodes in the routing DAG must be complete (node is "ready" to work)
-
-4. Sorted by due date (urgent first), then by job number
-
-**API:** `GET /api/operator/jobs?operation_type_id={uuid}`
-
-### How routing_node_id is Determined
-
-When an operator starts work on a job, the system infers the specific job_operation_id:
-
-1. Operator scans station QR → provides `operation_type_id`
-
-2. Operator selects a job → provides `job_id`
-
-3. System queries to find the job_operation where:
-
-- `routing_id` matches the jobs parts routing
-
-- `operation_type_id` matches the scanned station
-
-- `completed_at` is NULL (not yet completed)
-
-1. This gives the specific job_operation_id to track in the session
-
----
-
-## Routing Advancement Logic
-
-When an operator marks an operation as complete:
-
-1. The specific job_operation is marked as completed with timestamp
-
-2. The current operator_session is ended (end_time set)
-
-3. If job was in PENDING status, it transitions to IN_PROGRESS
-
-4. System checks if ALL job_operations for this job are now complete
-
-5. If all nodes complete → Job status automatically transitions to COMPLETE
-
-6. Downstream nodes (successors in the DAG) become "ready" for operators at those stations
-
-**Note:** For parallel routing branches, multiple nodes can be in progress simultaneously on different stations.
-
----
-
-## UI Screens
-
-### 1. Station Login
-
-**Route:** `/operator/{companyId}/login`
-
-Mobile-first login screen with email/password authentication. Station is pre-selected if operator scanned a station QR code:
-
-- Email and password form - mobile-optimized input fields with large touch targets
-
-- Station QR code parameter auto-captured from URL when scanned
-
-- Clear error messaging for invalid credentials
-
-- If operator is already authenticated and scans a new station QR code, the station updates automatically and the operator is redirected to the jobs list without needing to log in again
-
-### Password Change (First Login)
-
-Route: /operator/{companyId}/change-password
-
-When operator logs in for the first time with temp password set by admin:
-
-- Show "Change Password" prompt (required before proceeding)
-
-- Fields: Current password, New password, Confirm password
-
-- Minimum 8 characters for new password
-
-- On success: Clear needs_password_change flag, redirect to jobs list
-
-- Store flag in Supabase user metadata: needs_password_change: false
-
-Implementation: Use supabase.auth.updateUser() with password and data fields.
-
-### 2. Job List
-
-**Route:** `/operator/{companyId}/jobs`
-
-List of available jobs the operator can work on, filtered to the current station:
-
-- Large, tappable job cards with job number, customer, and part info
-
-- Visual status indicators (pending, in progress by others)
-
-- Due date with color coding (on time = green, at risk = yellow, overdue = red)
-
-- Refresh button for latest job data
-
-- Jobs filtered by current station's operation_type_id
-
-### 3. Active Job View
-
-**Route:** `/operator/{companyId}/jobs/{jobId}`
-
-Job detail screen when operator is working on a job:
-
-- Job header with job number, customer, part details
-
-- Live timer showing time on current session
-
-- Large STOP button to pause work
-
-- COMPLETE button to mark operation done
-
-- View attached files (PDFs, drawings)
-
-- Optional notes field for operator comments
-
-### 4. Job Complete Confirmation
-
-Modal/screen shown after marking a job complete:
-
-- Summary of time spent on job
-
-- Optional quality notes or issue flagging
-
-- Confirm button to finalize
-
-- Returns to job list after confirmation
-
-### 5. Profile
-
-**Route:** `/operator/{companyId}/profile`
-
-Operator profile and work history screen:
-
-- Operator info card showing name, email, and current station
-
-- Work session history list showing:
-  - Job number
-  - Operation name
-  - Date (formatted)
-  - Duration (HH:MM:SS)
-  - Status indicator (completed vs stopped/paused)
-
-- Change password link (navigates to `/operator/{companyId}/change-password`)
-
-- Logout button
-
----
-
-## API Architecture
-
-### Backend Endpoint (Operator Creation Only)
-
-| Method | Endpoint | Description | Auth |
-|---|---|---|---|
-| POST | /api/operators | Create operator with Supabase Auth user | Admin JWT |
-
-> **Note:** Operator creation requires the backend API to use the Supabase service role key for creating auth.users entries. All other operations use direct Supabase client calls.
-
-### Direct Supabase Operations
-
-All standard operations use the Supabase client with RLS policies (no backend API needed):
-
-- **Sign in:** `supabase.auth.signInWithPassword()`
-- **Sign out:** `supabase.auth.signOut()`
-- **Validate operator:** Query `user_company_access` where `role='operator'`
-- **List operators:** Query `user_company_access` with RLS
-- **List jobs:** Query `jobs` table with RLS
-- **Start/stop/complete session:** CRUD `operator_sessions` with RLS
-- **Update password:** `supabase.auth.updateUser()`
-
-See `utils/operatorAccess.ts` for implementation details.
-
----
-
-## Mobile Design Requirements
-
-The operator view is designed mobile-first for use on smartphones in shop floor environments. Key design considerations:
-
-### Touch Targets
-
-- Minimum 48px x 48px touch targets for all interactive elements
-
-- Large buttons for primary actions (Start, Stop, Complete)
-
-- Generous spacing between tappable elements to prevent mis-taps
-
-### Visibility
-
-- High contrast colors for readability under bright shop floor lighting
-
-- Minimum 16px font size for body text
-
-- Clear status indicators with color + icon (not color alone)
-
-- Dark theme to reduce glare and match admin interface
-
-### Navigation
-
-- Bottom navigation bar (thumb-friendly)
-
-- Simple 2-tab structure: Jobs, Profile
-
-- No complex nested navigation
-
-### Station Display & Switching
-
-- Current station name displayed in the top AppBar alongside operator name (e.g., "John Smith | CNC Turning")
-
-- Station can be switched two ways:
-  1. **QR Code Scan:** Operator scans a new station QR code. If already authenticated, the station updates and the jobs list re-filters automatically without re-login.
-  2. **Dropdown Selector:** A dropdown in the AppBar lists all available operation types for the company. Operator selects a different station, and the jobs list re-filters.
-
-- Station selection persists via sessionStorage until changed or session ends
-
-### Performance
-
-- Fast initial load (target < 3 seconds on 4G)
-
-- Offline-tolerant - queue actions if connection drops
-
-- Optimized for portrait orientation
-
----
-
-## Acceptance Criteria
-
-### Authentication
-
-- [ ] Operator can scan station QR code to identify workstation
-
-- [ ] Operator can authenticate via email/password
-
-- [ ] Invalid credentials show clear error message
-
-- [ ] Session persists until explicit logout or timeout
-
-- [ ] Scanning a new station QR while already authenticated updates station without re-login
-
-### Station Management
-
-- [ ] Current station name displayed in AppBar next to operator name
-
-- [ ] Operator can switch stations via dropdown selector in AppBar
-
-- [ ] Operator can switch stations by scanning a new station QR code
-
-- [ ] Switching stations re-filters the jobs list automatically
-
-### Job Management
-
-- [ ] Operator can view list of pending/available jobs
-
-- [ ] Operator can start work on a job
-
-- [ ] Starting work creates a session record with start_time
-
-- [ ] Job status updates to In Progress when started
-
-- [ ] Operator can pause/stop work on a job
-
-- [ ] Stopping work records end_time on session
-
-- [ ] Operator can mark job operation as complete
-
-### Time Tracking
-
-- [ ] Active session shows live timer on job view
-
-- [ ] Multiple sessions per job are tracked separately
-
-- [ ] Total time per job is calculated from all sessions
-
-### Profile
-
-- [ ] Operator can view their work session history
-
-- [ ] Session history shows job number, operation name, duration, and date
-
-- [ ] Operator can change their password from the profile page
-
-### Admin Features
-
-- [ ] Owner can create operator accounts with name and email
-
-- [ ] Owner can view list of active operators
-
-- [ ] Owner can delete operator accounts
-
-- [ ] Owner can reset operator password via email
-
-- [ ] Owner can bulk delete operators
-
-- [ ] Owner can export operators to CSV
-
-## Material Consumption Logging
-
-> 🚧 Future Enhancement: This feature is planned but not yet implemented in the current release. The Job Complete Modal currently supports quantity tracking and notes only.
-
-When completing an operation, operators log materials consumed. Expected materials are pre-defined in routing nodes.
-
-### Workflow
-
-1. Routing nodes define expected materials (inventory_item_id, quantity, unit)
-
-2. When operator taps "Complete", system shows materials expected for this operation
-
-3. Operator can confirm quantities or adjust if different amounts were used
-
-4. On submit, inventory transactions are created (type: depletion)
-
-5. Transactions link to job_id and operator_id for traceability
-
-### UI Update: Job Complete Confirmation Screen
-
-- Add "Materials Used" section showing expected materials from routing
-
-- Editable quantity fields for each material
-
-- Unit selector (primary + secondary units)
-
-- "No materials used" option if routing has no materials defined
-
----
-
-## Admin Screens (Operator Management)
-
-Owners manage operator accounts from the admin dashboard.
-
-### 1. Operator List
-
-**Route:** `/dashboard/{companyId}/team` (tabbed interface with Operators tab)
-
-- Table: Name, Status (Active/Inactive), Last Login, Actions
-
-- + New Operator button
-
-- Active Operators Now widget showing currently logged-in operators
-
-### 2. Create/Edit Operator
-
-**Route:** `/dashboard/{companyId}/team/operators/new` or `/{id}`
-
-- Name (required)
-
-- Email (required) - linked to Supabase user account
-
-- Active toggle
-
-- View Work History (link to sessions list)
-
----
-
-## QR Code Specification
-
-### Station QR Codes
-
-**Format:** URL encoding operation_type UUID
-
-`https://app.jigged.io/operator/{companyId}/login?station={operation_type_id}`
-
-- Printed and posted at each workstation/machine
-
-- Operator scans to identify which station they are working at
-
-- Generated from the Operations module (each operation_type has a QR code)
-
-- If operator is already authenticated, scanning updates the station and redirects to the jobs list
-
-### Job QR Codes
-
-**Format:** URL encoding job UUID
-
-`https://app.jigged.io/operator/{companyId}/login?job={job_id}`
-
-- Printed on job travelers (physical paperwork that moves with the part through the shop)
-
-- Operator scans to navigate directly to a specific job's detail page
-
-- Generated from the admin Jobs module (each job has a QR code on its detail page)
-
-- If operator is already authenticated, scanning redirects to the job detail page
-
-- If operator is not authenticated, the job parameter is preserved through login and the operator is redirected to the job detail page after successful authentication
-
-- The operator still needs a station selected to start work on the job (station determines which operation step they work on). They can select a station from the header dropdown.
-
-- A single QR code per job — works regardless of which station the operator is at
-
----
-
-## Token & Session Lifecycle
-
-- Authentication: Supabase Auth (email/password)
-
-- Session: Managed by Supabase (standard user session)
-
-- Storage: Supabase client handles session storage
-
-- On Expiry: Redirect to login screen (Supabase handles session refresh)
-
-- Refresh: Automatic via Supabase session refresh tokens
-
----
-
-## Edge Cases & Concurrent Sessions
-
-### Job Already In Progress
-
-If operator tries to start a job/routing node already being worked by someone else:
-
-- Show warning: "John is currently working on this operation"
-
-- Allow "Take Over" option (ends Johns session, starts new session)
-
-- Johns time is still recorded up to takeover point
-
-### Operator Has Active Session
-
-If operator with an active session tries to start a new job:
-
-- Auto-stop current session (end_time set to now)
-
-- Start new session on the new job
-
-- Show brief confirmation toast
-
-### Multi-Device Login
-
-If same operator logs in from a different device:
-
-- Both sessions remain valid (operators may switch devices)
-
-- Work sessions are tied to operator, not device
-
-- Future: Consider notifying when active session exists on another device
-
----
+## Out of scope (deliberate)
+
+Single-tap completion keeps the operator's burden minimal. Intentionally **not** part of this
+module: start/stop, time tracking, shift/clock-in, downtime reasons, operation-level WIP status,
+and permanent operator↔station assignment. Scrap/defect capture is in discovery (see
+[operator-paperless-flow.md](../operator-paperless-flow.md) §5.4).

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -121,13 +121,13 @@ Role restrictions are enforced at **two levels**:
 | FR-3b | Direct Job Creation from Purchase Order | When a customer sends a PO with no prior quote, the salesperson can create a job directly via **New Job from PO** on the jobs list: pick the customer, enter the PO #, add one or more **existing** parts (each with a quantity and the agreed unit price), optionally attach the PO PDF, and accept. No quote is involved (`quote_id` null; job number `J-NNNN` drawn from the shared per-company order counter — same sequence quotes use, so a direct job just takes the next number). v1 supports existing parts that already have a routing. | Must | Given a customer PO for existing parts, when the salesperson completes "Accept Purchase Order", then a job is created with the PO #, the agreed price on each part, cloned routing operations, and the optional PO PDF attached. |
 | FR-3a | Quote PDF Export | Salesperson can export any quote as a branded, customer-facing PDF that includes the shop's FROM block (company name/logo/address/contact), a Customer · Ship-to (only when it differs from billing) · Customer-contact row, part/quantity/unit price/total, validity (Valid Until), lead time, payment terms, and an acceptance block instructing the customer to **reply with a purchase order referencing the quote** (no signature/date line) plus a "Prepared by" line. Internal details (routing, cost breakdown, markup, internal status) are excluded. The **Email** action opens a dialog that downloads the PDF and drafts a To/Cc message in the user's mail client (reminding them to attach the PDF). Shop contact info is configured in Settings → Company Profile; logo in Settings → Company Branding. | Must | Given an active quote, when salesperson exports the PDF, then a `Quote-{number}.pdf` downloads with the shop FROM block, the customer/ship-to/contact row, Valid Until + Lead Time + Payment Terms, and a reply-with-a-PO acceptance block — with no signature line and no routing or markup visible. |
 | FR-4 | Quote Lifecycle | A quote is "Active" until its expiration date passes, at which point it flips to "Expired" (read-only but still convertible with a warning). A quote becomes a job via the Convert action, which copies lead time and computes the job due date. The pending-approval / approved / rejected states were removed in April 2026. | Must | Given an active quote with 14-day lead time, when the owner converts it, then a job is created with due_date = today + 14 and the quote links to that job via converted_to_job_id. |
-| FR-5 | Station QR Code Login | Operators scan a QR code at a station to log in. The QR code encodes the station ID. After scanning, operator enters their PIN or scans their personal QR badge to identify themselves. | Must | Given an operator at Station 3, when they scan station QR and enter PIN, then they are logged into Station 3 and can assign work orders. |
-| FR-6 | Work Order Assignment to Station | Logged-in operator can enter a work order number to begin working on it. System records start time, associates operator with the work order, and tracks time until operator logs out or assigns a different work order. | Must | Given an operator logged into Station 3, when they enter WO-1234, then time tracking begins and WO-1234 shows "In Progress at Station 3". |
+| FR-5 | Station QR Code Sign-In | Operators scan a posted **station QR placard** (one per work center) to select their station, then sign in with **email/password** on their own phone (the Supabase session persists, so sign-in is effectively one-time per device). An already-signed-in operator who scans a placard just has their station switched. No PIN or badge. | Must | Given an operator who scans the CNC Lathe #2 placard and signs in, then their station is set to CNC Lathe #2 and they land on that station's job list. |
+| FR-6 | Pick Work from the Station Queue | The operator's station job list shows every (job, part) with an operation ready or in progress at that station, sorted by due date. The operator taps a row to open the step and records work with a single **Mark Complete** — no work-order entry, no start/stop, no timer (see §4.3, Complete-Only). | Must | Given an operator at CNC Lathe #2 with ready work, when they open the job list, then they see the ready (job, part) rows and can Mark Complete in one tap. |
 | FR-7 | File Attachment Support | Work orders and **parts** support PDF and CAD (STEP/DWG) file attachments. Jobs accept PDF attachments; parts accept PDF/STEP/DWG on the part workspace Files tab. **Status (June 2026): admin/office-side delivered** — attachments + in-app PDF and STEP 3D viewing live in the admin-only part/job workspaces (STEP via `online-3d-viewer`, with occt-import-js fetched from the jsdelivr CDN at runtime). DWG is download-only (Contour standardizes on PDF upstream). **Not yet delivered:** operator-on-device viewing — the part workspace is not the operator shop-floor view, so surfacing attachment viewing in the operator view is a separate future step that closes this FR. | Must | Given a part with an attached PDF drawing, when an office user opens it from the part's Files tab, then it renders inline. *(Operator-on-device acceptance pending the operator-view step.)* |
 | FR-8 | Work Order Status Lifecycle | Work orders progress through defined statuses: Requested → Approved → In Progress → Quality Checked → Shipped → Delivered → Invoiced → Complete. Status changes are logged with timestamp and user. | Must | Given a work order in Quality Checked status, when QC approves, then status changes to ready for shipping with audit log entry. |
 | FR-9 | Invoice Generation | Bookkeeper can generate an invoice for any work order in Shipped or Delivered status. Invoice includes work order details, line items, customer info, and calculated totals. Invoices can be exported as PDF. | Must | Given a shipped work order, when bookkeeper clicks Generate Invoice, then an invoice is created with correct pricing and can be downloaded as PDF. |
 | FR-10 | Invoice Payment Tracking | Bookkeeper can mark invoices as Paid and record payment date, amount, and method. System shows aging report of outstanding invoices. | Must | Given an outstanding invoice, when bookkeeper marks as paid with $500, then invoice status updates and aging report reflects the change. |
-| FR-11 | Work Order Templates | Owner/Engineer can create templates that define station routing (series or parallel flows), estimated time per station, and materials consumed. Templates speed up work order creation for repeat jobs. | Should | Given a template for "Custom Reamer", when salesperson creates work order using template, then routing and material estimates auto-populate. |
+| FR-11 | Routing Templates | Owner/Engineer can define a part's routing as a **linear sequence** of operations (no parallel/DAG branching), with estimated setup/run time per operation and the materials consumed. Routings speed up job creation for repeat parts. | Should | Given a routing for "Custom Reamer", when a job is created for that part, then its operations and material estimates are cloned onto the job. |
 | FR-12 | Operator Performance Gamification | Operators see real-time performance metrics including jobs completed, average time per station, and streaks for consecutive on-time completions. Achievements unlock for milestones. | Should | Given an operator who completes 5 jobs on-time, when they view dashboard, then a "5-streak" badge is visible. |
 | FR-13 | Inventory Transaction History | All inventory changes (additions, depletions, adjustments) are logged with timestamp, user, work order (if applicable), and quantity. Users can filter and export transaction history. | Should | Given an inventory item, when user views history, then all transactions are listed chronologically with full details. |
 | FR-14 | Shipping Label Generation | Admin can generate shipping labels for completed work orders. Integration with USPS, UPS, and FedEx APIs. Focus on USPS flat rate boxes for initial release. | Should | Given a work order ready to ship, when admin clicks Generate Label, then a USPS label is created and tracking number is stored. |
@@ -135,7 +135,7 @@ Role restrictions are enforced at **two levels**:
 | FR-16 | Legacy Data Migration | System supports CSV upload for inventory items, customers, and work order history. Upload wizard validates data, flags errors, and allows user correction before import. | Should | Given a CSV export from Tangle, when owner uploads to migration wizard, then data is validated and imported with error report. |
 | FR-17 | Owner Dashboard with Insights | Dashboard displays key metrics: active work orders, revenue in progress, inventory alerts, operator compliance rate, and jobs at risk of delay. AI-powered insights highlight bottlenecks. | Should | Given current shop data, when owner views dashboard, then they see WIP value, 3 inventory alerts, and 2 at-risk jobs flagged by AI. |
 | FR-18 | Natural Language Business Queries | Owner can type questions like "What was revenue last month?" or "Which customer has the most open orders?" and receive AI-generated answers based on system data. | Could | Given the question "What's my average order value this quarter?", when owner submits, then AI returns calculated answer with source data. |
-| FR-19 | Quality Inspection Workflow | Quality Checker can view completed work orders, perform inspection, and mark as Pass or Fail. Failed jobs route back to production with notes. Passed jobs advance to Shipped queue. | Must | Given a work order awaiting QC, when checker marks Fail with notes "Tolerance out of spec", then work order routes back to operator with notes visible. |
+| FR-19 | Quality Inspection Workflow | *(Not yet built.)* A future Quality Checker role would inspect completed work and mark Pass/Fail, routing failures back with notes. Operator-side quality/scrap capture is in **discovery** — see [operator-paperless-flow.md](operator-paperless-flow.md) §5.4. | Could | Given a work order awaiting QC, when checker marks Fail with notes "Tolerance out of spec", then work order routes back to operator with notes visible. |
 | FR-20 | Customer Management | System maintains customer records with contact info, shipping addresses, and order history. New customers are created when first work order is entered. Admin can edit/delete customer records. | Should | Given a new work order for "Acme Corp", when submitted, then Acme Corp customer record is created if not exists with contact details. |
 
 ### 4.2 Flows and Scenarios
@@ -148,7 +148,7 @@ Flow 1: job Happy Path
 
 3. Salesperson/Owner converts quote directly into a job (job.due_date = today + lead_time)
 
-4. Operator scans operation type QR, enters job number (status: In Progress)
+4. Operator scans the station QR placard (or a job's per-operation QR), opens the step, and taps Mark Complete (part → In Progress)
 
 5. Operator completes work, logs output
 
@@ -196,19 +196,19 @@ Flow 1: job Happy Path
 
 7. Reorder alert clears
 
-**Flow 4: Operator Shift Start**
+**Flow 4: Operator Station Sign-In**
 
-1. Operator arrives at operation type (e.g., CNC Lathe #2)
+1. Operator arrives at a work center (e.g., CNC Lathe #2)
 
-2. Operator scans operation type QR code with personal phone
+2. Operator scans the posted station QR placard with their own phone
 
-3. System prompts for operator identification (PIN or badge scan)
+3. If not already signed in, they sign in with email/password (effectively one-time per device); an already-signed-in operator simply has their station switched
 
-4. Operator authenticated and logged into operation type
+4. Their station is set to CNC Lathe #2 and they land on that station's job list
 
-5. Operator views available jobs, selects one
+5. Operator picks a ready job and opens the step
 
-6. Time tracking begins for operator + job + operation type combination
+6. Operator records the work with a single Mark Complete — no start/stop, no timer (see §4.3)
 
 ---
 
@@ -456,110 +456,10 @@ Shop floors are noisy, dirty, and workers may have gloves on. UI elements should
   1. Nice to have
 
 7. Should job templates support parallel operation type routing (e.g., two operations happen simultaneously) or only series?
-  1. Parallel is a must have
+  1. Resolved (2026): routings are a **linear sequence only** — no parallel/DAG branching. The earlier "parallel is a must have" was reversed in favor of shop-floor simplicity.
 
 8. What gamification elements are most motivating for operators? (Leaderboards? Badges? Cash bonuses tied to achievements?)
   1. Leaderboards, badges and customization. no cash bonuses as all value should be intrinsic to the app
 
 
 
-[PRD Critique](prd-critique.md)
-# Executive Summary
-
-  > ⚠️ Overall Assessment: NEEDS WORK - Significant gaps exist between documentation and implementation on main branch.
-
-## Key Strengths
-
-  - Clear problem statement addressing real pain points for small machine shops
-
-  - Well-defined user personas (Owner, Operator, Salesperson, Estimator)
-
-  - Comprehensive user stories in table format for each module
-
-  - Proper multi-tenancy architecture (company_id isolation)
-
-## Critical Gaps
-
-  1. Quotes module not on main branch - Fully developed on feature branch but not merged
-
-  2. Jobs module is placeholder only - DB schema exists but no UI/functionality
-
-  3. Dashboard is empty - Spec calls for KPI cards, due-this-week list, activity feed
-
-  4. Routings module missing entirely - Not even a placeholder page
-
-  ---
-
-# PRD Completeness Analysis
-
-  ✅ Present: Vision & Summary, Problem Statement, User Stories, Functional Requirements, Data Model, Dependencies
-
-  ⚠️ Partial: User Personas, Scope (In/Out), Timeline/Phases
-
-  ❌ Missing: Non-Functional Requirements, Success Metrics, Assumptions, Risks
-
-  ---
-
-# Module Gap Analysis
-
-## Customers Module ✅
-
-  FULL MATCH - All 9 user stories implemented. CRUD, CSV import with AI mapping, bulk operations, soft delete all working.
-
-## Parts Module ⚠️
-
-  MOSTLY ALIGNED - Missing: Filter by customer dropdown, Active/inactive status field and filter
-
-## Quotes Module ❌
-
-  CRITICAL: NOT ON MAIN BRANCH - Exists on feature/quotes-module branch with ~3,320 lines but not merged. Users cannot create quotes.
-
-## Jobs Module ❌
-
-  CRITICAL: PLACEHOLDER ONLY - Page shows 'jobs & Jobs - coming soon'. DB schema exists but no frontend. This is the CORE of manufacturing ERP.
-
-## Operations Module ✅
-
-  FULL MATCH - Resource groups and operation types with labor rates. Only gap: custom fields not implemented (low priority).
-
-## Dashboard Module ❌
-
-  CRITICAL: MINIMAL - Spec has detailed wireframe with 4 KPI cards, jobs due list, activity feed. Implementation is just 'Welcome to Jigged'.
-
-## Routings Module ❌
-
-  PLACEHOLDER ONLY - Page shows 'Production Routings - coming soon'. Schema exists but no UI.
-
-  ---
-
-# Recommendations
-
-## Critical (Must Fix)
-
-  1. Merge Quotes module to main - Sales pipeline is blocked without quoting
-
-  2. Implement Jobs module - Core of manufacturing ERP; without it, system is just a CRM
-
-  3. Build Dashboard KPIs - Owners need at-a-glance visibility
-
-## Important (Should Fix)
-
-  1. Add Routings module - Jobs without routings lack manufacturing process definition
-
-  2. Add Parts filtering - Customer filter and active/inactive status per spec
-
-  3. Document RLS policies - Security configuration should be in PRD
-
-## Minor (Nice to Have)
-
-  1. Add success metrics to PRD
-
-  2. Add non-functional requirements to PRD
-
-  3. Create risk register
-
-  ---
-
-  **Evaluated: **2026-01-02 by Claude Code (Opus 4.5)
-
-  **Branch: **main

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -55,6 +55,16 @@ export interface OperatorJob {
 }
 
 /**
+ * A whole-plant ("All Stations") job row — an OperatorJob plus which station
+ * (work center) its ready operation runs at, so the list can group by station.
+ * Returned by getAllStationsOperatorJobs(); the per-station list uses OperatorJob.
+ */
+export interface OperatorPlantJob extends OperatorJob {
+  work_center_id: string | null;
+  work_center_name: string | null;
+}
+
+/**
  * Per-part operator detail view — the page where Start/Stop/Complete lives.
  */
 export interface OperatorJobDetail {
@@ -136,7 +146,32 @@ export interface JobTraveler {
   due_date: string | null;
   customer_po_number: string | null;
   production_status: string;
+  /** Number of parts on the parent job — drives the "all parts" hub link. */
+  job_part_count: number;
   operations: JobTravelerOperation[];
+}
+
+/**
+ * A whole-job parts overview for the operator parts hub — the job header plus
+ * each part with its progress, used to navigate a multi-part job.
+ */
+export interface JobPartsOverview {
+  job_id: string;
+  job_number: string;
+  customer_name: string | null;
+  due_date: string | null;
+  parts: JobPartSummary[];
+}
+
+/** One part row in the parts hub. */
+export interface JobPartSummary {
+  /** job_part_id — navigation key into the part traveler. */
+  job_part_id: string;
+  part_name: string | null;
+  quantity: number;
+  production_status: string;
+  operations_total: number;
+  operations_completed: number;
 }
 
 /**

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -26,10 +26,12 @@ import type { Database } from '@/types/database';
 type UserCompanyAccessUpdate = Database['public']['Tables']['user_company_access']['Update'];
 import type {
   OperatorJob,
+  OperatorPlantJob,
   OperatorJobDetail,
   Station,
   JobCompleteResponse,
   JobTraveler,
+  JobPartsOverview,
   JobTravelerOperation,
   JobNote,
   JobNoteMedia,
@@ -218,17 +220,61 @@ export async function getOperatorJobs(
   companyId: string,
   operationTypeId?: string,
 ): Promise<OperatorJob[]> {
-  const supabase = getSupabase();
-
   if (!operationTypeId) {
-    // No station selected — return an empty list. The UI prompts the operator
-    // to pick a station first; we don't show "all jobs" because the station
-    // is the primary navigation key.
+    // No station selected — the station-scoped list needs a station. The
+    // whole-plant view is getAllStationsOperatorJobs() instead.
     return [];
   }
 
   const readyRows = await getReadyOperationsForStation(companyId, operationTypeId);
+  return buildOperatorJobs(readyRows);
+}
+
+/**
+ * Whole-plant ("All Stations") job list: the work ready/in-progress across
+ * every station, so a roaming operator or lead can see all active jobs without
+ * picking one station. Reuses the SAME per-station readiness RPC, called once
+ * per station in parallel, then tags each row with its station and enriches
+ * once — a single source of truth for "ready" (no duplicated readiness logic).
+ * Rows are returned flat; the UI groups them by station.
+ */
+export async function getAllStationsOperatorJobs(
+  companyId: string,
+  stations: Station[],
+): Promise<OperatorPlantJob[]> {
+  const perStation = await Promise.all(
+    stations.map(async (station) => {
+      const rows = await getReadyOperationsForStation(companyId, station.id);
+      return rows.map((row) => ({ row, station }));
+    }),
+  );
+  const tagged = perStation.flat();
+  if (tagged.length === 0) return [];
+
+  // job_operation_id is unique per ready row, so we can re-attach each row's
+  // station after enrichment without depending on array order.
+  const stationByOp = new Map<string, Station>();
+  for (const t of tagged) stationByOp.set(t.row.job_operation_id, t.station);
+
+  const jobs = await buildOperatorJobs(tagged.map((t) => t.row));
+  return jobs.map((job) => {
+    const station = job.operation_id ? stationByOp.get(job.operation_id) : undefined;
+    return {
+      ...job,
+      work_center_id: station?.id ?? null,
+      work_center_name: station?.name ?? null,
+    };
+  });
+}
+
+/**
+ * Shared enrichment: turn ready rows (from one station or the whole plant) into
+ * OperatorJob rows by fetching per-part progress, customer, and part status.
+ * Preserves input order (a 1:1 map over readyRows).
+ */
+async function buildOperatorJobs(readyRows: ReadyRow[]): Promise<OperatorJob[]> {
   if (readyRows.length === 0) return [];
+  const supabase = getSupabase();
 
   const jobPartIds = readyRows.map((r) => r.job_part_id);
 
@@ -736,6 +782,12 @@ export async function getJobPartTraveler(
     };
   });
 
+  // How many parts the parent job has — drives the traveler's "all parts" link.
+  const { count: jobPartCount } = await supabase
+    .from('job_parts')
+    .select('id', { count: 'exact', head: true })
+    .eq('job_id', p.job_id);
+
   return {
     job_part_id: p.id,
     job_id: p.job_id,
@@ -749,7 +801,84 @@ export async function getJobPartTraveler(
     due_date: jobJoin?.due_date ?? null,
     customer_po_number: jobJoin?.customer_po_number ?? null,
     production_status: p.production_status,
+    job_part_count: jobPartCount ?? 1,
     operations,
+  };
+}
+
+/**
+ * Whole-job parts overview for the operator parts hub: the job header plus every
+ * child part with its progress. Used to navigate a multi-part job; single-part
+ * jobs skip the hub (the page redirects straight to the traveler).
+ */
+export async function getJobPartsOverview(
+  jobId: string,
+  companyId: string,
+): Promise<JobPartsOverview | null> {
+  const supabase = getSupabase();
+
+  const { data: job, error } = await supabase
+    .from('jobs')
+    .select('id, job_number, due_date, customers(name)')
+    .eq('id', jobId)
+    .eq('company_id', companyId)
+    .single();
+  if (error || !job) return null;
+
+  type JobRow = {
+    id: string;
+    job_number: string;
+    due_date: string | null;
+    customers: { name: string } | { name: string }[] | null;
+  };
+  const j = job as JobRow;
+  const customer = Array.isArray(j.customers) ? j.customers[0] : j.customers;
+
+  const { data: partRows } = await supabase
+    .from('job_parts')
+    .select('id, quantity, production_status, parts(part_name)')
+    .eq('job_id', jobId);
+  type PartRow = {
+    id: string;
+    quantity: number;
+    production_status: string;
+    parts: { part_name: string } | { part_name: string }[] | null;
+  };
+  const parts = (partRows ?? []) as PartRow[];
+
+  // Per-part progress (ops total + completed).
+  const jobPartIds = parts.map((p) => p.id);
+  const progressByPart = new Map<string, { total: number; done: number }>();
+  if (jobPartIds.length > 0) {
+    const { data: ops } = await supabase
+      .from('job_operations')
+      .select('job_part_id, status')
+      .in('job_part_id', jobPartIds);
+    for (const op of (ops ?? []) as { job_part_id: string; status: string }[]) {
+      const acc = progressByPart.get(op.job_part_id) ?? { total: 0, done: 0 };
+      acc.total += 1;
+      if (op.status === 'completed') acc.done += 1;
+      progressByPart.set(op.job_part_id, acc);
+    }
+  }
+
+  return {
+    job_id: j.id,
+    job_number: j.job_number,
+    customer_name: customer?.name ?? null,
+    due_date: j.due_date,
+    parts: parts.map((p) => {
+      const partJoin = Array.isArray(p.parts) ? p.parts[0] : p.parts;
+      const progress = progressByPart.get(p.id) ?? { total: 0, done: 0 };
+      return {
+        job_part_id: p.id,
+        part_name: partJoin?.part_name ?? null,
+        quantity: p.quantity,
+        production_status: p.production_status,
+        operations_total: progress.total,
+        operations_completed: progress.done,
+      };
+    }),
   };
 }
 


### PR DESCRIPTION
## Why

Follow-ups from the merged operator paperless-flow proposal (#465, `docs/operator-paperless-flow.md`). This covers three of the four deferred items. **Scrap/defect is intentionally excluded** — it needs discovery first (building an unvalidated quality model risks the anemic-named-entity trap), and it's already framed for discovery in §5.4 of the proposal.

## What

### 1. Doc cleanups (proposal §9)
Reconcile the stale PRD + operator module spec with the shipped app:
- **`prd.md`**: FR-5 (email/password, not PIN/badge), FR-6 + Flow 4 (complete-only — no time tracking/shift), FR-11 + Open Q7 (linear routings, not parallel/DAG), FR-19 (QC not built; quality capture in discovery), Flow 1 step 4. Removed the stale **Jan-2026 audit tail** that marked Quotes/Jobs/Dashboard/Routings as unbuilt placeholders (all shipped).
- **`operator-view.md`**: rewritten to `work_centers` / linear routings / complete-only (was `operation_type` / DAG / `operator_sessions` / PIN).

### 2. Whole-plant "All Stations" view
A lens toggle on the operator jobs page: **My Station** (the existing dispatch list) ↔ **All Stations** (every active job across the floor, grouped by station) — the "sign into the plant" ask for roaming operators and leads. Reuses the **same per-station readiness RPC**, called once per station in parallel, then tags + enriches once — a single source of truth for "ready", **no migration and no duplicated logic**. Acting on a row routes through the existing operation-page station-match guard.

### 3. Multi-part job hub
New `jobs/[jobId]` page listing a job's parts with progress; **single-part jobs redirect straight to the traveler** (no redundant hub). Adds an "All N parts" link on the traveler (via a new `job_part_count`) so siblings are reachable — previously navigation always dropped onto a single part with no way across.

## Testing
- `pnpm exec tsc --noEmit` clean.
- `__tests__/utils/operatorAccess.test.ts`: added a test for the whole-plant fan-out (one readiness query per station; empty short-circuit). **11/11 pass.**
- The whole-plant + multi-part access fns reuse the shipped readiness RPC and existing join patterns; a manual smoke of the operator views is advisable before relying on them in production.

## Not included
- **Scrap / defect / quality flagging** — deferred to discovery (proposal §5.4). FR-19 / Flow 2 (Pass/Fail QC) are noted as not-built pending that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
