### PR TITLE
perf(queries): parallelize/batch N+1-ish reads (issue #68)

### DIFF
--- a/__tests__/utils/customerAccess.test.ts
+++ b/__tests__/utils/customerAccess.test.ts
@@ -52,6 +52,7 @@ vi.mock('@/lib/supabase', () => ({
 import {
   getAllCustomers,
   getCustomer,
+  getCustomerWithRelations,
   checkCustomerNameExists,
   createCustomer,
   updateCustomer,
@@ -163,6 +164,50 @@ describe('customerAccess utilities', () => {
       // getCustomer now returns CustomerWithAddresses — the addresses
       // array is normalized to [] when the join returns nothing.
       expect(result).toEqual({ ...mockCustomer, addresses: [] });
+    });
+  });
+
+  describe('getCustomerWithRelations', () => {
+    const mockCustomer: Customer = {
+      id: 'customer-1',
+      company_id: 'company-1',
+      name: 'Customer One',
+      website: null,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    };
+
+    it('returns the customer with quotes/jobs counts from the parallel queries', async () => {
+      mockQueryBuilder.data = mockCustomer;
+      mockQueryBuilder.count = 5;
+      mockQueryBuilder.error = null;
+
+      const result = await getCustomerWithRelations('customer-1');
+
+      // Customer fetch plus the two count queries are all issued.
+      expect(mockSupabase.from).toHaveBeenCalledWith('customers');
+      expect(mockSupabase.from).toHaveBeenCalledWith('quotes');
+      expect(mockSupabase.from).toHaveBeenCalledWith('jobs');
+      // Shared mock builder returns the same count for both, but the point is
+      // the counts flow through to the mapped result.
+      expect(result).not.toBeNull();
+      expect(result?.quotes_count).toBe(5);
+      expect(result?.jobs_count).toBe(5);
+      expect(result?.addresses).toEqual([]);
+    });
+
+    it('returns null and skips the count queries when the customer is missing', async () => {
+      mockQueryBuilder.data = null;
+      mockQueryBuilder.error = null;
+
+      const result = await getCustomerWithRelations('missing');
+
+      expect(result).toBeNull();
+      // The early null-return must short-circuit before the counts — the
+      // parallelization must not eagerly fire quotes/jobs for a missing row.
+      expect(mockSupabase.from).toHaveBeenCalledWith('customers');
+      expect(mockSupabase.from).not.toHaveBeenCalledWith('quotes');
+      expect(mockSupabase.from).not.toHaveBeenCalledWith('jobs');
     });
   });
 

--- a/components/parts/PartBomPanel.tsx
+++ b/components/parts/PartBomPanel.tsx
@@ -172,48 +172,87 @@ export default function PartBomPanel({
       const supabase = getSupabase();
       const next = new Map<string, ChildCostTier[]>();
 
+      // Discover each child's qty break points in a fixed number of queries
+      // (was ~2 per child — a per-row fan-out that scaled with BOM size).
+      // Bought children take break points from their PREFERRED vendor's
+      // procurement tiers (compute_part_cost_at_qty restricts the rollup to
+      // preferred_vendor_id, so other vendors' tiers don't apply); made
+      // children take them from their own pricing tiers.
+      const boughtIds = rows
+        .filter((r) => r.child_part.source === 'bought')
+        .map((r) => r.child_part.id);
+      const madeIds = rows
+        .filter((r) => r.child_part.source !== 'bought')
+        .map((r) => r.child_part.id);
+
+      const breakpointsByChild = new Map<string, number[]>();
+      try {
+        if (boughtIds.length > 0) {
+          // Preferred vendor per bought child.
+          const { data: vendorRows } = await supabase
+            .from('parts')
+            .select('id, preferred_vendor_id')
+            .in('id', boughtIds);
+          const preferredByChild = new Map<string, string | null>();
+          for (const r of (vendorRows ?? []) as Array<{
+            id: string;
+            preferred_vendor_id: string | null;
+          }>) {
+            preferredByChild.set(r.id, r.preferred_vendor_id ?? null);
+          }
+
+          // All bought children's procurement tiers in one query; keep only
+          // the rows under each child's preferred vendor.
+          const { data: procRows } = await supabase
+            .from('part_procurement_tiers')
+            .select('part_id, vendor_id, min_quantity')
+            .in('part_id', boughtIds);
+          const qtysByChild = new Map<string, number[]>();
+          for (const t of (procRows ?? []) as Array<{
+            part_id: string;
+            vendor_id: string;
+            min_quantity: number | string;
+          }>) {
+            if (preferredByChild.get(t.part_id) !== t.vendor_id) continue;
+            const arr = qtysByChild.get(t.part_id) ?? [];
+            arr.push(Number(t.min_quantity));
+            qtysByChild.set(t.part_id, arr);
+          }
+          for (const [partId, qtys] of qtysByChild) {
+            breakpointsByChild.set(partId, [...new Set(qtys)].sort((a, b) => a - b));
+          }
+        }
+
+        if (madeIds.length > 0) {
+          // All made children's pricing tiers in one query, ordered by qty so
+          // each child's break points come out ascending (matches the prior
+          // per-child .order('quantity') behavior).
+          const { data: priceRows } = await supabase
+            .from('part_pricing_tiers')
+            .select('part_id, quantity')
+            .in('part_id', madeIds)
+            .order('quantity', { ascending: true });
+          for (const t of (priceRows ?? []) as Array<{
+            part_id: string;
+            quantity: number | string;
+          }>) {
+            const arr = breakpointsByChild.get(t.part_id) ?? [];
+            arr.push(Number(t.quantity));
+            breakpointsByChild.set(t.part_id, arr);
+          }
+        }
+      } catch (err) {
+        // Degrade to empty ladders (matches the prior per-child catch).
+        console.warn('Failed to load BOM tier break points', err);
+      }
+
+      // Cost ladder per row — one compute_part_cost_at_qty per (child, qty),
+      // parallelized exactly as before.
       await Promise.all(
         rows.map(async (row) => {
           const child = row.child_part;
           const unit = child.primary_unit ?? '';
-
-          let breakpoints: number[] = [];
-          try {
-            if (child.source === 'bought') {
-              const { data: partRow } = await supabase
-                .from('parts')
-                .select('preferred_vendor_id')
-                .eq('id', child.id)
-                .maybeSingle();
-              const preferred = partRow?.preferred_vendor_id ?? null;
-              // Only the preferred vendor's tiers contribute to the rollup
-              // (compute_part_cost_at_qty restricts to preferred_vendor_id),
-              // so showing other vendors here would suggest costs that don't
-              // actually apply.
-              if (preferred) {
-                const { data } = await supabase
-                  .from('part_procurement_tiers')
-                  .select('min_quantity')
-                  .eq('part_id', child.id)
-                  .eq('vendor_id', preferred);
-                const rows = (data ?? []) as Array<{ min_quantity: number | string }>;
-                breakpoints = [
-                  ...new Set(rows.map((t) => Number(t.min_quantity))),
-                ].sort((a, b) => a - b);
-              }
-            } else {
-              const { data } = await supabase
-                .from('part_pricing_tiers')
-                .select('quantity')
-                .eq('part_id', child.id)
-                .order('quantity', { ascending: true });
-              const rows = (data ?? []) as Array<{ quantity: number | string }>;
-              breakpoints = rows.map((t) => Number(t.quantity));
-            }
-          } catch (err) {
-            console.warn('Failed to load tier breakpoints for', child.id, err);
-            breakpoints = [];
-          }
+          const breakpoints = breakpointsByChild.get(child.id) ?? [];
 
           if (breakpoints.length === 0) {
             next.set(row.id, []);

--- a/utils/customerAccess.ts
+++ b/utils/customerAccess.ts
@@ -217,23 +217,28 @@ export async function getCustomerWithRelations(
     return null;
   }
 
-  const { count: quotesCount, error: quotesError } = await supabase
-    .from('quotes')
-    .select('*', { count: 'exact', head: true })
-    .eq('customer_id', customerId);
+  // The two counts are independent of each other (and of the customer fetch),
+  // so run them in parallel — was two sequential round-trips after the fetch.
+  const [quotesRes, jobsRes] = await Promise.all([
+    supabase
+      .from('quotes')
+      .select('*', { count: 'exact', head: true })
+      .eq('customer_id', customerId),
+    supabase
+      .from('jobs')
+      .select('*', { count: 'exact', head: true })
+      .eq('customer_id', customerId),
+  ]);
 
-  if (quotesError) {
-    console.error('Error fetching quotes count:', quotesError);
+  if (quotesRes.error) {
+    console.error('Error fetching quotes count:', quotesRes.error);
+  }
+  if (jobsRes.error) {
+    console.error('Error fetching jobs count:', jobsRes.error);
   }
 
-  const { count: jobsCount, error: jobsError } = await supabase
-    .from('jobs')
-    .select('*', { count: 'exact', head: true })
-    .eq('customer_id', customerId);
-
-  if (jobsError) {
-    console.error('Error fetching jobs count:', jobsError);
-  }
+  const quotesCount = quotesRes.count;
+  const jobsCount = jobsRes.count;
 
   const typedCustomer = customer as CustomerWithPrimaryContactRow & {
     addresses?: CustomerAddress[];

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -277,12 +277,26 @@ async function buildOperatorJobs(readyRows: ReadyRow[]): Promise<OperatorJob[]> 
   const supabase = getSupabase();
 
   const jobPartIds = readyRows.map((r) => r.job_part_id);
+  const jobIds = Array.from(new Set(readyRows.map((r) => r.job_id)));
 
-  // Fetch per-part progress (count of ops total + completed per part).
-  const { data: partOps } = await supabase
-    .from('job_operations')
-    .select('job_part_id, status')
-    .in('job_part_id', jobPartIds);
+  // Three independent reads, each already batched via .in(...). Run them in
+  // parallel — this is the operator hot path (station polling / whole-plant
+  // view), so collapsing 3 sequential round-trips to 1 matters most here.
+  const [{ data: partOps }, { data: jobMeta }, { data: partStatusRows }] =
+    await Promise.all([
+      // Per-part progress (count of ops total + completed per part).
+      supabase
+        .from('job_operations')
+        .select('job_part_id, status')
+        .in('job_part_id', jobPartIds),
+      // Each job's customer name.
+      supabase.from('jobs').select('id, customers(name)').in('id', jobIds),
+      // Each part's current production status.
+      supabase
+        .from('job_parts')
+        .select('id, production_status')
+        .in('id', jobPartIds),
+    ]);
 
   type PartOpRow = { job_part_id: string; status: string };
   const progressByPart = new Map<string, { total: number; done: number }>();
@@ -293,22 +307,12 @@ async function buildOperatorJobs(readyRows: ReadyRow[]): Promise<OperatorJob[]> 
     progressByPart.set(row.job_part_id, acc);
   }
 
-  // Fetch each part's current status + customer (one query per (jobs, job_parts)).
-  const jobIds = Array.from(new Set(readyRows.map((r) => r.job_id)));
-  const { data: jobMeta } = await supabase
-    .from('jobs')
-    .select('id, customers(name)')
-    .in('id', jobIds);
   type JobMeta = { id: string; customers: { name: string } | null };
   const customerByJob = new Map<string, string | null>();
   for (const j of (jobMeta ?? []) as JobMeta[]) {
     customerByJob.set(j.id, j.customers?.name ?? null);
   }
 
-  const { data: partStatusRows } = await supabase
-    .from('job_parts')
-    .select('id, production_status')
-    .in('id', jobPartIds);
   type PartStatus = { id: string; production_status: string };
   const statusByPart = new Map<string, string>();
   for (const r of (partStatusRows ?? []) as PartStatus[]) {


### PR DESCRIPTION
## What

Addresses the N+1 line item in #68's performance check. A two-agent audit of the access layer + components/pages/API found **no correctness bugs** — every finding was a latency optimization. This PR ships the safe, high-value core; all three changes are behavior-preserving.

- **`getCustomerWithRelations`** ([utils/customerAccess.ts](utils/customerAccess.ts)) — the independent quotes/jobs `count` queries now run via `Promise.all` instead of two sequential awaits. The not-found early-return is kept *before* the counts, so a missing customer still issues zero count queries.
- **`buildOperatorJobs`** ([utils/operatorAccess.ts](utils/operatorAccess.ts)) — the three independent `.in(...)` reads (progress, customer, status) now run in parallel. 3 sequential round-trips → 1, on the operator shop-floor hot path (station polling / whole-plant view).
- **`PartBomPanel`** ([components/parts/PartBomPanel.tsx](components/parts/PartBomPanel.tsx)) — the per-child tier-breakpoint discovery is hoisted out of the per-row loop into batched `.in(...)` queries (**~2N → at most 3**). The per-`(child, qty)` cost ladder is unchanged.

## Deliberately deferred

A batch cost RPC (`compute_part_costs_at_qtys`) to collapse the BOM cost ladder's N×K `compute_part_cost_at_qty` calls — it would be a **second implementation of business-critical recursive cost math** (feeds quoting/pricing), which the codebase's "two sources of truth" guidance warns against. The win isn't justified at current small-shop BOM/tier volumes; revisit only if a real BOM measures slow. Also left as-is: the `updateJobPart*` fail-fast guards and the quote-save loops (tiers already cached, ordered writes).

## Verification

- `pnpm exec tsc --noEmit` — clean.
- `pnpm exec vitest run __tests__/utils/customerAccess.test.ts __tests__/utils/operatorAccess.test.ts` — **25 passed**, including 2 new `getCustomerWithRelations` tests (counts flow through; not-found short-circuits before the count queries) and the existing `getAllStationsOperatorJobs` suite that exercises `buildOperatorJobs`.
- **Manual parity check still owed** before closing #68: on the part detail BOM tab, confirm the tier ladders render identical breakpoints + per-qty costs for a part with both a bought child (preferred-vendor procurement tiers) and a made child (pricing tiers).

## Notes

- No migration; no prod push owed.
- Does **not** auto-close #68 — the issue has other criteria (AG Grid pagination, JSONB pricing-tier perf) treated as satisfied by prod performance; close manually post-merge.

Refs #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)