### PR TITLE
feat(ci): verify types/database.ts matches migrations (issue #406)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,9 @@ jobs:
         with:
           # Pinned (not `latest`): resolving "latest" hits the releases API,
           # which flakes with a Gateway Time-out and isn't reproducible.
-          version: 2.106.0
+          # Keep in lockstep with test.yml — its types-drift check diffs a
+          # --local regen, so the pinned CLI version must match everywhere.
+          version: 2.109.0
 
       - name: Start local Supabase
         run: supabase start

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,11 +75,34 @@ jobs:
         with:
           # Pinned (not `latest`): resolving "latest" hits the releases API,
           # which flakes with a Gateway Time-out and isn't reproducible.
-          version: 2.106.0
+          # Keep in lockstep with e2e-tests.yml and the CLI devs use for
+          # `pnpm gen:db-types` — the types-drift check below diffs a --local
+          # regen, so a version skew would produce a spurious failure.
+          version: 2.109.0
 
       - name: Start local Supabase
         working-directory: ./
         run: supabase start
+
+      - name: Verify generated DB types match migrations (issue #406)
+        working-directory: ./
+        # The local stack (started above) has replayed supabase/migrations/.
+        # Regenerate types/database.ts from it and assert the committed file is
+        # identical — catches a migration that changed the schema without a
+        # `pnpm gen:db-types`, or a hand-edited types file (the class that let
+        # PR #405 ship green). Pinned CLI + fixed config.toml make this a
+        # deterministic, normalization-free diff: the --local generator emits
+        # no volatile PostgrestVersion header.
+        run: |
+          supabase gen types typescript --local > types/database.ts
+          if ! git diff --exit-code -- types/database.ts; then
+            echo "::error::types/database.ts is out of sync with supabase/migrations/."
+            echo "A migration changed the schema but the committed types were not"
+            echo "regenerated (or types/database.ts was hand-edited). Fix with:"
+            echo "    supabase start && pnpm gen:db-types"
+            echo "then commit the updated types/database.ts."
+            exit 1
+          fi
 
       - name: Export prod-aligned env vars
         # `supabase status -o env` emits API_URL / ANON_KEY / SERVICE_ROLE_KEY.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,15 +26,26 @@ Jigged is a web-based data platform for small-scale precision manufacturing shop
 `lib/supabase.ts` exposes two getters that share one singleton:
 
 - `getSupabase()` — untyped. Existing `utils/*Access.ts` files use this. Schema mistakes compile silently (this is how the May 2026 `jobs.status` regression shipped).
-- `getTypedSupabase()` — `<Database>`-generic. Every `.from('table').select('...')` chain is checked against [`types/database.ts`](types/database.ts), generated from the linked Supabase project.
+- `getTypedSupabase()` — `<Database>`-generic. Every `.from('table').select('...')` chain is checked against [`types/database.ts`](types/database.ts), generated from the **local** Supabase stack (migrations replayed) — see the regen + CI-enforcement note below.
 
 **Use `getTypedSupabase()` for any new access function.** When converting an existing file, expect `tsc` to surface real bugs (column drift, narrow-enum mismatches, missing NOT-NULL columns on inserts) — fix them rather than papering over with `as any`. The [`schemaEmbedCheck`](scripts/schemaEmbedCheck.ts) test catches the embed-string class of drift today; typed mode catches everything else.
 
-Regenerate types after every migration that changes columns:
+Regenerate types after every migration that changes columns — run it against a
+running local stack (`supabase start`), since it now reads the local DB (not a
+remote project):
 
 ```bash
-pnpm gen:db-types  # wraps: supabase gen types typescript --linked
+pnpm gen:db-types  # wraps: supabase gen types typescript --local
 ```
+
+CI enforces that the committed `types/database.ts` matches the migrations: the
+backend job in [`.github/workflows/test.yml`](.github/workflows/test.yml)
+regenerates types from the migration-replayed local stack and fails on any diff
+(issue #406) — so a schema change without a regen, or a hand-edited types file,
+goes red. Because that check diffs a `--local` regen, the Supabase CLI is pinned
+(currently `2.109.0`) in both CI workflows; if you bump your local CLI and the
+check flags a formatting-only diff, regenerate + commit and bump the CI pin to
+match — treat `types/database.ts` like a lockfile.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,16 @@ CI enforces that the committed `types/database.ts` matches the migrations: the
 backend job in [`.github/workflows/test.yml`](.github/workflows/test.yml)
 regenerates types from the migration-replayed local stack and fails on any diff
 (issue #406) — so a schema change without a regen, or a hand-edited types file,
-goes red. Because that check diffs a `--local` regen, the Supabase CLI is pinned
-(currently `2.109.0`) in both CI workflows; if you bump your local CLI and the
-check flags a formatting-only diff, regenerate + commit and bump the CI pin to
-match — treat `types/database.ts` like a lockfile.
+goes red.
+
+Because that check diffs a `--local` regen, the **generator version is pinned in
+the `gen:db-types` script itself** (`npx supabase@<version>`), so your globally
+installed `supabase` CLI can auto-update freely without ever affecting type
+generation. The same version is pinned in the two CI workflows' `setup-cli`. To
+move to a newer CLI, bump the version in **three places together** —
+`package.json` (`gen:db-types`), `.github/workflows/test.yml`, and
+`.github/workflows/e2e-tests.yml` — then `pnpm gen:db-types` and commit. Treat
+`types/database.ts` like a lockfile.
 
 ---
 

--- a/api/index.py
+++ b/api/index.py
@@ -28,12 +28,16 @@ sentry_sdk.init(
     send_default_pii=True,
 )
 
-# Initialize Supabase client
+# Initialize Supabase client.
+# Prefer SUPABASE_SECRET_KEY (recommended); fall back to SUPABASE_SERVICE_ROLE_KEY
+# — the name the Supabase<->Vercel branching integration injects — so preview
+# deployments against a branch DB don't silently disable database features.
+# Mirrors the fallback already used in operators_routes.py / admin_routes.py.
 supabase_url = os.getenv("SUPABASE_URL")
-supabase_key = os.getenv("SUPABASE_SECRET_KEY")
+supabase_key = os.getenv("SUPABASE_SECRET_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 
 if not supabase_url or not supabase_key:
-    logger.warning("SUPABASE_URL or SUPABASE_SECRET_KEY not set - database features disabled")
+    logger.warning("SUPABASE_URL or SUPABASE_SECRET_KEY/SERVICE_ROLE_KEY not set - database features disabled")
     supabase: Client = None
 else:
     supabase: Client = create_client(supabase_url, supabase_key)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:local": "node e2e/run-stack.mjs",
     "seed": "node scripts/seed-dev.ts",
-    "gen:db-types": "supabase gen types typescript --linked > types/database.ts"
+    "gen:db-types": "supabase gen types typescript --local > types/database.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:local": "node e2e/run-stack.mjs",
     "seed": "node scripts/seed-dev.ts",
-    "gen:db-types": "supabase gen types typescript --local > types/database.ts"
+    "gen:db-types": "npx --yes supabase@2.109.0 gen types typescript --local > types/database.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/types/database.ts
+++ b/types/database.ts
@@ -7,11 +7,6 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.4"
-  }
   graphql_public: {
     Tables: {
       [_ in never]: never
@@ -3303,3 +3298,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+


### PR DESCRIPTION
## What & why

Addresses the primary ask in #406 (the CI sync-check). CI never verified that the committed `types/database.ts` matches the migrations, so a hand-edited types file — or a forgotten `pnpm gen:db-types` — could pass green and then 400 at runtime. That's the class that let PR #405 ship (the `jobs.status`-style silent failure).

It's also **Phase A / groundwork** for the approved Supabase Branching migration, but it stands entirely on its own.

## Changes

- **`package.json`** — `gen:db-types` now wraps `supabase gen types --local` (was `--linked`). Local is the deterministic reference and where the migrations live; the standalone staging project (`--linked`'s target) is being retired in the branching migration.
- **`types/database.ts`** — regenerated from `--local`. The only change is dropping the unused `__InternalSupabase.PostgrestVersion` header (its value drifted `14.1`→`14.4` historically and would cause spurious diffs). `tsc` stays green — the header is type-only and unused here.
- **`.github/workflows/test.yml`** — the backend job (which already boots a migration-replayed local stack) now regenerates types and `git diff --exit-code`s them. A schema change without a regen, or a hand-edited types file, fails CI with a copy-pasteable fix message.
- **`.github/workflows/{test,e2e-tests}.yml`** — Supabase CLI pin → `2.109.0` (lockstep) so the `--local` diff is deterministic.
- **`api/index.py`** — fall back to `SUPABASE_SERVICE_ROLE_KEY` (the name the Supabase↔Vercel branching integration injects) so preview deploys don't silently disable DB features. Mirrors the fallback already in `operators_routes.py` / `admin_routes.py`.
- **`CLAUDE.md`** — document the `--local` regen, the CI enforcement, and treating `types/database.ts` like a lockfile.

## Verified locally

- ✅ `supabase db reset` replays baseline + 35 migrations cleanly (exit 0) — migrations are branch-ready.
- ✅ Two consecutive `--local` regens are **byte-identical** — no field-ordering flakiness; CI won't spuriously fail.
- ✅ Committed file == fresh `--local` regen — CI diff is clean for correct state.
- ✅ A phantom column in the committed types (no backing migration) makes the check **fail** — the guard works.
- ✅ `api/index.py` builds the client from the service-role key alone; `tsc --noEmit` green.

## Note on the CLI pin

The check diffs a `--local` regen, so the CLI that generated the committed file must match CI's — pinned to `2.109.0` in both workflows. If you bump your local CLI and the check flags a formatting-only diff, regenerate + commit and bump the pin (treat the types file like a lockfile). Easy to switch to an `npx supabase@<ver>`-pinned `gen:db-types` later if version churn gets annoying — that makes your global CLI version irrelevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
