### PR TITLE
fix(db): remove staging-pointing webhook triggers from baseline (branch portability)

### DIFF
--- a/supabase/migrations/20260527151536_baseline.sql
+++ b/supabase/migrations/20260527151536_baseline.sql
@@ -4234,7 +4234,13 @@ CREATE OR REPLACE TRIGGER "enforce_transaction_notes_only_update" BEFORE UPDATE 
 
 
 
-CREATE OR REPLACE TRIGGER "feedback" AFTER INSERT ON "public"."feedback" FOR EACH ROW EXECUTE FUNCTION "supabase_functions"."http_request"('https://rxjrshezmuttbbxmhojd.supabase.co/functions/v1/notify-feedback', 'POST', '{"Content-type":"application/json","Authorization":"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJ4anJzaGV6bXV0dGJieG1ob2pkIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc3MzUzMzY0NCwiZXhwIjoyMDg5MTA5NjQ0fQ.TpegQhEp_3NCIZ2MMDNyW_tmUX0mcajre-koWIrtIuw"}', '{}', '5000');
+-- (Removed for branch portability) "feedback" Database Webhook trigger →
+-- notify-feedback. This was a dashboard-managed webhook captured from a
+-- live-DB dump: it hardcoded the (retired) staging project URL + a service-role
+-- token, and it depends on the supabase_functions schema that a fresh preview
+-- branch does not have — which broke migration replay on branches. Prod keeps
+-- its already-applied trigger; if prod feedback notifications are still wanted,
+-- re-create the webhook in the PROD dashboard pointing at prod's edge function.
 
 
 
@@ -4362,7 +4368,8 @@ CREATE OR REPLACE TRIGGER "vendors_updated_at" BEFORE UPDATE ON "public"."vendor
 
 
 
-CREATE OR REPLACE TRIGGER "waitlist" AFTER INSERT OR UPDATE ON "public"."waitlist" FOR EACH ROW EXECUTE FUNCTION "supabase_functions"."http_request"('https://rxjrshezmuttbbxmhojd.supabase.co/functions/v1/notify-waitlist', 'POST', '{"Content-type":"application/json","Authorization":"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJ4anJzaGV6bXV0dGJieG1ob2pkIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc3MzUzMzY0NCwiZXhwIjoyMDg5MTA5NjQ0fQ.TpegQhEp_3NCIZ2MMDNyW_tmUX0mcajre-koWIrtIuw"}', '{}', '5000');
+-- (Removed for branch portability) "waitlist" Database Webhook trigger →
+-- notify-waitlist. Same rationale as the "feedback" webhook removal above.
 
 
 

--- a/supabase/migrations/20260527151536_baseline.sql
+++ b/supabase/migrations/20260527151536_baseline.sql
@@ -1,6 +1,9 @@
 
 
 
+-- Baseline made preview-branch-portable: two Database Webhook triggers that
+-- called supabase_functions.http_request (a schema fresh preview branches lack)
+-- were removed — see the "(Removed for branch portability)" notes below.
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;

--- a/supabase/migrations/20260704002911_branching_pipeline_validation.sql
+++ b/supabase/migrations/20260704002911_branching_pipeline_validation.sql
@@ -1,9 +1,0 @@
--- Branching pipeline validation — THROWAWAY.
---
--- Purpose: prove the Supabase preview-branch pipeline works end-to-end
--- (preview branch auto-created on PR, committed migrations applied, seed.sql
--- run, Vercel preview deployed against the branch DB, required check reported).
---
--- This only sets a harmless table comment. Close the PR WITHOUT merging so it
--- never reaches production; the preview branch is deleted automatically.
-comment on table public.companies is 'branching pipeline validation — safe to revert';

--- a/supabase/migrations/20260704002911_branching_pipeline_validation.sql
+++ b/supabase/migrations/20260704002911_branching_pipeline_validation.sql
@@ -1,0 +1,9 @@
+-- Branching pipeline validation — THROWAWAY.
+--
+-- Purpose: prove the Supabase preview-branch pipeline works end-to-end
+-- (preview branch auto-created on PR, committed migrations applied, seed.sql
+-- run, Vercel preview deployed against the branch DB, required check reported).
+--
+-- This only sets a harmless table comment. Close the PR WITHOUT merging so it
+-- never reaches production; the preview branch is deleted automatically.
+comment on table public.companies is 'branching pipeline validation — safe to revert';


### PR DESCRIPTION
Fixes the blocker Phase D surfaced: fresh Supabase preview branches failed their **Migrations** task with `schema "supabase_functions" does not exist`.

The baseline captured two **Database Webhook** triggers (`notify-feedback`, `notify-waitlist`) from a live-DB dump. They call `supabase_functions.http_request` (a schema a fresh preview branch lacks — local replay only passed because `supabase start` provisions it) and hardcode the **retired staging** project's URL + a `service_role` token.

**Fix:** remove both from the baseline.
- Prod is unaffected — the baseline is already applied there (tracked), so this only changes fresh replays (branches + local), which should never POST to staging anyway.
- The committed staging JWT self-resolves when the staging project is deleted (Phase E).
- If prod still needs feedback/waitlist notifications, re-create those webhooks in the **prod** dashboard pointing at **prod's** edge functions (part of staging retirement).

Verified locally: `db reset` clean, seed intact (18 parts / 12 quotes / 8 jobs), triggers gone, no `supabase_functions`/JWT left in the baseline. Re-running the preview branch (close+reopen) to confirm the branch now deploys green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)