### PR TITLE
feat(insights): per-company AI Insights flag + configurable rate limit (#80)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,11 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 
 ## Development Commands
 
+> **Backend Python runs in the `jigged` conda environment.** Always use it
+> (`conda run -n jigged <cmd>` or activate it) for `python index.py`, `pytest`,
+> and backend scripts — the system `python3` lacks the API deps. Never create
+> per-repo venvs.
+
 ```bash
 # Install dependencies
 pnpm install
@@ -315,8 +320,8 @@ pnpm install
 # Run frontend dev server
 pnpm dev
 
-# Run backend dev server (separate terminal)
-cd api && python index.py
+# Run backend dev server (separate terminal) — jigged conda env
+cd api && conda run -n jigged python index.py
 
 # Build for production
 pnpm build
@@ -469,6 +474,19 @@ They land gitignored in the worktree, so they're never committed. Note the
 local stack (above), so they're correct in any worktree without copying.
 (Claude can run `supabase status -o env`, and `supabase start` if the stack
 isn't up, to fetch them — they're local-only, not secrets.)
+
+**Node deps + Python env in a worktree.** `node_modules` is gitignored too, so
+a fresh worktree has none — run `pnpm install` **inside the worktree** (fast:
+pnpm hardlinks from its global store, so it's correct for that branch's exact
+deps and costs almost no extra disk). Do **not** symlink the primary's
+`node_modules` — it silently breaks when a branch's deps differ, and a stray
+`pnpm install` would mutate the primary. Backend Python uses the shared
+`jigged` conda env (`conda run -n jigged …`) — nothing to install per worktree.
+
+```bash
+pnpm install                                       # node deps for THIS worktree
+conda run -n jigged python -m pytest tests/unit/   # backend tests, jigged env
+```
 
 ### E2E gotchas
 

--- a/__tests__/lib/featureFlags.test.ts
+++ b/__tests__/lib/featureFlags.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  isAiInsightsEnabled,
   isInventoryLocationsEnabled,
   readCompanyFeatures,
   KNOWN_FEATURES,
@@ -31,5 +32,40 @@ describe('featureFlags: inventory_locations', () => {
 
   it('shipments is no longer a feature flag (now core / always-on)', () => {
     expect(KNOWN_FEATURES.map((f) => f.key)).not.toContain('shipments');
+  });
+});
+
+describe('featureFlags: ai_insights (opt-out / default-on)', () => {
+  it('is registered with defaultEnabled true (renders a toggle, defaults on)', () => {
+    const descriptor = KNOWN_FEATURES.find((f) => f.key === 'ai_insights');
+    expect(descriptor).toBeDefined();
+    expect(descriptor?.defaultEnabled).toBe(true);
+  });
+
+  it('defaults ON when the company has no explicit value', () => {
+    // Missing key, missing features block, missing settings, and null/undefined
+    // company all read as enabled — this is a GA feature with a kill-switch.
+    expect(isAiInsightsEnabled({ settings: { features: {} } })).toBe(true);
+    expect(isAiInsightsEnabled({ settings: {} })).toBe(true);
+    expect(isAiInsightsEnabled(null)).toBe(true);
+    expect(isAiInsightsEnabled(undefined)).toBe(true);
+  });
+
+  it('stays ON for an explicit true (boolean or "true")', () => {
+    expect(isAiInsightsEnabled({ settings: { features: { ai_insights: true } } })).toBe(true);
+    expect(isAiInsightsEnabled({ settings: { features: { ai_insights: 'true' } } })).toBe(true);
+  });
+
+  it('turns OFF only when explicitly disabled', () => {
+    expect(isAiInsightsEnabled({ settings: { features: { ai_insights: false } } })).toBe(false);
+  });
+
+  it('readCompanyFeatures reflects the opt-out default without leaking to opt-in flags', () => {
+    const noneSet = readCompanyFeatures({ settings: { features: {} } });
+    expect(noneSet.ai_insights).toBe(true); // opt-out default on
+    expect(noneSet.inventory_locations).toBe(false); // opt-in default off, unaffected
+
+    const disabled = readCompanyFeatures({ settings: { features: { ai_insights: false } } });
+    expect(disabled.ai_insights).toBe(false);
   });
 });

--- a/api/models/admin_models.py
+++ b/api/models/admin_models.py
@@ -87,6 +87,9 @@ class CompanyListItem(BaseModel):
     # lib/featureFlags.ts KNOWN_FEATURES so the admin UI can render
     # toggles without hardcoding the list per call site.
     features: dict[str, bool] = {}
+    # Per-company AI chat rate limit (queries/hour), from
+    # companies.settings.ai_limits.chat_per_hour. Defaults to 20 when unset.
+    ai_chat_limit_per_hour: int = 20
 
 
 class CompanyFeaturesUpdateRequest(BaseModel):
@@ -96,8 +99,21 @@ class CompanyFeaturesUpdateRequest(BaseModel):
     Anything omitted is treated as false (replace-style, not patch-style)
     so the request is self-describing — the caller sends what they want
     on, the server stores exactly that under settings.features.
+
+    Optionally carries the per-company AI chat rate limit (queries/hour),
+    persisted to settings.ai_limits.chat_per_hour. Omitted → left unchanged.
     """
     features: dict[str, bool]
+    ai_chat_limit_per_hour: Optional[int] = None
+
+    @field_validator("ai_chat_limit_per_hour")
+    @classmethod
+    def validate_chat_limit(cls, v):
+        if v is None:
+            return v
+        if v < 1 or v > 1000:
+            raise ValueError("ai_chat_limit_per_hour must be between 1 and 1000")
+        return v
 
 
 class CompanyFeaturesUpdateResponse(BaseModel):

--- a/api/models/insights_models.py
+++ b/api/models/insights_models.py
@@ -1,6 +1,5 @@
 """Pydantic models for AI Insights & Charts feature."""
 
-from datetime import datetime
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -24,19 +23,3 @@ class ChatResponse(BaseModel):
     )
     provider: str = Field(..., description="AI provider used (e.g. 'anthropic')")
     tokens_used: Optional[int] = Field(None, description="Total tokens consumed by the request")
-
-
-class ChatHistoryItem(BaseModel):
-    """A single item from chat history."""
-
-    id: str = Field(..., description="Unique chat query ID")
-    question: str = Field(..., description="The original question asked")
-    response: str = Field(..., description="The AI response text")
-    has_chart: bool = Field(False, description="Whether the response included a chart")
-    created_at: datetime = Field(..., description="When the query was made")
-
-
-class ChatHistoryResponse(BaseModel):
-    """Response containing chat history items."""
-
-    queries: list[ChatHistoryItem]

--- a/api/routes/admin_routes.py
+++ b/api/routes/admin_routes.py
@@ -157,8 +157,20 @@ async def list_companies(request: Request):
                     break
 
             settings = company.get("settings") or {}
-            features_raw = settings.get("features") if isinstance(settings, dict) else {}
-            features = _normalize_features(features_raw)
+            settings = settings if isinstance(settings, dict) else {}
+            features = _normalize_features(settings.get("features"))
+            # ai_insights is opt-out (GA feature + kill-switch): report it ON
+            # for companies that never set it, so the admin toggle mirrors the
+            # effective state (see lib/featureFlags.ts defaultEnabled).
+            features.setdefault("ai_insights", True)
+
+            ai_limits = settings.get("ai_limits") or {}
+            raw_limit = ai_limits.get("chat_per_hour")
+            ai_chat_limit_per_hour = (
+                int(raw_limit)
+                if isinstance(raw_limit, (int, float)) and int(raw_limit) > 0
+                else 20
+            )
 
             companies.append(CompanyListItem(
                 id=company["id"],
@@ -169,6 +181,7 @@ async def list_companies(request: Request):
                 owner_email=owner_email,
                 member_count=member_count,
                 features=features,
+                ai_chat_limit_per_hour=ai_chat_limit_per_hour,
             ))
 
         return companies
@@ -468,6 +481,14 @@ async def update_company_features(
         # but future settings sub-keys may live here).
         new_settings = dict(current_settings)
         new_settings["features"] = {k: bool(v) for k, v in body.features.items()}
+
+        # Persist the per-company AI chat rate limit alongside the flags, under
+        # settings.ai_limits.chat_per_hour. Omitted → leave the existing value.
+        if body.ai_chat_limit_per_hour is not None:
+            new_settings["ai_limits"] = {
+                **(current_settings.get("ai_limits") or {}),
+                "chat_per_hour": int(body.ai_chat_limit_per_hour),
+            }
 
         result = (
             service_client.table("companies")

--- a/api/routes/insights_routes.py
+++ b/api/routes/insights_routes.py
@@ -3,7 +3,6 @@ API routes for AI Insights & Charts feature.
 
 Endpoints:
 - POST /{company_id}/chat        - Submit natural language question
-- GET  /{company_id}/chat/history - Get last 20 chat queries
 
 Note: Saved insights CRUD (get/save/delete) is handled client-side
 via direct Supabase queries with RLS policies. Per-company alerts
@@ -24,8 +23,6 @@ from fastapi import APIRouter, HTTPException
 from supabase import Client, create_client
 
 from models.insights_models import (
-    ChatHistoryItem,
-    ChatHistoryResponse,
     ChatRequest,
     ChatResponse,
 )
@@ -46,27 +43,99 @@ def _get_supabase_service_role() -> Client:
     return create_client(url, key)
 
 
-def _check_chat_rate_limit(company_id: str) -> None:
+# Default per-company hourly cap, used when a company has no explicit override
+# in settings.ai_limits.chat_per_hour. A system admin can raise/lower it per
+# company from /admin.
+DEFAULT_CHAT_LIMIT_PER_HOUR = 20
+
+
+def _get_company_ai_settings(company_id: str) -> tuple[bool, int]:
+    """Read (ai_insights_enabled, chat_per_hour) from companies.settings.
+
+    ai_insights is opt-OUT — a GA feature with a per-tenant kill-switch: enabled
+    unless the company row explicitly stores settings.features.ai_insights =
+    false. The rate limit falls back to DEFAULT_CHAT_LIMIT_PER_HOUR when unset
+    or invalid.
+
+    Fails open — (True, default) — on a read error, matching the rate limiter's
+    allow-through-on-error stance so a transient DB blip never dark-launches the
+    GA feature off.
     """
-    Check if the company has exceeded the chat rate limit (20 queries/hour).
+    try:
+        supabase = _get_supabase_service_role()
+        resp = (
+            supabase.table("companies")
+            .select("settings")
+            .eq("id", company_id)
+            .single()
+            .execute()
+        )
+        settings = (resp.data or {}).get("settings") or {}
+    except Exception as e:
+        logger.warning(f"Failed to read company AI settings: {e}")
+        return True, DEFAULT_CHAT_LIMIT_PER_HOUR
+
+    features = settings.get("features") or {}
+    raw_enabled = features.get("ai_insights")
+    # Missing key → default on; explicit false (bool or legacy "false") → off.
+    enabled = raw_enabled is None or raw_enabled is True or raw_enabled == "true"
+
+    limits = settings.get("ai_limits") or {}
+    raw_limit = limits.get("chat_per_hour")
+    limit = (
+        int(raw_limit)
+        if isinstance(raw_limit, (int, float)) and int(raw_limit) > 0
+        else DEFAULT_CHAT_LIMIT_PER_HOUR
+    )
+    return enabled, limit
+
+
+def _seconds_until_window_frees(oldest_created_at, now: datetime) -> int:
+    """Seconds until the oldest in-window query ages past the 1-hour window.
+
+    Clamped to [1, 3600]; falls back to 3600 if the timestamp can't be parsed.
+    """
+    try:
+        # PostgREST returns ISO 8601; tolerate a trailing 'Z'.
+        oldest = datetime.fromisoformat(str(oldest_created_at).replace("Z", "+00:00"))
+        remaining = int((oldest + timedelta(hours=1) - now).total_seconds())
+    except (ValueError, TypeError):
+        return 3600
+    return max(1, min(remaining, 3600))
+
+
+def _check_chat_rate_limit(company_id: str, limit: int) -> None:
+    """
+    Enforce the company's chat rate limit (queries in the last hour).
+
+    On breach, raises 429 with a message reflecting the company's actual limit
+    and a Retry-After header set to the seconds until the oldest in-window query
+    ages out. A read error is non-fatal (allow the request through).
     """
     supabase = _get_supabase_service_role()
-    one_hour_ago = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    now = datetime.now(timezone.utc)
+    one_hour_ago = now - timedelta(hours=1)
 
     try:
         response = (
             supabase.table("ai_chat_queries")
-            .select("id", count="exact")
+            .select("created_at")
             .eq("company_id", company_id)
-            .gte("created_at", one_hour_ago)
+            .gte("created_at", one_hour_ago.isoformat())
+            .order("created_at", desc=False)
             .execute()
         )
 
-        count = response.count or 0
-        if count >= 20:
+        rows = response.data or []
+        if len(rows) >= limit:
+            retry_after = _seconds_until_window_frees(rows[0].get("created_at"), now)
             raise HTTPException(
                 status_code=429,
-                detail="Rate limit exceeded. Maximum 20 AI chat queries per hour per company.",
+                detail=(
+                    f"Rate limit exceeded. Maximum {limit} AI chat queries "
+                    f"per hour per company."
+                ),
+                headers={"Retry-After": str(retry_after)},
             )
     except HTTPException:
         raise
@@ -86,10 +155,16 @@ async def chat(company_id: str, request: ChatRequest):
     Submit a natural language question about company data.
     Uses AI tool-use to query metrics and generate a response.
 
-    Rate limited to 20 queries per company per hour.
+    Gated on the per-company ai_insights flag (403 when disabled) and rate
+    limited to the company's configured hourly cap.
     """
-    # Check rate limit
-    _check_chat_rate_limit(company_id)
+    ai_enabled, chat_limit = _get_company_ai_settings(company_id)
+    if not ai_enabled:
+        raise HTTPException(
+            status_code=403,
+            detail="AI Insights is disabled for this company.",
+        )
+    _check_chat_rate_limit(company_id, chat_limit)
 
     start_time = time.time()
 
@@ -141,7 +216,6 @@ async def chat(company_id: str, request: ChatRequest):
             supabase = _get_supabase_service_role()
             supabase.table("ai_chat_queries").insert({
                 "company_id": company_id,
-                "user_id": None,
                 "question": request.question,
                 "tool_calls": result.get("tool_calls", []),
                 "response": result["content"],
@@ -409,43 +483,3 @@ def _select_chart_type(config: dict | None, question: str = "") -> dict | None:
         chosen = "bar_horizontal" if (longest > 14 or n > 8) else "bar"
 
     return {**config, "chart_type": chosen}
-
-
-@router.get("/{company_id}/chat/history", response_model=ChatHistoryResponse)
-async def get_chat_history(company_id: str):
-    """
-    Get the last 20 chat queries for this company.
-    """
-    try:
-        supabase = _get_supabase_service_role()
-
-        response = (
-            supabase.table("ai_chat_queries")
-            .select("id, question, response, chart_config, created_at")
-            .eq("company_id", company_id)
-            .order("created_at", desc=True)
-            .limit(20)
-            .execute()
-        )
-
-        queries = []
-        for row in response.data or []:
-            queries.append(
-                ChatHistoryItem(
-                    id=row["id"],
-                    question=row["question"],
-                    response=row["response"],
-                    has_chart=row.get("chart_config") is not None,
-                    created_at=row["created_at"],
-                )
-            )
-
-        return ChatHistoryResponse(queries=queries)
-
-    except Exception as e:
-        logger.error(f"Error fetching chat history: {e}", exc_info=True)
-        sentry_sdk.capture_exception(e)
-        raise HTTPException(
-            status_code=500,
-            detail="Internal server error",
-        )

--- a/api/tests/unit/test_insights_rate_limit.py
+++ b/api/tests/unit/test_insights_rate_limit.py
@@ -1,0 +1,152 @@
+"""
+Unit tests for the AI Insights per-company flag + configurable rate limit.
+
+Covers the pure logic added for issue #80:
+- _get_company_ai_settings: opt-out ai_insights flag + configurable chat limit
+- _check_chat_rate_limit: honors the passed limit, emits 429 + Retry-After
+- _seconds_until_window_frees: Retry-After computation
+
+The Supabase client is mocked, so these need no DB / env.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from routes import insights_routes
+from routes.insights_routes import (
+    DEFAULT_CHAT_LIMIT_PER_HOUR,
+    _check_chat_rate_limit,
+    _get_company_ai_settings,
+    _seconds_until_window_frees,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _fluent_client(execute_data):
+    """A Supabase-style fluent mock whose terminal .execute() returns an object
+    with `.data = execute_data`. Every builder method returns the same mock."""
+    client = MagicMock()
+    for method in ("table", "select", "eq", "gte", "order", "single"):
+        getattr(client, method).return_value = client
+    result = MagicMock()
+    result.data = execute_data
+    client.execute.return_value = result
+    return client
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+class TestGetCompanyAiSettings:
+    @patch.object(insights_routes, "_get_supabase_service_role")
+    def test_defaults_when_settings_null(self, mock_sr):
+        mock_sr.return_value = _fluent_client({"settings": None})
+        enabled, limit = _get_company_ai_settings("c1")
+        assert enabled is True
+        assert limit == DEFAULT_CHAT_LIMIT_PER_HOUR
+
+    @patch.object(insights_routes, "_get_supabase_service_role")
+    def test_opt_out_default_on_when_key_absent(self, mock_sr):
+        mock_sr.return_value = _fluent_client({"settings": {"features": {}}})
+        enabled, _ = _get_company_ai_settings("c1")
+        assert enabled is True
+
+    @patch.object(insights_routes, "_get_supabase_service_role")
+    def test_explicit_false_disables(self, mock_sr):
+        mock_sr.return_value = _fluent_client(
+            {"settings": {"features": {"ai_insights": False}}}
+        )
+        enabled, _ = _get_company_ai_settings("c1")
+        assert enabled is False
+
+    @patch.object(insights_routes, "_get_supabase_service_role")
+    def test_explicit_true_enables(self, mock_sr):
+        mock_sr.return_value = _fluent_client(
+            {"settings": {"features": {"ai_insights": True}}}
+        )
+        enabled, _ = _get_company_ai_settings("c1")
+        assert enabled is True
+
+    @patch.object(insights_routes, "_get_supabase_service_role")
+    def test_custom_limit_read(self, mock_sr):
+        mock_sr.return_value = _fluent_client(
+            {"settings": {"ai_limits": {"chat_per_hour": 100}}}
+        )
+        _, limit = _get_company_ai_settings("c1")
+        assert limit == 100
+
+    @patch.object(insights_routes, "_get_supabase_service_role")
+    def test_invalid_limit_falls_back(self, mock_sr):
+        mock_sr.return_value = _fluent_client(
+            {"settings": {"ai_limits": {"chat_per_hour": 0}}}
+        )
+        _, limit = _get_company_ai_settings("c1")
+        assert limit == DEFAULT_CHAT_LIMIT_PER_HOUR
+
+    @patch.object(insights_routes, "_get_supabase_service_role")
+    def test_fails_open_on_read_error(self, mock_sr):
+        mock_sr.side_effect = RuntimeError("db down")
+        enabled, limit = _get_company_ai_settings("c1")
+        assert enabled is True
+        assert limit == DEFAULT_CHAT_LIMIT_PER_HOUR
+
+
+class TestCheckChatRateLimit:
+    @patch.object(insights_routes, "_get_supabase_service_role")
+    def test_under_limit_passes(self, mock_sr):
+        rows = [{"created_at": _iso(datetime.now(timezone.utc))} for _ in range(2)]
+        mock_sr.return_value = _fluent_client(rows)
+        # 2 queries, limit 20 → no raise
+        _check_chat_rate_limit("c1", 20)
+
+    @patch.object(insights_routes, "_get_supabase_service_role")
+    def test_at_limit_raises_429_with_retry_after(self, mock_sr):
+        now = datetime.now(timezone.utc)
+        rows = [
+            {"created_at": _iso(now - timedelta(minutes=30))},
+            {"created_at": _iso(now - timedelta(minutes=5))},
+        ]
+        mock_sr.return_value = _fluent_client(rows)
+        with pytest.raises(HTTPException) as exc:
+            _check_chat_rate_limit("c1", 2)
+        assert exc.value.status_code == 429
+        assert "Maximum 2" in exc.value.detail
+        # Retry-After present and sane (oldest was ~30 min into the hour window).
+        retry_after = int(exc.value.headers["Retry-After"])
+        assert 1 <= retry_after <= 3600
+
+    @patch.object(insights_routes, "_get_supabase_service_role")
+    def test_query_error_allows_through(self, mock_sr):
+        client = MagicMock()
+        for method in ("table", "select", "eq", "gte", "order"):
+            getattr(client, method).return_value = client
+        client.execute.side_effect = RuntimeError("query blew up")
+        mock_sr.return_value = client
+        # Read failure is non-fatal — must not raise.
+        _check_chat_rate_limit("c1", 1)
+
+
+class TestSecondsUntilWindowFrees:
+    _NOW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_parses_offset_timestamp(self):
+        # Oldest 30 min ago → 30 min left in the 1-hour window.
+        assert (
+            _seconds_until_window_frees("2026-01-01T11:30:00+00:00", self._NOW) == 1800
+        )
+
+    def test_tolerates_trailing_z(self):
+        assert _seconds_until_window_frees("2026-01-01T11:30:00Z", self._NOW) == 1800
+
+    def test_clamps_to_minimum_one(self):
+        # Oldest exactly an hour ago → 0 remaining → clamped up to 1.
+        assert _seconds_until_window_frees("2026-01-01T11:00:00+00:00", self._NOW) == 1
+
+    def test_unparseable_falls_back_to_hour(self):
+        assert _seconds_until_window_frees("not-a-date", self._NOW) == 3600
+        assert _seconds_until_window_frees(None, self._NOW) == 3600

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -49,6 +49,7 @@ interface CompanyListItem {
   owner_email: string | null;
   member_count: number;
   features: Record<string, boolean>;
+  ai_chat_limit_per_hour: number;
 }
 
 // Stable empty fallback so the filtered-companies memo doesn't recompute on
@@ -108,6 +109,9 @@ export default function AdminCompaniesPage() {
   const [featuresOpen, setFeaturesOpen] = useState(false);
   const [featuresCompany, setFeaturesCompany] = useState<CompanyListItem | null>(null);
   const [featuresDraft, setFeaturesDraft] = useState<Record<string, boolean>>({});
+  // AI chat rate limit (queries/hour) for the company being edited — kept as a
+  // string so the number field can be cleared while typing without snapping to 0.
+  const [aiLimitDraft, setAiLimitDraft] = useState('20');
   const [featuresSaving, setFeaturesSaving] = useState(false);
   const [featuresError, setFeaturesError] = useState('');
 
@@ -222,6 +226,7 @@ export default function AdminCompaniesPage() {
       seeded[f.key] = Boolean(company.features?.[f.key]);
     }
     setFeaturesDraft(seeded);
+    setAiLimitDraft(String(company.ai_chat_limit_per_hour ?? 20));
     setFeaturesError('');
     setFeaturesOpen(true);
   }, []);
@@ -231,11 +236,21 @@ export default function AdminCompaniesPage() {
     setFeaturesOpen(false);
     setFeaturesCompany(null);
     setFeaturesDraft({});
+    setAiLimitDraft('20');
     setFeaturesError('');
   };
 
   const handleFeaturesSave = async () => {
     if (!featuresCompany) return;
+
+    // Validate the AI chat limit before hitting the API (mirrors the server's
+    // 1..1000 bound so the admin gets an inline error, not a 422).
+    const aiLimit = Number(aiLimitDraft);
+    if (!Number.isInteger(aiLimit) || aiLimit < 1 || aiLimit > 1000) {
+      setFeaturesError('Chat queries per hour must be a whole number between 1 and 1000.');
+      return;
+    }
+
     setFeaturesSaving(true);
     setFeaturesError('');
     try {
@@ -245,7 +260,10 @@ export default function AdminCompaniesPage() {
         {
           method: 'PATCH',
           headers,
-          body: JSON.stringify({ features: featuresDraft }),
+          body: JSON.stringify({
+            features: featuresDraft,
+            ai_chat_limit_per_hour: aiLimit,
+          }),
         },
       );
       if (!response.ok) {
@@ -260,6 +278,7 @@ export default function AdminCompaniesPage() {
       setFeaturesOpen(false);
       setFeaturesCompany(null);
       setFeaturesDraft({});
+      setAiLimitDraft('20');
       // Refetch the canonical list so this change — and any other admins'
       // concurrent changes — show up.
       fetchCompanies();
@@ -850,6 +869,18 @@ export default function AdminCompaniesPage() {
                   }
                   sx={{ alignItems: 'flex-start' }}
                 />
+                {f.key === 'ai_insights' && Boolean(featuresDraft[f.key]) && (
+                  <TextField
+                    label="Chat queries per hour"
+                    type="number"
+                    size="small"
+                    value={aiLimitDraft}
+                    onChange={(e) => setAiLimitDraft(e.target.value)}
+                    inputProps={{ min: 1, max: 1000, step: 1 }}
+                    helperText="Per-company AI chat rate limit (1–1000)."
+                    sx={{ mt: 1, ml: 6, width: 240 }}
+                  />
+                )}
               </Box>
             ))}
             {KNOWN_FEATURES.length === 0 && (

--- a/app/dashboard/[companyId]/page.tsx
+++ b/app/dashboard/[companyId]/page.tsx
@@ -7,23 +7,20 @@ import Box from '@mui/material/Box';
 import { InsightsSection, PinnedMetrics, RecentActivity } from '@/components/dashboard';
 import { InsightsChat } from '@/components/insights';
 import OnboardingCard from '@/components/demo/OnboardingCard';
+import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 import { getMetricValue, getDashboardActivity, type ActivityItem } from '@/utils/dashboardAccess';
 
 export default function DashboardPage() {
   const params = useParams();
   const companyId = params.companyId as string;
+  const { features, loading: featuresLoading } = useCompanyFeatures();
   const [savedVersion, setSavedVersion] = useState(0);
-  const [savedCount, setSavedCount] = useState(0);
   const [isEmpty, setIsEmpty] = useState(false);
   const [activities, setActivities] = useState<ActivityItem[]>([]);
   const [activitiesLoading, setActivitiesLoading] = useState(true);
 
   const handleInsightSaved = useCallback(() => {
     setSavedVersion((v) => v + 1);
-  }, []);
-
-  const handleSavedCountChange = useCallback((count: number) => {
-    setSavedCount(count);
   }, []);
 
   useEffect(() => {
@@ -50,6 +47,11 @@ export default function DashboardPage() {
     return () => { active = false; };
   }, [companyId]);
 
+  // AI Insights is opt-out (on unless a system admin disabled it for this
+  // tenant). Gate the whole AI area — ask-bar + saved charts — on the flag;
+  // kept hidden while the flag is still loading so it never flashes in then out.
+  const aiInsightsEnabled = !featuresLoading && features.ai_insights;
+
   return (
     <Box>
       {/* Onboarding Card — shown when dashboard is empty and no demo exists */}
@@ -69,21 +71,24 @@ export default function DashboardPage() {
         />
       </Box>
 
-      {/* Ask Bar */}
-      <Box sx={{ mb: 4 }}>
-        <InsightsChat
-          companyId={companyId}
-          onInsightSaved={handleInsightSaved}
-          savedCount={savedCount}
-        />
-      </Box>
+      {/* AI Insights — ask-bar + saved charts, gated per-company */}
+      {aiInsightsEnabled && (
+        <>
+          {/* Ask Bar */}
+          <Box sx={{ mb: 4 }}>
+            <InsightsChat
+              companyId={companyId}
+              onInsightSaved={handleInsightSaved}
+            />
+          </Box>
 
-      {/* Saved Charts */}
-      <InsightsSection
-        companyId={companyId}
-        savedVersion={savedVersion}
-        onSavedCountChange={handleSavedCountChange}
-      />
+          {/* Saved Charts */}
+          <InsightsSection
+            companyId={companyId}
+            savedVersion={savedVersion}
+          />
+        </>
+      )}
     </Box>
   );
 }

--- a/components/dashboard/InsightsSection.tsx
+++ b/components/dashboard/InsightsSection.tsx
@@ -14,8 +14,6 @@ import {
 } from '@/utils/savedInsightsAccess';
 import type { SavedInsight } from '@/utils/insightsAccess';
 
-const MAX_SAVED = 5;
-
 // Stable empty fallback so derived data doesn't churn while the first load runs.
 const EMPTY_INSIGHTS: SavedInsight[] = [];
 
@@ -23,8 +21,6 @@ interface InsightsSectionProps {
   companyId: string;
   /** Incremented when a new insight is saved, to trigger refetch */
   savedVersion?: number;
-  /** Called with current saved count so parent can pass to InsightsChat */
-  onSavedCountChange?: (count: number) => void;
 }
 
 /**
@@ -35,7 +31,6 @@ interface InsightsSectionProps {
 export default function InsightsSection({
   companyId,
   savedVersion = 0,
-  onSavedCountChange,
 }: InsightsSectionProps) {
   const [error, setError] = useState<string | null>(null);
 
@@ -45,15 +40,11 @@ export default function InsightsSection({
     reload: fetchSavedInsights,
   } = useLoad(
     async () => {
-      // No company yet → nothing to fetch (and report a zero count so the
-      // parent's chat affordance stays in sync).
+      // No company yet → nothing to fetch.
       if (!companyId) {
-        onSavedCountChange?.(0);
         return [] as SavedInsight[];
       }
-      const saved = await getSavedInsights(companyId);
-      onSavedCountChange?.(saved.length);
-      return saved;
+      return await getSavedInsights(companyId);
     },
     [companyId, savedVersion],
     {
@@ -93,11 +84,6 @@ export default function InsightsSection({
           </Typography>
           <AutoAwesomeIcon sx={{ fontSize: 20, color: 'primary.main' }} />
         </Box>
-        {!loading && savedCount > 0 && (
-          <Typography variant="body2" color="text.secondary" sx={{ ml: 1.5 }}>
-            ({savedCount}/{MAX_SAVED})
-          </Typography>
-        )}
       </Box>
 
       {/* Error State */}

--- a/components/insights/InsightsChat.tsx
+++ b/components/insights/InsightsChat.tsx
@@ -22,8 +22,6 @@ import {
 } from '@/utils/insightsAccess';
 import { saveInsight } from '@/utils/savedInsightsAccess';
 
-const MAX_SAVED = 5;
-
 const EXAMPLE_PROMPTS = [
   'What is my revenue trend over time?',
   'Who is my top customer by revenue?',
@@ -41,8 +39,6 @@ interface InsightsChatProps {
   companyId: string;
   /** Called when user saves an insight so InsightsSection can refresh */
   onInsightSaved?: () => void;
-  /** Current number of saved insights (for limit enforcement) */
-  savedCount?: number;
 }
 
 interface ChatResult {
@@ -55,7 +51,7 @@ interface ChatResult {
  * AskBar: Compact question input with inline response.
  * Latest response appears directly below with optional chart + save action.
  */
-export default function InsightsChat({ companyId, onInsightSaved, savedCount = 0 }: InsightsChatProps) {
+export default function InsightsChat({ companyId, onInsightSaved }: InsightsChatProps) {
   const [question, setQuestion] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -118,10 +114,8 @@ export default function InsightsChat({ companyId, onInsightSaved, savedCount = 0
     }
   };
 
-  const atLimit = savedCount >= MAX_SAVED;
-
   const handleSave = async () => {
-    if (!result || saving || saved || atLimit) return;
+    if (!result || saving || saved) return;
 
     setSaving(true);
     try {
@@ -232,10 +226,10 @@ export default function InsightsChat({ companyId, onInsightSaved, savedCount = 0
                 size="small"
                 variant="outlined"
                 onClick={handleSave}
-                disabled={saving || atLimit}
+                disabled={saving}
                 startIcon={saving ? <CircularProgress size={14} /> : <BookmarkBorderIcon />}
               >
-                {atLimit ? 'Limit reached' : 'Save to dashboard'}
+                Save to dashboard
               </Button>
             </Box>
           )}

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -5,7 +5,13 @@
  * `settings.features.<key> = true` on that company's row (UI + access-layer
  * gate; DB columns/triggers ship to everyone). Shipments + invoicing used to
  * be gated this way; they're now core (always on) and the flag was removed —
- * `inventory_locations` is the remaining example.
+ * `inventory_locations` is the remaining opt-in example.
+ *
+ * Most flags are opt-IN (default off): a company must be explicitly enabled.
+ * A flag can instead be opt-OUT (default on) via `defaultEnabled: true` on its
+ * descriptor — for a GA feature that ships enabled everywhere but needs a
+ * per-tenant kill-switch (e.g. `ai_insights`). An opt-out flag stays on until
+ * a company's row explicitly stores the key as `false`.
  *
  * Toggle for a pilot tenant:
  *   UPDATE public.companies
@@ -36,6 +42,13 @@ export interface FeatureFlagDescriptor {
   key: string;
   label: string;
   description: string;
+  /**
+   * State to assume when a company has no explicit value for this key.
+   * Omit (or `false`) for opt-in pilot flags. Set `true` for a GA feature
+   * that ships on for everyone but needs a per-tenant kill-switch — it then
+   * reads enabled unless the company row explicitly stores `false`.
+   */
+  defaultEnabled?: boolean;
 }
 
 export const KNOWN_FEATURES: readonly FeatureFlagDescriptor[] = [
@@ -45,31 +58,48 @@ export const KNOWN_FEATURES: readonly FeatureFlagDescriptor[] = [
     description:
       'QR-addressable storage locations with per-location stock: the Locations manager + visual builder, per-part location tracking, and bin scanning. The base inventory list is unaffected.',
   },
+  {
+    key: 'ai_insights',
+    label: 'AI Insights',
+    description:
+      'Dashboard ask-bar (natural-language questions about shop data) and the saved-charts section. On by default; turning it off hides the AI area and blocks the chat endpoint for this tenant.',
+    // GA feature with a kill-switch: enabled unless explicitly turned off.
+    defaultEnabled: true,
+  },
 ] as const;
 
 export type KnownFeatureKey = (typeof KNOWN_FEATURES)[number]['key'];
 
+/**
+ * Read one flag. `defaultEnabled` is returned when the company has no explicit
+ * value (missing settings, missing features block, or missing key) — an
+ * explicit stored `false` always wins over an opt-out default.
+ */
 function readFeatureFlag(
   company: SettingsLike | null | undefined,
   feature: string,
+  defaultEnabled = false,
 ): boolean {
-  if (!company?.settings) return false;
+  if (!company?.settings) return defaultEnabled;
   const settings = company.settings as Record<string, unknown>;
   const features = settings.features as Record<string, unknown> | undefined;
-  if (!features) return false;
+  if (!features) return defaultEnabled;
   const value = features[feature];
+  if (value === undefined || value === null) return defaultEnabled;
   return value === true || value === 'true';
 }
 
 /**
- * Generic flag check. Prefer the named helpers below at call sites — they
- * encode the contract that the feature key is known to the registry.
+ * Generic flag check. Honors the registry's `defaultEnabled`, so opt-out flags
+ * read correctly. Prefer the named helpers below at call sites — they encode
+ * the contract that the feature key is known to the registry.
  */
 export function isFeatureEnabled(
   company: SettingsLike | null | undefined,
   feature: string,
 ): boolean {
-  return readFeatureFlag(company, feature);
+  const descriptor = KNOWN_FEATURES.find((f) => f.key === feature);
+  return readFeatureFlag(company, feature, descriptor?.defaultEnabled ?? false);
 }
 
 export function isInventoryLocationsEnabled(
@@ -79,16 +109,27 @@ export function isInventoryLocationsEnabled(
 }
 
 /**
+ * AI Insights is opt-OUT: enabled for every tenant unless their company row
+ * explicitly sets settings.features.ai_insights = false.
+ */
+export function isAiInsightsEnabled(
+  company: Pick<Company, 'settings'> | null | undefined,
+): boolean {
+  return readFeatureFlag(company, 'ai_insights', true);
+}
+
+/**
  * Read the full feature-flag state for a company. Returns a dense map
  * keyed by KNOWN_FEATURES entries — anything unknown to the registry is
- * dropped on read.
+ * dropped on read. Each key resolves against its descriptor's default, so
+ * opt-out flags (ai_insights) report `true` unless explicitly disabled.
  */
 export function readCompanyFeatures(
   company: SettingsLike | null | undefined,
 ): Record<KnownFeatureKey, boolean> {
   const out = {} as Record<KnownFeatureKey, boolean>;
   for (const f of KNOWN_FEATURES) {
-    out[f.key] = readFeatureFlag(company, f.key);
+    out[f.key] = readFeatureFlag(company, f.key, f.defaultEnabled ?? false);
   }
   return out;
 }

--- a/supabase/migrations/20260704162749_drop_ai_chat_queries_user_id.sql
+++ b/supabase/migrations/20260704162749_drop_ai_chat_queries_user_id.sql
@@ -1,0 +1,12 @@
+-- Drop the unused ai_chat_queries.user_id column.
+--
+-- Rationale (issue #80): AI chat rate limiting is per-company, not per-user.
+-- Every insert wrote user_id = NULL and nothing ever read it — the rate-limit
+-- count keys off company_id, and the only other reader (the chat-history
+-- endpoint) was removed in this change and never selected user_id anyway.
+--
+-- The dependent FK constraint (ai_chat_queries_user_id_fkey -> auth.users) and
+-- the column comment drop automatically with the column. No RLS policy or index
+-- references user_id (all are company_id-based), so nothing else is affected.
+
+ALTER TABLE public.ai_chat_queries DROP COLUMN IF EXISTS user_id;

--- a/types/database.ts
+++ b/types/database.ts
@@ -47,7 +47,6 @@ export type Database = {
           response: string
           tokens_used: number | null
           tool_calls: Json
-          user_id: string | null
         }
         Insert: {
           chart_config?: Json | null
@@ -61,7 +60,6 @@ export type Database = {
           response: string
           tokens_used?: number | null
           tool_calls?: Json
-          user_id?: string | null
         }
         Update: {
           chart_config?: Json | null
@@ -75,7 +73,6 @@ export type Database = {
           response?: string
           tokens_used?: number | null
           tool_calls?: Json
-          user_id?: string | null
         }
         Relationships: [
           {

--- a/utils/insightsAccess.ts
+++ b/utils/insightsAccess.ts
@@ -31,18 +31,6 @@ export interface ChatResponse {
   tokens_used: number | null;
 }
 
-export interface ChatHistoryItem {
-  id: string;
-  question: string;
-  response: string;
-  has_chart: boolean;
-  created_at: string;
-}
-
-export interface ChatHistoryResponse {
-  queries: ChatHistoryItem[];
-}
-
 export interface SavedInsight {
   id: string;
   question: string;
@@ -94,45 +82,13 @@ export async function submitChatQuery(
   );
 
   if (!response.ok) {
+    // Surface the backend's message verbatim: it carries the company's real
+    // rate-limit number on 429 and the "AI Insights is disabled" text on 403.
     const errorData = await response.json().catch(() => ({}));
-
-    if (response.status === 429) {
-      throw new Error(
-        'Rate limit exceeded. Maximum 20 AI chat queries per hour. Please try again later.'
-      );
-    }
-
     throw new Error(
       errorData.detail || `Failed to submit chat query (${response.status})`
     );
   }
 
   return await response.json();
-}
-
-/**
- * Get the last 20 chat queries for this company.
- */
-export async function getChatHistory(
-  companyId: string
-): Promise<ChatHistoryItem[]> {
-  const headers = await getAuthHeaders();
-
-  const response = await fetch(
-    `${API_BASE_URL}/api/insights/${companyId}/chat/history`,
-    {
-      method: 'GET',
-      headers,
-    }
-  );
-
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(
-      errorData.detail || `Failed to fetch chat history (${response.status})`
-    );
-  }
-
-  const data: ChatHistoryResponse = await response.json();
-  return data.queries;
 }

--- a/utils/savedInsightsAccess.ts
+++ b/utils/savedInsightsAccess.ts
@@ -30,7 +30,6 @@ export async function getSavedInsights(
 
 /**
  * Save a chart/insight to the user's dashboard.
- * Maximum 5 saved insights per company per user.
  * RLS policy validates user_id = auth.uid() on INSERT.
  */
 export async function saveInsight(
@@ -47,20 +46,6 @@ export async function saveInsight(
   } = await supabase.auth.getUser();
   if (!user) {
     throw new Error('Not authenticated');
-  }
-
-  // Check count of existing saved insights
-  const { count, error: countError } = await supabase
-    .from('saved_insights')
-    .select('id', { count: 'exact', head: true })
-    .eq('company_id', companyId);
-
-  if (countError) {
-    throw new Error(`Failed to check saved insights count: ${countError.message}`);
-  }
-
-  if ((count ?? 0) >= 5) {
-    throw new Error('Maximum 5 saved insights per company. Remove one to save another.');
   }
 
   const { data, error } = await supabase


### PR DESCRIPTION
## Summary

Adds a per-company on/off flag for the dashboard AI feature ("AI Insights" — the ask-bar + saved charts) and makes the chat rate limit configurable per company from the system-admin page. Narrows issue #80 to what the product needs and closes it.

Closes #80.

## Changes

- **Feature flag** `ai_insights` (`lib/featureFlags.ts`) with **opt-out / default-on** semantics — it's a live GA feature, so it stays enabled unless a system admin explicitly disables it. Adds a `defaultEnabled` descriptor field + `isAiInsightsEnabled` helper.
- **Dashboard** (`app/dashboard/[companyId]/page.tsx`) gates the ask-bar + saved charts on the flag.
- **Backend** (`api/routes/insights_routes.py`): the chat endpoint reads `companies.settings` — returns **403** when disabled, and enforces the per-company limit (`settings.ai_limits.chat_per_hour`, default 20) with an **accurate 429 message + `Retry-After` header**.
- **Admin** (`app/admin/page.tsx`, `api/routes/admin_routes.py`, `api/models/admin_models.py`): the Feature Flags dialog gains a **"Chat queries per hour"** field (1–1000); the `ai_insights` toggle shows ON by default via effective-value logic on the list endpoint.
- **Removed** the 5-saved-insights cap entirely (the only other limit).
- **Removed dead code**: the unused `GET /chat/history` endpoint + its client function + models (no callers anywhere; the endpoint also queried with the service-role client and had **no auth guard**).
- **Dropped** the always-NULL, never-read `ai_chat_queries.user_id` column (migration `20260704162749_drop_ai_chat_queries_user_id.sql`) and regenerated `types/database.ts`.
- **Docs**: separate commit codifies the worktree dev setup in `CLAUDE.md` (jigged conda env for Python; `pnpm install` per worktree, not a `node_modules` symlink).

## Deliberately out of scope (issue #80 scoping)

No per-user rate limiting (there was none — the limit was always per-company), no "X queries left" warning, no admin usage dashboard.

## Verification

- `tsc --noEmit` clean · **14** frontend tests (featureFlags opt-out cases + InsightChart) · **50** backend unit tests (rate-limit/flag read, 429 + Retry-After, retry-after computation, plus chat-formatting/chart-config).
- **Live backend smoke** against a local Supabase stack (real HTTP → FastAPI → Postgres JSONB settings): 403-when-disabled, 429 with accurate "Maximum N" message + Retry-After, opt-out default-on, and the `ai_chat_queries` insert works post-column-drop. No Claude credits spent — every checked path precedes the AI call.

## Deploy note

The migration deploys on **merge to `main`** via Supabase Branching (no staging push). The PR's preview branch applies it and reports the required migration check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
