### PR TITLE
docs(claude): note the local Supabase stack tracks the primary checkout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,6 +488,23 @@ pnpm install                                       # node deps for THIS worktree
 conda run -n jigged python -m pytest tests/unit/   # backend tests, jigged env
 ```
 
+**The local Supabase stack follows the _primary_ checkout's branch, not your
+worktree.** `supabase start` / `supabase db reset` replay the migrations on the
+branch checked out in the **primary** working tree (the first entry in
+`git worktree list`) — a linked worktree's un-merged migrations are **not** on
+the local stack. So when working from a worktree:
+
+- **No migration changes in your branch?** The local stack is a valid substrate
+  — run `pnpm dev`, unit tests, and E2E against it from the worktree normally.
+  This is why a UI/logic-only change can be fully verified locally from a
+  worktree (the schema it needs already exists).
+- **Your branch adds or edits migrations?** Verify them on the PR's Supabase
+  **preview branch**, which applies the migration to its own isolated DB —
+  that's the gate. Do **not** try to reproduce them on the local stack from a
+  worktree: checking the branch out in the primary tree or `db reset`-ing to
+  pick them up just confuses what the local stack represents (and mutates the
+  primary's checkout). Keep migration verification on the preview branch.
+
 ### E2E gotchas
 
 - **`csv-import` spec skips in CI** via `test.skip(!!process.env.CI)`.


### PR DESCRIPTION
## What

Adds a note to the **"Running E2E (or `pnpm dev`) from a git worktree"** section of `CLAUDE.md` capturing a non-obvious operational fact:

> The local Supabase stack (`supabase start` / `db reset`) replays the migrations on the branch checked out in the **primary** working tree — a linked worktree's un-merged migrations are **not** on the local stack.

With the practical consequence spelled out:
- **No migration changes** → the local stack is a valid substrate to verify a UI/logic-only change from a worktree.
- **Migration changes** → verify on the PR's Supabase preview branch (its own isolated DB). Do **not** try to reproduce them on the local stack from a worktree (checking the branch out in the primary tree or `db reset`-ing) — that just confuses what the local stack represents and mutates the primary's checkout.

## Why

This bit us while verifying a worktree-based change: it's easy to assume `supabase start` reflects the worktree's branch. Codifying it in `CLAUDE.md` (checked in, loaded every session) means every agent/human hits the guidance exactly where it's relevant — in the worktree section.

Docs-only; no code or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)