### PR TITLE
Overdue-status fix, quote-PDF cleanup, operator internal-only stations

### DIFF
--- a/__tests__/types/job.test.ts
+++ b/__tests__/types/job.test.ts
@@ -3,6 +3,7 @@ import {
   getJobLifecycleStage,
   isJobClosed,
   isJobDone,
+  isJobOverdue,
   JOB_LIFECYCLE_STAGE_CONFIG,
   STAGE_TO_JOB_FILTERS,
   type JobLifecycleStage,
@@ -143,5 +144,57 @@ describe('STAGE_TO_JOB_FILTERS', () => {
       productionStatus: ['cancelled'],
       showClosed: true,
     });
+  });
+});
+
+describe('isJobOverdue', () => {
+  // `due_date` is a bare YYYY-MM-DD parsed at LOCAL midnight, so build the
+  // fixtures relative to the machine's today to stay deterministic anywhere.
+  function localDateOffset(days: number): string {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    d.setDate(d.getDate() + days);
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  }
+  const pastDue = localDateOffset(-2);
+  const futureDue = localDateOffset(2);
+
+  it('is overdue when past due and production is still active + unshipped', () => {
+    expect(
+      isJobOverdue({ due_date: pastDue, production_status: 'not_started', fulfillment_status: 'unshipped' }),
+    ).toBe(true);
+    expect(
+      isJobOverdue({ due_date: pastDue, production_status: 'in_progress', fulfillment_status: 'partially_shipped' }),
+    ).toBe(true);
+  });
+
+  it('is NOT overdue once production is completed, even if unshipped (the reported fix)', () => {
+    expect(
+      isJobOverdue({ due_date: pastDue, production_status: 'completed', fulfillment_status: 'unshipped' }),
+    ).toBe(false);
+  });
+
+  it('is NOT overdue once production is cancelled, even if unshipped', () => {
+    expect(
+      isJobOverdue({ due_date: pastDue, production_status: 'cancelled', fulfillment_status: 'unshipped' }),
+    ).toBe(false);
+  });
+
+  it('is NOT overdue once fully shipped, even while production is still active', () => {
+    expect(
+      isJobOverdue({ due_date: pastDue, production_status: 'in_progress', fulfillment_status: 'fully_shipped' }),
+    ).toBe(false);
+  });
+
+  it('is NOT overdue when the due date is in the future or absent', () => {
+    expect(
+      isJobOverdue({ due_date: futureDue, production_status: 'in_progress', fulfillment_status: 'unshipped' }),
+    ).toBe(false);
+    expect(
+      isJobOverdue({ due_date: null, production_status: 'in_progress', fulfillment_status: 'unshipped' }),
+    ).toBe(false);
   });
 });

--- a/__tests__/utils/jobsAccess.test.ts
+++ b/__tests__/utils/jobsAccess.test.ts
@@ -39,6 +39,7 @@ vi.mock('@/utils/jobAttachmentsAccess', () => ({
 }));
 
 import {
+  applyOverdueJobsFilter,
   deleteJob,
   bulkCancelJobs,
   createJobFromPurchaseOrder,
@@ -210,6 +211,25 @@ describe('jobsAccess', () => {
       mockQueryBuilder.data = null;
       const customers = await getCustomersForSelect('co-1');
       expect(customers).toEqual([]);
+    });
+  });
+
+  describe('applyOverdueJobsFilter', () => {
+    it('applies the canonical overdue clauses and returns the same builder', () => {
+      const builder: Record<string, ReturnType<typeof vi.fn>> = {};
+      ['not', 'lt', 'in'].forEach((m) => {
+        builder[m] = vi.fn().mockImplementation(() => builder);
+      });
+
+      const result = applyOverdueJobsFilter(builder);
+
+      expect(result).toBe(builder);
+      // Past due (local date), production active, not fully shipped — the single
+      // server-side definition shared by the list filter and dashboard count.
+      expect(builder.not).toHaveBeenNthCalledWith(1, 'due_date', 'is', null);
+      expect(builder.lt).toHaveBeenCalledWith('due_date', expect.any(String));
+      expect(builder.not).toHaveBeenNthCalledWith(2, 'fulfillment_status', 'eq', 'fully_shipped');
+      expect(builder.in).toHaveBeenCalledWith('production_status', ['not_started', 'in_progress']);
     });
   });
 

--- a/__tests__/utils/jobsAccess.test.ts
+++ b/__tests__/utils/jobsAccess.test.ts
@@ -44,7 +44,6 @@ import {
   createJobFromPurchaseOrder,
   getAllJobs,
   getCustomersForSelect,
-  getOverdueJobsCount,
   getReadyOperationsForJobs,
   reopenJob,
   searchJobsByIdentifier,
@@ -211,25 +210,6 @@ describe('jobsAccess', () => {
       mockQueryBuilder.data = null;
       const customers = await getCustomersForSelect('co-1');
       expect(customers).toEqual([]);
-    });
-  });
-
-  describe('getOverdueJobsCount', () => {
-    it('uses count: exact head:true with company + due_date + status filters', async () => {
-      mockQueryBuilder.count = 4;
-      const count = await getOverdueJobsCount('co-1');
-      expect(count).toBe(4);
-      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'co-1');
-      expect(mockQueryBuilder.not).toHaveBeenCalledWith('due_date', 'is', null);
-      expect(mockQueryBuilder.lt).toHaveBeenCalledWith('due_date', expect.any(String));
-      expect(mockQueryBuilder.not).toHaveBeenCalledWith('fulfillment_status', 'eq', 'fully_shipped');
-      expect(mockQueryBuilder.not).toHaveBeenCalledWith('production_status', 'eq', 'cancelled');
-    });
-
-    it('returns 0 when supabase returns null count', async () => {
-      mockQueryBuilder.count = null;
-      const count = await getOverdueJobsCount('co-1');
-      expect(count).toBe(0);
     });
   });
 

--- a/__tests__/utils/quotePdf.test.ts
+++ b/__tests__/utils/quotePdf.test.ts
@@ -426,7 +426,7 @@ describe('generateQuotePdf', () => {
     expect(rendered).toContain('Jane Smith');
   });
 
-  it('renders the ACCEPTANCE block with reply-with-a-PO copy and NO signature/date lines', async () => {
+  it('no longer renders an ACCEPTANCE block (acceptance is by returning a PO)', async () => {
     await generateQuotePdf(baseQuote, baseCompany);
 
     const docInstance = jsPDFCtor.mock.results[0].value;
@@ -434,18 +434,14 @@ describe('generateQuotePdf', () => {
       .map((c: unknown[]) => c[0])
       .filter((t: unknown): t is string => typeof t === 'string');
 
-    expect(rendered).toContain('ACCEPTANCE');
-    // Acceptance is now by returning a PO — the wet-signature ruled lines are gone.
-    expect(rendered).not.toContain('Signature');
-    expect(rendered).not.toContain('PO #');
-    expect(rendered).not.toContain('Date');
-    // The acceptance sentence is wrapped via splitTextToSize; assert its input.
+    expect(rendered).not.toContain('ACCEPTANCE');
+    // The old acceptance sentence (wrapped via splitTextToSize) is gone too.
     const splitInputs = docInstance.splitTextToSize.mock.calls.map((c: unknown[]) => c[0]);
     expect(
       splitInputs.some(
         (t: unknown) => typeof t === 'string' && t.includes('purchase order referencing quote'),
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('renders a "Prepared by" line (not a CREATED BY column) when the creator is known', async () => {
@@ -462,9 +458,11 @@ describe('generateQuotePdf', () => {
       .map((c: unknown[]) => c[0])
       .filter((t: unknown): t is string => typeof t === 'string');
 
-    // "Created by" is no longer a top column — it's a "Prepared by" footer line.
+    // "Created by" is no longer a top column — it's a "Prepared by" footer line
+    // that replaced the old "Generated <date> · <company>" footer text.
     expect(rendered).not.toContain('CREATED BY');
     expect(rendered).toContain('Prepared by Sam T · sam@example.com');
+    expect(rendered.some((t) => t.startsWith('Generated'))).toBe(false);
   });
 
   it('omits the "Prepared by" line when there is no creator on the quote', async () => {

--- a/types/job.ts
+++ b/types/job.ts
@@ -157,8 +157,13 @@ export function isJobOverdue(
   job: Pick<Job, 'due_date' | 'production_status' | 'fulfillment_status'>,
 ): boolean {
   if (!job.due_date) return false;
-  if (isJobDone(job)) return false;
-  if (job.production_status === 'cancelled') return false;
+  // Not overdue once production has ended (completed or cancelled) or the job
+  // is fully shipped — a delivered or closed-out job can't be late. Keyed off
+  // production_status directly (not isJobDone, which additionally requires full
+  // shipment) so a completed-but-unshipped job also clears. Mirrors the
+  // server-side overdue filters in jobsAccess/dashboardAccess.
+  if (job.production_status === 'completed' || job.production_status === 'cancelled') return false;
+  if (job.fulfillment_status === 'fully_shipped') return false;
   const [y, m, d] = job.due_date.split('-').map((n) => parseInt(n, 10));
   if (!y || !m || !d) return false;
   const dueLocal = new Date(y, m - 1, d);
@@ -170,8 +175,7 @@ export function isJobOverdue(
 /**
  * FR-18 "done" predicate. A job is done when production has ended
  * (completed or cancelled) AND every part is fully shipped. Used by the
- * jobs-list default filter (hide done), the dashboard active-jobs count,
- * and the overdue check above.
+ * jobs-list default filter (hide done) and the dashboard active-jobs count.
  */
 export function isJobDone(
   job: Pick<Job, 'production_status' | 'fulfillment_status'>,

--- a/utils/dashboardAccess.ts
+++ b/utils/dashboardAccess.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nextjs';
 // Typed Supabase client (typed-client rollout). Aliased so the 8 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { applyOverdueJobsFilter } from '@/utils/jobsAccess';
 
 // ============== Types ==============
 
@@ -339,15 +340,16 @@ async function getCompletedJobsInRange(
 
 async function getOverdueJobs(companyId: string): Promise<number> {
   const supabase = getSupabase();
-  const now = new Date().toISOString();
 
-  const { count, error } = await supabase
-    .from('jobs')
-    .select('*', { count: 'exact', head: true })
-    .eq('company_id', companyId)
-    .in('production_status', ['not_started', 'in_progress'])
-    .not('fulfillment_status', 'eq', 'fully_shipped')
-    .lt('due_date', now);
+  // Overdue predicate is defined once in applyOverdueJobsFilter (shared with the
+  // jobs-list filter), so this count agrees with the list and the row badges —
+  // including on the day boundary (local date, not a UTC timestamp).
+  const { count, error } = await applyOverdueJobsFilter(
+    supabase
+      .from('jobs')
+      .select('*', { count: 'exact', head: true })
+      .eq('company_id', companyId),
+  );
 
   if (error) throw error;
   return count || 0;

--- a/utils/jobsAccess.ts
+++ b/utils/jobsAccess.ts
@@ -65,6 +65,32 @@ function todayLocalISODate(): string {
   return `${y}-${m}-${day}`;
 }
 
+/**
+ * The single server-side definition of "overdue" for a jobs query: due date set
+ * and in the past (local date, via todayLocalISODate), production still active
+ * (not_started or in_progress), and not fully shipped. Shared by the jobs-list
+ * "overdue only" filter (getAllJobs) and the dashboard overdue-count metric so
+ * the two SQL queries can't drift — including agreeing on the day boundary
+ * (local date, not a UTC timestamp). The client-side mirror, applied per-row for
+ * the overdue icon/badge, is isJobOverdue() in types/job.ts.
+ *
+ * Typed structurally (method syntax) so it accepts both the untyped and typed
+ * Supabase filter builders and returns the same builder for further chaining.
+ */
+export function applyOverdueJobsFilter<
+  Q extends {
+    not(column: string, operator: string, value: unknown): Q;
+    lt(column: string, value: unknown): Q;
+    in(column: string, values: readonly unknown[]): Q;
+  },
+>(query: Q): Q {
+  return query
+    .not('due_date', 'is', null)
+    .lt('due_date', todayLocalISODate())
+    .not('fulfillment_status', 'eq', 'fully_shipped')
+    .in('production_status', ['not_started', 'in_progress']);
+}
+
 // ============== Read Queries ==============
 
 /**
@@ -134,17 +160,9 @@ export async function getAllJobs(
       query = query.or(`job_number.ilike.%${sanitized}%`);
     }
     if (filters.overdue) {
-      // Overdue: due_date in the past AND production still active
-      // (not_started/in_progress) AND not fully shipped. Completing or
-      // cancelling a job — or fully shipping it — clears overdue. This is the
-      // exact server-side equivalent of the client isJobOverdue predicate
-      // (local-date today via todayLocalISODate), so no client refinement is
-      // needed.
-      query = query
-        .not('due_date', 'is', null)
-        .lt('due_date', todayLocalISODate())
-        .not('fulfillment_status', 'eq', 'fully_shipped')
-        .in('production_status', ['not_started', 'in_progress']);
+      // Single source of truth for the overdue predicate — see
+      // applyOverdueJobsFilter (mirrors client isJobOverdue + dashboard count).
+      query = applyOverdueJobsFilter(query);
     }
 
     const { data, error } = await query;

--- a/utils/jobsAccess.ts
+++ b/utils/jobsAccess.ts
@@ -134,16 +134,17 @@ export async function getAllJobs(
       query = query.or(`job_number.ilike.%${sanitized}%`);
     }
     if (filters.overdue) {
-      // Overdue: due_date past AND not the FR-18 "done" state. Done is
-      // production IN (completed, cancelled) AND fulfillment = fully_shipped.
-      // Encode by excluding rows that satisfy both halves; we approximate
-      // server-side with the fulfillment half and let isJobOverdue refine
-      // client-side. Uses local-date today (see todayLocalISODate) so the
-      // server agrees with the client's isJobOverdue check.
+      // Overdue: due_date in the past AND production still active
+      // (not_started/in_progress) AND not fully shipped. Completing or
+      // cancelling a job — or fully shipping it — clears overdue. This is the
+      // exact server-side equivalent of the client isJobOverdue predicate
+      // (local-date today via todayLocalISODate), so no client refinement is
+      // needed.
       query = query
         .not('due_date', 'is', null)
         .lt('due_date', todayLocalISODate())
-        .not('fulfillment_status', 'eq', 'fully_shipped');
+        .not('fulfillment_status', 'eq', 'fully_shipped')
+        .in('production_status', ['not_started', 'in_progress']);
     }
 
     const { data, error } = await query;
@@ -1448,70 +1449,6 @@ export async function getCustomersForSelect(
   }
 
   return data || [];
-}
-
-// ============== Overdue ==============
-
-/**
- * Count jobs that are past their due date and not yet at the FR-18 done
- * state. Done = production_status IN (completed, cancelled) AND
- * fulfillment_status = fully_shipped. Server-side we approximate by
- * excluding the fulfillment half (fully_shipped) — cancelled jobs whose
- * fulfillment isn't fully_shipped are still "live" from the customer's
- * perspective and remain overdue if past due_date.
- */
-export async function getOverdueJobsCount(companyId: string): Promise<number> {
-  const supabase = getSupabase();
-
-  const { count, error } = await supabase
-    .from('jobs')
-    .select('*', { count: 'exact', head: true })
-    .eq('company_id', companyId)
-    .not('due_date', 'is', null)
-    .lt('due_date', todayLocalISODate())
-    .not('fulfillment_status', 'eq', 'fully_shipped')
-    .not('production_status', 'eq', 'cancelled');
-
-  if (error) {
-    console.error('Error fetching overdue jobs count:', error);
-    throw error;
-  }
-
-  return count || 0;
-}
-
-/**
- * Fetch overdue jobs for dashboard/list use. Same server-side
- * approximation as getOverdueJobsCount; callers that need the exact
- * FR-18 predicate refine client-side via isJobOverdue.
- */
-export async function getOverdueJobs(
-  companyId: string,
-  limit: number = 50,
-): Promise<JobWithRelations[]> {
-  const supabase = getSupabase();
-
-  const { data, error } = await supabase
-    .from('jobs')
-    .select(`
-      *,
-      customers!left(id, name),
-      job_parts(id, sequence, parts(id, part_name))
-    `)
-    .eq('company_id', companyId)
-    .not('due_date', 'is', null)
-    .lt('due_date', todayLocalISODate())
-    .not('fulfillment_status', 'eq', 'fully_shipped')
-    .not('production_status', 'eq', 'cancelled')
-    .order('due_date', { ascending: true })
-    .limit(limit);
-
-  if (error) {
-    console.error('Error fetching overdue jobs:', error);
-    throw error;
-  }
-
-  return (data || []) as unknown as JobWithRelations[];
 }
 
 // ============== Current Operation Batch Query ==============

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -677,6 +677,9 @@ export async function getStationOperationTypes(
     .from('work_centers')
     .select('id, name')
     .eq('company_id', companyId)
+    // Operators only run internal stations; external/vendor work centers are
+    // handled through the routing/job workflow, not picked at the station.
+    .eq('kind', 'internal')
     .order('name');
 
   if (error) throw new Error(error.message);

--- a/utils/quotePdf.ts
+++ b/utils/quotePdf.ts
@@ -393,48 +393,16 @@ export async function generateQuotePdf(
     cursorY += 20;
   }
 
-  // ---------- Acceptance block (compact) ----------
-  // Acceptance is by returning a purchase order — no wet signature/date lines.
-  const acceptanceHeight = 56;
-  const footerReserve = 50;
-
-  if (cursorY + acceptanceHeight > pageHeight - MARGIN - footerReserve) {
-    doc.addPage();
-    cursorY = MARGIN;
-  } else {
-    cursorY += 10;
-  }
-
-  doc.setFont('helvetica', 'bold');
-  doc.setFontSize(9);
-  doc.setTextColor(120);
-  doc.text('ACCEPTANCE', MARGIN, cursorY);
-  cursorY += 14;
-
-  doc.setFont('helvetica', 'normal');
-  doc.setFontSize(10);
-  doc.setTextColor(60);
-  const acceptCopy =
-    `To accept, reply to this quote with a purchase order referencing quote ${quote.quote_number ?? ''}.`.trim();
-  const wrappedCopy = doc.splitTextToSize(acceptCopy, pageWidth - MARGIN * 2);
-  doc.text(wrappedCopy, MARGIN, cursorY);
-  cursorY += wrappedCopy.length * 12 + 12;
-
-  // Prepared by — relocated from the old top "CREATED BY" column.
+  // ---------- Footer (every page) ----------
+  // The company name and quote dates already sit in the header, so the footer
+  // carries the preparer credit (relocated from the old top "CREATED BY"
+  // column) on the left and the page number on the right. The left side is
+  // blank when the quote has no known creator.
   const preparedName = quote.created_by_member?.name ?? null;
   const preparedEmail = quote.created_by_member?.email ?? null;
-  if (preparedName || preparedEmail) {
-    const preparedText = [preparedName, preparedEmail].filter(Boolean).join(' · ');
-    doc.setFont('helvetica', 'normal');
-    doc.setFontSize(9);
-    doc.setTextColor(120);
-    doc.text(`Prepared by ${preparedText}`, MARGIN, cursorY);
-    cursorY += 12;
-  }
+  const preparedText = [preparedName, preparedEmail].filter(Boolean).join(' · ');
+  const footerLeft = preparedText ? `Prepared by ${preparedText}` : '';
 
-  // ---------- Footer (every page) ----------
-  // "Prepared by" now lives in the acceptance block, so the footer is
-  // generated-on/page-of only.
   const pageCount = doc.getNumberOfPages();
   for (let p = 1; p <= pageCount; p++) {
     doc.setPage(p);
@@ -446,11 +414,9 @@ export async function generateQuotePdf(
     doc.setFont('helvetica', 'normal');
     doc.setFontSize(9);
     doc.setTextColor(130);
-    doc.text(
-      `Generated ${formatDate(new Date().toISOString())} · ${company.name}`,
-      MARGIN,
-      footerY,
-    );
+    if (footerLeft) {
+      doc.text(footerLeft, MARGIN, footerY);
+    }
     doc.text(`Page ${p} of ${pageCount}`, pageWidth - MARGIN, footerY, { align: 'right' });
   }
 


### PR DESCRIPTION
Three related correctness fixes reported together, plus one refactor that fell out of review.

## 1. Jobs no longer overdue once complete or cancelled
A completed-but-unshipped job kept showing as overdue: the rule required a job to be terminal **and** fully shipped before it stopped counting. The overdue rule lived in several places that disagreed; this unifies them on **past due (local date) AND `production_status ∈ {not_started, in_progress}` AND not `fully_shipped`**:
- `isJobOverdue` (client predicate for the row due-date icon + badge)
- the jobs-list "overdue only" filter (`getAllJobs`)
- the dashboard "Overdue Jobs" metric (already used this rule)
- Removed two orphaned helpers (`getOverdueJobs` / `getOverdueJobsCount` in `jobsAccess`) — no app callers; the dashboard rolls its own count.

## 2. Quote PDF: drop acceptance section, move "Prepared by" to footer
The company name and quote dates already sit in the PDF header, so the footer's "Generated … · Company" was redundant. Removed the ACCEPTANCE block; the footer now reads "Prepared by &lt;name&gt; · &lt;email&gt;" (blank when the quote has no known creator). PDF-only — the web quote page has no acceptance block and already renders "Prepared by" below the line items.

## 3. Operator station picker: internal work centers only
`getStationOperationTypes` fetched every work center, so external/vendor centers appeared as selectable operator stations. Filtered to `kind = 'internal'`, matching the `getWorkCentersByKind` pattern. Its only caller is the operator station context.

## 4. (Refactor) One shared SQL overdue filter
Extracted `applyOverdueJobsFilter(query)` so the jobs-list filter and the dashboard count share a single predicate. This also fixed a latent day-boundary disagreement: the list used a local date (`todayLocalISODate`) while the dashboard used a UTC timestamp (`new Date().toISOString()`), so a job due **today** could count as overdue on the dashboard but not in the list. `isJobOverdue` remains the client-side mirror for per-row rendering.

### Behavioral note
The unified rule keeps the "fully shipped ⇒ not overdue" clause, so a fully-shipped-but-still-in-progress job also stops showing overdue (matches prior server-side behavior; a delivered job isn't late).

### Testing
- `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- `pnpm test --run` on `jobsAccess`, `dashboardPinnedMetrics`, `types/job`, `quotePdf` — all green; added `isJobOverdue` and `applyOverdueJobsFilter` coverage, updated `quotePdf` assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
