### PR TITLE
fix(operator): show station jobs (RPC column) + declutter the station picker

### DIFF
--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -56,6 +56,20 @@ describe('getAllStationsOperatorJobs', () => {
     });
     expect(result).toEqual([]);
   });
+
+  it('throws (surfaces the error) when the readiness RPC fails, instead of returning []', async () => {
+    // Regression guard: a swallowed RPC error used to read as "no work" to
+    // operators (the jobs.status column bug). It must propagate so the jobs
+    // page can show it in an Alert rather than a bare "No jobs available".
+    mockSupabase.rpc.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'column j.status does not exist' },
+    });
+
+    await expect(
+      getAllStationsOperatorJobs('c1', [{ id: 'wc1', name: 'Lathe' }]),
+    ).rejects.toThrow(/column j\.status does not exist/);
+  });
 });
 
 describe('getJobNotes', () => {

--- a/api/tests/database/test_operator_ready_ops_rpc.py
+++ b/api/tests/database/test_operator_ready_ops_rpc.py
@@ -1,0 +1,56 @@
+"""
+Regression guard for the operator dispatch RPC ``get_ready_operations_for_station``.
+
+The RPC's ``eligible_jobs`` CTE once filtered ``jobs.status`` — a column that
+does not exist (the real column is ``production_status``). Postgres raises
+``column j.status does not exist`` when it plans the function, and the app-side
+caller (``utils/operatorAccess.ts::getReadyOperationsForStation``) swallowed
+that error into an empty list — so operators saw *no* jobs with no visible
+error, even though the same work showed in admin views. This is the "May 2026
+jobs.status regression" CLAUDE.md warns about: an untyped Supabase call plus a
+SQL function body, both of which bypass TypeScript checking.
+
+Because a missing-column reference is a **plan-time** failure, it fires for any
+arguments — even UUIDs that match no rows. So this guard needs no data setup: if
+the function references a nonexistent column again, ``.execute()`` raises instead
+of returning an empty set, and the test fails loudly. That property is exactly
+what makes the guard robust — it depends on the schema/function contract, not on
+seeded rows (which differ across the local stack, preview branches, and CI).
+
+The positive path (the fixed RPC returns ready operations for a station that has
+work) is verified against ``supabase/seed.sql`` — the Vanguard Precision Works
+seed yields 5 ready operations across its stations after ``supabase db reset``.
+
+Runs against the local Supabase stack via the service-role ``supabase_admin``
+fixture (see ``api/tests/conftest.py`` — it refuses to fall back to prod).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from supabase import Client
+
+pytestmark = pytest.mark.integration
+
+
+def test_get_ready_operations_for_station_plans_against_real_columns(
+    supabase_admin: Client,
+) -> None:
+    """Calling the RPC must not raise a plan-time missing-column error.
+
+    Arbitrary UUIDs match no company/work-center, so the correct answer is zero
+    rows. The guarantee under test is that the call *returns* (cleanly) rather
+    than raising the ``column ... does not exist`` error the old ``j.status``
+    filter caused. An empty list confirms the function planned and executed
+    against columns that actually exist.
+    """
+    resp = supabase_admin.rpc(
+        "get_ready_operations_for_station",
+        {
+            "p_company_id": str(uuid.uuid4()),
+            "p_work_center_id": str(uuid.uuid4()),
+        },
+    ).execute()
+
+    assert resp.data == []

--- a/app/operator/[companyId]/jobs/page.tsx
+++ b/app/operator/[companyId]/jobs/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -13,8 +13,6 @@ import LinearProgress from '@mui/material/LinearProgress';
 import Alert from '@mui/material/Alert';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import RefreshIcon from '@mui/icons-material/Refresh';
-import IconButton from '@mui/material/IconButton';
 import { getOperatorJobs, getAllStationsOperatorJobs } from '@/utils/operatorAccess';
 import { useStationContext } from '@/components/operator/OperatorStationContext';
 import StationSelector from '@/components/operator/StationSelector';
@@ -43,27 +41,6 @@ export default function OperatorJobsPage() {
   const [plantJobs, setPlantJobs] = useState<OperatorPlantJob[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
-  const loadJobs = useCallback(async () => {
-    if (lens === 'station' && !stationId) {
-      setJobs([]);
-      setLoading(false);
-      return;
-    }
-    setLoading(true);
-    setError(null);
-    try {
-      if (lens === 'plant') {
-        setPlantJobs(await getAllStationsOperatorJobs(companyId, stations));
-      } else {
-        setJobs(await getOperatorJobs(companyId, stationId as string));
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load jobs');
-    } finally {
-      setLoading(false);
-    }
-  }, [companyId, stationId, lens, stations]);
 
   useEffect(() => {
     // Re-run on lens / station / stations change. Cancellation guards against a
@@ -194,32 +171,24 @@ export default function OperatorJobsPage() {
 
   return (
     <Box>
-      {/* Header: lens toggle + refresh */}
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          mb: 2,
-          gap: 1,
-        }}
-      >
-        <ToggleButtonGroup
-          size="small"
-          exclusive
-          value={lens}
-          onChange={(_e, value) => {
-            if (value) setLens(value as Lens);
-          }}
-          aria-label="Job list scope"
-        >
-          <ToggleButton value="station">My Station</ToggleButton>
-          <ToggleButton value="plant">All Stations</ToggleButton>
-        </ToggleButtonGroup>
-        <IconButton onClick={loadJobs} disabled={loading} aria-label="Refresh">
-          <RefreshIcon />
-        </IconButton>
-      </Box>
+      {/* Lens toggle (My Station / All Stations) — hidden on the station picker,
+          where there's no selected station to scope by yet. */}
+      {!showStationSelector && (
+        <Box sx={{ mb: 2 }}>
+          <ToggleButtonGroup
+            size="small"
+            exclusive
+            value={lens}
+            onChange={(_e, value) => {
+              if (value) setLens(value as Lens);
+            }}
+            aria-label="Job list scope"
+          >
+            <ToggleButton value="station">My Station</ToggleButton>
+            <ToggleButton value="plant">All Stations</ToggleButton>
+          </ToggleButtonGroup>
+        </Box>
+      )}
 
       {error && (
         <Alert severity="error" sx={{ mb: 2 }}>

--- a/docs/operator-paperless-flow.md
+++ b/docs/operator-paperless-flow.md
@@ -103,8 +103,9 @@ scrap/defect discovery framing, and the stale-doc fix list.
   work is warned, not blocked.
 - A row links to `…/jobs/{job_id}/parts/{job_part_id}` and deep-links straight to the ready
   `…/operations/{operation_id}` when known (`jobs/page.tsx:87`).
-- **Returns an empty list when no station is selected** (`getOperatorJobs` short-circuits) —
-  i.e. there is **no "all stations / whole plant" mode** today.
+- **The My Station lens returns an empty list when no station is selected** (`getOperatorJobs`
+  short-circuits). The whole-plant **"All Stations"** lens (shipped — see §7) is the mode that
+  covers "no single station," e.g. a roaming operator or lead.
 
 ### Action & capture
 - Operation action page: **Mark Complete** + **Undo**, append-only **notes + photo/video**
@@ -195,9 +196,11 @@ An operation is **pending → completed** (single tap; `completed_by`/`completed
 meaningfully or is vestigial under complete-only; if vestigial, simplify to pending/completed.
 
 ### 5.3 Freshness: manual refresh
-**Decided:** manual refresh (the dispatch list already has a refresh control); **no
-WebSockets / live push** for now. It's simpler and probably sufficient. Revisit only if we
-validate a concrete need (e.g. two operators colliding on the same step often enough to matter).
+**Decided:** manual refresh via **browser reload / pull-to-refresh**; **no WebSockets / live
+push** for now. (The in-app refresh button on the dispatch list was removed to declutter the
+operator UI — reloading the page is equivalent and one less control to explain.) It's simpler and
+probably sufficient. Revisit only if we validate a concrete need (e.g. two operators colliding on
+the same step often enough to matter).
 
 ### 5.4 Scrap / defect / quality flagging — **discovery needed**
 Nothing exists today, and we haven't designed it. This needs real discovery before building.
@@ -253,32 +256,30 @@ placard flow onto the floor and make the queue path *win* over paper.
 
 ---
 
-## 7. Whole-plant view (proposed)
+## 7. Whole-plant view ("All Stations") — shipped
 
 **Why:** the one clear missing capability and your explicit "sign into the plant" ask. Serves the
 roaming operator (station idle → find work elsewhere), the working lead (floor-wide status), and
 the "where is job #123?" lookup — without walking the floor (the Andon/visibility pattern).
 
-**Proposed shape:**
-- A lens toggle on the operator jobs page: **My Station** (default) ↔ **All stations**.
-- "All stations" lists every ready/in-progress (job, part, operation) across the company,
-  **grouped by station**, sorted by due date (urgent first). Reuse the dispatch row UI.
-- Implementation seam: a variant of `get_ready_operations_for_station` that omits the
-  `work_center_id` filter (or a sibling RPC) returning all ready operations company-wide; the
-  jobs page already short-circuits to empty without a station, so this is an additive mode.
+**Shipped shape:**
+- A lens toggle on the operator jobs page: **My Station** (default) ↔ **All Stations**
+  (`app/operator/[companyId]/jobs/page.tsx`). The toggle is **hidden on the station-picker
+  screen** — it only appears once a station is selected and there's a list to scope.
+- "All Stations" lists every ready/in-progress (job, part, operation) across the company,
+  **grouped by station**, reusing the dispatch row card.
+- Implementation: rather than a filter-less variant RPC, `getAllStationsOperatorJobs`
+  (`utils/operatorAccess.ts`) fans out the **same** per-station `get_ready_operations_for_station`
+  RPC once per station in parallel and tags each row with its station — one source of truth for
+  "ready," no duplicated readiness logic.
 
-**Open questions (answer from the journey before building):**
-- Is it **read-only visibility**, or can an operator **act** (Mark Complete) directly from it?
-  (Acting from it weakens the station-guard intent — `prd.md` §4.3 — so maybe tapping a row at a
-  *different* station still routes through the station-switch guard.)
-- Default lens: always My Station, or remember the operator's last choice?
-- Does it **complement** station mode (recommended) or could it **replace** per-station entirely?
-- Owner/office already have job lists in `/dashboard` — is the operator whole-plant view distinct
-  from (lighter than) the office jobs list, or should it reuse it?
-
-**Recommendation:** complement, don't replace. Default to My Station; offer All-stations as a
-toggle aimed at "find work / floor visibility," routing any *action* through the existing
-station-switch guard.
+**How the open questions resolved:**
+- **Read-only or act?** Operators can act. Tapping a row at a *different* station routes through
+  the operation page's station-switch guard (`prd.md` §4.3), so the station-guard intent holds.
+- **Default lens:** always My Station.
+- **Complement or replace?** Complements — both lenses coexist; per-station stays the default.
+- **Distinct from the office list?** Yes — it's the lighter operator dispatch card, not the
+  `/dashboard` office jobs table.
 
 ---
 

--- a/supabase/migrations/20260707001934_fix_operator_ready_ops_production_status.sql
+++ b/supabase/migrations/20260707001934_fix_operator_ready_ops_production_status.sql
@@ -1,0 +1,63 @@
+-- Fix: the operator dispatch RPC filtered on a nonexistent column.
+--
+-- get_ready_operations_for_station's eligible_jobs CTE filtered
+--   jobs.status IN ('not_started', 'in_progress')
+-- but the jobs table has no `status` column — the real column is
+-- `production_status` (CHECK: not_started/in_progress/completed/cancelled).
+-- Referencing the missing column made the function raise
+-- `column j.status does not exist`; the app-side caller
+-- (utils/operatorAccess.ts::getReadyOperationsForStation) swallowed that error
+-- and returned [], so operators saw an empty job list with no visible error.
+-- Both operator lenses ("My Station" and "All Stations") call this RPC, so this
+-- one-line correction repairs both.
+--
+-- Signature is unchanged from the current definition (part_quantity is already
+-- numeric, widened in 20260623143220), so a plain CREATE OR REPLACE suffices —
+-- no DROP needed. Body is byte-identical to today's except the filter column.
+
+CREATE OR REPLACE FUNCTION public.get_ready_operations_for_station(p_company_id uuid, p_work_center_id uuid)
+ RETURNS TABLE(job_id uuid, job_part_id uuid, job_operation_id uuid, operation_name text, op_status text, job_number text, part_id uuid, part_name text, part_description text, part_quantity numeric)
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+BEGIN
+    RETURN QUERY
+    WITH eligible_jobs AS (
+        SELECT j.id, j.job_number FROM jobs j
+        WHERE j.company_id = p_company_id
+          AND j.production_status IN ('not_started', 'in_progress')  -- was j.status (nonexistent column)
+    ),
+    station_ops AS (
+        SELECT jo.id, jo.job_id, jo.job_part_id, jo.operation_name, jo.status, jo.sequence, ej.job_number
+        FROM job_operations jo
+        JOIN eligible_jobs ej ON ej.id = jo.job_id
+        WHERE jo.work_center_id = p_work_center_id
+          AND jo.status IN ('pending', 'in_progress')
+    ),
+    ready_or_active AS (
+        SELECT so.id, so.job_id, so.job_part_id, so.operation_name, so.status, so.job_number
+        FROM station_ops so
+        WHERE so.status = 'in_progress'
+           OR NOT EXISTS (
+               SELECT 1 FROM job_operations prev
+               WHERE prev.job_part_id = so.job_part_id
+                 AND prev.sequence < so.sequence
+                 AND prev.status <> 'completed'
+           )
+    )
+    SELECT
+        ra.job_id,
+        ra.job_part_id,
+        ra.id AS job_operation_id,
+        ra.operation_name,
+        ra.status AS op_status,
+        ra.job_number,
+        jp.part_id,
+        p.part_name,
+        p.description AS part_description,
+        jp.quantity AS part_quantity
+    FROM ready_or_active ra
+    JOIN job_parts jp ON jp.id = ra.job_part_id
+    JOIN parts p ON p.id = jp.part_id;
+END;
+$function$;

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -201,8 +201,12 @@ async function getReadyOperationsForStation(
   });
 
   if (error) {
-    console.error('Error fetching ready operations for station:', error);
-    return [];
+    // Surface the failure instead of swallowing it into an empty list — a
+    // swallowed RPC error is exactly how the jobs.status column bug read as
+    // "no jobs" to operators rather than a visible error. Both callers
+    // (getOperatorJobs / getAllStationsOperatorJobs) run inside the jobs page's
+    // try/catch, which shows this message in an Alert.
+    throw new Error(`Failed to load ready operations for station: ${error.message}`);
   }
 
   return (data || []) as ReadyRow[];


### PR DESCRIPTION
## Why

Two problems blocked the paperless-operator journey:

1. **No jobs ever showed in the operator view.** Both operator lenses ("My Station" and "All Stations") get their data from one RPC, `get_ready_operations_for_station`. Its first CTE filtered `j.status IN ('not_started','in_progress')`, but the `jobs` table has **no `status` column** — the real column is `production_status`. Postgres raised `column j.status does not exist` at plan time, and `getReadyOperationsForStation` **swallowed the error into an empty list** — so operators saw nothing, with no visible error, even though admin views showed the same work. This is the "May 2026 `jobs.status` regression" `CLAUDE.md` warns about (an RPC's SQL body bypasses the typed client).

2. **The station-picker screen was cluttered** with a "My Station / All Stations" toggle and a refresh button that make no sense before a station is chosen.

## What changed

- **Migration** [`20260707001934_fix_operator_ready_ops_production_status`](supabase/migrations/20260707001934_fix_operator_ready_ops_production_status.sql) — `j.status` → `j.production_status` in the readiness RPC (signature unchanged → plain `CREATE OR REPLACE`). Fixes both operator lenses.
- **`utils/operatorAccess.ts`** — `getReadyOperationsForStation` now **throws** instead of returning `[]` on RPC error, so a failure surfaces in the jobs-page `Alert` rather than looking like "no jobs." (This swallow is *why* the bug shipped silently.)
- **`app/operator/[companyId]/jobs/page.tsx`** — removed the refresh button everywhere (page reload is equivalent; this also deletes `loadJobs`, which was a duplicate of the `useEffect` loader), and hid the lens toggle until a station is selected.
- **`docs/operator-paperless-flow.md`** — the All Stations lens is **shipped**, not "proposed"; freshness is now page-reload, not an in-app refresh control.

## Tests

- `api/tests/database/test_operator_ready_ops_rpc.py` — DB-contract guard: the RPC must plan against real columns (calling it with any UUIDs returns cleanly instead of raising the plan-time missing-column error). Passes on the local stack.
- `__tests__/utils/operatorAccess.test.ts` — new unit test asserting the readiness error propagates instead of being swallowed.

## Verification

- `supabase db reset` replays the migration in sequence cleanly.
- Against seed, the fixed RPC returns **5 ready ops** (Final Inspection ×3, Assembly Bench ×2), e.g. J-0006 / J-0007 — vs. the old form which reproduces `ERROR: column j.status does not exist`.
- `tsc --noEmit` clean; operatorAccess vitest 8/8; RPC contract test 1/1.

To eyeball: sign in as `operator1@jigged.test` / `jigged-dev-1234` (Vanguard Precision Works), pick a station (e.g. Assembly Bench), and the work now lists. The migration is validated on this PR's Supabase preview branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)