### PR TITLE
fix(theme): richer, WCAG-safe app canvas — lit backdrop + deep glass cards

### DIFF
--- a/app/dashboard/[companyId]/layout.tsx
+++ b/app/dashboard/[companyId]/layout.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { useParams } from 'next/navigation';
 import Box from '@mui/material/Box';
 import { Sidebar, Header } from '@/components/layout';
+import AppAmbientBackdrop from '@/components/layout/AppAmbientBackdrop';
 import { PageTitleProvider } from '@/components/layout/PageTitleProvider';
 import { AuthGuard } from '@/components/auth';
 import DemoModeProvider from '@/components/providers/DemoModeProvider';
@@ -31,13 +32,17 @@ export default function DashboardLayout({
     <AuthGuard companyId={companyId} requireCompany>
       <DemoModeProvider>
         <PageTitleProvider>
-        <Box sx={{ display: 'flex', minHeight: '100vh' }}>
-          <Sidebar isMobile={isMobile} open={drawerOpen} onClose={closeDrawer} onFeedbackClick={feedback.openDialog} />
-          <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', ml: { xs: 0, md: '240px' }, minWidth: 0 }}>
-            <Header isMobile={isMobile} onMenuClick={openDrawer} />
-            <DemoModeBanner />
-            <Box component="main" sx={{ flex: 1, p: { xs: 2, md: 3 }, overflow: 'auto' }}>
-              {children}
+        <Box sx={{ position: 'relative', minHeight: '100vh' }}>
+          {/* Ambient shop-floor backdrop — sits behind the workspace, above the theme base */}
+          <AppAmbientBackdrop />
+          <Box sx={{ position: 'relative', zIndex: 1, display: 'flex', minHeight: '100vh' }}>
+            <Sidebar isMobile={isMobile} open={drawerOpen} onClose={closeDrawer} onFeedbackClick={feedback.openDialog} />
+            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', ml: { xs: 0, md: '240px' }, minWidth: 0 }}>
+              <Header isMobile={isMobile} onMenuClick={openDrawer} />
+              <DemoModeBanner />
+              <Box component="main" sx={{ flex: 1, p: { xs: 2, md: 3 }, overflow: 'auto' }}>
+                {children}
+              </Box>
             </Box>
           </Box>
         </Box>

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -21,6 +21,7 @@ import WarehouseOutlinedIcon from '@mui/icons-material/WarehouseOutlined';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import { getSupabase } from '@/lib/supabase';
+import AppAmbientBackdrop from '@/components/layout/AppAmbientBackdrop';
 import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 import { OperatorStationProvider, useStationContext } from '@/components/operator/OperatorStationContext';
 import JiggedIcon from '@/components/branding/JiggedIcon';
@@ -226,6 +227,11 @@ function OperatorShell({
         bgcolor: 'background.default',
       }}
     >
+      {/* Same lit gradient canvas as the dashboard shell, for a consistent app look.
+          The fixed AppBar/BottomNav (high z-index) and the main content (z-index 1 below)
+          sit above it. */}
+      <AppAmbientBackdrop />
+
       {/* Top App Bar */}
       <AppBar
         position="fixed"
@@ -332,6 +338,8 @@ function OperatorShell({
       <Box
         component="main"
         sx={{
+          position: 'relative',
+          zIndex: 1, // above the fixed ambient backdrop
           flex: 1,
           mt: '48px', // Single-row AppBar height
           mb: navVisible ? '56px' : 0, // BottomNavigation height

--- a/components/layout/AppAmbientBackdrop.tsx
+++ b/components/layout/AppAmbientBackdrop.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Box from '@mui/material/Box';
+
+/**
+ * The app workspace canvas.
+ *
+ * The dashboard went flat when we darkened the global background to fix a contrast bug
+ * (white text on the old steel `#4682B4` = 4.11:1). But that bug was specifically text
+ * sitting DIRECTLY on the steel — now that cards are opaque, the canvas itself can be a
+ * rich, lit steel-indigo again, as long as its lightest point stays under the failure
+ * threshold. The base stops stay dark enough that grey secondary labels on the bare
+ * canvas keep ~5.9:1; the extra brightness is concentrated in the top-right steel bloom,
+ * which tops out ~`#426289` (white ≈ 6.4:1) — and that corner carries white text/icons
+ * only, so text clears WCAG AA everywhere it actually lands.
+ *
+ * Deliberately 2D — a top-lit gradient plus soft brand auroras (steel off the top-right,
+ * teal off the bottom-left), no literal 3D scene: concrete objects behind live data read
+ * as distracting the same way a video would. Auroras fade to zero-alpha (never
+ * `transparent`, which bands a lighter grey mid-fade).
+ *
+ * Painted opaque and `position: fixed` so it becomes the app's own canvas over the dark
+ * global theme base — the marketing pages keep that dark base. `aria-hidden` +
+ * `pointer-events: none`: purely decorative, never intercepts input.
+ */
+export default function AppAmbientBackdrop() {
+  return (
+    <Box
+      aria-hidden
+      sx={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 0,
+        pointerEvents: 'none',
+        background: `
+          radial-gradient(78% 58% at 88% -6%, rgba(88, 148, 198, 0.32), rgba(88, 148, 198, 0) 66%),
+          radial-gradient(55% 52% at 0% 100%, rgba(43, 188, 179, 0.12), rgba(43, 188, 179, 0) 70%),
+          linear-gradient(158deg, #344668 0%, #232d58 46%, #181f45 100%)
+        `,
+      }}
+    />
+  );
+}

--- a/components/providers/ThemeProvider.tsx
+++ b/components/providers/ThemeProvider.tsx
@@ -16,7 +16,27 @@ export default function ThemeProvider({ children }: ThemeProviderProps) {
       <Box
         sx={{
           minHeight: '100vh',
-          background: 'linear-gradient(135deg, #111439 0%, #4682B4 50%, #111439 100%)',
+          // Dark, near-neutral indigo canvas. The old middle stop was a saturated steel
+          // blue (#4682B4, L≈0.21) that dropped white body text to 4.11:1 app-wide; the
+          // deep-indigo base restores 15:1+. This Box is the calm SUBSTRATE — a solid
+          // readable base plus one top-anchored steel glow whose center is pushed
+          // off-screen above the fold (only its soft falloff shows behind the header) and
+          // fades to ZERO-ALPHA steel — never `transparent`, which interpolates a lighter
+          // grey band mid-fade, the exact class of bug we just fixed.
+          //
+          // The richer ambient treatment lives per-shell on top of this: the app
+          // workspace layers a lit steel-indigo gradient + brand aurora
+          // (components/layout/AppAmbientBackdrop) so a working screen gets some of the
+          // marketing page's shop-floor character. Deliberately 2D — no literal 3D scene
+          // or looping video behind live data (both read as distracting); the marketing
+          // page keeps its own hero video. Opaque cards (lib/theme.ts MuiCard) are the
+          // readability firewall, so every ambient layer stays legible.
+          backgroundColor: '#111439',
+          backgroundImage: `
+            radial-gradient(120% 62% at 50% -12%, rgba(70, 130, 180, 0.18) 0%, rgba(70, 130, 180, 0) 60%),
+            linear-gradient(135deg, #111439 0%, #1a1f4a 50%, #111439 100%)
+          `,
+          backgroundSize: '100% 100%, 100% 100%',
           backgroundAttachment: 'fixed',
         }}
       >

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -50,7 +50,13 @@ const jiggedTheme = createTheme({
     },
     background: {
       default: '#111439',   // Deep Indigo (per design system spec)
-      paper: 'rgba(26, 31, 74, 0.55)',  // Semi-transparent for substantial cards
+      // Cards are DEEP indigo glass panels, not lighter ones. On the lit steel-indigo
+      // canvas (AppAmbientBackdrop) a pale surface goes washed-out/muddy; a deeper,
+      // slightly translucent panel reads as substantial (frosted blur lets the lit canvas
+      // glow through faintly) and is sealed by a crisp light hairline (below). Deeper =
+      // safer too: white text on this sits ~13:1. This is the glass-on-lit-canvas model,
+      // matching the richer look the shop pages had.
+      paper: 'rgba(32, 38, 82, 0.78)',
     },
     text: {
       primary: '#ffffff',
@@ -136,10 +142,16 @@ const jiggedTheme = createTheme({
       },
       styleOverrides: {
         root: {
-          backgroundColor: 'rgba(26, 31, 74, 0.55)',  // Semi-transparent for substantial cards
+          // A DEEP indigo glass panel over the lit canvas — a lighter fill here just looks
+          // washed-out. Slightly translucent so the frosted blur carries a hint of the lit
+          // canvas; the crisp hairline (below) does the edge definition, not a lightness
+          // step. Deep + mostly opaque = the text's contrast floor (~13:1).
+          backgroundColor: 'rgba(32, 38, 82, 0.78)',
           backdropFilter: 'blur(15px)',               // Frosted glass effect
           WebkitBackdropFilter: 'blur(15px)',         // Safari support
-          border: '1px solid rgba(255, 255, 255, 0.15)',
+          // Brighter hairline: on the dark canvas a 0.18 border nearly vanished; 0.28 white
+          // gives cards a crisp defined edge that seals the panel against the lit canvas.
+          border: '1px solid rgba(255, 255, 255, 0.28)',
           // boxShadow handled by elevation prop
           transition: 'transform 0.2s ease, box-shadow 0.2s ease',
           '&:hover': {


### PR DESCRIPTION
## What & why

The May contrast fix darkened the global background to solve white-on-steel text
(`#4682B4` = 4.11:1, a WCAG AA fail), but the flat dark wash left the dashboard and
operator views looking dull. This restores depth and the "alive" shop-floor character
the table pages used to have — **without reintroducing the contrast bug**.

The key insight: now that cards are opaque, they act as a **readability firewall**. Text
never sits directly on the canvas, so the canvas itself can be a rich, lit steel-indigo
again — as long as its lightest point stays under the contrast-failure threshold.

## Changes (5 files, app-wide)

- **`ThemeProvider`** — deep-indigo substrate with one top-anchored steel glow that fades
  to zero-alpha (never `transparent`, which bands a grey mid-fade — the exact class of bug
  we just fixed). White body text on the bare canvas is back to **15:1+**.
- **`AppAmbientBackdrop`** (new) — a **2D** lit steel-indigo gradient + soft brand auroras
  (steel top-right, teal bottom-left) painted behind the dashboard and operator shells.
  Deliberately 2D: no literal 3D scene or looping video behind live data (both read as
  distracting). Lightest point (~`#426289`, white ≈ **6.4:1**) carries white text/icons
  only, so AA holds everywhere text actually lands. `aria-hidden` + `pointer-events: none`.
- **Cards → deep glass** (`rgba(32,38,82,0.78)`) sealed by a crisp `0.28` white hairline.
  Deep + mostly opaque, not lighter — a pale panel goes washed-out on the lit canvas. White
  text on a card sits **~13:1**.
- **Dashboard + operator layouts** render the same backdrop for one consistent app look.

## Scope / not in scope

- **App-wide** (every dashboard + operator screen). Marketing pages keep the dark theme
  base — they have their own hero video and stay dark by design.
- The marketing landing-page rebuild (issue #489) **stacks on top of this** as a follow-up PR.

## Verification

- `tsc --noEmit` clean.
- WCAG AA re-checked at the canvas's brightest point and on cards (numbers above).
- Walked dashboard (tables, cards) + operator (queue, job step) at desktop and phone widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
