### PR TITLE
fix(theme): soften card hairline 0.28 → 0.20

### DIFF
--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -149,9 +149,13 @@ const jiggedTheme = createTheme({
           backgroundColor: 'rgba(32, 38, 82, 0.78)',
           backdropFilter: 'blur(15px)',               // Frosted glass effect
           WebkitBackdropFilter: 'blur(15px)',         // Safari support
-          // Brighter hairline: on the dark canvas a 0.18 border nearly vanished; 0.28 white
-          // gives cards a crisp defined edge that seals the panel against the lit canvas.
-          border: '1px solid rgba(255, 255, 255, 0.28)',
+          // Hairline that seals the panel against the lit canvas. 0.18 nearly vanished on the
+          // dark canvas, but 0.28 — crisp on a small card — read as a bright frame stretched
+          // around large full-width tables (Jobs/Parts/Quotes wrap an AG Grid in a Card, and
+          // that Card edge IS the table's outer border). 0.20 is the middle: still a defined
+          // edge on cards, calm around big tables. Internal grid row lines keep their own
+          // fainter 0.12 (lib/agGridTheme.ts).
+          border: '1px solid rgba(255, 255, 255, 0.20)',
           // boxShadow handled by elevation prop
           transition: 'transform 0.2s ease, box-shadow 0.2s ease',
           '&:hover': {


### PR DESCRIPTION
## What

Softens the MUI `Card` hairline from `rgba(255,255,255,0.28)` → `0.20`.

## Why

`0.28` (from the readability/depth PR) looks crisp and right on the **small dashboard glass cards**. But every list page — Jobs, Parts, Quotes, Customers, Inventory — wraps an **AG Grid in a `<Card>`** and strips the grid's own outer border (`.ag-root-wrapper { border: none }`), so that Card hairline **is** the table's outer frame. Stretched around a full-width table, `0.28` read as a bright rectangle — the one line that pops on the page.

`0.20` calms that frame while keeping a defined edge on cards (which also lean on elevation shadow + the deep fill). Judged by eye on the Jobs page:

| alpha | read |
|---|---|
| `0.28` (was) | crisp on cards, **bright frame** on big tables |
| **`0.20` (this PR)** | still a defined edge, **calm** table frame |
| `0.16` | top edge starts to dissolve — table feels unbounded |

The internal AG Grid row lines (`0.12`, `lib/agGridTheme.ts`) are untouched — they were already appropriately faint.

## Scope

One line in `lib/theme.ts`. App-wide (all `Card`s). No behavior change.

Follow-up to the app-canvas/readability work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
