### PR TITLE
fix(operator): simplify the station-mismatch guard (warn + plain complete, no switch)

### DIFF
--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -307,8 +307,7 @@ export default function OperatorOperationActionPage() {
               <WarningAmberIcon fontSize="small" sx={{ mt: 0.25, flexShrink: 0 }} />
               <Typography variant="body2" color="inherit">
                 You&apos;re at <strong>{stationName || 'another station'}</strong>, but this step runs
-                at <strong>{job.operation_work_center_name || 'another station'}</strong> — complete
-                only if it&apos;s yours.
+                at <strong>{job.operation_work_center_name || 'another station'}</strong>.
               </Typography>
             </Box>
           )}

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -14,6 +14,7 @@ import LinearProgress from '@mui/material/LinearProgress';
 import Alert from '@mui/material/Alert';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import UndoIcon from '@mui/icons-material/Undo';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import {
   getOperatorOperationDetail,
   getCurrentOperator,
@@ -304,23 +305,20 @@ export default function OperatorOperationActionPage() {
           </Box>
         </Button>
       ) : stationMismatch ? (
-        // This step's work center isn't the operator's selected station. With
+        // This step's work center isn't the operator's selected station — with
         // login + station-select (not blind QR scans), that usually just means
-        // they opened another station's job — so state it plainly and offer a
-        // one-tap switch-and-complete for legit cross-station work. Backing out
-        // is the header's back arrow, so there's no separate button here.
+        // they opened another station's job. Warn (in warning colour) and state
+        // the consequence — completing switches their station — but keep the
+        // action a normal MARK COMPLETE. Backing out is the header's back arrow.
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-          <Typography variant="body2" color="text.secondary" sx={{ px: 0.5 }}>
-            This step runs at{' '}
-            <Box component="strong" sx={{ color: 'text.primary' }}>
-              {job.operation_work_center_name || 'another station'}
-            </Box>{' '}
-            — not your station (
-            <Box component="strong" sx={{ color: 'text.primary' }}>
-              {stationName || '—'}
-            </Box>
-            ).
-          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, px: 0.5, color: 'warning.main' }}>
+            <WarningAmberIcon fontSize="small" sx={{ mt: 0.25, flexShrink: 0 }} />
+            <Typography variant="body2" color="inherit">
+              You&apos;re at <strong>{stationName || 'another station'}</strong>, but this step runs
+              at <strong>{job.operation_work_center_name || 'another station'}</strong> — completing
+              it switches your station there.
+            </Typography>
+          </Box>
           <Button
             fullWidth
             variant="contained"
@@ -329,13 +327,9 @@ export default function OperatorOperationActionPage() {
             startIcon={<CheckCircleIcon />}
             onClick={handleSwitchAndComplete}
             disabled={actionLoading}
-            sx={{ minHeight: 64, fontSize: '1.15rem', fontWeight: 600 }}
+            sx={{ minHeight: 64, fontSize: '1.25rem', fontWeight: 600 }}
           >
-            {actionLoading ? (
-              <CircularProgress size={24} />
-            ) : (
-              `Switch to ${job.operation_work_center_name || 'this station'} & complete`
-            )}
+            {actionLoading ? <CircularProgress size={24} /> : 'MARK COMPLETE'}
           </Button>
         </Box>
       ) : (

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -53,7 +53,7 @@ export default function OperatorOperationActionPage() {
 
   const travelerHref = `/operator/${companyId}/jobs/${jobId}/parts/${jobPartId}`;
 
-  const { stationId, stationName, setStation, initializing } = useStationContext();
+  const { stationId, stationName, initializing } = useStationContext();
 
   const [currentOperatorId, setCurrentOperatorId] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState(false);
@@ -116,15 +116,6 @@ export default function OperatorOperationActionPage() {
     } finally {
       setActionLoading(false);
     }
-  };
-
-  // The operator confirms they are at this step's station, then completes in the
-  // same tap. setStation persists the choice so later scans match too.
-  const handleSwitchAndComplete = async () => {
-    if (job?.operation_work_center_id) {
-      setStation(job.operation_work_center_id);
-    }
-    await handleComplete();
   };
 
   const isCompleted = job?.operation_status === 'completed';
@@ -304,47 +295,36 @@ export default function OperatorOperationActionPage() {
             )}
           </Box>
         </Button>
-      ) : stationMismatch ? (
-        // This step's work center isn't the operator's selected station — with
-        // login + station-select (not blind QR scans), that usually just means
-        // they opened another station's job. Warn (in warning colour) and state
-        // the consequence — completing switches their station — but keep the
-        // action a normal MARK COMPLETE. Backing out is the header's back arrow.
+      ) : (
+        // Not completed. A station mismatch (this step's work center ≠ the
+        // operator's selected station) only WARNS — completion doesn't need or
+        // record the station (completeOperation keys off the operation id), so
+        // the action stays a plain MARK COMPLETE and we don't silently switch
+        // their station. They change it from the header if they've actually moved.
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-          <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, px: 0.5, color: 'warning.main' }}>
-            <WarningAmberIcon fontSize="small" sx={{ mt: 0.25, flexShrink: 0 }} />
-            <Typography variant="body2" color="inherit">
-              You&apos;re at <strong>{stationName || 'another station'}</strong>, but this step runs
-              at <strong>{job.operation_work_center_name || 'another station'}</strong> — completing
-              it switches your station there.
-            </Typography>
-          </Box>
+          {stationMismatch && (
+            <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, px: 0.5, color: 'warning.main' }}>
+              <WarningAmberIcon fontSize="small" sx={{ mt: 0.25, flexShrink: 0 }} />
+              <Typography variant="body2" color="inherit">
+                You&apos;re at <strong>{stationName || 'another station'}</strong>, but this step runs
+                at <strong>{job.operation_work_center_name || 'another station'}</strong> — complete
+                only if it&apos;s yours.
+              </Typography>
+            </Box>
+          )}
           <Button
             fullWidth
             variant="contained"
             size="large"
             color="primary"
             startIcon={<CheckCircleIcon />}
-            onClick={handleSwitchAndComplete}
+            onClick={handleComplete}
             disabled={actionLoading}
             sx={{ minHeight: 64, fontSize: '1.25rem', fontWeight: 600 }}
           >
             {actionLoading ? <CircularProgress size={24} /> : 'MARK COMPLETE'}
           </Button>
         </Box>
-      ) : (
-        <Button
-          fullWidth
-          variant="contained"
-          size="large"
-          color="primary"
-          startIcon={<CheckCircleIcon />}
-          onClick={handleComplete}
-          disabled={actionLoading}
-          sx={{ minHeight: 64, fontSize: '1.25rem', fontWeight: 600 }}
-        >
-          {actionLoading ? <CircularProgress size={24} /> : 'MARK COMPLETE'}
-        </Button>
       )}
 
       {/* Job feed — capture notes/photos for THIS step (auto-tagged), and read

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -12,7 +12,6 @@ import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import LinearProgress from '@mui/material/LinearProgress';
 import Alert from '@mui/material/Alert';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import UndoIcon from '@mui/icons-material/Undo';
 import {
@@ -46,7 +45,6 @@ import PartReferenceRow from '@/components/operator/PartReferenceRow';
  */
 export default function OperatorOperationActionPage() {
   const params = useParams();
-  const router = useRouter();
   const companyId = params.companyId as string;
   const jobId = params.jobId as string;
   const jobPartId = params.jobPartId as string;
@@ -306,12 +304,23 @@ export default function OperatorOperationActionPage() {
           </Box>
         </Button>
       ) : stationMismatch ? (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <Alert severity="warning">
-            This step runs at <strong>{job.operation_work_center_name || 'another station'}</strong>.
-            You&apos;re at <strong>{stationName || 'a different station'}</strong> — did you scan the
-            wrong code?
-          </Alert>
+        // This step's work center isn't the operator's selected station. With
+        // login + station-select (not blind QR scans), that usually just means
+        // they opened another station's job — so state it plainly and offer a
+        // one-tap switch-and-complete for legit cross-station work. Backing out
+        // is the header's back arrow, so there's no separate button here.
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+          <Typography variant="body2" color="text.secondary" sx={{ px: 0.5 }}>
+            This step runs at{' '}
+            <Box component="strong" sx={{ color: 'text.primary' }}>
+              {job.operation_work_center_name || 'another station'}
+            </Box>{' '}
+            — not your station (
+            <Box component="strong" sx={{ color: 'text.primary' }}>
+              {stationName || '—'}
+            </Box>
+            ).
+          </Typography>
           <Button
             fullWidth
             variant="contained"
@@ -327,17 +336,6 @@ export default function OperatorOperationActionPage() {
             ) : (
               `Switch to ${job.operation_work_center_name || 'this station'} & complete`
             )}
-          </Button>
-          <Button
-            variant="outlined"
-            size="large"
-            color="inherit"
-            startIcon={<ArrowBackIcon />}
-            onClick={() => router.push(travelerHref)}
-            disabled={actionLoading}
-            sx={{ minHeight: 56, fontSize: '1.1rem', fontWeight: 600 }}
-          >
-            Not my step — back to traveler
           </Button>
         </Box>
       ) : (


### PR DESCRIPTION
## Summary

Follow-up to #547 (merged) — a focused simplification of the operation page's **station-mismatch guard** (the state shown when a step's work center differs from the operator's selected station). These commits landed on the branch after #547 had already merged, so they need their own PR. **Op-page only, net −29 lines.**

## What changed

- **Language** — "Did you scan the wrong code?" no longer fits: operators log in and *select* a station, then browse jobs, so opening another station's job is normal navigation, not a mis-scan. It's now a neutral warning: *"You're at **Bandsaw**, but this step runs at **Final Inspection**."*

- **No station switch on complete** — `completeOperation` keys off the operation id and records the auth user + timestamp; it never reads or records the operator's selected station. Auto-switching it was a scan-era holdover (the old comment: *"so later scans match too"*). A mismatch now **only warns**; the action is a plain `MARK COMPLETE` identical to an in-station step, and the operator's station is left untouched — they change it deliberately from the header dropdown if they've actually moved.

- **Two elements instead of three** — dropped the redundant "back to traveler" button (the header back arrow already does that) and the amber alert box → a compact warning line. Merged the mismatch and normal render branches into one, and removed `handleSwitchAndComplete` + the now-unused `setStation`.

## Result

```
⚠  You're at Bandsaw, but this step runs at Final Inspection.

   [  ✓ MARK COMPLETE  ]
```

## Testing

`tsc --noEmit` + `pnpm lint` clean. No access-layer or schema changes; rebased on the current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
