### PR TITLE
feat(operator): shop-floor link, completed-jobs view, leaner cards, back-nav fix

### DIFF
--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // --- Chainable Supabase mock (same shape as partAttachmentsAccess.test.ts) ---
 const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
   const builder: Record<string, ReturnType<typeof vi.fn> | unknown> = {};
-  const chainMethods = ['from', 'select', 'insert', 'update', 'delete', 'eq', 'in', 'order', 'single'];
+  const chainMethods = ['from', 'select', 'insert', 'update', 'delete', 'eq', 'in', 'not', 'order', 'limit', 'single'];
   chainMethods.forEach((m) => {
     builder[m] = vi.fn().mockImplementation(() => builder);
   });
@@ -29,7 +29,13 @@ vi.mock('@/lib/supabaseErrors', () => ({
     opts?.fallback ?? 'error',
 }));
 
-import { getJobNotes, addJobNote, getAllStationsOperatorJobs } from '@/utils/operatorAccess';
+import {
+  getJobNotes,
+  addJobNote,
+  getAllStationsOperatorJobs,
+  getCompletedOperatorJobs,
+  getAllStationsCompletedOperatorJobs,
+} from '@/utils/operatorAccess';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -69,6 +75,54 @@ describe('getAllStationsOperatorJobs', () => {
     await expect(
       getAllStationsOperatorJobs('c1', [{ id: 'wc1', name: 'Lathe' }]),
     ).rejects.toThrow(/column j\.status does not exist/);
+  });
+});
+
+describe('getCompletedOperatorJobs', () => {
+  it('returns [] without querying when no station is selected', async () => {
+    const result = await getCompletedOperatorJobs('c1');
+    expect(result).toEqual([]);
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+
+  it('queries completed job_operations for the station (recent-first, capped) and returns [] when none', async () => {
+    mockQueryBuilder.data = [];
+    const result = await getCompletedOperatorJobs('c1', 'wc1');
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('job_operations');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('status', 'completed');
+    expect(mockQueryBuilder.in).toHaveBeenCalledWith('work_center_id', ['wc1']);
+    expect(mockQueryBuilder.order).toHaveBeenCalledWith('completed_at', { ascending: false });
+    expect(mockQueryBuilder.limit).toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('throws (surfaces the error) when the completed query fails', async () => {
+    mockQueryBuilder.error = { message: 'boom' };
+    await expect(getCompletedOperatorJobs('c1', 'wc1')).rejects.toThrow(
+      /Failed to load completed operations/,
+    );
+  });
+});
+
+describe('getAllStationsCompletedOperatorJobs', () => {
+  it('returns [] without querying when there are no stations', async () => {
+    const result = await getAllStationsCompletedOperatorJobs('c1', []);
+    expect(result).toEqual([]);
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+
+  it('queries completed operations across all given stations', async () => {
+    mockQueryBuilder.data = [];
+    const stations = [
+      { id: 'wc1', name: 'Lathe' },
+      { id: 'wc2', name: 'Mill' },
+    ];
+    const result = await getAllStationsCompletedOperatorJobs('c1', stations);
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('job_operations');
+    expect(mockQueryBuilder.in).toHaveBeenCalledWith('work_center_id', ['wc1', 'wc2']);
+    expect(result).toEqual([]);
   });
 });
 

--- a/app/dashboard/[companyId]/jobs/page.tsx
+++ b/app/dashboard/[companyId]/jobs/page.tsx
@@ -56,6 +56,7 @@ import {
 import Tooltip from '@mui/material/Tooltip';
 import ScheduleIcon from '@mui/icons-material/Schedule';
 import AddIcon from '@mui/icons-material/Add';
+import PrecisionManufacturingIcon from '@mui/icons-material/PrecisionManufacturing';
 import AcceptPurchaseOrderModal from '@/components/jobs/AcceptPurchaseOrderModal';
 import type { JobWithRelations, JobFilters, JobLifecycleStage } from '@/types/job';
 
@@ -640,6 +641,16 @@ export default function JobsPage() {
         )}
 
         <Box sx={{ flex: 1 }} />
+
+        {/* Open the shop-floor (operator) view to watch/monitor jobs live. The
+            operator shell has a matching Dashboard icon to return. */}
+        <Button
+          variant="outlined"
+          startIcon={<PrecisionManufacturingIcon />}
+          onClick={() => router.push(`/operator/${companyId}`)}
+        >
+          Shop floor view
+        </Button>
 
         <Button
           variant="contained"

--- a/app/operator/[companyId]/jobs/[jobId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/page.tsx
@@ -14,7 +14,7 @@ import LinearProgress from '@mui/material/LinearProgress';
 import Alert from '@mui/material/Alert';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { getJobPartsOverview } from '@/utils/operatorAccess';
-import { useSetOperatorChrome } from '@/components/operator/OperatorChromeContext';
+import { useSetOperatorChrome, useOperatorNav } from '@/components/operator/OperatorChromeContext';
 import type { JobPartsOverview, JobPartSummary } from '@/types/operator';
 
 const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
@@ -33,6 +33,7 @@ function statusColor(status: string): 'default' | 'primary' | 'success' {
 export default function OperatorJobPartsHubPage() {
   const params = useParams();
   const router = useRouter();
+  const nav = useOperatorNav();
   const companyId = params.companyId as string;
   const jobId = params.jobId as string;
 
@@ -40,8 +41,9 @@ export default function OperatorJobPartsHubPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Header back → the station jobs list. Registered on mount so it's present
-  // even for the brief single-part case before this hub redirects to the traveler.
+  // Header back pops in-app history (nav.goBack); this href is only the deep-link
+  // fallback — the jobs list. Registered on mount so it's present even for the
+  // brief single-part case before this hub redirects to the traveler.
   useSetOperatorChrome({ back: { href: `/operator/${companyId}/jobs`, label: 'Back to jobs' } }, [companyId]);
 
   useEffect(() => {
@@ -76,7 +78,7 @@ export default function OperatorJobPartsHubPage() {
   }, [companyId, jobId, router]);
 
   const openPart = (part: JobPartSummary) => {
-    router.push(`/operator/${companyId}/jobs/${jobId}/parts/${part.job_part_id}`);
+    nav.push(`/operator/${companyId}/jobs/${jobId}/parts/${part.job_part_id}`);
   };
 
   if (loading) {
@@ -93,7 +95,7 @@ export default function OperatorJobPartsHubPage() {
         <Alert severity="error" sx={{ mb: 2 }}>
           {error || 'Job not found.'}
         </Alert>
-        <Button variant="outlined" onClick={() => router.push(`/operator/${companyId}/jobs`)}>
+        <Button variant="outlined" onClick={() => nav.push(`/operator/${companyId}/jobs`)}>
           Back to jobs
         </Button>
       </Box>

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Suspense, useState, useEffect } from 'react';
-import { useParams, useSearchParams } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -43,9 +43,8 @@ import PartReferenceRow from '@/components/operator/PartReferenceRow';
  * by a guide with a one-tap "switch & complete" (for legit cross-station work)
  * and a way back to the traveler.
  */
-function OperatorOperationActionPageContent() {
+export default function OperatorOperationActionPage() {
   const params = useParams();
-  const searchParams = useSearchParams();
   const companyId = params.companyId as string;
   const jobId = params.jobId as string;
   const jobPartId = params.jobPartId as string;
@@ -53,27 +52,15 @@ function OperatorOperationActionPageContent() {
 
   const travelerHref = `/operator/${companyId}/jobs/${jobId}/parts/${jobPartId}`;
 
-  // Header back retraces the entry path: the caller threads ?back=<return url>
-  // (the traveler when opened from it; the jobs list on the My-Station fast
-  // path). Falls back to the traveler for a direct/QR deep-link.
-  const rawBack = searchParams.get('back');
-  const backHref = rawBack && rawBack.startsWith('/operator/') ? rawBack : travelerHref;
-  const backPath = backHref.split('?')[0];
-  const backLabel = backPath.endsWith('/jobs')
-    ? 'Back to jobs'
-    : backPath.includes('/parts/')
-      ? 'Back to traveler'
-      : 'Back';
-
   const { stationId, stationName, initializing } = useStationContext();
 
   const [currentOperatorId, setCurrentOperatorId] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // (Files + Previous notes live in an in-content reference row below the job
-  // card, not the header.)
-  useSetOperatorChrome({ back: { href: backHref, label: backLabel } }, [backHref, backLabel]);
+  // Header back pops in-app history (nav.goBack). This href is only the deep-link
+  // fallback — the part's traveler — for an operation scanned into directly.
+  useSetOperatorChrome({ back: { href: travelerHref, label: 'Back to traveler' } }, [travelerHref]);
 
   useEffect(() => {
     async function loadOperator() {
@@ -342,20 +329,5 @@ function OperatorOperationActionPageContent() {
       </Box>
 
     </Box>
-  );
-}
-
-export default function OperatorOperationActionPage() {
-  // useSearchParams (for the ?back return target) requires a Suspense boundary.
-  return (
-    <Suspense
-      fallback={
-        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
-          <CircularProgress />
-        </Box>
-      }
-    >
-      <OperatorOperationActionPageContent />
-    </Suspense>
   );
 }

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useParams } from 'next/navigation';
+import { Suspense, useState, useEffect } from 'react';
+import { useParams, useSearchParams } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import LinearProgress from '@mui/material/LinearProgress';
 import Alert from '@mui/material/Alert';
@@ -44,8 +43,9 @@ import PartReferenceRow from '@/components/operator/PartReferenceRow';
  * by a guide with a one-tap "switch & complete" (for legit cross-station work)
  * and a way back to the traveler.
  */
-export default function OperatorOperationActionPage() {
+function OperatorOperationActionPageContent() {
   const params = useParams();
+  const searchParams = useSearchParams();
   const companyId = params.companyId as string;
   const jobId = params.jobId as string;
   const jobPartId = params.jobPartId as string;
@@ -53,15 +53,27 @@ export default function OperatorOperationActionPage() {
 
   const travelerHref = `/operator/${companyId}/jobs/${jobId}/parts/${jobPartId}`;
 
+  // Header back retraces the entry path: the caller threads ?back=<return url>
+  // (the traveler when opened from it; the jobs list on the My-Station fast
+  // path). Falls back to the traveler for a direct/QR deep-link.
+  const rawBack = searchParams.get('back');
+  const backHref = rawBack && rawBack.startsWith('/operator/') ? rawBack : travelerHref;
+  const backPath = backHref.split('?')[0];
+  const backLabel = backPath.endsWith('/jobs')
+    ? 'Back to jobs'
+    : backPath.includes('/parts/')
+      ? 'Back to traveler'
+      : 'Back';
+
   const { stationId, stationName, initializing } = useStationContext();
 
   const [currentOperatorId, setCurrentOperatorId] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Header back → the traveler for this part. (Files + Previous notes live in an
-  // in-content reference row below the job card, not the header.)
-  useSetOperatorChrome({ back: { href: travelerHref, label: 'Back to traveler' } }, [travelerHref]);
+  // (Files + Previous notes live in an in-content reference row below the job
+  // card, not the header.)
+  useSetOperatorChrome({ back: { href: backHref, label: backLabel } }, [backHref, backLabel]);
 
   useEffect(() => {
     async function loadOperator() {
@@ -119,12 +131,6 @@ export default function OperatorOperationActionPage() {
   };
 
   const isCompleted = job?.operation_status === 'completed';
-
-  const statusColor = (status: string | null): 'success' | 'primary' | 'default' => {
-    if (status === 'completed') return 'success';
-    if (status === 'in_progress') return 'primary';
-    return 'default';
-  };
 
   // Wait for BOTH the job fetch and the station context's one-time init before
   // deciding what to render — otherwise the "no station" branch can flash for an
@@ -184,19 +190,13 @@ export default function OperatorOperationActionPage() {
         sx={{ mb: 3, bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' }}
       >
         <CardContent>
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2 }}>
-            <Box>
-              <Typography variant="h5" component="h1" fontWeight={700}>
-                {job.job_number}
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                {job.customer_name || 'No customer'}
-              </Typography>
-            </Box>
-            <Chip
-              label={job.operation_status || job.production_status}
-              color={statusColor(job.operation_status)}
-            />
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="h5" component="h1" fontWeight={700}>
+              {job.job_number}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {job.customer_name || 'No customer'}
+            </Typography>
           </Box>
 
           {/* Lead with the part (what they're making). The operation's work
@@ -342,5 +342,20 @@ export default function OperatorOperationActionPage() {
       </Box>
 
     </Box>
+  );
+}
+
+export default function OperatorOperationActionPage() {
+  // useSearchParams (for the ?back return target) requires a Suspense boundary.
+  return (
+    <Suspense
+      fallback={
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+          <CircularProgress />
+        </Box>
+      }
+    >
+      <OperatorOperationActionPageContent />
+    </Suspense>
   );
 }

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { Suspense, useState } from 'react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -53,18 +53,24 @@ function StepIcon({ status }: { status: string }) {
  * the operation pages) is shown read-only up top; capture happens on the
  * operation page where the operator is working.
  */
-export default function OperatorJobTravelerPage() {
+function OperatorJobTravelerPageContent() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const companyId = params.companyId as string;
   const jobId = params.jobId as string;
   const jobPartId = params.jobPartId as string;
 
   const [error, setError] = useState<string | null>(null);
 
-  // Header back → the station jobs list. (Files + Previous notes live in an
-  // in-content reference row; the "All N parts" jump stays in-content too.)
-  useSetOperatorChrome({ back: { href: `/operator/${companyId}/jobs`, label: 'Back to jobs' } }, [companyId]);
+  // Header back → the jobs list the operator came from. The caller threads
+  // ?back=<jobs url with scope+completed> (e.g. from All Stations); default to
+  // the plain jobs list for a direct/QR deep-link. (Files + Previous notes live
+  // in an in-content reference row; the "All N parts" jump stays in-content.)
+  const rawBack = searchParams.get('back');
+  const backToJobs =
+    rawBack && rawBack.startsWith('/operator/') ? rawBack : `/operator/${companyId}/jobs`;
+  useSetOperatorChrome({ back: { href: backToJobs, label: 'Back to jobs' } }, [backToJobs]);
 
   const { data: traveler, loading } = useLoad(
     async () => {
@@ -83,7 +89,15 @@ export default function OperatorJobTravelerPage() {
   );
 
   const openStep = (op: JobTravelerOperation) => {
-    router.push(`/operator/${companyId}/jobs/${jobId}/parts/${jobPartId}/operations/${op.id}`);
+    // Thread THIS traveler's URL (including its own ?back) as the operation's
+    // return target, so Back retraces operation → traveler → the jobs list it
+    // all started from.
+    const selfUrl = `/operator/${companyId}/jobs/${jobId}/parts/${jobPartId}${
+      rawBack && rawBack.startsWith('/operator/') ? `?back=${encodeURIComponent(rawBack)}` : ''
+    }`;
+    router.push(
+      `/operator/${companyId}/jobs/${jobId}/parts/${jobPartId}/operations/${op.id}?back=${encodeURIComponent(selfUrl)}`,
+    );
   };
 
   if (loading) {
@@ -100,7 +114,7 @@ export default function OperatorJobTravelerPage() {
         <Alert severity="error" sx={{ mb: 2 }}>
           {error || 'Job not found.'}
         </Alert>
-        <Button variant="outlined" onClick={() => router.push(`/operator/${companyId}/jobs`)}>
+        <Button variant="outlined" onClick={() => router.push(backToJobs)}>
           Back to jobs
         </Button>
       </Box>
@@ -255,5 +269,20 @@ export default function OperatorJobTravelerPage() {
       </Box>
 
     </Box>
+  );
+}
+
+export default function OperatorJobTravelerPage() {
+  // useSearchParams (for the ?back return target) requires a Suspense boundary.
+  return (
+    <Suspense
+      fallback={
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+          <CircularProgress />
+        </Box>
+      }
+    >
+      <OperatorJobTravelerPageContent />
+    </Suspense>
   );
 }

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Suspense, useState } from 'react';
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { useState } from 'react';
+import { useParams } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -18,7 +18,7 @@ import PlayCircleFilledIcon from '@mui/icons-material/PlayCircleFilled';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { getJobPartTraveler } from '@/utils/operatorAccess';
-import { useSetOperatorChrome } from '@/components/operator/OperatorChromeContext';
+import { useSetOperatorChrome, useOperatorNav } from '@/components/operator/OperatorChromeContext';
 import JobFeed from '@/components/operator/JobFeed';
 import PartReferenceRow from '@/components/operator/PartReferenceRow';
 import type { JobTravelerOperation } from '@/types/operator';
@@ -53,24 +53,19 @@ function StepIcon({ status }: { status: string }) {
  * the operation pages) is shown read-only up top; capture happens on the
  * operation page where the operator is working.
  */
-function OperatorJobTravelerPageContent() {
+export default function OperatorJobTravelerPage() {
   const params = useParams();
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const nav = useOperatorNav();
   const companyId = params.companyId as string;
   const jobId = params.jobId as string;
   const jobPartId = params.jobPartId as string;
 
   const [error, setError] = useState<string | null>(null);
 
-  // Header back → the jobs list the operator came from. The caller threads
-  // ?back=<jobs url with scope+completed> (e.g. from All Stations); default to
-  // the plain jobs list for a direct/QR deep-link. (Files + Previous notes live
-  // in an in-content reference row; the "All N parts" jump stays in-content.)
-  const rawBack = searchParams.get('back');
-  const backToJobs =
-    rawBack && rawBack.startsWith('/operator/') ? rawBack : `/operator/${companyId}/jobs`;
-  useSetOperatorChrome({ back: { href: backToJobs, label: 'Back to jobs' } }, [backToJobs]);
+  const jobsHref = `/operator/${companyId}/jobs`;
+  // Header back pops in-app history (nav.goBack). This href is only the deep-link
+  // fallback — the jobs list — for a traveler scanned into directly.
+  useSetOperatorChrome({ back: { href: jobsHref, label: 'Back to jobs' } }, [jobsHref]);
 
   const { data: traveler, loading } = useLoad(
     async () => {
@@ -89,15 +84,7 @@ function OperatorJobTravelerPageContent() {
   );
 
   const openStep = (op: JobTravelerOperation) => {
-    // Thread THIS traveler's URL (including its own ?back) as the operation's
-    // return target, so Back retraces operation → traveler → the jobs list it
-    // all started from.
-    const selfUrl = `/operator/${companyId}/jobs/${jobId}/parts/${jobPartId}${
-      rawBack && rawBack.startsWith('/operator/') ? `?back=${encodeURIComponent(rawBack)}` : ''
-    }`;
-    router.push(
-      `/operator/${companyId}/jobs/${jobId}/parts/${jobPartId}/operations/${op.id}?back=${encodeURIComponent(selfUrl)}`,
-    );
+    nav.push(`/operator/${companyId}/jobs/${jobId}/parts/${jobPartId}/operations/${op.id}`);
   };
 
   if (loading) {
@@ -114,7 +101,7 @@ function OperatorJobTravelerPageContent() {
         <Alert severity="error" sx={{ mb: 2 }}>
           {error || 'Job not found.'}
         </Alert>
-        <Button variant="outlined" onClick={() => router.push(backToJobs)}>
+        <Button variant="outlined" onClick={() => nav.push(jobsHref)}>
           Back to jobs
         </Button>
       </Box>
@@ -133,7 +120,7 @@ function OperatorJobTravelerPageContent() {
           <Button
             size="small"
             startIcon={<LayersIcon />}
-            onClick={() => router.push(`/operator/${companyId}/jobs/${jobId}`)}
+            onClick={() => nav.push(`/operator/${companyId}/jobs/${jobId}`)}
           >
             All {traveler.job_part_count} parts
           </Button>
@@ -269,20 +256,5 @@ function OperatorJobTravelerPageContent() {
       </Box>
 
     </Box>
-  );
-}
-
-export default function OperatorJobTravelerPage() {
-  // useSearchParams (for the ?back return target) requires a Suspense boundary.
-  return (
-    <Suspense
-      fallback={
-        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
-          <CircularProgress />
-        </Box>
-      }
-    >
-      <OperatorJobTravelerPageContent />
-    </Suspense>
   );
 }

--- a/app/operator/[companyId]/jobs/page.tsx
+++ b/app/operator/[companyId]/jobs/page.tsx
@@ -7,13 +7,13 @@ import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardActionArea from '@mui/material/CardActionArea';
-import Chip from '@mui/material/Chip';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import CircularProgress from '@mui/material/CircularProgress';
 import LinearProgress from '@mui/material/LinearProgress';
 import Alert from '@mui/material/Alert';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import {
   getOperatorJobs,
   getAllStationsOperatorJobs,
@@ -215,9 +215,11 @@ function OperatorJobsPageContent() {
 
   return (
     <Box>
-      {/* Toolbar: scope segmented control (primary) + a "Completed" filter chip
-          (secondary). Hidden on the station picker, where there's no selected
-          station to scope by yet. */}
+      {/* Toolbar: scope segmented control (primary) + a "Show completed"
+          checkbox (secondary — an explicit on/off so it's clear whether you're
+          viewing completed vs. active work, which a single color-toggle chip
+          didn't convey). Hidden on the station picker, where there's no
+          selected station to scope by yet. */}
       {!showStationSelector && (
         <Box
           sx={{
@@ -243,14 +245,22 @@ function OperatorJobsPageContent() {
 
           <Box sx={{ flex: 1 }} />
 
-          <Chip
-            icon={<CheckCircleOutlineIcon />}
-            label="Completed"
-            color={completed ? 'primary' : 'default'}
-            variant={completed ? 'filled' : 'outlined'}
-            onClick={() => updateView({ completed: !completed })}
-            aria-pressed={completed}
-            sx={{ minHeight: 40 }}
+          {/* Explicit on/off: checked = viewing completed, unchecked = active.
+              Mirrors the dashboard jobs list's "Overdue only" checkbox, incl. the
+              high-contrast styling that reads on the dark toolbar. */}
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={completed}
+                onChange={(e) => updateView({ completed: e.target.checked })}
+                sx={{
+                  color: 'rgba(255,255,255,0.6)',
+                  '&.Mui-checked': { color: 'primary.light' },
+                }}
+              />
+            }
+            label="Show completed"
+            sx={{ mr: 0, minHeight: 48 }}
           />
         </Box>
       )}

--- a/app/operator/[companyId]/jobs/page.tsx
+++ b/app/operator/[companyId]/jobs/page.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/utils/operatorAccess';
 import { useStationContext } from '@/components/operator/OperatorStationContext';
 import StationSelector from '@/components/operator/StationSelector';
+import { useOperatorNav } from '@/components/operator/OperatorChromeContext';
 import type { OperatorJob, OperatorPlantJob } from '@/types/operator';
 
 /**
@@ -50,6 +51,7 @@ function OperatorJobsPageContent() {
   const searchParams = useSearchParams();
   const companyId = params.companyId as string;
   const { stationId, stations, initializing } = useStationContext();
+  const nav = useOperatorNav();
 
   // Scope + completed are URL-backed so Back restores this exact view.
   const scope: Scope = searchParams.get('scope') === 'plant' ? 'plant' : 'station';
@@ -60,8 +62,8 @@ function OperatorJobsPageContent() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // The URL for this exact view — used both to write toggle changes and as the
-  // "return here" target threaded into detail pages (see handlePartClick).
+  // The URL for this exact view — used to write the scope/completed toggle state
+  // into the URL (so Back restores the exact view the operator left).
   const jobsUrl = (s: Scope, c: boolean) =>
     `/operator/${companyId}/jobs?scope=${s}${c ? '&completed=1' : ''}`;
 
@@ -109,15 +111,14 @@ function OperatorJobsPageContent() {
   // Tapping a row. My Station + Active keeps the one-tap fast path straight to
   // the ready operation (highest-frequency action). All Stations, or any
   // Completed row, opens the traveler instead — the operator picks the step
-  // there — so Back retraces exactly one step. Either way we thread this exact
-  // jobs view as the return target so Back lands where they came from.
+  // there. nav.push records the hop so the header back retraces it (see
+  // OperatorChromeContext); no return URL is threaded.
   const handlePartClick = (row: OperatorJob) => {
-    const back = encodeURIComponent(jobsUrl(scope, completed));
     const base = `/operator/${companyId}/jobs/${row.job_id}/parts/${row.id}`;
     if (completed || scope === 'plant' || !row.operation_id) {
-      router.push(`${base}?back=${back}`);
+      nav.push(base);
     } else {
-      router.push(`${base}/operations/${row.operation_id}?back=${back}`);
+      nav.push(`${base}/operations/${row.operation_id}`);
     }
   };
 

--- a/app/operator/[companyId]/jobs/page.tsx
+++ b/app/operator/[companyId]/jobs/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { Suspense, useState, useEffect, useMemo } from 'react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
@@ -13,7 +13,13 @@ import LinearProgress from '@mui/material/LinearProgress';
 import Alert from '@mui/material/Alert';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import { getOperatorJobs, getAllStationsOperatorJobs } from '@/utils/operatorAccess';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import {
+  getOperatorJobs,
+  getAllStationsOperatorJobs,
+  getCompletedOperatorJobs,
+  getAllStationsCompletedOperatorJobs,
+} from '@/utils/operatorAccess';
 import { useStationContext } from '@/components/operator/OperatorStationContext';
 import StationSelector from '@/components/operator/StationSelector';
 import type { OperatorJob, OperatorPlantJob } from '@/types/operator';
@@ -21,33 +27,56 @@ import type { OperatorJob, OperatorPlantJob } from '@/types/operator';
 /**
  * Operator Jobs List Page.
  *
- * Two lenses:
- *  - "My Station" — work ready/in-progress at the selected station (the
- *    dispatch list). Prompts for a station if none is selected.
- *  - "All Stations" — the whole plant: every active job grouped by station, so
- *    a roaming operator or lead can find work / see floor status without
- *    picking one station.
+ * Two controls, orthogonal:
+ *  - Scope (segmented, the primary/high-frequency switch):
+ *    - "My Station" — work ready/in-progress at the selected station (the
+ *      dispatch list). Prompts for a station if none is selected.
+ *    - "All Stations" — the whole plant: every active job grouped by station, so
+ *      a roaming operator or lead can find work / see floor status.
+ *  - "Completed" (a filter chip, secondary): swaps the list to recently
+ *    completed work so an operator can reopen a step finished by mistake and
+ *    undo it. Off by default — the plain list IS the active/ready view (there is
+ *    deliberately no "Active" label; the app has no "active" state).
+ *
+ * Both controls live in the URL (?scope=, ?completed=1) so returning to this
+ * page — e.g. Back from a traveler opened via All Stations — restores the exact
+ * view the operator left.
  */
-type Lens = 'station' | 'plant';
+type Scope = 'station' | 'plant';
 
-export default function OperatorJobsPage() {
+function OperatorJobsPageContent() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const companyId = params.companyId as string;
   const { stationId, stations, initializing } = useStationContext();
 
-  const [lens, setLens] = useState<Lens>('station');
+  // Scope + completed are URL-backed so Back restores this exact view.
+  const scope: Scope = searchParams.get('scope') === 'plant' ? 'plant' : 'station';
+  const completed = searchParams.get('completed') === '1';
+
   const [jobs, setJobs] = useState<OperatorJob[]>([]);
   const [plantJobs, setPlantJobs] = useState<OperatorPlantJob[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // The URL for this exact view — used both to write toggle changes and as the
+  // "return here" target threaded into detail pages (see handlePartClick).
+  const jobsUrl = (s: Scope, c: boolean) =>
+    `/operator/${companyId}/jobs?scope=${s}${c ? '&completed=1' : ''}`;
+
+  const updateView = (next: { scope?: Scope; completed?: boolean }) => {
+    const nextScope = next.scope ?? scope;
+    const nextCompleted = next.completed ?? completed;
+    router.replace(jobsUrl(nextScope, nextCompleted));
+  };
+
   useEffect(() => {
-    // Re-run on lens / station / stations change. Cancellation guards against a
-    // slow fetch landing after the inputs changed (e.g. station just resolved).
+    // Re-run on scope / completed / station / stations change. Cancellation
+    // guards against a slow fetch landing after the inputs changed.
     let cancelled = false;
     (async () => {
-      if (lens === 'station' && !stationId) {
+      if (scope === 'station' && !stationId) {
         setJobs([]);
         setLoading(false);
         return;
@@ -55,11 +84,15 @@ export default function OperatorJobsPage() {
       setLoading(true);
       setError(null);
       try {
-        if (lens === 'plant') {
-          const data = await getAllStationsOperatorJobs(companyId, stations);
+        if (scope === 'plant') {
+          const data = completed
+            ? await getAllStationsCompletedOperatorJobs(companyId, stations)
+            : await getAllStationsOperatorJobs(companyId, stations);
           if (!cancelled) setPlantJobs(data);
         } else {
-          const data = await getOperatorJobs(companyId, stationId as string);
+          const data = completed
+            ? await getCompletedOperatorJobs(companyId, stationId as string)
+            : await getOperatorJobs(companyId, stationId as string);
           if (!cancelled) setJobs(data);
         }
       } catch (err) {
@@ -71,31 +104,24 @@ export default function OperatorJobsPage() {
     return () => {
       cancelled = true;
     };
-  }, [companyId, stationId, lens, stations]);
+  }, [companyId, stationId, scope, completed, stations]);
 
-  // Tapping a row opens the ready operation (skipping the traveler). When the
-  // row is at a different station than the operator's current selection, the
-  // operation page's station-match guard handles the mismatch ("switch &
-  // complete") — so the All-Stations lens reuses the same safe path.
+  // Tapping a row. My Station + Active keeps the one-tap fast path straight to
+  // the ready operation (highest-frequency action). All Stations, or any
+  // Completed row, opens the traveler instead — the operator picks the step
+  // there — so Back retraces exactly one step. Either way we thread this exact
+  // jobs view as the return target so Back lands where they came from.
   const handlePartClick = (row: OperatorJob) => {
+    const back = encodeURIComponent(jobsUrl(scope, completed));
     const base = `/operator/${companyId}/jobs/${row.job_id}/parts/${row.id}`;
-    router.push(row.operation_id ? `${base}/operations/${row.operation_id}` : base);
-  };
-
-  const getStatusColor = (status: string): 'default' | 'primary' | 'success' | 'warning' | 'error' => {
-    switch (status) {
-      case 'completed':
-        return 'success';
-      case 'in_progress':
-        return 'primary';
-      case 'not_started':
-        return 'default';
-      default:
-        return 'default';
+    if (completed || scope === 'plant' || !row.operation_id) {
+      router.push(`${base}?back=${back}`);
+    } else {
+      router.push(`${base}/operations/${row.operation_id}?back=${back}`);
     }
   };
 
-  // Group whole-plant rows by station for the "All Stations" lens.
+  // Group whole-plant rows by station for the "All Stations" scope.
   const plantGroups = useMemo(() => {
     const map = new Map<string, OperatorPlantJob[]>();
     for (const row of plantJobs) {
@@ -120,6 +146,7 @@ export default function OperatorJobsPage() {
               display: 'flex',
               justifyContent: 'space-between',
               alignItems: 'flex-start',
+              gap: 1,
               mb: 1,
             }}
           >
@@ -131,11 +158,17 @@ export default function OperatorJobsPage() {
                 Order qty {row.part_quantity}
               </Typography>
             </Box>
-            <Chip
-              label={row.operation_status || row.production_status}
-              size="small"
-              color={getStatusColor(row.operation_status || row.production_status)}
-            />
+            {/* Completed rows show WHEN they were finished where the (removed)
+                status chip used to sit; active rows convey state via the bar. */}
+            {row.completed_at && (
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}
+              >
+                Completed {formatCompletedAt(row.completed_at)}
+              </Typography>
+            )}
           </Box>
 
           <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
@@ -167,7 +200,7 @@ export default function OperatorJobsPage() {
     </Card>
   );
 
-  const showStationSelector = lens === 'station' && !stationId;
+  const showStationSelector = scope === 'station' && !stationId;
 
   // Wait for the station context to hydrate its stored default before deciding
   // whether to prompt for a station — avoids a one-paint picker flash for a
@@ -182,22 +215,43 @@ export default function OperatorJobsPage() {
 
   return (
     <Box>
-      {/* Lens toggle (My Station / All Stations) — hidden on the station picker,
-          where there's no selected station to scope by yet. */}
+      {/* Toolbar: scope segmented control (primary) + a "Completed" filter chip
+          (secondary). Hidden on the station picker, where there's no selected
+          station to scope by yet. */}
       {!showStationSelector && (
-        <Box sx={{ mb: 2 }}>
+        <Box
+          sx={{
+            mb: 2,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            flexWrap: 'wrap',
+          }}
+        >
           <ToggleButtonGroup
             size="small"
             exclusive
-            value={lens}
+            value={scope}
             onChange={(_e, value) => {
-              if (value) setLens(value as Lens);
+              if (value) updateView({ scope: value as Scope });
             }}
             aria-label="Job list scope"
           >
             <ToggleButton value="station">My Station</ToggleButton>
             <ToggleButton value="plant">All Stations</ToggleButton>
           </ToggleButtonGroup>
+
+          <Box sx={{ flex: 1 }} />
+
+          <Chip
+            icon={<CheckCircleOutlineIcon />}
+            label="Completed"
+            color={completed ? 'primary' : 'default'}
+            variant={completed ? 'filled' : 'outlined'}
+            onClick={() => updateView({ completed: !completed })}
+            aria-pressed={completed}
+            sx={{ minHeight: 40 }}
+          />
         </Box>
       )}
 
@@ -220,30 +274,16 @@ export default function OperatorJobsPage() {
         >
           <CircularProgress />
         </Box>
-      ) : lens === 'station' ? (
+      ) : scope === 'station' ? (
         jobs.length === 0 ? (
-          <Box sx={{ textAlign: 'center', py: 8, px: 2 }}>
-            <Typography variant="h6" color="text.secondary" gutterBottom>
-              No jobs available
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              There are no pending jobs for your station at this time.
-            </Typography>
-          </Box>
+          <EmptyState completed={completed} scope="station" />
         ) : (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            {jobs.map((row) => renderJobCard(row, row.id))}
+            {jobs.map((row) => renderJobCard(row, row.operation_id ?? row.id))}
           </Box>
         )
       ) : plantJobs.length === 0 ? (
-        <Box sx={{ textAlign: 'center', py: 8, px: 2 }}>
-          <Typography variant="h6" color="text.secondary" gutterBottom>
-            No active jobs
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            There is no ready or in-progress work across the plant right now.
-          </Typography>
-        </Box>
+        <EmptyState completed={completed} scope="plant" />
       ) : (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
           {plantGroups.map(([station, rows]) => (
@@ -263,5 +303,56 @@ export default function OperatorJobsPage() {
         </Box>
       )}
     </Box>
+  );
+}
+
+/** Empty-state copy, keyed on scope + whether the Completed filter is on. */
+function EmptyState({ completed, scope }: { completed: boolean; scope: Scope }) {
+  const [title, body] = completed
+    ? scope === 'station'
+      ? ['No recently completed jobs', 'You haven’t completed any steps at this station recently.']
+      : ['No recently completed jobs', 'No steps have been completed across the plant recently.']
+    : scope === 'station'
+      ? ['No jobs available', 'There are no pending jobs for your station at this time.']
+      : ['No active jobs', 'There is no ready or in-progress work across the plant right now.'];
+  return (
+    <Box sx={{ textAlign: 'center', py: 8, px: 2 }}>
+      <Typography variant="h6" color="text.secondary" gutterBottom>
+        {title}
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        {body}
+      </Typography>
+    </Box>
+  );
+}
+
+/** Compact "how long ago" for a completion timestamp; falls back to a date. */
+function formatCompletedAt(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return null;
+  const min = Math.round((Date.now() - then) / 60000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export default function OperatorJobsPage() {
+  // useSearchParams requires a Suspense boundary (matches app/login/page.tsx).
+  return (
+    <Suspense
+      fallback={
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '40vh' }}>
+          <CircularProgress />
+        </Box>
+      }
+    >
+      <OperatorJobsPageContent />
+    </Suspense>
   );
 }

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -24,7 +24,7 @@ import { getSupabase } from '@/lib/supabase';
 import AppAmbientBackdrop from '@/components/layout/AppAmbientBackdrop';
 import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 import { OperatorStationProvider, useStationContext } from '@/components/operator/OperatorStationContext';
-import { OperatorChromeProvider, useOperatorChrome } from '@/components/operator/OperatorChromeContext';
+import { OperatorChromeProvider, useOperatorChrome, useOperatorNav } from '@/components/operator/OperatorChromeContext';
 import JiggedIcon from '@/components/branding/JiggedIcon';
 import type { AuthChangeEvent } from '@supabase/supabase-js';
 
@@ -187,6 +187,7 @@ function OperatorShell({
 }) {
   const { stationId, stationName, stations, setStation } = useStationContext();
   const chrome = useOperatorChrome();
+  const nav = useOperatorNav();
   const { features } = useCompanyFeatures();
   const pathname = usePathname();
   const router = useRouter();
@@ -242,9 +243,7 @@ function OperatorShell({
               color="inherit"
               size="small"
               aria-label={chrome.back.label ?? 'Back'}
-              onClick={() => {
-                if (chrome.back) router.push(chrome.back.href);
-              }}
+              onClick={() => nav.goBack()}
             >
               <ArrowBackIcon fontSize="small" />
             </IconButton>

--- a/components/operator/OperatorChromeContext.tsx
+++ b/components/operator/OperatorChromeContext.tsx
@@ -1,39 +1,89 @@
 'use client';
 
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import type { DependencyList, ReactNode } from 'react';
 
 /**
- * Header chrome for the operator shell.
+ * Header chrome + in-app navigation for the operator shell.
  *
- * Each operator page declares, from its own render, the contextual back target
- * for the fixed AppBar (or none, on the back-less "home" roots where the JIG
- * logo shows instead). `OperatorShell` is presentational — it renders whatever
- * the current page registered.
+ * BACK BUTTON — holistic, not per-hop. The browser history stack already IS
+ * "where you came from", so the header back button just pops it (router.back()).
+ * We don't thread a `?back=` return URL through every navigation; instead every
+ * in-app forward navigation goes through `useOperatorNav().push`, which bumps a
+ * depth counter, and the header back calls `goBack()`:
+ *   - depth > 0  → there's an in-app page behind us → router.back() (retraces
+ *     the exact path the operator took, through the parts hub and everything).
+ *   - depth === 0 → a QR deep-link landed straight on this page with no in-app
+ *     history to pop → navigate to the page's declared parent `back.href`
+ *     (the fallback) so we climb the hierarchy instead of leaving the app.
  *
- * Why a context and not "compute back from the pathname": pages already know
- * their exact parent (the operation page literally computes `travelerHref`), and
- * a QR deep-link into a page has no in-app history for `router.back()` to use.
+ * The depth ref lives in the provider, which sits in the operator layout and
+ * stays mounted across client navigations, so it survives jobs → traveler →
+ * hub → … and resets to 0 only on a fresh load (i.e. a real deep-link entry).
  */
 export interface OperatorChromeConfig {
-  /** Back target for the header. Omit/null on back-less roots (logo shows). */
+  /**
+   * Header back target. Omit/null on back-less roots (the JIG logo shows).
+   * `href` is the FALLBACK parent, used only on a deep-link entry (no in-app
+   * history) — normal back pops real history via goBack(). `label` is the
+   * button's aria-label.
+   */
   back?: { href: string; label?: string } | null;
 }
 
 interface OperatorChromeContextValue {
   config: OperatorChromeConfig;
   setConfig: (config: OperatorChromeConfig) => void;
+  push: (href: string) => void;
+  goBack: () => void;
 }
 
 const OperatorChromeContext = createContext<OperatorChromeContextValue>({
   config: {},
   setConfig: () => {},
+  push: () => {},
+  goBack: () => {},
 });
 
 export function OperatorChromeProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
   const [config, setConfig] = useState<OperatorChromeConfig>({});
+
+  // In-app navigation depth from the operator-view entry page (see the file
+  // header). A ref, not state — it must survive client navigations without
+  // re-rendering, and only the goBack handler reads it.
+  const depthRef = useRef(0);
+  // Latest config, so goBack can read the current page's fallback href without
+  // being re-created (and re-subscribing the shell) on every chrome change.
+  // Synced in an effect (not during render); the config always settles before a
+  // back tap, and the fallback only matters on a depth-0 deep-link anyway.
+  const configRef = useRef(config);
+  useEffect(() => {
+    configRef.current = config;
+  }, [config]);
+
+  const push = useCallback(
+    (href: string) => {
+      depthRef.current += 1;
+      router.push(href);
+    },
+    [router],
+  );
+
+  const goBack = useCallback(() => {
+    if (depthRef.current > 0) {
+      depthRef.current -= 1;
+      router.back();
+      return;
+    }
+    // Deep-link entry: nothing in-app to pop — climb to the declared parent.
+    const fallback = configRef.current.back?.href;
+    if (fallback) router.push(fallback);
+  }, [router]);
+
   return (
-    <OperatorChromeContext.Provider value={{ config, setConfig }}>
+    <OperatorChromeContext.Provider value={{ config, setConfig, push, goBack }}>
       {children}
     </OperatorChromeContext.Provider>
   );
@@ -42,6 +92,19 @@ export function OperatorChromeProvider({ children }: { children: ReactNode }) {
 /** Read the current header chrome (used by the shell). */
 export function useOperatorChrome(): OperatorChromeConfig {
   return useContext(OperatorChromeContext).config;
+}
+
+/**
+ * In-app navigation for operator pages. Use `push(href)` for EVERY forward
+ * navigation inside the operator shell (it records one level of depth so the
+ * header back can safely router.back()); `goBack()` powers the header back
+ * button. Same-page URL updates (e.g. `?scope=`/`?completed=` on the jobs list)
+ * and single-part hub redirects should keep using `router.replace` directly —
+ * a replace doesn't add a history entry, so it must not bump depth.
+ */
+export function useOperatorNav(): { push: (href: string) => void; goBack: () => void } {
+  const { push, goBack } = useContext(OperatorChromeContext);
+  return { push, goBack };
 }
 
 /**

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -52,6 +52,12 @@ export interface OperatorJob {
   // Per-part progress
   operations_total: number;
   operations_completed: number;
+  /**
+   * When this row's operation was completed (job_operations.completed_at).
+   * Only set on rows from the "Completed" list (getCompletedOperatorJobs /
+   * getAllStationsCompletedOperatorJobs); undefined on the ready list.
+   */
+  completed_at?: string | null;
 }
 
 /**

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -343,6 +343,172 @@ async function buildOperatorJobs(readyRows: ReadyRow[]): Promise<OperatorJob[]> 
 }
 
 // ============================================================================
+// COMPLETED JOB LIST (the jobs page "Completed" filter)
+// ============================================================================
+
+// Cap the "recently completed" list. An operator reaches it to undo a mis-tapped
+// completion, so what matters is the LATEST completions, not full history —
+// ordered by completed_at desc, this is "the most recent N completed steps".
+const COMPLETED_LIST_LIMIT = 50;
+
+// A completed job_operation shaped as a ReadyRow (so buildOperatorJobs can enrich
+// it exactly like the ready list), plus the two fields the completed list adds:
+// which station it ran at and when it was completed.
+interface CompletedOpRow {
+  ready: ReadyRow;
+  work_center_id: string | null;
+  completed_at: string | null;
+}
+
+// Fetch the most-recently-completed operations across the given station(s),
+// joined to their part/job for the display fields buildOperatorJobs needs.
+// Company isolation is enforced two ways: the explicit jobs.company_id filter and
+// work_center_id ∈ this company's stations.
+async function getCompletedOperationRows(
+  companyId: string,
+  workCenterIds: string[],
+): Promise<CompletedOpRow[]> {
+  if (workCenterIds.length === 0) return [];
+  const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from('job_operations')
+    .select(`
+      id, job_id, job_part_id, operation_name, status, completed_at, work_center_id,
+      job_parts!inner(
+        quantity, part_id,
+        parts(part_name, description),
+        jobs!inner(job_number, company_id)
+      )
+    `)
+    .eq('status', 'completed')
+    .eq('job_parts.jobs.company_id', companyId)
+    .in('work_center_id', workCenterIds)
+    .not('completed_at', 'is', null)
+    .order('completed_at', { ascending: false })
+    .limit(COMPLETED_LIST_LIMIT);
+
+  if (error) {
+    // Mirror getReadyOperationsForStation: surface the failure instead of
+    // swallowing it into an empty list (the jobs page shows it in an Alert).
+    throw new Error(`Failed to load completed operations: ${error.message}`);
+  }
+
+  type Row = {
+    id: string;
+    job_id: string;
+    job_part_id: string;
+    operation_name: string;
+    status: string;
+    completed_at: string | null;
+    work_center_id: string | null;
+    job_parts:
+      | {
+          quantity: number;
+          part_id: string;
+          parts: { part_name: string; description: string | null } | { part_name: string; description: string | null }[] | null;
+          jobs: { job_number: string } | { job_number: string }[] | null;
+        }
+      | {
+          quantity: number;
+          part_id: string;
+          parts: { part_name: string; description: string | null } | { part_name: string; description: string | null }[] | null;
+          jobs: { job_number: string } | { job_number: string }[] | null;
+        }[]
+      | null;
+  };
+
+  return ((data ?? []) as Row[]).map((r) => {
+    const partJoin = Array.isArray(r.job_parts) ? r.job_parts[0] : r.job_parts;
+    const partsJoin = partJoin
+      ? Array.isArray(partJoin.parts) ? partJoin.parts[0] : partJoin.parts
+      : null;
+    const jobJoin = partJoin
+      ? Array.isArray(partJoin.jobs) ? partJoin.jobs[0] : partJoin.jobs
+      : null;
+    return {
+      ready: {
+        job_id: r.job_id,
+        job_part_id: r.job_part_id,
+        job_operation_id: r.id,
+        operation_name: r.operation_name,
+        op_status: r.status,
+        job_number: jobJoin?.job_number ?? '',
+        part_id: partJoin?.part_id ?? '',
+        part_name: partsJoin?.part_name ?? '',
+        part_description: partsJoin?.description ?? null,
+        part_quantity: partJoin?.quantity ?? 0,
+      },
+      work_center_id: r.work_center_id,
+      completed_at: r.completed_at,
+    };
+  });
+}
+
+/**
+ * Recently completed work at ONE station — backs the jobs list's "Completed"
+ * filter under the My Station scope. One card per job_part (its most recent
+ * completed operation at the station), most-recent first, so an operator can
+ * reopen a step they finished by mistake and undo it. Mirrors getOperatorJobs
+ * (the ready list) but keyed on completed operations instead of the readiness RPC.
+ */
+export async function getCompletedOperatorJobs(
+  companyId: string,
+  workCenterId?: string,
+): Promise<OperatorJob[]> {
+  if (!workCenterId) return [];
+  const rows = await getCompletedOperationRows(companyId, [workCenterId]);
+
+  // Dedupe by job_part (rows are completed_at-desc, so the first seen per part is
+  // its most recent completion) → one card per part, like the ready list.
+  const seen = new Set<string>();
+  const unique = rows.filter((r) => {
+    if (seen.has(r.ready.job_part_id)) return false;
+    seen.add(r.ready.job_part_id);
+    return true;
+  });
+
+  const jobs = await buildOperatorJobs(unique.map((r) => r.ready));
+  // buildOperatorJobs preserves input order (1:1 over readyRows), so index-align
+  // the completed_at timestamps back onto the enriched rows.
+  return jobs.map((job, i) => ({ ...job, completed_at: unique[i].completed_at }));
+}
+
+/**
+ * Whole-plant ("All Stations") "Completed" list: recently completed work across
+ * every station, grouped by station in the UI. One card per (job_part, station),
+ * since a part can have completed work at more than one station.
+ */
+export async function getAllStationsCompletedOperatorJobs(
+  companyId: string,
+  stations: Station[],
+): Promise<OperatorPlantJob[]> {
+  const stationIds = stations.map((s) => s.id);
+  if (stationIds.length === 0) return [];
+  const rows = await getCompletedOperationRows(companyId, stationIds);
+
+  const nameById = new Map(stations.map((s) => [s.id, s.name] as const));
+  const seen = new Set<string>();
+  const unique = rows.filter((r) => {
+    const key = `${r.ready.job_part_id}:${r.work_center_id ?? ''}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  const jobs = await buildOperatorJobs(unique.map((r) => r.ready));
+  return jobs.map((job, i) => {
+    const wcId = unique[i].work_center_id;
+    return {
+      ...job,
+      completed_at: unique[i].completed_at,
+      work_center_id: wcId,
+      work_center_name: wcId ? nameById.get(wcId) ?? null : null,
+    };
+  });
+}
+
+// ============================================================================
 // PER-PART JOB DETAIL (the page where Start/Stop/Complete lives)
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Four operator-view improvements surfaced while dogfooding on a tablet:

1. **Admin → shop-floor link** — a "Shop floor view" button on the dashboard Jobs toolbar → the operator view, completing the round-trip with the operator view's existing Dashboard shortcut. No role gating (operators never see the dashboard; admins + managers both monitor the floor).
2. **Leaner operator cards** — removed the redundant status chip on the operation page and the job cards; kept the "Part progress / X of Y operations" bar + count. (The traveler's overall-status chip stays — no progress bar there.)
3. **Completed-jobs view** — a single lightweight **"Completed" filter chip** beside the scope toggle (Material 3 filter-chip pattern; no "Active" label). New Supabase-first `getCompletedOperatorJobs` / `getAllStationsCompletedOperatorJobs` (reuse `buildOperatorJobs`; no migration — `completed_at` already exists). Tapping a completed job opens its traveler, where the existing per-step **Undo** reverses a mistaken completion.
4. **Back-nav fix** — scope + completed are URL-backed (`?scope=`, `?completed=1`); All Stations (and any Completed) taps open the **traveler** instead of jumping to the operation, and each detail page derives its back href from a threaded return target so **Back always retraces the path in**. My Station keeps its one-tap fast path.

## Verification

- `tsc`, `eslint`, **13 unit tests** (5 new for the completed access fns), and a full **production build** (all routes compile; Suspense boundaries OK).
- The completed query's nested embed + two-level company filter validated against the **local PostgREST** (returns enriched rows).
- **Live browser drive** on a seeded local stack: operator login → All Stations → tap job → **traveler** (not the operation) → Back → **All Stations**; Completed chip → completed cards ("Completed <date>") → traveler → Undo; admin → dashboard Jobs → **Shop floor view** → operator view.

## Note

Overlaps with the legacy-cleanup PR (`chore/retire-legacy-operator-debt`) in a few files (`operatorAccess.ts`, `types/operator.ts`, the operation page). Recommend **merging this PR first**, then rebasing the cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
