### PR TITLE
feat: read-only AI data health / import-readiness report (#492)

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -73,6 +73,7 @@ from routes.insights_routes import router as insights_router
 from routes.admin_routes import router as system_admin_router
 from routes.quote_email_routes import router as quote_email_router
 from routes.quickbooks_routes import router as quickbooks_router
+from routes.health_report_routes import router as health_report_router
 
 app.include_router(import_router)
 app.include_router(parts_import_router)
@@ -85,6 +86,7 @@ app.include_router(insights_router)
 app.include_router(system_admin_router)
 app.include_router(quote_email_router)
 app.include_router(quickbooks_router)
+app.include_router(health_report_router)
 
 
 # For local development

--- a/api/models/health_report_models.py
+++ b/api/models/health_report_models.py
@@ -1,0 +1,232 @@
+"""Pydantic models + shared constants for the read-only Data Health / Import-Readiness report.
+
+This feature is an ONBOARDING aid (not a sales demo): a shop already committed to
+adopting Jigged uploads its legacy ERP CSV exports, and the tool produces a read-only,
+advisory report of what's in the files, what won't import cleanly, and what to fix —
+plus an informative guess at the source ERP. It NEVER writes to any business system.
+
+Design notes:
+  - The report is computed on demand and returned; nothing is persisted server-side in
+    this slice. The schema is kept reuse-ready (``schema_version`` + a structured
+    ``ErpDetection``) so detection templates / fine-tuning data can be derived later
+    (#524) without a migration now.
+  - The deterministic findings layer cannot key on canonical field names directly,
+    because uploaded CSVs are RAW ERP exports whose headers are the source system's own
+    column names. So an AI "structure" pass first produces, per file, a
+    ``column_roles`` map (canonical_field -> raw_header); the analyzer consumes that.
+  - Cross-file joins are ASYMMETRIC: vendors/work_centers/customers identify by ``name``
+    while parts identify by ``part_name``. See ``REFERENTIAL_LINKS``.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+# Canonical target schemas reused verbatim from the import layer. Importing them here
+# keeps a single source of truth for "what fields does each entity have + which are
+# required" and gives the AI structure prompt the exact canonical vocabulary to map to.
+from models.bom_import_models import BOM_SCHEMA
+from models.import_models import CUSTOMER_SCHEMA
+from models.parts_import_models import PART_SCHEMA
+from models.routings_import_models import ROUTING_SCHEMA
+from models.vendors_import_models import VENDOR_SCHEMA
+from models.work_centers_import_models import WORK_CENTER_SCHEMA
+
+
+class EntityType(str, Enum):
+    """Which Jigged entity a given uploaded file holds."""
+
+    PARTS = "parts"
+    VENDORS = "vendors"
+    WORK_CENTERS = "work_centers"
+    ROUTINGS = "routings"
+    BOM = "bom"
+    CUSTOMERS = "customers"
+    UNKNOWN = "unknown"  # classifier could not confidently decide — surfaced, never guessed
+
+
+class Severity(str, Enum):
+    INFO = "info"  # neutral facts (record counts)
+    WARNING = "warning"  # duplicates, gaps, inactive flags, name variants
+    CRITICAL = "critical"  # missing required columns / broken cross-file references
+
+
+class FindingCategory(str, Enum):
+    RECORD_COUNT = "record_count"
+    DUPLICATE = "duplicate"  # within-file duplicate identity values
+    ORPHAN_REFERENCE = "orphan_reference"  # cross-file reference with no matching parent
+    MISSING_COLUMN = "missing_column"  # a required field's column wasn't identified
+    DATA_GAP = "data_gap"  # required column present but blank in some rows
+    INACTIVE_FLAG = "inactive_flag"  # rows flagged inactive/archived in the source
+    COST_COVERAGE = "cost_coverage"  # parts lacking a cost/price
+    NAME_VARIANT = "name_variant"  # near-duplicate names (spelling variants)
+    NOT_CHECKED = "not_checked"  # a check couldn't run (missing prerequisite) — never silent
+    ERP_GOTCHA = "erp_gotcha"  # AI-surfaced, informative, unverified observation (#522 hook)
+
+
+# ---------------------------------------------------------------------------
+# ERP detection (#520)
+# ---------------------------------------------------------------------------
+class MatchedHeader(BaseModel):
+    """One piece of header evidence for the detected ERP."""
+
+    header: str  # the raw CSV header that matched
+    signal: str  # why it points to this ERP
+
+
+class ErpAlternative(BaseModel):
+    source: str
+    confidence: float = Field(ge=0.0, le=1.0)
+
+
+class ErpDetection(BaseModel):
+    """Detected source ERP. Mirrors MappingSuggestion's 0.0-1.0 confidence contract."""
+
+    source: str = "unknown"  # e.g. "jobboss2" | "e2" | "tangle" | "unknown" | free-form
+    display_name: str = "Unknown"
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    matched_headers: list[MatchedHeader] = []
+    evidence: str = ""
+    alternatives: list[ErpAlternative] = []
+    # Reuse hooks (#524): the exact signal a confirmed detection can be replayed from.
+    header_signature: str = ""  # MD5 of the sorted headers across the bundle
+    ai_provider: str = ""
+    ai_model: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Per-file classification
+# ---------------------------------------------------------------------------
+class FileClassification(BaseModel):
+    """AI-produced classification of one uploaded file.
+
+    ``column_roles`` maps a canonical Jigged field to the RAW header that holds it, e.g.
+    ``{"part_name": "ItemNum", "preferred_vendor_name": "Vendor"}``. The deterministic
+    analyzer keys every check on this map — it is the fix for "can't run on raw headers."
+    """
+
+    filename: str
+    entity_type: EntityType = EntityType.UNKNOWN
+    entity_confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    headers: list[str] = []
+    row_count: int = 0
+    column_roles: dict[str, str] = {}  # canonical_field -> raw_header
+
+
+# ---------------------------------------------------------------------------
+# Findings
+# ---------------------------------------------------------------------------
+class Finding(BaseModel):
+    id: str  # stable slug, e.g. "orphan.parts.preferred_vendor_name"
+    category: FindingCategory
+    severity: Severity
+    entity_type: EntityType = EntityType.UNKNOWN
+    title: str  # plain-English one-liner
+    detail: str = ""  # human explanation
+    count: int = 0  # affected rows / instances
+    examples: list[str] = []  # up to 5 sample values
+    source_files: list[str] = []
+    verified: bool = True  # deterministic == True; AI-inferred gotcha == False
+    recommended_action: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Request / response
+# ---------------------------------------------------------------------------
+class UploadedFile(BaseModel):
+    filename: str
+    headers: list[str]
+    rows: list[dict[str, str]]  # header -> value, matching the import-route row shape
+
+
+class HealthReportRequest(BaseModel):
+    company_id: str
+    files: list[UploadedFile]
+
+
+class HealthReport(BaseModel):
+    """The advisory report. Kept reuse-ready (schema_version + structured detection)."""
+
+    schema_version: int = 1
+    erp_detection: ErpDetection
+    files: list[FileClassification]
+    findings: list[Finding]  # sorted by severity at render time
+    summary: str = ""  # AI narrative, plain text (no markdown)
+    recommendations: list[str] = []
+    narrative_available: bool = True  # False -> UI shows "AI summary unavailable"
+    ai_provider: str = ""
+    ai_model: str = ""
+    generated_at: str = ""  # ISO 8601, stamped by the route
+
+
+class HealthReportResponse(BaseModel):
+    report: HealthReport
+
+
+# ---------------------------------------------------------------------------
+# Shared constants (single source of truth for the analyzer + the AI structure prompt)
+# ---------------------------------------------------------------------------
+
+# Entity -> its canonical import schema.
+ENTITY_SCHEMAS: dict[EntityType, dict] = {
+    EntityType.PARTS: PART_SCHEMA,
+    EntityType.VENDORS: VENDOR_SCHEMA,
+    EntityType.WORK_CENTERS: WORK_CENTER_SCHEMA,
+    EntityType.ROUTINGS: ROUTING_SCHEMA,
+    EntityType.BOM: BOM_SCHEMA,
+    EntityType.CUSTOMERS: CUSTOMER_SCHEMA,
+}
+
+# The single field that identifies a row of each entity (for duplicate + join targets).
+# NOTE the asymmetry: parts identify by ``part_name``; vendors/work_centers/customers by
+# ``name``. Routings and BOM have no single identity row (they are line-item files).
+ENTITY_IDENTITY_FIELD: dict[EntityType, str] = {
+    EntityType.PARTS: "part_name",
+    EntityType.VENDORS: "name",
+    EntityType.WORK_CENTERS: "name",
+    EntityType.CUSTOMERS: "name",
+}
+
+# Cross-file referential links: (child_entity, child_field) -> (parent_entity, parent_field).
+# A child value that has no matching parent identity value is an orphan reference.
+REFERENTIAL_LINKS: list[tuple[EntityType, str, EntityType, str]] = [
+    (EntityType.PARTS, "preferred_vendor_name", EntityType.VENDORS, "name"),
+    (EntityType.WORK_CENTERS, "vendor_name", EntityType.VENDORS, "name"),
+    (EntityType.ROUTINGS, "work_center_name", EntityType.WORK_CENTERS, "name"),
+    (EntityType.ROUTINGS, "part_name", EntityType.PARTS, "part_name"),
+    (EntityType.BOM, "parent_part_name", EntityType.PARTS, "part_name"),
+    (EntityType.BOM, "child_part_name", EntityType.PARTS, "part_name"),
+]
+
+# ERP catalog — prompt grounding ONLY (not a detection lookup). E2 and JobBOSS² are
+# merged branding (ECI folded E2 Shop into JobBOSS²), so hints are intentionally loose.
+ERP_CATALOG: list[dict[str, str]] = [
+    {
+        "source": "jobboss2",
+        "display_name": "JobBOSS²",
+        "header_hint": "ECI JobBOSS²/E2 lineage; job-shop fields like Job, WorkCenter, OperationType, PartNo.",
+    },
+    {
+        "source": "e2",
+        "display_name": "E2 (Shoptech)",
+        "header_hint": "E2 Shop System (now part of JobBOSS²); similar job-shop vocabulary.",
+    },
+    {
+        "source": "tangle",
+        "display_name": "Tangle",
+        "header_hint": "Legacy job-shop system; exports to Excel/CSV for all data elements.",
+    },
+]
+
+
+def entity_type_from_str(value: Optional[str]) -> EntityType:
+    """Coerce an AI-provided entity string to EntityType, defaulting to UNKNOWN."""
+    if not value:
+        return EntityType.UNKNOWN
+    try:
+        return EntityType(str(value).strip().lower())
+    except ValueError:
+        return EntityType.UNKNOWN

--- a/api/routes/health_report_routes.py
+++ b/api/routes/health_report_routes.py
@@ -1,0 +1,298 @@
+"""Read-only Data Health / Import-Readiness report endpoint (#523).
+
+Strictly advisory. This route performs NO writes to any table and calls no
+``auth.admin`` — its only database access is SELECTs (verify caller access, read the
+company feature flag, resolve the AI provider from ``ai_config``). It deliberately does
+NOT import any ``*_import_routes`` / execute path, so there is no reachable write.
+
+Flow (one explicit user action — the frontend "Analyze" button):
+  1. Verify the caller has access to ``company_id`` (never trust the body alone).
+  2. Server-side feature-flag gate (opt-in; the client flag only hides the UI).
+  3. Enforce size caps (files / headers / total rows).
+  4. Best-effort in-memory rate limit (real bound is flag + caller-auth; a serverless
+     in-memory limiter is weak by itself — see plan).
+  5. AI "structure" call: per-file entity + raw->canonical column_roles + ERP detection.
+  6. Deterministic findings over the uploaded bundle (pure Python, no AI, no DB).
+  7. AI "narrative" call, grounded strictly in those findings (informative, never
+     fabricating numbers; degrades to raw findings if it fails).
+
+No on-disk cache is used here: the reused import-route cache would write the uploaded
+rows to disk (a data-at-rest leak, and it EROFS-fails on Vercel anyway).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from supabase import Client, create_client
+
+from models.health_report_models import (
+    ENTITY_SCHEMAS,
+    ERP_CATALOG,
+    ErpDetection,
+    FileClassification,
+    Finding,
+    FindingCategory,
+    HealthReport,
+    HealthReportRequest,
+    HealthReportResponse,
+    Severity,
+    entity_type_from_str,
+)
+from services.ai.factory import get_provider
+from services.health_report_analyzer import AnalyzedFile, analyze_bundle
+from utils.rate_limiter import RateLimiter
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/health-report", tags=["health-report"])
+
+FEATURE_FLAG = "data_health_report"
+
+# Size caps — reject oversized bundles (413) rather than silently truncate, which would
+# make the deterministic counts wrong.
+MAX_FILES = 12
+MAX_HEADERS_PER_FILE = 300
+MAX_TOTAL_ROWS = 200_000
+_SAMPLE_SCAN_ROWS = 50  # rows scanned to find one non-empty sample value per column
+
+# Best-effort per-company limiter (10 reports / 10 min). Weak on serverless cold starts;
+# the meaningful bound is the feature flag + caller authorization.
+_limiter = RateLimiter(max_requests=10, window_seconds=600)
+
+
+def _service_client() -> Client:
+    url = os.getenv("NEXT_PUBLIC_SUPABASE_URL") or os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SECRET_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    if not url or not key:
+        raise HTTPException(status_code=503, detail="Database not configured")
+    return create_client(url, key)
+
+
+async def _verify_company_access(request: Request, company_id: str, client: Client) -> str:
+    """Verify the bearer-token caller has a user_company_access row for company_id.
+
+    Read-only (auth.get_user + one SELECT). Mirrors quickbooks_routes._verify_company_access.
+    """
+    token = request.headers.get("Authorization", "").replace("Bearer ", "")
+    if not token:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    try:
+        user_response = client.auth.get_user(token)
+        if not user_response or not user_response.user:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        user_id = user_response.user.id
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Token verification failed: %s", exc)
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+    access = (
+        client.table("user_company_access")
+        .select("id")
+        .eq("user_id", user_id)
+        .eq("company_id", company_id)
+        .limit(1)
+        .execute()
+    )
+    if not access.data:
+        raise HTTPException(status_code=403, detail="No access to this company")
+    return user_id
+
+
+def _feature_enabled(company_id: str, client: Client) -> bool:
+    """Opt-IN gate: only true when companies.settings.features.data_health_report is set.
+
+    Unlike ai_insights (opt-out), this new tool is off unless explicitly enabled per
+    company. Fails CLOSED on read error — an advisory extra shouldn't dark-launch on a
+    DB blip.
+    """
+    try:
+        resp = (
+            client.table("companies")
+            .select("settings")
+            .eq("id", company_id)
+            .single()
+            .execute()
+        )
+        settings = (resp.data or {}).get("settings") or {}
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Failed to read company feature flags: %s", e)
+        return False
+    features = settings.get("features") or {}
+    raw = features.get(FEATURE_FLAG)
+    return raw is True or raw == "true"
+
+
+def _enforce_caps(files) -> None:
+    if len(files) > MAX_FILES:
+        raise HTTPException(status_code=413, detail=f"Too many files (max {MAX_FILES}).")
+    total_rows = sum(len(f.rows) for f in files)
+    if total_rows > MAX_TOTAL_ROWS:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Too many rows in one upload (max {MAX_TOTAL_ROWS:,}).",
+        )
+    for f in files:
+        if len(f.headers) > MAX_HEADERS_PER_FILE:
+            raise HTTPException(
+                status_code=413,
+                detail=f"'{f.filename}' has too many columns (max {MAX_HEADERS_PER_FILE}).",
+            )
+
+
+def _column_samples(headers: list[str], rows: list[dict]) -> dict[str, str]:
+    """One non-empty sample value per column, scanning only the first few rows."""
+    out: dict[str, str] = {}
+    scan = rows[:_SAMPLE_SCAN_ROWS]
+    for h in headers:
+        for row in scan:
+            v = (row.get(h) or "").strip()
+            if v:
+                out[h] = v
+                break
+    return out
+
+
+def _bundle_signature(files) -> str:
+    per_file = ["|".join(sorted(f.headers)) for f in files]
+    return hashlib.md5("||".join(sorted(per_file)).encode()).hexdigest()
+
+
+@router.post("/analyze", response_model=HealthReportResponse)
+async def analyze(request: HealthReportRequest, req: Request) -> HealthReportResponse:
+    company_id = request.company_id
+    client = _service_client()
+
+    # 1-2. authorization + opt-in feature gate (both before any paid AI work)
+    await _verify_company_access(req, company_id, client)
+    if not _feature_enabled(company_id, client):
+        raise HTTPException(status_code=403, detail="Data Health report is not enabled for this company.")
+
+    # 3. size caps
+    _enforce_caps(request.files)
+
+    # 4. best-effort rate limit
+    if not _limiter.check(company_id):
+        raise HTTPException(
+            status_code=429,
+            detail="Too many data-health analyses. Please wait a few minutes and try again.",
+            headers={"Retry-After": "600"},
+        )
+
+    try:
+        # 5. AI structure + source detection
+        entity_schemas = {et.value: schema for et, schema in ENTITY_SCHEMAS.items()}
+        struct_input = [
+            {
+                "filename": f.filename,
+                "headers": f.headers,
+                "column_samples": _column_samples(f.headers, f.rows),
+            }
+            for f in request.files
+        ]
+        provider = await get_provider(client, company_id, "csv_mapping")
+        structure = await provider.analyze_structure(struct_input, entity_schemas, ERP_CATALOG)
+        model = getattr(provider, "model", "")
+
+        # 6. deterministic findings over the AI-identified column roles
+        rows_by_name = {f.filename: f.rows for f in request.files}
+        headers_by_name = {f.filename: f.headers for f in request.files}
+        analyzed = [
+            AnalyzedFile(
+                filename=fs.filename,
+                entity_type=entity_type_from_str(fs.entity_type),
+                column_roles=fs.column_roles,
+                rows=rows_by_name.get(fs.filename, []),
+                headers=headers_by_name.get(fs.filename, []),
+            )
+            for fs in structure.files
+        ]
+        findings = analyze_bundle(analyzed)
+
+        # 7. grounded narrative
+        file_summaries = [
+            {"filename": af.filename, "entity_type": af.entity_type.value, "row_count": len(af.rows)}
+            for af in analyzed
+        ]
+        findings_payload = [
+            {
+                "id": f.id,
+                "category": f.category.value,
+                "severity": f.severity.value,
+                "title": f.title,
+                "detail": f.detail,
+                "count": f.count,
+                "examples": f.examples[:3],
+            }
+            for f in findings
+        ]
+        narrative = await provider.generate_health_narrative(
+            erp=structure.erp.model_dump(),
+            findings=findings_payload,
+            file_summaries=file_summaries,
+        )
+
+        # AI "gotchas" are informative but unverified — appended as verified=False findings.
+        for i, g in enumerate(narrative.gotchas):
+            findings.append(
+                Finding(
+                    id=f"gotcha.{i}",
+                    category=FindingCategory.ERP_GOTCHA,
+                    severity=Severity.INFO,
+                    title=g.get("title", "Worth verifying"),
+                    detail=g.get("detail", ""),
+                    recommended_action=g.get("recommended_action", ""),
+                    verified=False,
+                )
+            )
+
+        classifications = [
+            FileClassification(
+                filename=fs.filename,
+                entity_type=entity_type_from_str(fs.entity_type),
+                entity_confidence=fs.entity_confidence,
+                headers=headers_by_name.get(fs.filename, []),
+                row_count=len(rows_by_name.get(fs.filename, [])),
+                column_roles=fs.column_roles,
+            )
+            for fs in structure.files
+        ]
+
+        erp = structure.erp
+        erp_detection = ErpDetection(
+            source=erp.source,
+            display_name=erp.display_name,
+            confidence=erp.confidence,
+            matched_headers=erp.matched_headers,
+            evidence=erp.evidence,
+            alternatives=erp.alternatives,
+            header_signature=_bundle_signature(request.files),
+            ai_provider=provider.provider_name,
+            ai_model=model,
+        )
+
+        report = HealthReport(
+            erp_detection=erp_detection,
+            files=classifications,
+            findings=findings,
+            summary=narrative.summary if narrative.available else "",
+            recommendations=narrative.recommendations,
+            narrative_available=narrative.available,
+            ai_provider=provider.provider_name,
+            ai_model=model,
+            generated_at=datetime.now(timezone.utc).isoformat(),
+        )
+        return HealthReportResponse(report=report)
+    except HTTPException:
+        raise
+    except Exception as e:  # noqa: BLE001
+        # Log the error TYPE only — never the uploaded row content (avoids leaking a
+        # shop's data into logs/Sentry, since send_default_pii is on).
+        logger.warning("Health report analysis failed: %s", type(e).__name__)
+        raise HTTPException(status_code=500, detail="Failed to analyze the uploaded files.")

--- a/api/services/ai/base_provider.py
+++ b/api/services/ai/base_provider.py
@@ -15,6 +15,42 @@ class MappingSuggestion(BaseModel):
     reasoning: str
 
 
+class ErpDetectionResult(BaseModel):
+    """AI guess at the source ERP. Same 0.0-1.0 confidence contract as MappingSuggestion."""
+
+    source: str = "unknown"
+    display_name: str = "Unknown"
+    confidence: float = 0.0
+    matched_headers: list[dict] = []  # {"header": str, "signal": str}
+    evidence: str = ""
+    alternatives: list[dict] = []  # {"source": str, "confidence": float}
+
+
+class FileStructure(BaseModel):
+    """AI classification of one uploaded file: entity type + raw->canonical column roles."""
+
+    filename: str
+    entity_type: str = "unknown"
+    entity_confidence: float = 0.0
+    column_roles: dict[str, str] = {}  # canonical_field -> raw_header
+
+
+class StructureResult(BaseModel):
+    """Combined structure + source analysis of an uploaded bundle."""
+
+    erp: ErpDetectionResult = ErpDetectionResult()
+    files: list[FileStructure] = []
+
+
+class HealthNarrativeResult(BaseModel):
+    """Plain-text narrative + guidance, grounded in the deterministic findings."""
+
+    summary: str = ""
+    recommendations: list[str] = []
+    gotchas: list[dict] = []  # {"title","detail","recommended_action"} — informative, unverified
+    available: bool = True  # False -> narrative generation failed; UI shows raw findings only
+
+
 class AIProvider(ABC):
     """Abstract base class for AI providers."""
 
@@ -43,5 +79,38 @@ class AIProvider(ABC):
 
         Returns:
             List of MappingSuggestion objects with confidence scores
+        """
+        pass
+
+    @abstractmethod
+    async def analyze_structure(
+        self,
+        files: list[dict],
+        entity_schemas: dict[str, dict],
+        erp_catalog: list[dict],
+    ) -> StructureResult:
+        """Classify each uploaded file (entity type + raw->canonical column_roles) and
+        detect the likely source ERP in a single call.
+
+        Args:
+            files: [{"filename", "headers": [str], "column_samples": {header: sample}}]
+            entity_schemas: {entity_name: schema_dict} — the canonical fields to map onto
+            erp_catalog: [{"source","display_name","header_hint"}] — prompt grounding only
+
+        Returns:
+            StructureResult (should degrade to unknown rather than raise on a bad response).
+        """
+        pass
+
+    @abstractmethod
+    async def generate_health_narrative(
+        self,
+        erp: dict,
+        findings: list[dict],
+        file_summaries: list[dict],
+    ) -> HealthNarrativeResult:
+        """Write a plain-text data-health narrative grounded STRICTLY in the given
+        deterministic findings (no invented numbers). Returns available=False on failure
+        so the caller can show raw findings instead of fabricated prose.
         """
         pass

--- a/api/services/ai/claude_provider.py
+++ b/api/services/ai/claude_provider.py
@@ -8,10 +8,99 @@ from typing import Optional
 
 import anthropic
 
-from .base_provider import AIProvider, MappingSuggestion
+from .base_provider import (
+    AIProvider,
+    ErpDetectionResult,
+    FileStructure,
+    HealthNarrativeResult,
+    MappingSuggestion,
+    StructureResult,
+)
 from .model_config import DEFAULT_ANTHROPIC_MODEL
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_json_response(response_text: str) -> dict:
+    """Extract a JSON object from a Claude text response.
+
+    Strips a leading/trailing ```json ... ``` fence if present, then json.loads.
+    Raises json.JSONDecodeError on malformed content (callers handle the fallback).
+    Shared by every ClaudeProvider method that expects a JSON object back.
+    """
+    text = response_text.strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        json_lines: list[str] = []
+        in_json = False
+        for line in lines:
+            if line.startswith("```") and not in_json:
+                in_json = True
+                continue
+            elif line.startswith("```") and in_json:
+                break
+            elif in_json:
+                json_lines.append(line)
+        text = "\n".join(json_lines)
+    return json.loads(text)
+
+
+def _clamp01(value) -> float:
+    try:
+        return max(0.0, min(1.0, float(value)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+STRUCTURE_PROMPT_TEMPLATE = """You are analyzing CSV files a machine shop exported from its previous manufacturing ERP, to help it migrate the data into a new platform. Do TWO things: (1) classify each file to one entity type and map its raw columns to canonical fields, and (2) identify the likely source ERP.
+
+## Canonical entity schemas (map raw columns onto THESE fields):
+{schemas_json}
+
+## Known source ERPs (for naming only — do not force a match):
+{erp_catalog_json}
+
+## Uploaded files (raw headers + one sample value per non-empty column):
+{files_json}
+
+## Instructions:
+1. For each file, choose the single best `entity_type` from: {entity_names}, or "unknown" if none fits.
+2. Build `column_roles`: a map of canonical_field -> the RAW header (verbatim from that file) that holds it. Only include fields you can identify; omit the rest. NEVER invent a header that isn't in the file, and NEVER invent a canonical field that isn't in that entity's schema.
+3. Give `entity_confidence` 0.0-1.0.
+4. Detect the source ERP: set `source` (a short slug like "jobboss2"/"e2"/"tangle" or your best guess), `display_name`, `confidence` 0.0-1.0, `matched_headers` (the specific headers that point to it, each with a short `signal`), a one-sentence `evidence`, and up to 2 `alternatives`. If nothing clearly indicates an ERP, return source "unknown" with low confidence — do NOT guess to seem confident.
+
+Return ONLY valid JSON in this exact shape (no markdown, no prose):
+{{
+  "erp": {{"source": "unknown", "display_name": "Unknown", "confidence": 0.0, "matched_headers": [{{"header": "WorkCenter", "signal": "job-shop op vocabulary"}}], "evidence": "", "alternatives": [{{"source": "e2", "confidence": 0.3}}]}},
+  "files": [
+    {{"filename": "parts.csv", "entity_type": "parts", "entity_confidence": 0.9, "column_roles": {{"part_name": "PartNo", "preferred_vendor_name": "Vendor"}}}}
+  ]
+}}"""
+
+
+NARRATIVE_PROMPT_TEMPLATE = """You are helping a machine-shop owner get their legacy data ready to import into a new manufacturing platform. Write a clear, practical, plain-English report about what's in their files and what to fix. Audience: a hands-on shop owner (not technical). Be thorough and specific — surface everything that would help them get all their data in correctly.
+
+## Detected source ERP:
+{erp_json}
+
+## Files uploaded:
+{files_json}
+
+## Deterministic findings (the ONLY facts you may cite):
+{findings_json}
+
+## Grounding rules (critical):
+- You may reference ONLY the findings above. Every number you state MUST be the `count` of a specific finding — do not compute or invent any other number.
+- Do NOT introduce any issue, record count, or ERP behavior that is not in the findings.
+- If there is little to report, say so plainly. Never pad with invented problems.
+- `gotchas` are OPTIONAL, clearly-hedged tips about likely source-system quirks worth double-checking; phrase them as "worth verifying", never as established fact.
+
+Return ONLY valid JSON in this exact shape (no markdown, plain text in every string):
+{{
+  "summary": "2-4 short paragraphs summarizing data readiness, citing finding counts.",
+  "recommendations": ["ordered, concrete next steps the owner can act on"],
+  "gotchas": [{{"title": "short", "detail": "why it might matter", "recommended_action": "what to check"}}]
+}}"""
 
 
 MAPPING_PROMPT_TEMPLATE = """You are analyzing a CSV file to map columns to a customer database schema for a manufacturing operations data platform.
@@ -118,22 +207,7 @@ class ClaudeProvider(AIProvider):
 
         # Try to extract JSON from the response
         try:
-            # Handle potential markdown code blocks
-            if response_text.startswith("```"):
-                lines = response_text.split("\n")
-                json_lines = []
-                in_json = False
-                for line in lines:
-                    if line.startswith("```") and not in_json:
-                        in_json = True
-                        continue
-                    elif line.startswith("```") and in_json:
-                        break
-                    elif in_json:
-                        json_lines.append(line)
-                response_text = "\n".join(json_lines)
-
-            data = json.loads(response_text)
+            data = _parse_json_response(response_text)
             mappings = []
 
             for item in data.get("mappings", []):
@@ -159,6 +233,128 @@ class ClaudeProvider(AIProvider):
                 )
                 for header in csv_headers
             ]
+
+    async def analyze_structure(
+        self,
+        files: list[dict],
+        entity_schemas: dict[str, dict],
+        erp_catalog: list[dict],
+    ) -> StructureResult:
+        """Classify each file (entity + raw->canonical column_roles) and detect the ERP."""
+
+        def _fmt_samples(samples: dict) -> str:
+            lines = [f'    {c}: "{v}"' for c, v in (samples or {}).items()]
+            return "\n".join(lines) if lines else "    (no sample data)"
+
+        files_block = "\n".join(
+            f"### {f.get('filename', '(unnamed)')}\n"
+            f"  headers: {json.dumps(f.get('headers', []))}\n"
+            f"  samples:\n{_fmt_samples(f.get('column_samples'))}"
+            for f in files
+        )
+        prompt = STRUCTURE_PROMPT_TEMPLATE.format(
+            schemas_json=json.dumps(entity_schemas, indent=2),
+            erp_catalog_json=json.dumps(erp_catalog, indent=2),
+            files_json=files_block,
+            entity_names=", ".join(entity_schemas.keys()),
+        )
+
+        try:
+            response = self.client.messages.create(
+                model=self.model,
+                max_tokens=8192,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            data = _parse_json_response(response.content[0].text.strip())
+        except Exception as e:  # noqa: BLE001 — degrade to unknown, never raise into the route
+            logger.warning(f"analyze_structure failed to parse AI response: {e}")
+            return StructureResult(
+                erp=ErpDetectionResult(evidence=f"ERP detection unavailable: {e}"),
+                files=[FileStructure(filename=f.get("filename", "")) for f in files],
+            )
+
+        erp_raw = data.get("erp", {}) or {}
+        erp = ErpDetectionResult(
+            source=str(erp_raw.get("source", "unknown") or "unknown"),
+            display_name=str(erp_raw.get("display_name", "Unknown") or "Unknown"),
+            confidence=_clamp01(erp_raw.get("confidence", 0.0)),
+            matched_headers=[
+                {"header": str(m.get("header", "")), "signal": str(m.get("signal", ""))}
+                for m in (erp_raw.get("matched_headers") or [])
+                if isinstance(m, dict)
+            ],
+            evidence=str(erp_raw.get("evidence", "") or ""),
+            alternatives=[
+                {"source": str(a.get("source", "")), "confidence": _clamp01(a.get("confidence", 0.0))}
+                for a in (erp_raw.get("alternatives") or [])
+                if isinstance(a, dict)
+            ],
+        )
+
+        valid_headers_by_file = {f.get("filename", ""): set(f.get("headers", []) or []) for f in files}
+        file_structs: list[FileStructure] = []
+        for item in data.get("files", []):
+            if not isinstance(item, dict):
+                continue
+            fname = str(item.get("filename", ""))
+            allowed = valid_headers_by_file.get(fname, set())
+            roles_raw = item.get("column_roles", {}) or {}
+            # Keep only roles whose raw header actually exists in that file (guards against
+            # the model hallucinating a header). If we can't validate the file, keep as-is.
+            roles = {
+                str(k): str(v)
+                for k, v in roles_raw.items()
+                if not allowed or str(v) in allowed
+            }
+            file_structs.append(
+                FileStructure(
+                    filename=fname,
+                    entity_type=str(item.get("entity_type", "unknown") or "unknown"),
+                    entity_confidence=_clamp01(item.get("entity_confidence", 0.0)),
+                    column_roles=roles,
+                )
+            )
+        return StructureResult(erp=erp, files=file_structs)
+
+    async def generate_health_narrative(
+        self,
+        erp: dict,
+        findings: list[dict],
+        file_summaries: list[dict],
+    ) -> HealthNarrativeResult:
+        """Write a plain-text narrative grounded strictly in the deterministic findings."""
+        prompt = NARRATIVE_PROMPT_TEMPLATE.format(
+            erp_json=json.dumps(erp, indent=2),
+            files_json=json.dumps(file_summaries, indent=2),
+            findings_json=json.dumps(findings, indent=2),
+        )
+        try:
+            response = self.client.messages.create(
+                model=self.model,
+                max_tokens=4096,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            data = _parse_json_response(response.content[0].text.strip())
+        except Exception as e:  # noqa: BLE001 — surface the gap, never fabricate prose
+            logger.warning(f"generate_health_narrative failed: {e}")
+            return HealthNarrativeResult(available=False)
+
+        recs = [str(r) for r in (data.get("recommendations") or []) if str(r).strip()]
+        gotchas = [
+            {
+                "title": str(g.get("title", "")),
+                "detail": str(g.get("detail", "")),
+                "recommended_action": str(g.get("recommended_action", "")),
+            }
+            for g in (data.get("gotchas") or [])
+            if isinstance(g, dict) and str(g.get("title", "")).strip()
+        ]
+        return HealthNarrativeResult(
+            summary=str(data.get("summary", "") or ""),
+            recommendations=recs,
+            gotchas=gotchas,
+            available=True,
+        )
 
     async def chat_with_tools(
         self,

--- a/api/services/ai/gemini_provider.py
+++ b/api/services/ai/gemini_provider.py
@@ -6,7 +6,12 @@ from typing import Optional
 
 from google import genai
 
-from .base_provider import AIProvider, MappingSuggestion
+from .base_provider import (
+    AIProvider,
+    HealthNarrativeResult,
+    MappingSuggestion,
+    StructureResult,
+)
 
 
 MAPPING_PROMPT_TEMPLATE = """You are analyzing a CSV file to map columns to a customer database schema for a manufacturing operations data platform.
@@ -64,6 +69,13 @@ class GeminiProvider(AIProvider):
     @property
     def provider_name(self) -> str:
         return "gemini"
+
+    async def analyze_structure(self, files, entity_schemas, erp_catalog) -> StructureResult:
+        # The data-health report is Anthropic-only for now (factory defaults to Anthropic).
+        raise NotImplementedError("analyze_structure is not implemented for the Gemini provider")
+
+    async def generate_health_narrative(self, erp, findings, file_summaries) -> HealthNarrativeResult:
+        raise NotImplementedError("generate_health_narrative is not implemented for the Gemini provider")
 
     async def suggest_column_mappings(
         self,

--- a/api/services/ai/openai_provider.py
+++ b/api/services/ai/openai_provider.py
@@ -6,7 +6,12 @@ from typing import Optional
 
 from openai import OpenAI
 
-from .base_provider import AIProvider, MappingSuggestion
+from .base_provider import (
+    AIProvider,
+    HealthNarrativeResult,
+    MappingSuggestion,
+    StructureResult,
+)
 
 
 MAPPING_PROMPT_TEMPLATE = """You are analyzing a CSV file to map columns to a customer database schema for a manufacturing operations data platform.
@@ -64,6 +69,13 @@ class OpenAIProvider(AIProvider):
     @property
     def provider_name(self) -> str:
         return "openai"
+
+    async def analyze_structure(self, files, entity_schemas, erp_catalog) -> StructureResult:
+        # The data-health report is Anthropic-only for now (factory defaults to Anthropic).
+        raise NotImplementedError("analyze_structure is not implemented for the OpenAI provider")
+
+    async def generate_health_narrative(self, erp, findings, file_summaries) -> HealthNarrativeResult:
+        raise NotImplementedError("generate_health_narrative is not implemented for the OpenAI provider")
 
     async def suggest_column_mappings(
         self,

--- a/api/services/health_report_analyzer.py
+++ b/api/services/health_report_analyzer.py
@@ -1,0 +1,461 @@
+"""Deterministic data-health analyzer for the read-only import-readiness report.
+
+Pure Python: NO AI, NO DB, NO writes. This is the factual backbone that grounds the
+AI narrative and makes the endpoint's "no domain-table writes" guarantee trivially true
+(this module imports nothing that can write).
+
+It consumes files that have ALREADY been given ``column_roles`` by the AI "structure"
+pass — a map from a canonical Jigged field to the RAW header that holds it. Every check
+keys on that map, which is what lets it work on raw ERP exports whose headers are the
+source system's own column names (``ItemNum``, ``PartNo``, ``Vendor``, …).
+
+Guarantees the review demanded:
+  - Cross-file joins use the CORRECT asymmetric keys (parts identify by ``part_name``;
+    vendors/work_centers/customers by ``name``) via ``REFERENTIAL_LINKS``.
+  - Join/duplicate matching is NORMALIZED (trim/case/whitespace) so ``ACME`` vs ``Acme``
+    doesn't produce phantom orphans.
+  - A check that cannot run (missing file, unidentified column) emits ONE explicit
+    "not checked" finding — never a silent ``0`` and never N phantom orphans.
+  - A file whose labeled entity has none of its required columns identified yields ONE
+    "classification uncertain" finding, not a flood of missing-column noise.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Optional
+
+from models.health_report_models import (
+    ENTITY_IDENTITY_FIELD,
+    ENTITY_SCHEMAS,
+    REFERENTIAL_LINKS,
+    EntityType,
+    Finding,
+    FindingCategory,
+    Severity,
+)
+from models.parts_import_models import parse_bool
+
+_MAX_EXAMPLES = 5
+_INACTIVE_HEADER_TOKENS = {"active", "is_active", "isactive", "status", "inactive", "disabled", "archived"}
+_INACTIVE_STATUS_VALUES = {"inactive", "archived", "disabled", "closed", "obsolete", "discontinued", "hold", "onhold"}
+_COMPANY_SUFFIXES = (
+    "incorporated", "corporation", "company", "limited",
+    "inc", "llc", "corp", "co", "ltd", "lp", "plc",
+)
+_SEVERITY_ORDER = {Severity.CRITICAL: 0, Severity.WARNING: 1, Severity.INFO: 2}
+
+
+@dataclass
+class AnalyzedFile:
+    """One uploaded file after AI structure classification. The analyzer's unit of input."""
+
+    filename: str
+    entity_type: EntityType
+    column_roles: dict[str, str]  # canonical_field -> raw_header
+    rows: list[dict[str, str]]
+    headers: list[str] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------- helpers
+def _norm(value: Optional[str]) -> str:
+    return (value or "").strip().casefold()
+
+
+def _aggressive_norm(value: Optional[str]) -> str:
+    """Strip non-alphanumerics and common company suffixes for name-variant grouping."""
+    s = re.sub(r"[^a-z0-9]+", "", _norm(value))
+    changed = True
+    while changed:
+        changed = False
+        for suf in _COMPANY_SUFFIXES:
+            if len(s) > len(suf) and s.endswith(suf):
+                s = s[: -len(suf)]
+                changed = True
+    return s
+
+
+def _role_col(af: AnalyzedFile, canonical_field: str) -> Optional[str]:
+    return af.column_roles.get(canonical_field)
+
+
+def _cell(row: dict[str, str], col: Optional[str]) -> str:
+    return row.get(col, "") if col else ""
+
+
+def _files_of(files: list[AnalyzedFile], entity: EntityType) -> list[AnalyzedFile]:
+    return [af for af in files if af.entity_type == entity]
+
+
+def _entity_label(entity: EntityType) -> str:
+    return entity.value.replace("_", " ")
+
+
+# --------------------------------------------------------------------------- checks
+def _record_counts(files: list[AnalyzedFile]) -> list[Finding]:
+    out: list[Finding] = []
+    for af in files:
+        out.append(
+            Finding(
+                id=f"count.{af.filename}",
+                category=FindingCategory.RECORD_COUNT,
+                severity=Severity.INFO,
+                entity_type=af.entity_type,
+                title=f"{len(af.rows)} rows in {af.filename}",
+                detail=f"Detected as {_entity_label(af.entity_type)}.",
+                count=len(af.rows),
+                source_files=[af.filename],
+            )
+        )
+    return out
+
+
+def _within_file_duplicates(af: AnalyzedFile) -> list[Finding]:
+    identity = ENTITY_IDENTITY_FIELD.get(af.entity_type)
+    if not identity:
+        return []
+    col = _role_col(af, identity)
+    if not col:
+        return []  # missing-required check reports the unidentified column separately
+    seen: dict[str, list[int]] = defaultdict(list)
+    originals: dict[str, str] = {}
+    for i, row in enumerate(af.rows):
+        raw = _cell(row, col)
+        key = _norm(raw)
+        if not key:
+            continue
+        seen[key].append(i + 1)
+        originals.setdefault(key, raw.strip())
+    dup_keys = [k for k, rows in seen.items() if len(rows) > 1]
+    if not dup_keys:
+        return []
+    affected = sum(len(seen[k]) for k in dup_keys)
+    examples = [originals[k] for k in dup_keys[:_MAX_EXAMPLES]]
+    return [
+        Finding(
+            id=f"duplicate.{af.entity_type.value}.{identity}",
+            category=FindingCategory.DUPLICATE,
+            severity=Severity.WARNING,
+            entity_type=af.entity_type,
+            title=f"{len(dup_keys)} duplicate {identity} value(s) in {af.filename}",
+            detail=(
+                f"{affected} rows share a {identity} with another row (case/space-insensitive). "
+                "Duplicate identities collide on import — merge or disambiguate them."
+            ),
+            count=affected,
+            examples=examples,
+            source_files=[af.filename],
+            recommended_action=f"Deduplicate the {identity} column before import.",
+        )
+    ]
+
+
+def _missing_or_empty_required(af: AnalyzedFile) -> list[Finding]:
+    schema = ENTITY_SCHEMAS.get(af.entity_type)
+    if not schema:
+        return []
+    required = [k for k, v in schema.items() if v.get("required")]
+    if not required:
+        return []
+    identified = [k for k in required if _role_col(af, k)]
+    if not identified:
+        # None of the required columns were found — the file is probably misclassified.
+        return [
+            Finding(
+                id=f"classification_uncertain.{af.filename}",
+                category=FindingCategory.NOT_CHECKED,
+                severity=Severity.WARNING,
+                entity_type=af.entity_type,
+                title=f"Could not confidently read {af.filename} as {_entity_label(af.entity_type)}",
+                detail=(
+                    f"None of the required {_entity_label(af.entity_type)} columns "
+                    f"({', '.join(required)}) were identified in this file. It may be a "
+                    "different kind of data, or use headers we couldn't map. Detailed "
+                    "checks were skipped to avoid misleading results."
+                ),
+                source_files=[af.filename],
+                recommended_action="Confirm this file's type and column headers.",
+            )
+        ]
+    out: list[Finding] = []
+    total = len(af.rows)
+    for key in required:
+        col = _role_col(af, key)
+        if not col:
+            out.append(
+                Finding(
+                    id=f"missing.{af.entity_type.value}.{key}",
+                    category=FindingCategory.MISSING_COLUMN,
+                    severity=Severity.CRITICAL,
+                    entity_type=af.entity_type,
+                    title=f"Required field '{key}' not found in {af.filename}",
+                    detail=f"No column in {af.filename} maps to the required field '{key}'.",
+                    source_files=[af.filename],
+                    recommended_action=f"Add or map a column for '{key}'.",
+                )
+            )
+            continue
+        blanks = sum(1 for row in af.rows if not _norm(_cell(row, col)))
+        if total and blanks == total:
+            out.append(
+                Finding(
+                    id=f"missing.{af.entity_type.value}.{key}",
+                    category=FindingCategory.MISSING_COLUMN,
+                    severity=Severity.CRITICAL,
+                    entity_type=af.entity_type,
+                    title=f"Required field '{key}' is entirely blank in {af.filename}",
+                    detail=f"The column mapped to '{key}' has no values in any row.",
+                    count=total,
+                    source_files=[af.filename],
+                    recommended_action=f"Populate the '{key}' column before import.",
+                )
+            )
+        elif blanks:
+            out.append(
+                Finding(
+                    id=f"gap.{af.entity_type.value}.{key}",
+                    category=FindingCategory.DATA_GAP,
+                    severity=Severity.WARNING,
+                    entity_type=af.entity_type,
+                    title=f"{blanks} of {total} rows missing '{key}' in {af.filename}",
+                    detail=f"'{key}' is required but blank in {blanks} row(s).",
+                    count=blanks,
+                    source_files=[af.filename],
+                    recommended_action=f"Fill in the missing '{key}' values.",
+                )
+            )
+    return out
+
+
+def _not_checked(link_id: str, entity: EntityType, title: str, detail: str, files: list[str]) -> Finding:
+    return Finding(
+        id=f"not_checked.{link_id}",
+        category=FindingCategory.NOT_CHECKED,
+        severity=Severity.WARNING,
+        entity_type=entity,
+        title=title,
+        detail=detail,
+        source_files=files,
+    )
+
+
+def _cross_file_orphans(files: list[AnalyzedFile]) -> list[Finding]:
+    out: list[Finding] = []
+    for child_entity, child_field, parent_entity, parent_field in REFERENTIAL_LINKS:
+        child_files = _files_of(files, child_entity)
+        if not child_files:
+            continue
+        link_id = f"{child_entity.value}.{child_field}"
+        child_cols = {af.filename: _role_col(af, child_field) for af in child_files}
+        if not any(child_cols.values()):
+            continue  # this reference isn't present in the uploaded child files — nothing to check
+
+        parent_files = _files_of(files, parent_entity)
+        if not parent_files:
+            out.append(
+                _not_checked(
+                    link_id,
+                    child_entity,
+                    f"{_entity_label(child_entity)} reference {_entity_label(parent_entity)}, "
+                    f"but no {_entity_label(parent_entity)} file was uploaded",
+                    f"Could not verify that every {child_field} exists — upload the "
+                    f"{_entity_label(parent_entity)} file to check these references.",
+                    [af.filename for af in child_files],
+                )
+            )
+            continue
+        parent_cols = [_role_col(af, parent_field) for af in parent_files]
+        if not any(parent_cols):
+            out.append(
+                _not_checked(
+                    link_id,
+                    child_entity,
+                    f"Could not verify {_entity_label(child_entity)} → {_entity_label(parent_entity)} references",
+                    f"The '{parent_field}' column could not be identified in the "
+                    f"{_entity_label(parent_entity)} file(s).",
+                    [af.filename for af in parent_files],
+                )
+            )
+            continue
+
+        parent_values: set[str] = set()
+        for af in parent_files:
+            pcol = _role_col(af, parent_field)
+            if not pcol:
+                continue
+            for row in af.rows:
+                v = _norm(_cell(row, pcol))
+                if v:
+                    parent_values.add(v)
+
+        orphan_count = 0
+        orphan_examples: list[str] = []
+        seen_examples: set[str] = set()
+        for af in child_files:
+            ccol = child_cols.get(af.filename)
+            if not ccol:
+                continue
+            for row in af.rows:
+                raw = _cell(row, ccol)
+                v = _norm(raw)
+                if not v:
+                    continue
+                if v not in parent_values:
+                    orphan_count += 1
+                    if v not in seen_examples and len(orphan_examples) < _MAX_EXAMPLES:
+                        orphan_examples.append(raw.strip())
+                        seen_examples.add(v)
+        if orphan_count:
+            out.append(
+                Finding(
+                    id=f"orphan.{link_id}",
+                    category=FindingCategory.ORPHAN_REFERENCE,
+                    severity=Severity.CRITICAL,
+                    entity_type=child_entity,
+                    title=(
+                        f"{orphan_count} {_entity_label(child_entity)} row(s) reference a "
+                        f"{_entity_label(parent_entity)} that isn't in the upload"
+                    ),
+                    detail=(
+                        f"The {child_field} value on these rows has no matching "
+                        f"{parent_field} in the {_entity_label(parent_entity)} file. These "
+                        "references will break on import."
+                    ),
+                    count=orphan_count,
+                    examples=orphan_examples,
+                    source_files=[af.filename for af in child_files if child_cols.get(af.filename)],
+                    recommended_action=(
+                        f"Add the missing {_entity_label(parent_entity)} records, or correct "
+                        f"the {child_field} values."
+                    ),
+                )
+            )
+    return out
+
+
+def _cost_coverage(files: list[AnalyzedFile]) -> list[Finding]:
+    out: list[Finding] = []
+    for af in _files_of(files, EntityType.PARTS):
+        col = _role_col(af, "cost_per_unit")
+        total = len(af.rows)
+        if not col or not total:
+            continue
+        missing = sum(1 for row in af.rows if not _norm(_cell(row, col)))
+        if not missing:
+            continue
+        pct = round(100 * missing / total)
+        out.append(
+            Finding(
+                id=f"cost_coverage.{af.filename}",
+                category=FindingCategory.COST_COVERAGE,
+                severity=Severity.WARNING if pct >= 10 else Severity.INFO,
+                entity_type=EntityType.PARTS,
+                title=f"{pct}% of parts in {af.filename} have no cost/price",
+                detail=(
+                    f"{missing} of {total} parts have no value in the cost column. Parts "
+                    "without a cost can't be quoted or costed accurately."
+                ),
+                count=missing,
+                source_files=[af.filename],
+                recommended_action="Fill in unit costs where available before import.",
+            )
+        )
+    return out
+
+
+def _name_variants(files: list[AnalyzedFile]) -> list[Finding]:
+    out: list[Finding] = []
+    for entity in (EntityType.PARTS, EntityType.VENDORS):
+        identity = ENTITY_IDENTITY_FIELD.get(entity)
+        if not identity:
+            continue
+        for af in _files_of(files, entity):
+            col = _role_col(af, identity)
+            if not col:
+                continue
+            groups: dict[str, set[str]] = defaultdict(set)
+            for row in af.rows:
+                raw = _cell(row, col).strip()
+                if not raw:
+                    continue
+                key = _aggressive_norm(raw)
+                if key:
+                    groups[key].add(raw)
+            variant_groups = [sorted(v) for v in groups.values() if len(v) > 1]
+            if not variant_groups:
+                continue
+            examples = [" / ".join(g) for g in variant_groups[:_MAX_EXAMPLES]]
+            out.append(
+                Finding(
+                    id=f"name_variant.{entity.value}.{af.filename}",
+                    category=FindingCategory.NAME_VARIANT,
+                    severity=Severity.WARNING,
+                    entity_type=entity,
+                    title=f"{len(variant_groups)} likely name variant group(s) in {af.filename}",
+                    detail=(
+                        "These names look like spelling variants of the same "
+                        f"{_entity_label(entity)} (e.g. differing case, punctuation, or "
+                        "Inc/LLC suffixes). They import as separate records."
+                    ),
+                    count=len(variant_groups),
+                    examples=examples,
+                    source_files=[af.filename],
+                    recommended_action="Standardize each name to a single spelling before import.",
+                )
+            )
+    return out
+
+
+def _inactive_flags(af: AnalyzedFile) -> list[Finding]:
+    header_by_norm = {re.sub(r"[^a-z0-9_]+", "", _norm(h)): h for h in af.headers}
+    match = next((orig for n, orig in header_by_norm.items() if n in _INACTIVE_HEADER_TOKENS), None)
+    if not match:
+        return []
+    n = re.sub(r"[^a-z0-9_]+", "", _norm(match))
+    inactive = 0
+    for row in af.rows:
+        val = _cell(row, match)
+        if n in ("active", "is_active", "isactive"):
+            if parse_bool(val) is False:
+                inactive += 1
+        elif n in ("inactive", "disabled", "archived"):
+            if parse_bool(val) is True:
+                inactive += 1
+        else:  # status
+            if _norm(val) in _INACTIVE_STATUS_VALUES:
+                inactive += 1
+    if not inactive:
+        return []
+    return [
+        Finding(
+            id=f"inactive.{af.filename}",
+            category=FindingCategory.INACTIVE_FLAG,
+            severity=Severity.INFO,
+            entity_type=af.entity_type,
+            title=f"{inactive} inactive/archived record(s) in {af.filename}",
+            detail=(
+                f"The '{match}' column marks {inactive} row(s) as inactive. Decide whether "
+                "to import these historical records or leave them behind."
+            ),
+            count=inactive,
+            source_files=[af.filename],
+            recommended_action="Confirm whether inactive records should be migrated.",
+        )
+    ]
+
+
+def analyze_bundle(files: list[AnalyzedFile]) -> list[Finding]:
+    """Run every deterministic check and return findings sorted by severity."""
+    findings: list[Finding] = []
+    findings += _record_counts(files)
+    for af in files:
+        findings += _within_file_duplicates(af)
+        findings += _missing_or_empty_required(af)
+        findings += _inactive_flags(af)
+    findings += _cross_file_orphans(files)
+    findings += _cost_coverage(files)
+    findings += _name_variants(files)
+    findings.sort(key=lambda f: (_SEVERITY_ORDER.get(f.severity, 99), f.id))
+    return findings

--- a/api/tests/integration/test_health_report_api.py
+++ b/api/tests/integration/test_health_report_api.py
@@ -1,0 +1,229 @@
+"""API tests for the read-only Data Health report endpoint (routes/health_report_routes.py).
+
+Fully mocked (no DB, no AI). Covers the happy path, caller-authorization, the opt-in
+feature gate, size caps, and — critically for #523 — the write-free guarantee (both a
+static source check and a runtime mock that raises on any write).
+"""
+
+import ast
+import inspect
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+import routes.health_report_routes as hr
+from index import app
+from services.ai.base_provider import ErpDetectionResult, FileStructure, HealthNarrativeResult, StructureResult
+
+pytestmark = pytest.mark.unit
+
+
+# --------------------------------------------------------------------------- mocks
+class _Resp:
+    def __init__(self, data):
+        self.data = data
+
+
+class _Table:
+    """Chainable read mock. Any write method raises — enforces the no-write guarantee."""
+
+    def __init__(self, name, data, on_write):
+        self.name = name
+        self._data = data
+        self._on_write = on_write
+
+    def select(self, *a, **k):
+        return self
+
+    def eq(self, *a, **k):
+        return self
+
+    def limit(self, *a, **k):
+        return self
+
+    def single(self):
+        return self
+
+    def maybe_single(self):
+        return self
+
+    def order(self, *a, **k):
+        return self
+
+    def gte(self, *a, **k):
+        return self
+
+    def execute(self):
+        return _Resp(self._data)
+
+    def insert(self, *a, **k):
+        self._on_write(f"insert:{self.name}")
+
+    def update(self, *a, **k):
+        self._on_write(f"update:{self.name}")
+
+    def upsert(self, *a, **k):
+        self._on_write(f"upsert:{self.name}")
+
+    def delete(self, *a, **k):
+        self._on_write(f"delete:{self.name}")
+
+
+class _Auth:
+    def __init__(self, user_id):
+        self._user_id = user_id
+
+    def get_user(self, token):
+        if not self._user_id:
+            return SimpleNamespace(user=None)
+        return SimpleNamespace(user=SimpleNamespace(id=self._user_id))
+
+
+class MockClient:
+    def __init__(self, has_access=True, features=None, user_id="user-1"):
+        self._has_access = has_access
+        self._features = features if features is not None else {"data_health_report": True}
+        self.auth = _Auth(user_id)
+        self.writes: list[str] = []
+
+    def _record_write(self, what):
+        self.writes.append(what)
+        raise AssertionError(f"Unexpected write attempted: {what}")
+
+    def table(self, name):
+        if name == "user_company_access":
+            data = [{"id": "acc-1"}] if self._has_access else []
+        elif name == "companies":
+            data = {"settings": {"features": self._features}}
+        else:
+            data = []
+        return _Table(name, data, self._record_write)
+
+
+class MockProvider:
+    provider_name = "mock"
+    model = "mock-model"
+
+    async def analyze_structure(self, files, entity_schemas, erp_catalog):
+        structs = []
+        for f in files:
+            name = f["filename"]
+            if "vendor" in name:
+                structs.append(FileStructure(filename=name, entity_type="vendors",
+                                             entity_confidence=0.9, column_roles={"name": "VendName"}))
+            else:
+                structs.append(FileStructure(filename=name, entity_type="parts", entity_confidence=0.9,
+                                             column_roles={"part_name": "PartNo", "preferred_vendor_name": "Vendor"}))
+        return StructureResult(
+            erp=ErpDetectionResult(source="tangle", display_name="Tangle", confidence=0.8,
+                                   matched_headers=[{"header": "PartNo", "signal": "job-shop id"}]),
+            files=structs,
+        )
+
+    async def generate_health_narrative(self, erp, findings, file_summaries):
+        return HealthNarrativeResult(
+            summary="Your data is mostly ready to import.",
+            recommendations=["Add the missing vendor 'Ghost Co'."],
+            gotchas=[{"title": "Check units", "detail": "verify", "recommended_action": "review"}],
+            available=True,
+        )
+
+
+_BUNDLE = {
+    "company_id": "co-1",
+    "files": [
+        {"filename": "parts.csv", "headers": ["PartNo", "Vendor"],
+         "rows": [{"PartNo": "A", "Vendor": "Acme"}, {"PartNo": "B", "Vendor": "Ghost Co"}]},
+        {"filename": "vendors.csv", "headers": ["VendName"],
+         "rows": [{"VendName": "Acme"}]},
+    ],
+}
+
+
+async def _post(client_mock, body=None, headers=None):
+    body = body if body is not None else _BUNDLE
+    headers = headers if headers is not None else {"Authorization": "Bearer test-token"}
+    with patch.object(hr, "_service_client", return_value=client_mock), \
+         patch.object(hr, "get_provider", new=AsyncMock(return_value=MockProvider())):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            return await ac.post("/api/health-report/analyze", json=body, headers=headers)
+
+
+# --------------------------------------------------------------------------- tests
+async def test_happy_path_returns_report_with_orphan_and_narrative():
+    resp = await _post(MockClient())
+    assert resp.status_code == 200
+    report = resp.json()["report"]
+    assert report["erp_detection"]["source"] == "tangle"
+    assert report["erp_detection"]["header_signature"]  # signature stamped
+    assert report["narrative_available"] is True
+    assert "ready" in report["summary"].lower()
+    ids = {f["id"] for f in report["findings"]}
+    assert "orphan.parts.preferred_vendor_name" in ids  # Ghost Co has no vendor row
+    # AI gotcha appended as an unverified finding
+    assert any(f["category"] == "erp_gotcha" and f["verified"] is False for f in report["findings"])
+
+
+async def test_missing_token_is_401():
+    resp = await _post(MockClient(), headers={})
+    assert resp.status_code == 401
+
+
+async def test_no_company_access_is_403():
+    resp = await _post(MockClient(has_access=False))
+    assert resp.status_code == 403
+    assert "access" in resp.json()["detail"].lower()
+
+
+async def test_feature_flag_off_is_403():
+    resp = await _post(MockClient(features={}))
+    assert resp.status_code == 403
+    assert "not enabled" in resp.json()["detail"].lower()
+
+
+async def test_too_many_files_is_413():
+    body = {"company_id": "co-1",
+            "files": [{"filename": f"f{i}.csv", "headers": ["A"], "rows": []} for i in range(13)]}
+    resp = await _post(MockClient(), body=body)
+    assert resp.status_code == 413
+
+
+async def test_run_attempts_no_writes():
+    client = MockClient()
+    resp = await _post(client)
+    assert resp.status_code == 200
+    assert client.writes == []  # no insert/update/upsert/delete on any table
+
+
+# --------------------------------------------------------------------------- static write-free guard
+def test_route_module_has_no_write_calls_or_import_route_imports():
+    """AST-level guarantee: the route makes no write calls and imports no write path.
+
+    Parses the real code (not comments/docstrings) so the mention of these terms in the
+    module docstring doesn't cause a false positive.
+    """
+    tree = ast.parse(inspect.getsource(hr))
+    write_attrs = {"insert", "upsert", "update", "delete", "rpc"}
+    bad = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr in write_attrs:
+                bad.append(node.func.attr)
+        # `client.auth.admin...` chain
+        if isinstance(node, ast.Attribute) and node.attr == "admin":
+            if isinstance(node.value, ast.Attribute) and node.value.attr == "auth":
+                bad.append("auth.admin")
+    assert not bad, f"route contains forbidden write/admin calls: {bad}"
+
+    modules = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            modules.append(node.module)
+        elif isinstance(node, ast.Import):
+            modules.extend(a.name for a in node.names)
+    assert not any("_import_routes" in m or "execute_import" in m for m in modules), (
+        f"route must not import a write/import path: {modules}"
+    )

--- a/api/tests/unit/test_health_report_analyzer.py
+++ b/api/tests/unit/test_health_report_analyzer.py
@@ -1,0 +1,254 @@
+"""Unit tests for the deterministic data-health analyzer (services/health_report_analyzer.py).
+
+Pure logic — no AI, no DB. Feeds AnalyzedFile objects (which already carry the AI-produced
+``column_roles``) and asserts the findings. This is where the review's correctness concerns
+are locked down: asymmetric join keys, normalized matching, "never a silent 0 / never
+phantom N", and misclassification tolerance.
+"""
+
+import pytest
+
+from models.health_report_models import EntityType, FindingCategory, Severity
+from services.health_report_analyzer import AnalyzedFile, analyze_bundle
+
+pytestmark = pytest.mark.unit
+
+
+def _af(filename, entity, roles, rows, headers=None):
+    return AnalyzedFile(
+        filename=filename,
+        entity_type=entity,
+        column_roles=roles,
+        rows=rows,
+        headers=headers if headers is not None else (list(rows[0].keys()) if rows else []),
+    )
+
+
+def _by_cat(findings, category):
+    return [f for f in findings if f.category == category]
+
+
+def _ids(findings):
+    return {f.id for f in findings}
+
+
+# --------------------------------------------------------------------------- record counts
+def test_record_counts_one_per_file():
+    parts = _af("parts.csv", EntityType.PARTS, {"part_name": "PartNo"},
+                [{"PartNo": "A"}, {"PartNo": "B"}])
+    findings = analyze_bundle([parts])
+    counts = _by_cat(findings, FindingCategory.RECORD_COUNT)
+    assert len(counts) == 1
+    assert counts[0].count == 2
+    assert counts[0].severity == Severity.INFO
+
+
+# --------------------------------------------------------------------------- duplicates
+def test_within_file_duplicate_is_case_and_space_insensitive():
+    parts = _af("parts.csv", EntityType.PARTS, {"part_name": "PartNo"},
+                [{"PartNo": "Widget"}, {"PartNo": " widget "}, {"PartNo": "Bolt"}])
+    dups = _by_cat(analyze_bundle([parts]), FindingCategory.DUPLICATE)
+    assert len(dups) == 1
+    assert dups[0].count == 2  # two rows collide
+    assert dups[0].severity == Severity.WARNING
+
+
+def test_vendor_duplicates_key_on_name_not_vendor_name():
+    vendors = _af("v.csv", EntityType.VENDORS, {"name": "VendName"},
+                  [{"VendName": "Acme"}, {"VendName": "acme"}])
+    dups = _by_cat(analyze_bundle([vendors]), FindingCategory.DUPLICATE)
+    assert len(dups) == 1
+    assert dups[0].id == "duplicate.vendors.name"
+
+
+def test_no_duplicate_finding_when_unique():
+    parts = _af("parts.csv", EntityType.PARTS, {"part_name": "PartNo"},
+                [{"PartNo": "A"}, {"PartNo": "B"}])
+    assert not _by_cat(analyze_bundle([parts]), FindingCategory.DUPLICATE)
+
+
+# --------------------------------------------------------------------------- cross-file orphans
+def test_orphan_parts_to_vendors_asymmetric_join():
+    parts = _af("parts.csv", EntityType.PARTS,
+                {"part_name": "PartNo", "preferred_vendor_name": "Vendor"},
+                [{"PartNo": "A", "Vendor": "Acme"}, {"PartNo": "B", "Vendor": "Ghost Co"}])
+    vendors = _af("vendors.csv", EntityType.VENDORS, {"name": "VendName"},
+                  [{"VendName": "Acme"}])
+    orphans = _by_cat(analyze_bundle([parts, vendors]), FindingCategory.ORPHAN_REFERENCE)
+    assert len(orphans) == 1
+    assert orphans[0].id == "orphan.parts.preferred_vendor_name"
+    assert orphans[0].count == 1  # only "Ghost Co"
+    assert orphans[0].severity == Severity.CRITICAL
+    assert any("Ghost" in e for e in orphans[0].examples)
+
+
+def test_orphan_join_is_normalized_no_phantom():
+    # "ACME" (part) vs "Acme" (vendor) must NOT be flagged as an orphan.
+    parts = _af("parts.csv", EntityType.PARTS,
+                {"part_name": "PartNo", "preferred_vendor_name": "Vendor"},
+                [{"PartNo": "A", "Vendor": "ACME"}])
+    vendors = _af("vendors.csv", EntityType.VENDORS, {"name": "VendName"},
+                  [{"VendName": "Acme"}])
+    assert not _by_cat(analyze_bundle([parts, vendors]), FindingCategory.ORPHAN_REFERENCE)
+
+
+def test_routing_to_work_center_and_part_orphans():
+    routings = _af("rout.csv", EntityType.ROUTINGS,
+                   {"part_name": "Part", "work_center_name": "WC"},
+                   [{"Part": "P1", "WC": "Mill"}, {"Part": "P1", "WC": "Laser"}])
+    work_centers = _af("wc.csv", EntityType.WORK_CENTERS, {"name": "Name"},
+                       [{"Name": "Mill"}])
+    parts = _af("parts.csv", EntityType.PARTS, {"part_name": "PartNo"},
+                [{"PartNo": "P1"}])
+    findings = analyze_bundle([routings, work_centers, parts])
+    orphans = {f.id: f for f in _by_cat(findings, FindingCategory.ORPHAN_REFERENCE)}
+    assert "orphan.routings.work_center_name" in orphans  # "Laser" missing
+    assert orphans["orphan.routings.work_center_name"].count == 1
+    assert "orphan.routings.part_name" not in orphans  # P1 present
+
+
+def test_bom_child_and_parent_orphans_join_on_part_name():
+    bom = _af("bom.csv", EntityType.BOM,
+              {"parent_part_name": "Parent", "child_part_name": "Child", "quantity": "Qty", "unit": "U"},
+              [{"Parent": "ASM", "Child": "BOLT", "Qty": "2", "U": "pcs"}])
+    parts = _af("parts.csv", EntityType.PARTS, {"part_name": "PartNo"},
+                [{"PartNo": "ASM"}])  # BOLT missing
+    orphans = {f.id for f in _by_cat(analyze_bundle([bom, parts]), FindingCategory.ORPHAN_REFERENCE)}
+    assert "orphan.bom.child_part_name" in orphans
+    assert "orphan.bom.parent_part_name" not in orphans
+
+
+def test_referenced_file_absent_single_not_checked_never_phantom():
+    parts = _af("parts.csv", EntityType.PARTS,
+                {"part_name": "PartNo", "preferred_vendor_name": "Vendor"},
+                [{"PartNo": "A", "Vendor": "Acme"}, {"PartNo": "B", "Vendor": "Beta"}])
+    findings = analyze_bundle([parts])  # no vendors file
+    nc = [f for f in _by_cat(findings, FindingCategory.NOT_CHECKED)
+          if f.id == "not_checked.parts.preferred_vendor_name"]
+    assert len(nc) == 1  # exactly one, not N
+    assert not _by_cat(findings, FindingCategory.ORPHAN_REFERENCE)
+
+
+def test_parent_column_unidentified_not_checked():
+    parts = _af("parts.csv", EntityType.PARTS,
+                {"part_name": "PartNo", "preferred_vendor_name": "Vendor"},
+                [{"PartNo": "A", "Vendor": "Acme"}])
+    vendors = _af("vendors.csv", EntityType.VENDORS, {},  # name role NOT identified
+                  [{"Mystery": "Acme"}])
+    findings = analyze_bundle([parts, vendors])
+    assert "not_checked.parts.preferred_vendor_name" in _ids(findings)
+    assert not _by_cat(findings, FindingCategory.ORPHAN_REFERENCE)
+
+
+def test_child_column_unidentified_no_orphan_and_no_noise():
+    # parts file present but the vendor reference column wasn't identified -> skip silently
+    parts = _af("parts.csv", EntityType.PARTS, {"part_name": "PartNo"},
+                [{"PartNo": "A"}])
+    vendors = _af("vendors.csv", EntityType.VENDORS, {"name": "VendName"},
+                  [{"VendName": "Acme"}])
+    findings = analyze_bundle([parts, vendors])
+    assert not _by_cat(findings, FindingCategory.ORPHAN_REFERENCE)
+    assert "not_checked.parts.preferred_vendor_name" not in _ids(findings)
+
+
+# --------------------------------------------------------------------------- required columns
+def test_missing_required_column_is_critical():
+    # vendors requires `name`; role not identified
+    vendors = _af("v.csv", EntityType.VENDORS, {"legacy_id": "ID"},
+                  [{"ID": "1"}])
+    findings = analyze_bundle([vendors])
+    missing = _by_cat(findings, FindingCategory.MISSING_COLUMN)
+    # `name` unidentified -> whole file reads as "classification uncertain" (single finding)
+    assert "classification_uncertain.v.csv" in _ids(findings)
+    assert not missing  # we don't spam missing when nothing required was identified
+
+
+def test_partial_blank_required_is_data_gap():
+    parts = _af("parts.csv", EntityType.PARTS, {"part_name": "PartNo"},
+                [{"PartNo": "A"}, {"PartNo": ""}, {"PartNo": "C"}])
+    gaps = _by_cat(analyze_bundle([parts]), FindingCategory.DATA_GAP)
+    assert len(gaps) == 1
+    assert gaps[0].count == 1
+    assert gaps[0].severity == Severity.WARNING
+
+
+def test_bom_missing_one_required_among_several():
+    # quantity role missing, others present -> a real MISSING_COLUMN (others identified)
+    bom = _af("bom.csv", EntityType.BOM,
+              {"parent_part_name": "P", "child_part_name": "C", "unit": "U"},
+              [{"P": "ASM", "C": "BOLT", "U": "pcs"}])
+    missing = _by_cat(analyze_bundle([bom]), FindingCategory.MISSING_COLUMN)
+    assert any(f.id == "missing.bom.quantity" for f in missing)
+
+
+def test_misclassified_file_yields_single_uncertain_finding():
+    # labeled parts, but no required part column identified -> one uncertain finding, no spam
+    bogus = _af("junk.csv", EntityType.PARTS, {},
+                [{"Foo": "1", "Bar": "2"}])
+    findings = analyze_bundle([bogus])
+    assert "classification_uncertain.junk.csv" in _ids(findings)
+    assert not _by_cat(findings, FindingCategory.MISSING_COLUMN)
+
+
+# --------------------------------------------------------------------------- cost coverage
+def test_cost_coverage_percentage():
+    parts = _af("parts.csv", EntityType.PARTS,
+                {"part_name": "PartNo", "cost_per_unit": "Cost"},
+                [{"PartNo": "A", "Cost": "1.50"}, {"PartNo": "B", "Cost": ""},
+                 {"PartNo": "C", "Cost": ""}, {"PartNo": "D", "Cost": "9"}])
+    cov = _by_cat(analyze_bundle([parts]), FindingCategory.COST_COVERAGE)
+    assert len(cov) == 1
+    assert cov[0].count == 2
+    assert "50%" in cov[0].title
+
+
+# --------------------------------------------------------------------------- name variants
+def test_name_variants_group_spelling_differences():
+    vendors = _af("v.csv", EntityType.VENDORS, {"name": "VendName"},
+                  [{"VendName": "Acme Inc."}, {"VendName": "ACME"}, {"VendName": "Beta LLC"}])
+    variants = _by_cat(analyze_bundle([vendors]), FindingCategory.NAME_VARIANT)
+    assert len(variants) == 1
+    assert variants[0].count == 1  # one group: {Acme Inc., ACME}
+
+
+# --------------------------------------------------------------------------- inactive flags
+def test_inactive_flag_status_column():
+    parts = _af("parts.csv", EntityType.PARTS, {"part_name": "PartNo"},
+                [{"PartNo": "A", "Status": "active"}, {"PartNo": "B", "Status": "obsolete"}],
+                headers=["PartNo", "Status"])
+    inactive = _by_cat(analyze_bundle([parts]), FindingCategory.INACTIVE_FLAG)
+    assert len(inactive) == 1
+    assert inactive[0].count == 1
+
+
+def test_inactive_flag_boolean_active_column():
+    parts = _af("parts.csv", EntityType.PARTS, {"part_name": "PartNo"},
+                [{"PartNo": "A", "Active": "yes"}, {"PartNo": "B", "Active": "no"},
+                 {"PartNo": "C", "Active": "false"}],
+                headers=["PartNo", "Active"])
+    inactive = _by_cat(analyze_bundle([parts]), FindingCategory.INACTIVE_FLAG)
+    assert inactive and inactive[0].count == 2
+
+
+# --------------------------------------------------------------------------- edges
+def test_empty_bundle_returns_no_findings():
+    assert analyze_bundle([]) == []
+
+
+def test_headers_only_file_no_crash():
+    parts = _af("parts.csv", EntityType.PARTS, {"part_name": "PartNo"}, [], headers=["PartNo"])
+    findings = analyze_bundle([parts])
+    counts = _by_cat(findings, FindingCategory.RECORD_COUNT)
+    assert counts[0].count == 0
+
+
+def test_findings_sorted_critical_first():
+    parts = _af("parts.csv", EntityType.PARTS,
+                {"part_name": "PartNo", "preferred_vendor_name": "Vendor"},
+                [{"PartNo": "A", "Vendor": "Ghost"}])
+    vendors = _af("vendors.csv", EntityType.VENDORS, {"name": "VendName"},
+                  [{"VendName": "Acme"}])
+    findings = analyze_bundle([parts, vendors])
+    severities = [f.severity for f in findings]
+    # first non-info should be critical before any warning/info ordering within
+    assert severities[0] == Severity.CRITICAL

--- a/api/tests/unit/test_health_report_provider.py
+++ b/api/tests/unit/test_health_report_provider.py
@@ -1,0 +1,157 @@
+"""Unit tests for the health-report AI provider methods (services/ai/claude_provider.py).
+
+Mocks self.client.messages.create so no Anthropic calls happen. Covers the shared JSON
+parse helper, structure parsing (incl. hallucinated-header rejection + graceful degrade),
+narrative parsing (incl. the no-fabrication failure path), and that the OpenAI/Gemini
+subclasses are still concrete after the new abstract methods were added.
+"""
+
+import inspect
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.ai.base_provider import HealthNarrativeResult, StructureResult
+from services.ai.claude_provider import ClaudeProvider, _clamp01, _parse_json_response
+from services.ai.factory import create_provider
+
+pytestmark = pytest.mark.unit
+
+
+def _resp(text: str):
+    return SimpleNamespace(content=[SimpleNamespace(text=text)])
+
+
+def _provider_with_response(text: str) -> ClaudeProvider:
+    p = ClaudeProvider(api_key="test-key")
+    p.client = MagicMock()
+    p.client.messages.create = MagicMock(return_value=_resp(text))
+    return p
+
+
+# --------------------------------------------------------------------------- helpers
+class TestParseJsonResponse:
+    def test_plain_json(self):
+        assert _parse_json_response('{"a": 1}') == {"a": 1}
+
+    def test_json_fence(self):
+        assert _parse_json_response('```json\n{"a": 1}\n```') == {"a": 1}
+
+    def test_bare_fence(self):
+        assert _parse_json_response('```\n{"a": 2}\n```') == {"a": 2}
+
+    def test_malformed_raises(self):
+        with pytest.raises(json.JSONDecodeError):
+            _parse_json_response("not json at all {")
+
+    def test_clamp01(self):
+        assert _clamp01(1.5) == 1.0
+        assert _clamp01(-3) == 0.0
+        assert _clamp01("nope") == 0.0
+        assert _clamp01(0.42) == 0.42
+
+
+# --------------------------------------------------------------------------- subclasses concrete
+class TestProvidersConcrete:
+    def test_claude_openai_gemini_have_no_abstract_methods(self):
+        from services.ai.openai_provider import OpenAIProvider
+        from services.ai.gemini_provider import GeminiProvider
+
+        for cls in (ClaudeProvider, OpenAIProvider, GeminiProvider):
+            assert not inspect.isabstract(cls), f"{cls.__name__} still abstract"
+            assert cls.__abstractmethods__ == frozenset(), f"{cls.__name__} missing overrides"
+
+    def test_create_provider_openai_constructs(self, monkeypatch):
+        # Adding abstract methods must not make the subclass un-instantiable.
+        monkeypatch.setenv("OPENAI_API_KEY", "x")
+        assert create_provider("openai").provider_name == "openai"
+
+
+# --------------------------------------------------------------------------- analyze_structure
+class TestAnalyzeStructure:
+    async def test_parses_erp_and_column_roles(self):
+        payload = {
+            "erp": {
+                "source": "tangle",
+                "display_name": "Tangle",
+                "confidence": 0.82,
+                "matched_headers": [{"header": "JobNo", "signal": "job-shop id"}],
+                "evidence": "job-shop vocabulary",
+                "alternatives": [{"source": "e2", "confidence": 0.3}],
+            },
+            "files": [
+                {"filename": "parts.csv", "entity_type": "parts", "entity_confidence": 0.9,
+                 "column_roles": {"part_name": "PartNo", "preferred_vendor_name": "Vendor"}},
+            ],
+        }
+        p = _provider_with_response(json.dumps(payload))
+        result = await p.analyze_structure(
+            files=[{"filename": "parts.csv", "headers": ["PartNo", "Vendor"], "column_samples": {}}],
+            entity_schemas={"parts": {}},
+            erp_catalog=[],
+        )
+        assert isinstance(result, StructureResult)
+        assert result.erp.source == "tangle"
+        assert result.erp.confidence == 0.82
+        assert result.files[0].column_roles == {"part_name": "PartNo", "preferred_vendor_name": "Vendor"}
+
+    async def test_drops_hallucinated_headers(self):
+        payload = {
+            "erp": {"source": "unknown", "confidence": 0.0},
+            "files": [
+                {"filename": "parts.csv", "entity_type": "parts", "entity_confidence": 0.5,
+                 "column_roles": {"part_name": "PartNo", "preferred_vendor_name": "Ghost"}},
+            ],
+        }
+        p = _provider_with_response(json.dumps(payload))
+        result = await p.analyze_structure(
+            files=[{"filename": "parts.csv", "headers": ["PartNo"], "column_samples": {}}],
+            entity_schemas={"parts": {}},
+            erp_catalog=[],
+        )
+        # "Ghost" isn't a real header in the file -> dropped; "PartNo" kept.
+        assert result.files[0].column_roles == {"part_name": "PartNo"}
+
+    async def test_malformed_degrades_to_unknown_without_raising(self):
+        p = _provider_with_response("this is not json")
+        result = await p.analyze_structure(
+            files=[{"filename": "parts.csv", "headers": ["PartNo"], "column_samples": {}}],
+            entity_schemas={"parts": {}},
+            erp_catalog=[],
+        )
+        assert result.erp.source == "unknown"
+        assert result.files[0].filename == "parts.csv"
+        assert result.files[0].entity_type == "unknown"
+        assert result.files[0].column_roles == {}
+
+    async def test_clamps_out_of_range_confidence(self):
+        payload = {"erp": {"source": "x", "confidence": 5}, "files": []}
+        p = _provider_with_response(json.dumps(payload))
+        result = await p.analyze_structure(files=[], entity_schemas={}, erp_catalog=[])
+        assert result.erp.confidence == 1.0
+
+
+# --------------------------------------------------------------------------- narrative
+class TestGenerateNarrative:
+    async def test_parses_summary_recs_gotchas(self):
+        payload = {
+            "summary": "Your data is mostly ready.",
+            "recommendations": ["Dedupe vendors", "Fill missing costs"],
+            "gotchas": [{"title": "Trailing spaces", "detail": "check", "recommended_action": "trim"}],
+        }
+        p = _provider_with_response(json.dumps(payload))
+        result = await p.generate_health_narrative(erp={}, findings=[], file_summaries=[])
+        assert isinstance(result, HealthNarrativeResult)
+        assert result.available is True
+        assert result.summary.startswith("Your data")
+        assert len(result.recommendations) == 2
+        assert result.gotchas[0]["title"] == "Trailing spaces"
+
+    async def test_failure_sets_unavailable_and_no_fabricated_prose(self):
+        p = _provider_with_response("<garbage/>")
+        result = await p.generate_health_narrative(erp={}, findings=[], file_summaries=[])
+        assert result.available is False
+        assert result.summary == ""
+        assert result.recommendations == []

--- a/app/dashboard/[companyId]/health-report/page.tsx
+++ b/app/dashboard/[companyId]/health-report/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState } from 'react';
+import { useParams } from 'next/navigation';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import AIAnalysisLoading from '@/components/import/AIAnalysisLoading';
+import MultiFileDropzone from '@/components/health-report/MultiFileDropzone';
+import HealthReportView from '@/components/health-report/HealthReportView';
+import { API_BASE_URL } from '@/lib/api';
+import { getSupabase } from '@/lib/supabase';
+import type { HealthReport, HealthReportResponse, UploadedFilePayload } from '@/types/health-report';
+
+type Stage = 'upload' | 'analyzing' | 'review';
+
+export default function HealthReportPage() {
+  const params = useParams();
+  const companyId = params.companyId as string;
+
+  const [stage, setStage] = useState<Stage>('upload');
+  const [files, setFiles] = useState<UploadedFilePayload[]>([]);
+  const [report, setReport] = useState<HealthReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function analyze() {
+    setError(null);
+    setStage('analyzing');
+    try {
+      const supabase = getSupabase();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session?.access_token) {
+        throw new Error('Your session has expired. Please sign in again.');
+      }
+
+      const res = await fetch(`${API_BASE_URL}/api/health-report/analyze`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({ company_id: companyId, files }),
+      });
+
+      if (!res.ok) {
+        let detail = `Analysis failed (${res.status})`;
+        try {
+          const body = await res.json();
+          if (body?.detail) detail = typeof body.detail === 'string' ? body.detail : detail;
+        } catch {
+          /* keep default */
+        }
+        throw new Error(detail);
+      }
+
+      const data: HealthReportResponse = await res.json();
+      setReport(data.report);
+      setStage('review');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong.');
+      setStage('upload');
+    }
+  }
+
+  function reset() {
+    setFiles([]);
+    setReport(null);
+    setError(null);
+    setStage('upload');
+  }
+
+  return (
+    <Box>
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="h5" sx={{ fontWeight: 600 }}>
+          Data Health Check
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          Upload your existing ERP CSV exports to see what&apos;s in them and what to clean up
+          before we bring your data into Jigged. This is read-only — nothing is imported or saved.
+        </Typography>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {stage === 'analyzing' && (
+        <AIAnalysisLoading description="Reading your files, detecting the source system, and checking data quality…" />
+      )}
+
+      {stage === 'upload' && (
+        <Box>
+          <MultiFileDropzone files={files} onChange={setFiles} />
+          <Box sx={{ mt: 3, display: 'flex', justifyContent: 'flex-end' }}>
+            <Button
+              variant="contained"
+              size="large"
+              startIcon={<AutoAwesomeIcon />}
+              disabled={files.length === 0}
+              onClick={analyze}
+            >
+              Analyze {files.length > 0 ? `${files.length} file${files.length === 1 ? '' : 's'}` : ''}
+            </Button>
+          </Box>
+        </Box>
+      )}
+
+      {stage === 'review' && report && (
+        <Box>
+          <Box sx={{ mb: 2, display: 'flex', justifyContent: 'flex-end' }}>
+            <Button variant="outlined" startIcon={<RestartAltIcon />} onClick={reset}>
+              Start over
+            </Button>
+          </Box>
+          <HealthReportView report={report} />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/components/health-report/HealthReportView.tsx
+++ b/components/health-report/HealthReportView.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import ConfidenceChip from '@/components/import/ConfidenceChip';
+import type { Finding, HealthReport, Severity } from '@/types/health-report';
+
+const SEVERITY_ORDER: Severity[] = ['critical', 'warning', 'info'];
+
+const SEVERITY_META: Record<Severity, { label: string; color: 'error' | 'warning' | 'info' }> = {
+  critical: { label: 'Needs attention', color: 'error' },
+  warning: { label: 'Worth a look', color: 'warning' },
+  info: { label: 'For your information', color: 'info' },
+};
+
+function FindingCard({ finding }: { finding: Finding }) {
+  return (
+    <Card elevation={2} sx={{ mb: 1.5 }}>
+      <CardContent>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, flexWrap: 'wrap' }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, flex: 1 }}>
+            {finding.title}
+          </Typography>
+          {!finding.verified && <Chip size="small" color="default" variant="outlined" label="AI-inferred" />}
+        </Box>
+        {finding.detail && (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            {finding.detail}
+          </Typography>
+        )}
+        {finding.examples.length > 0 && (
+          <Box sx={{ mt: 1, display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+            {finding.examples.map((ex, i) => (
+              <Chip key={i} size="small" label={ex} sx={{ maxWidth: 320 }} />
+            ))}
+          </Box>
+        )}
+        {finding.recommended_action && (
+          <Typography variant="body2" sx={{ mt: 1, fontStyle: 'italic' }}>
+            → {finding.recommended_action}
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function HealthReportView({ report }: { report: HealthReport }) {
+  const { erp_detection: erp } = report;
+  // Detection is informative context, never a bold headline. Below ~0.5 confidence or
+  // "unknown", we don't present a verdict at all — the findings apply regardless.
+  const showErp = erp.confidence >= 0.5 && erp.source !== 'unknown';
+
+  const findingsBySeverity = SEVERITY_ORDER.map((sev) => ({
+    sev,
+    items: report.findings.filter((f) => f.severity === sev),
+  })).filter((g) => g.items.length > 0);
+
+  return (
+    <Box>
+      {/* Source system — modest, hedged */}
+      <Paper variant="outlined" sx={{ p: 2, mb: 3 }}>
+        {showErp ? (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+            <Typography variant="body2" color="text.secondary">
+              Looks consistent with:
+            </Typography>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+              {erp.display_name}
+            </Typography>
+            <ConfidenceChip confidence={erp.confidence} reasoning={erp.evidence} />
+            {erp.matched_headers.slice(0, 4).map((m) => (
+              <Chip key={m.header} size="small" variant="outlined" label={m.header} title={m.signal} />
+            ))}
+          </Box>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            Source system not auto-identified — the readiness report below applies regardless.
+          </Typography>
+        )}
+      </Paper>
+
+      {/* Per-file classification */}
+      <Typography variant="h6" gutterBottom>
+        Files
+      </Typography>
+      <Stack direction="row" spacing={1} sx={{ mb: 3, flexWrap: 'wrap', gap: 1 }}>
+        {report.files.map((f) => (
+          <Paper key={f.filename} variant="outlined" sx={{ p: 1.5, minWidth: 200 }}>
+            <Typography variant="subtitle2" noWrap>
+              {f.filename}
+            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5 }}>
+              <Chip
+                size="small"
+                label={f.entity_type === 'unknown' ? 'unrecognized' : f.entity_type.replace('_', ' ')}
+                color={f.entity_type === 'unknown' ? 'default' : 'primary'}
+              />
+              <ConfidenceChip confidence={f.entity_confidence} />
+            </Box>
+            <Typography variant="caption" color="text.secondary">
+              {f.row_count} rows
+            </Typography>
+          </Paper>
+        ))}
+      </Stack>
+
+      {/* Narrative summary */}
+      {report.narrative_available ? (
+        report.summary && (
+          <Card elevation={2} sx={{ mb: 3 }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Summary
+              </Typography>
+              <Typography variant="body1" sx={{ whiteSpace: 'pre-line' }}>
+                {report.summary}
+              </Typography>
+              {report.recommendations.length > 0 && (
+                <>
+                  <Divider sx={{ my: 2 }} />
+                  <Typography variant="subtitle2" gutterBottom>
+                    Recommended next steps
+                  </Typography>
+                  <List dense>
+                    {report.recommendations.map((r, i) => (
+                      <ListItem key={i} sx={{ py: 0.25 }}>
+                        <ListItemText primary={`${i + 1}. ${r}`} />
+                      </ListItem>
+                    ))}
+                  </List>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        )
+      ) : (
+        <Alert severity="info" sx={{ mb: 3 }}>
+          AI summary unavailable — showing the detailed findings below only.
+        </Alert>
+      )}
+
+      {/* Findings grouped by severity */}
+      {findingsBySeverity.map(({ sev, items }) => (
+        <Box key={sev} sx={{ mb: 3 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+            <Chip size="small" color={SEVERITY_META[sev].color} label={SEVERITY_META[sev].label} />
+            <Typography variant="body2" color="text.secondary">
+              {items.length} item{items.length === 1 ? '' : 's'}
+            </Typography>
+          </Box>
+          {items.map((f) => (
+            <FindingCard key={f.id} finding={f} />
+          ))}
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/components/health-report/MultiFileDropzone.tsx
+++ b/components/health-report/MultiFileDropzone.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import Typography from '@mui/material/Typography';
+import UploadFileIcon from '@mui/icons-material/UploadFile';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import { parseCSV } from '@/utils/csvParser';
+import type { UploadedFilePayload } from '@/types/health-report';
+
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB per file
+
+interface MultiFileDropzoneProps {
+  files: UploadedFilePayload[];
+  onChange: (files: UploadedFilePayload[]) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Multi-file drag-and-drop for legacy CSV exports. Parses each file locally into
+ * {filename, headers, rows}. Parsing on drop does NOT trigger any AI call — the page's
+ * explicit "Analyze" button does that (CLAUDE.md: AI requires a deliberate user action).
+ */
+export default function MultiFileDropzone({ files, onChange, disabled }: MultiFileDropzoneProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function addFiles(fileList: FileList | null) {
+    if (!fileList || fileList.length === 0) return;
+    setError(null);
+    const parsed: UploadedFilePayload[] = [];
+    const errors: string[] = [];
+
+    for (const file of Array.from(fileList)) {
+      if (file.size > MAX_FILE_SIZE_BYTES) {
+        errors.push(`${file.name} is larger than 10 MB`);
+        continue;
+      }
+      try {
+        const text = await file.text();
+        const rows = parseCSV(text);
+        if (rows.length === 0) {
+          errors.push(`${file.name} is empty`);
+          continue;
+        }
+        const headers = rows[0];
+        const dataRows = rows.slice(1).map((cells) => {
+          const record: Record<string, string> = {};
+          headers.forEach((h, i) => {
+            record[h] = cells[i] ?? '';
+          });
+          return record;
+        });
+        parsed.push({ filename: file.name, headers, rows: dataRows });
+      } catch {
+        errors.push(`Could not read ${file.name}`);
+      }
+    }
+
+    if (errors.length) setError(errors.join('; '));
+    if (parsed.length) {
+      // De-dupe by filename: a re-added file replaces the previous parse.
+      const byName = new Map(files.map((f) => [f.filename, f]));
+      parsed.forEach((f) => byName.set(f.filename, f));
+      onChange(Array.from(byName.values()));
+    }
+    if (inputRef.current) inputRef.current.value = '';
+  }
+
+  function removeFile(filename: string) {
+    onChange(files.filter((f) => f.filename !== filename));
+  }
+
+  return (
+    <Box>
+      <Box
+        onDragOver={(e) => {
+          e.preventDefault();
+          if (!disabled) setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragOver(false);
+          if (!disabled) void addFiles(e.dataTransfer.files);
+        }}
+        onClick={() => !disabled && inputRef.current?.click()}
+        sx={{
+          border: '2px dashed',
+          borderColor: dragOver ? 'primary.main' : 'divider',
+          borderRadius: 2,
+          p: 5,
+          textAlign: 'center',
+          cursor: disabled ? 'default' : 'pointer',
+          bgcolor: dragOver ? 'action.hover' : 'transparent',
+          transition: 'all 0.2s ease',
+          opacity: disabled ? 0.6 : 1,
+        }}
+      >
+        <UploadFileIcon sx={{ fontSize: 48, color: 'primary.main', mb: 1 }} />
+        <Typography variant="h6" gutterBottom>
+          Drop your legacy CSV exports here
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Parts, vendors, customers, work centers, routings, BOMs — add as many as you have.
+          Nothing is imported or saved; this only reads your files.
+        </Typography>
+        <Button variant="outlined" component="span" disabled={disabled}>
+          Choose files
+        </Button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".csv,text/csv"
+          multiple
+          hidden
+          onChange={(e) => void addFiles(e.target.files)}
+        />
+      </Box>
+
+      {error && (
+        <Typography variant="body2" color="error" sx={{ mt: 1 }}>
+          {error}
+        </Typography>
+      )}
+
+      {files.length > 0 && (
+        <List dense sx={{ mt: 2 }}>
+          {files.map((f) => (
+            <ListItem
+              key={f.filename}
+              secondaryAction={
+                !disabled && (
+                  <IconButton edge="end" aria-label={`Remove ${f.filename}`} onClick={() => removeFile(f.filename)}>
+                    <DeleteOutlineIcon />
+                  </IconButton>
+                )
+              }
+            >
+              <ListItemText
+                primary={f.filename}
+                secondary={
+                  <Box component="span" sx={{ display: 'inline-flex', gap: 1, alignItems: 'center' }}>
+                    <Chip size="small" label={`${f.rows.length} rows`} />
+                    <Chip size="small" variant="outlined" label={`${f.headers.length} columns`} />
+                  </Box>
+                }
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -22,6 +22,7 @@ import RequestQuoteIcon from '@mui/icons-material/RequestQuote';
 import PercentIcon from '@mui/icons-material/Percent';
 import GroupIcon from '@mui/icons-material/Group';
 import SettingsIcon from '@mui/icons-material/Settings';
+import FactCheckIcon from '@mui/icons-material/FactCheck';
 import FeedbackIcon from '@mui/icons-material/Feedback';
 import CompanySwitcher from './CompanySwitcher';
 import { useUserRole } from '@/hooks/useUserRole';
@@ -55,6 +56,7 @@ const menuItems: MenuItem[] = [
   { name: 'Vendors', path: '/vendors', icon: FactoryIcon },
   { name: 'Markup Rates', path: '/markup-rates', icon: PercentIcon },
   { name: 'Customers', path: '/customers', icon: BusinessIcon },
+  { name: 'Data Health', path: '/health-report', icon: FactCheckIcon, featureFlag: 'data_health_report' },
   { name: 'Team', path: '/team', icon: GroupIcon, adminOnly: true },
   { name: 'Settings', path: '/settings', icon: SettingsIcon, adminOnly: true },
 ];

--- a/docs/modules/data-health-report.md
+++ b/docs/modules/data-health-report.md
@@ -1,0 +1,82 @@
+# Data Health / Import-Readiness Report
+
+Read-only, advisory tool that helps a shop **already committed to adopting Jigged**
+get its legacy data in cleanly. The shop uploads its previous ERP's CSV exports; the
+tool reads them (never writing to any business system), identifies each file's columns,
+detects the likely source ERP, and reports data-health findings plus concrete fixes so
+the white-glove migration goes in accurately and completely.
+
+It is an **onboarding aid, not a sales-demo / conversion tool**.
+
+## Scope
+
+- **In:** multi-CSV upload; per-file entity classification + raw→canonical column mapping;
+  source-ERP detection with a confidence score and matched-header evidence; deterministic
+  data-health findings; a grounded plain-English narrative + recommendations.
+- **Out (deferred):** the per-ERP "gotcha" rule *library* (#522 — the AI surfaces
+  informative, clearly-labeled observations for now); server-side persistence and
+  detection-template / fine-tuning harvesting; any write/import path.
+
+## Architecture
+
+One explicit user action (the **Analyze** button) runs three stages:
+
+1. **AI "structure" call** — `AIProvider.analyze_structure`
+   ([api/services/ai/claude_provider.py](../../api/services/ai/claude_provider.py)).
+   Classifies each file to an entity type and maps its raw headers to canonical fields
+   (`column_roles`), and detects the source ERP. Uploaded CSVs use the *source ERP's* own
+   headers, so this column identification must happen before any field-keyed check. Bad
+   responses degrade to `source="unknown"` and drop hallucinated headers.
+2. **Deterministic analyzer** — `analyze_bundle`
+   ([api/services/health_report_analyzer.py](../../api/services/health_report_analyzer.py)).
+   Pure Python, no AI, no DB. Computes record counts, normalized within-file duplicates,
+   cross-file orphan references (using the **asymmetric** join keys in `REFERENTIAL_LINKS` —
+   parts identify by `part_name`, vendors/work-centers/customers by `name`),
+   missing/blank required columns, cost coverage %, name-variant grouping, and inactive
+   flags. A check that can't run emits one explicit "not checked" finding — never a silent
+   `0` and never phantom orphans.
+3. **AI "narrative" call** — `AIProvider.generate_health_narrative`. Writes plain-English
+   guidance grounded strictly in the deterministic findings (cites only their counts). On
+   failure it returns `available=False`, and the UI shows the raw findings rather than any
+   fabricated prose.
+
+## Endpoint
+
+`POST /api/health-report/analyze`
+([api/routes/health_report_routes.py](../../api/routes/health_report_routes.py)),
+registered in `api/index.py`. Advisory only:
+
+- **Caller authorization** via `_verify_company_access` (bearer JWT → `user_company_access`).
+- **Opt-in server-side feature gate**: `companies.settings.features.data_health_report`
+  (client flag only hides the nav; the endpoint enforces its own gate and fails closed).
+- **Size caps** (files / headers / total rows) → `413` rather than silent truncation.
+- **Best-effort in-memory rate limit** (weak on serverless; the real bound is the flag +
+  caller-auth).
+- **No writes**: only SELECTs; no `auth.admin`; no on-disk cache (which would leak
+  uploaded rows to disk). An AST-level test in
+  [api/tests/integration/test_health_report_api.py](../../api/tests/integration/test_health_report_api.py)
+  guards that the module makes no insert/upsert/update/delete/rpc/`auth.admin` call and
+  imports no `*_import_routes` path.
+
+## Frontend
+
+`/dashboard/{companyId}/health-report`
+([app/dashboard/[companyId]/health-report/page.tsx](../../app/dashboard/%5BcompanyId%5D/health-report/page.tsx)):
+`upload → analyzing → review`. Multi-file drag-and-drop (`MultiFileDropzone`); results in
+`HealthReportView` (a hedged detection line, per-file classification chips, severity-grouped
+findings, an "AI-inferred" chip on unverified gotchas). Nav item is gated behind the opt-in
+`data_health_report` flag. The AI call fires only on the explicit **Analyze** click.
+
+## Data model
+
+[api/models/health_report_models.py](../../api/models/health_report_models.py): `HealthReport`
+(`schema_version`, `ErpDetection`, `FileClassification[]` with `column_roles`, `Finding[]` by
+severity/category, `summary`, `recommendations`). The schema is kept reuse-ready so detection
+templates / fine-tuning data can be derived later without a migration; nothing is persisted
+server-side in this slice.
+
+## Related
+
+Epic #492; sub-issues #519 (upload UI), #520 (detection), #521 (findings), #522 (gotcha
+rules — deferred), #523 (endpoint), #524 (schema). Reuses the AI provider layer and the
+import-model target schemas (`PART_SCHEMA`, `VENDOR_SCHEMA`, …).

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -66,6 +66,12 @@ export const KNOWN_FEATURES: readonly FeatureFlagDescriptor[] = [
     // GA feature with a kill-switch: enabled unless explicitly turned off.
     defaultEnabled: true,
   },
+  {
+    key: 'data_health_report',
+    label: 'Data Health Report',
+    description:
+      'Read-only onboarding aid: upload legacy ERP CSV exports to get an advisory data-health / import-readiness report (record counts, duplicates, orphan references, gaps) plus a best-effort source-ERP guess. Never writes any data. Opt-in per tenant while onboarding.',
+  },
 ] as const;
 
 export type KnownFeatureKey = (typeof KNOWN_FEATURES)[number]['key'];
@@ -106,6 +112,16 @@ export function isInventoryLocationsEnabled(
   company: Pick<Company, 'settings'> | null | undefined,
 ): boolean {
   return readFeatureFlag(company, 'inventory_locations');
+}
+
+/**
+ * Data Health report is opt-IN: off unless the company row explicitly sets
+ * settings.features.data_health_report = true (enabled per tenant while onboarding).
+ */
+export function isDataHealthReportEnabled(
+  company: Pick<Company, 'settings'> | null | undefined,
+): boolean {
+  return readFeatureFlag(company, 'data_health_report');
 }
 
 /**

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,5 +1,8 @@
 # For detailed configuration reference documentation, visit:
 # https://supabase.com/docs/guides/local-development/cli/config
+# NOTE: this comment exists only to place a change under supabase/ so the Supabase
+# Branching integration opens a preview branch for a migration-free PR (it ignores PRs
+# with no supabase/-dir changes). No functional config change. Safe to remove later.
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
 project_id = "Jigged"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,8 +1,5 @@
 # For detailed configuration reference documentation, visit:
 # https://supabase.com/docs/guides/local-development/cli/config
-# NOTE: this comment exists only to place a change under supabase/ so the Supabase
-# Branching integration opens a preview branch for a migration-free PR (it ignores PRs
-# with no supabase/-dir changes). No functional config change. Safe to remove later.
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
 project_id = "Jigged"

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -67,8 +67,11 @@ insert into auth.identities (
 ) on conflict do nothing;
 
 -- ── Company + access ─────────────────────────────────────────────────────────
-insert into public.companies (id, name) values
-  ('22222222-2222-2222-2222-222222222222', 'Vanguard Precision Works')
+insert into public.companies (id, name, settings) values
+  ('22222222-2222-2222-2222-222222222222', 'Vanguard Precision Works',
+   -- Enable the opt-in data-health/import-readiness tool in dev + preview branches so
+   -- it's visible while the feature rolls out. Seed is local/preview-only, never prod.
+   '{"features": {"data_health_report": true}}'::jsonb)
 on conflict (id) do nothing;
 
 insert into public.user_company_access (id, user_id, company_id, role, name) values

--- a/types/health-report.ts
+++ b/types/health-report.ts
@@ -1,0 +1,75 @@
+/**
+ * Types for the read-only Data Health / Import-Readiness report.
+ * Mirrors api/models/health_report_models.py (HealthReportResponse).
+ */
+
+export type Severity = 'info' | 'warning' | 'critical';
+
+export interface MatchedHeader {
+  header: string;
+  signal: string;
+}
+
+export interface ErpAlternative {
+  source: string;
+  confidence: number;
+}
+
+export interface ErpDetection {
+  source: string;
+  display_name: string;
+  confidence: number;
+  matched_headers: MatchedHeader[];
+  evidence: string;
+  alternatives: ErpAlternative[];
+  header_signature: string;
+  ai_provider: string;
+  ai_model: string;
+}
+
+export interface FileClassification {
+  filename: string;
+  entity_type: string;
+  entity_confidence: number;
+  headers: string[];
+  row_count: number;
+  column_roles: Record<string, string>;
+}
+
+export interface Finding {
+  id: string;
+  category: string;
+  severity: Severity;
+  entity_type: string;
+  title: string;
+  detail: string;
+  count: number;
+  examples: string[];
+  source_files: string[];
+  verified: boolean;
+  recommended_action: string;
+}
+
+export interface HealthReport {
+  schema_version: number;
+  erp_detection: ErpDetection;
+  files: FileClassification[];
+  findings: Finding[];
+  summary: string;
+  recommendations: string[];
+  narrative_available: boolean;
+  ai_provider: string;
+  ai_model: string;
+  generated_at: string;
+}
+
+export interface HealthReportResponse {
+  report: HealthReport;
+}
+
+/** One uploaded CSV, parsed client-side, sent to the backend. */
+export interface UploadedFilePayload {
+  filename: string;
+  headers: string[];
+  rows: Record<string, string>[];
+}


### PR DESCRIPTION
Read-only, advisory **Data Health / Import-Readiness** tool for onboarding shops that arrive with legacy ERP data. A shop uploads its legacy CSV exports; the tool reads them (never writes to any business system), identifies each file's columns, detects the likely source ERP, and reports data-health findings + fixes so the (still white-glove) migration goes in cleanly.

Implements epic **#492** and sub-issues **#519** (multi-CSV upload UI), **#520** (ERP detection + confidence + matched-header evidence), **#521** (plain-English findings), **#523** (advisory endpoint, no write path), **#524** (reuse-ready report schema). **#522** (per-ERP gotcha-rule *library*) is deferred — the narrative surfaces informative, clearly-labeled observations for now.

## Approach
Uploaded CSVs are RAW ERP headers, so the deterministic checks can't key on canonical field names directly. An **AI "structure" call** first classifies each file (entity type + raw→canonical `column_roles`) and detects the ERP; the **pure-Python analyzer** then computes trustworthy findings (record counts, normalized duplicates, cross-file orphan references with correct *asymmetric* join keys, missing/blank required columns, cost-coverage %, name-variants, inactive flags); a second **grounded narrative call** writes plain-English guidance that cites only those findings. 2 AI calls total.

## Safety
- Endpoint does **only SELECTs** — caller authorization (`_verify_company_access`), an opt-in server-side feature flag (`data_health_report`), and provider lookup. No writes to any table, no `auth.admin`, no disk cache. An AST-level test guards this.
- AI calls fire only on the explicit "Analyze" button (never on mount/drop) per the AI-user-action rule.
- Failure modes surface, never fabricate: bad structure response → `source=unknown`; bad narrative → "AI summary unavailable", raw findings shown.

## Tests
216 backend pytest (analyzer, provider parse/degrade, endpoint auth/flag/caps + write-free guard) + `tsc` + eslint, all green. Migration-free.

## Owed (runtime, follow-up)
- Ground-truth eval against a real Tangle export (customer #1).
- Manual UI pass on a company with the `data_health_report` flag enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)