### PR TITLE
fix(search): escape reserved chars in PostgREST .or() filters

### DIFF
--- a/__tests__/utils/customerAccess.test.ts
+++ b/__tests__/utils/customerAccess.test.ts
@@ -126,7 +126,7 @@ describe('customerAccess utilities', () => {
       const result = await getAllCustomers('company-1', 'all', 'Customer One');
 
       expect(mockQueryBuilder.or).toHaveBeenCalledWith(
-        'name.ilike.%Customer One%'
+        'name.ilike."%Customer One%"'
       );
       expect(result).toHaveLength(1);
     });

--- a/__tests__/utils/partsAccess.test.ts
+++ b/__tests__/utils/partsAccess.test.ts
@@ -372,8 +372,32 @@ describe('partsAccess utilities', () => {
       await getAllParts('company-1', 'PART001');
 
       expect(mockQueryBuilder.or).toHaveBeenCalledWith(
-        'part_name.ilike.%PART001%,description.ilike.%PART001%'
+        'part_name.ilike."%PART001%",description.ilike."%PART001%"'
       );
+    });
+
+    it('double-quotes the value so parentheses in the term do not break the filter', async () => {
+      // Regression: a part named "F40750-1 (REX-76)" returned zero rows because
+      // the raw `)` terminated the PostgREST `.or()` group early. The value must
+      // now be double-quoted so PostgREST treats the parens literally.
+      mockQueryBuilder.data = [mockPart];
+      mockQueryBuilder.error = null;
+
+      await getAllParts('company-1', 'F40750-1 (REX-76)');
+
+      expect(mockQueryBuilder.or).toHaveBeenCalledWith(
+        'part_name.ilike."%F40750-1 (REX-76)%",description.ilike."%F40750-1 (REX-76)%"'
+      );
+    });
+
+    it('escapes ILIKE wildcards in the search term', async () => {
+      mockQueryBuilder.data = [mockPart];
+      mockQueryBuilder.error = null;
+
+      await getAllParts('company-1', '50%');
+
+      const filter = (mockQueryBuilder.or as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(filter).toContain('\\%'); // literal % escaped for ILIKE
     });
 
     it('throws error when Supabase query fails', async () => {

--- a/__tests__/utils/searchFilter.test.ts
+++ b/__tests__/utils/searchFilter.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { escapeIlikePattern, orIlikeValue } from '@/utils/searchFilter';
+
+describe('escapeIlikePattern', () => {
+  it('leaves a plain term unchanged', () => {
+    expect(escapeIlikePattern('PART001')).toBe('PART001');
+  });
+
+  it('escapes ILIKE wildcards % and _ so they match literally', () => {
+    expect(escapeIlikePattern('50%_off')).toBe('50\\%\\_off');
+  });
+
+  it('escapes backslashes first', () => {
+    expect(escapeIlikePattern('a\\b')).toBe('a\\\\b');
+  });
+
+  it('caps length at 100 chars', () => {
+    expect(escapeIlikePattern('a'.repeat(150))).toHaveLength(100);
+  });
+});
+
+describe('orIlikeValue', () => {
+  it('double-quotes a plain term as a %substring% pattern', () => {
+    expect(orIlikeValue('PART001')).toBe('"%PART001%"');
+  });
+
+  it('keeps parentheses literal inside the quoted value (the reported bug)', () => {
+    // Without the double-quoting, the `)` terminated the PostgREST `.or()`
+    // group early and the part returned zero rows.
+    expect(orIlikeValue('F40750-1 (REX-76)')).toBe('"%F40750-1 (REX-76)%"');
+  });
+
+  it('keeps commas literal inside the quoted value (no filter injection)', () => {
+    expect(orIlikeValue('a,b')).toBe('"%a,b%"');
+  });
+
+  it('escapes an embedded double-quote', () => {
+    expect(orIlikeValue('a"b')).toBe('"%a\\"b%"');
+  });
+
+  it('double-escapes wildcards for the quoted-value layer', () => {
+    expect(orIlikeValue('50%')).toBe('"%50\\\\%%"');
+  });
+
+  it('caps length at 100 chars before wrapping', () => {
+    // 100 chars + leading/trailing % + two surrounding quotes = 104.
+    expect(orIlikeValue('a'.repeat(150))).toHaveLength(104);
+  });
+});

--- a/__tests__/utils/vendorsAccess.test.ts
+++ b/__tests__/utils/vendorsAccess.test.ts
@@ -51,7 +51,7 @@ describe('vendorsAccess', () => {
       mockQueryBuilder.data = [];
       await getAllVendors('co-1', 'acme');
       expect(mockQueryBuilder.or).toHaveBeenCalledWith(
-        'name.ilike.%acme%,city.ilike.%acme%',
+        'name.ilike."%acme%",city.ilike."%acme%"',
       );
     });
 

--- a/__tests__/utils/workCentersAccess.test.ts
+++ b/__tests__/utils/workCentersAccess.test.ts
@@ -59,7 +59,7 @@ describe('workCentersAccess', () => {
     it('applies name ilike when search is non-empty', async () => {
       mockQueryBuilder.data = [];
       await getAllWorkCenters('co-1', 'mill');
-      expect(mockQueryBuilder.or).toHaveBeenCalledWith('name.ilike.%mill%');
+      expect(mockQueryBuilder.or).toHaveBeenCalledWith('name.ilike."%mill%"');
     });
 
     it('skips the or() filter when search is whitespace', async () => {

--- a/utils/customerAccess.ts
+++ b/utils/customerAccess.ts
@@ -18,6 +18,7 @@ import type {
   CustomerContactRole,
 } from '@/types/customerContact';
 import { createCustomerContact } from '@/utils/customerContactsAccess';
+import { orIlikeValue } from '@/utils/searchFilter';
 
 /**
  * Customer access layer.
@@ -85,7 +86,7 @@ export async function getCustomers(
     .range(offset, offset + limit - 1);
 
   if (search.trim()) {
-    query = query.or(`name.ilike.%${search}%`);
+    query = query.or(`name.ilike.${orIlikeValue(search)}`);
   }
 
   const { data, error, count } = await query;
@@ -134,7 +135,7 @@ export async function getAllCustomers(
       .range(offset, offset + BATCH_SIZE - 1);
 
     if (search.trim()) {
-      query = query.or(`name.ilike.%${search}%`);
+      query = query.or(`name.ilike.${orIlikeValue(search)}`);
     }
 
     const { data, error } = await query;

--- a/utils/jobsAccess.ts
+++ b/utils/jobsAccess.ts
@@ -32,21 +32,11 @@ import { isJobClosed } from '@/types/job';
 import type { PricingBasisSnapshot } from '@/types/quote';
 import { resolveTierFromSnapshot } from '@/utils/quotePricingResolver';
 import { getJobPartShipmentSummaries, countShipmentsForJob } from '@/utils/shipmentsAccess';
+import { orIlikeValue } from '@/utils/searchFilter';
 import {
   getQuickBooksInvoiceLinkForJob,
   getJobPartInvoiceSummaries,
 } from '@/utils/quickbooksAccess';
-
-/**
- * Sanitize search string for use in LIKE/ILIKE queries
- */
-function sanitizeSearchString(search: string): string {
-  return search
-    .replace(/\\/g, '\\\\')
-    .replace(/%/g, '\\%')
-    .replace(/_/g, '\\_')
-    .substring(0, 100);
-}
 
 /**
  * "Today" formatted as YYYY-MM-DD in the *user's local timezone*. The
@@ -156,8 +146,7 @@ export async function getAllJobs(
       }
       query = query.in('id', ids);
     } else if (filters.search?.trim()) {
-      const sanitized = sanitizeSearchString(filters.search.trim());
-      query = query.or(`job_number.ilike.%${sanitized}%`);
+      query = query.or(`job_number.ilike.${orIlikeValue(filters.search.trim())}`);
     }
     if (filters.overdue) {
       // Single source of truth for the overdue predicate — see

--- a/utils/partsAccess.ts
+++ b/utils/partsAccess.ts
@@ -22,6 +22,7 @@ import {
   deleteStoredFilesByPaths,
 } from '@/utils/partAttachmentsAccess';
 import { convertToBaseUnit } from '@/lib/unitPresets';
+import { orIlikeValue } from '@/utils/searchFilter';
 
 const PART_COLUMNS =
   'id, company_id, part_name, description, source, is_stocked, primary_unit, quantity, reorder_point, preferred_vendor_id, markup_rate_id, legacy_id, is_location_tracked, created_at, updated_at';
@@ -99,7 +100,7 @@ export async function getAllParts(
       .range(offset, offset + BATCH_SIZE - 1);
 
     if (search.trim()) {
-      query = query.or(`part_name.ilike.%${search}%,description.ilike.%${search}%`);
+      query = query.or(`part_name.ilike.${orIlikeValue(search)},description.ilike.${orIlikeValue(search)}`);
     }
 
     const { data, error } = await query;
@@ -146,7 +147,7 @@ export async function getStockedParts(
       .range(offset, offset + BATCH_SIZE - 1);
 
     if (search.trim()) {
-      query = query.or(`part_name.ilike.%${search}%,description.ilike.%${search}%`);
+      query = query.or(`part_name.ilike.${orIlikeValue(search)},description.ilike.${orIlikeValue(search)}`);
     }
 
     const { data, error } = await query;
@@ -188,7 +189,7 @@ export async function getMadeParts(
       .range(offset, offset + BATCH_SIZE - 1);
 
     if (search.trim()) {
-      query = query.or(`part_name.ilike.%${search}%,description.ilike.%${search}%`);
+      query = query.or(`part_name.ilike.${orIlikeValue(search)},description.ilike.${orIlikeValue(search)}`);
     }
 
     const { data, error } = await query;
@@ -232,7 +233,7 @@ export async function getBoughtParts(
       .range(offset, offset + BATCH_SIZE - 1);
 
     if (search.trim()) {
-      query = query.or(`part_name.ilike.%${search}%,description.ilike.%${search}%`);
+      query = query.or(`part_name.ilike.${orIlikeValue(search)},description.ilike.${orIlikeValue(search)}`);
     }
 
     const { data, error } = await query;
@@ -270,7 +271,7 @@ export async function getPartsPaginated(
     .range(offset, offset + limit - 1);
 
   if (search.trim()) {
-    query = query.or(`part_name.ilike.%${search}%,description.ilike.%${search}%`);
+    query = query.or(`part_name.ilike.${orIlikeValue(search)},description.ilike.${orIlikeValue(search)}`);
   }
 
   const { data, error } = await query;
@@ -298,7 +299,7 @@ export async function getPartsCount(
     .eq('company_id', companyId);
 
   if (search.trim()) {
-    query = query.or(`part_name.ilike.%${search}%,description.ilike.%${search}%`);
+    query = query.or(`part_name.ilike.${orIlikeValue(search)},description.ilike.${orIlikeValue(search)}`);
   }
 
   const { count, error } = await query;
@@ -669,7 +670,7 @@ export async function searchPartsForSelect(
 
   const trimmed = query.trim();
   if (trimmed) {
-    q = q.or(`part_name.ilike.%${trimmed}%,description.ilike.%${trimmed}%`);
+    q = q.or(`part_name.ilike.${orIlikeValue(trimmed)},description.ilike.${orIlikeValue(trimmed)}`);
   }
 
   const { data, error } = await q;

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -30,6 +30,7 @@ import {
   deleteLineItem,
 } from '@/utils/quoteLineItemsAccess';
 import { isDrifted, isDriftedDegraded } from '@/utils/quotePricingResolver';
+import { escapeIlikePattern } from '@/utils/searchFilter';
 import type { ComputedPartPricingTier } from '@/types/partPricing';
 
 /**
@@ -74,18 +75,6 @@ function normalizeLeadTime(formData: QuoteFormData): {
     throw new Error('Lead time must be 3,650 days or fewer.');
   }
   return { leadTimeValue: value, leadTimeUnit: unit, leadTimeDays };
-}
-
-/**
- * Sanitize search string for use in LIKE/ILIKE queries
- * Escapes SQL wildcards to prevent unintended pattern matching
- */
-function sanitizeSearchString(search: string): string {
-  return search
-    .replace(/\\/g, '\\\\')
-    .replace(/%/g, '\\%')
-    .replace(/_/g, '\\_')
-    .substring(0, 100);
 }
 
 /**
@@ -171,7 +160,7 @@ export async function getQuotes(
   if (filters.customerId) query = query.eq('customer_id', filters.customerId);
   if (filters.createdBy) query = query.eq('created_by', filters.createdBy);
   if (filters.search?.trim()) {
-    const sanitized = sanitizeSearchString(filters.search.trim());
+    const sanitized = escapeIlikePattern(filters.search.trim());
     query = query.ilike('quote_number', `%${sanitized}%`);
   }
 
@@ -220,7 +209,7 @@ export async function getAllQuotes(
     if (filters.customerId) query = query.eq('customer_id', filters.customerId);
     if (filters.createdBy) query = query.eq('created_by', filters.createdBy);
     if (filters.search?.trim()) {
-      const sanitized = sanitizeSearchString(filters.search.trim());
+      const sanitized = escapeIlikePattern(filters.search.trim());
       query = query.ilike('quote_number', `%${sanitized}%`);
     }
 
@@ -259,7 +248,7 @@ export async function getQuotesCount(
   if (filters.status && filters.status !== 'all') query = query.eq('status', filters.status);
   if (filters.customerId) query = query.eq('customer_id', filters.customerId);
   if (filters.search?.trim()) {
-    const sanitized = sanitizeSearchString(filters.search.trim());
+    const sanitized = escapeIlikePattern(filters.search.trim());
     query = query.ilike('quote_number', `%${sanitized}%`);
   }
 

--- a/utils/routingsAccess.ts
+++ b/utils/routingsAccess.ts
@@ -11,6 +11,7 @@
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { orIlikeValue } from '@/utils/searchFilter';
 import type { Database } from '@/types/database';
 
 // Insert payload for routing_operations, minus the columns the callers
@@ -146,7 +147,7 @@ export async function getRoutings(
     .eq('company_id', companyId);
 
   if (search?.trim()) {
-    query = query.or(`name.ilike.%${search}%,description.ilike.%${search}%`);
+    query = query.or(`name.ilike.${orIlikeValue(search)},description.ilike.${orIlikeValue(search)}`);
   }
 
   if (partId) {

--- a/utils/searchFilter.ts
+++ b/utils/searchFilter.ts
@@ -1,0 +1,41 @@
+// Single source of truth for escaping user-supplied search terms before they go
+// into a Supabase/PostgREST query. Two shapes exist in this codebase, and each
+// needs different handling — pick the function that matches the call:
+//
+//   - `.ilike(column, `%${escapeIlikePattern(term)}%`)`  → escapeIlikePattern
+//   - `.or(`col.ilike.${orIlikeValue(term)}`)`           → orIlikeValue
+//
+// Do NOT interpolate a raw term into a `.or()` string: PostgREST parses that
+// string, so a term containing `)`/`,`/`.` (e.g. a part named `F40750-1 (REX-76)`)
+// corrupts the filter and silently returns zero rows.
+
+const MAX_SEARCH_LEN = 100;
+
+/**
+ * Escape ILIKE wildcards so a user's `% _ \` match literally. Use for the
+ * `.ilike(column, `%${escapeIlikePattern(term)}%`)` shape, where postgrest-js
+ * sends the value as its own query-param (reserved chars are already safe).
+ */
+export function escapeIlikePattern(search: string): string {
+  return search
+    .substring(0, MAX_SEARCH_LEN)
+    .replace(/\\/g, '\\\\') // escape backslash first
+    .replace(/%/g, '\\%') // literal %
+    .replace(/_/g, '\\_'); // literal _
+}
+
+/**
+ * Build a PostgREST-safe, double-quoted ILIKE value for use inside a `.or()`
+ * filter string, e.g. `part_name.ilike.${orIlikeValue(term)}`.
+ *
+ * Double-quoting makes PostgREST treat reserved chars (`,` `.` `(` `)` `:`)
+ * literally instead of parsing them as filter syntax — this is what fixes
+ * searches for names like `F40750-1 (REX-76)`. Built on escapeIlikePattern
+ * (wildcards), then escaped again for the double-quoted-value layer.
+ */
+export function orIlikeValue(search: string): string {
+  const pattern = `%${escapeIlikePattern(search)}%`;
+  // PostgREST double-quoted value layer: escape backslash and double-quote.
+  const forQuotes = pattern.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return `"${forQuotes}"`;
+}

--- a/utils/vendorsAccess.ts
+++ b/utils/vendorsAccess.ts
@@ -2,6 +2,7 @@
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type { Database } from '@/types/database';
+import { orIlikeValue } from '@/utils/searchFilter';
 
 // Insert payload for the vendors table, minus company_id which is added
 // at the boundary. Narrowing this avoids the Record<string, unknown>
@@ -50,7 +51,7 @@ export async function getAllVendors(
     if (search.trim()) {
       // Search the vendor name + city only. Contact-name search would require a
       // join through vendor_contacts; defer until usability shows users want it.
-      query = query.or(`name.ilike.%${search}%,city.ilike.%${search}%`);
+      query = query.or(`name.ilike.${orIlikeValue(search)},city.ilike.${orIlikeValue(search)}`);
     }
 
     const { data, error } = await query;

--- a/utils/workCentersAccess.ts
+++ b/utils/workCentersAccess.ts
@@ -6,6 +6,7 @@ import type {
   WorkCenterWithRelations,
   WorkCenterImportResult,
 } from '@/types/workCenter';
+import { orIlikeValue } from '@/utils/searchFilter';
 
 const WORK_CENTER_COLUMNS =
   'id, company_id, name, kind, vendor_id, labor_rate, description, metadata, created_at, updated_at';
@@ -28,7 +29,7 @@ export async function getAllWorkCenters(
     .order(sortField, { ascending: sortDirection === 'asc' });
 
   if (search?.trim()) {
-    query = query.or(`name.ilike.%${search}%`);
+    query = query.or(`name.ilike.${orIlikeValue(search)}`);
   }
 
   const { data, error } = await query;
@@ -60,7 +61,7 @@ export async function getWorkCentersByKind(
     .order('name', { ascending: true });
 
   if (search?.trim()) {
-    query = query.or(`name.ilike.%${search}%`);
+    query = query.or(`name.ilike.${orIlikeValue(search)}`);
   }
 
   const { data, error } = await query;
@@ -91,7 +92,7 @@ export async function getWorkCentersFlat(
     query = query.eq('kind', options.kind);
   }
   if (options?.search?.trim()) {
-    query = query.or(`name.ilike.%${options.search}%`);
+    query = query.or(`name.ilike.${orIlikeValue(options.search)}`);
   }
 
   const { data, error } = await query;


### PR DESCRIPTION
## Problem

On the Parts page, searching a part's **full** name `F40750-1 (REX-76)` returned "No parts match these filters" — but the **half-typed** `F40750-1 (REX-76` (no closing paren) found it. The part's data completeness was identical in both cases; the only difference was the trailing `)`.

**Root cause:** the search term was interpolated **raw** into a PostgREST `.or()` filter *string*, which PostgREST parses. In that mini-syntax `,` separates conditions and `( )` group them, so the term's own `)` terminated the OR group early and the query silently returned zero rows. An open paren alone doesn't close the group — which is exactly why the partial search still matched.

```ts
// before — utils/partsAccess.ts
query = query.or(`part_name.ilike.%${search}%,description.ilike.%${search}%`);
```

## Fix

New **`utils/searchFilter.ts`** as the single source of truth for search-term escaping, with two shape-specific helpers:

- `orIlikeValue()` — double-quotes the value so PostgREST treats `( ) , . :` literally. For `.or()` string filters.
- `escapeIlikePattern()` — ILIKE wildcard escaping (`\ % _`). For `.ilike(col, val)` calls, where postgrest-js already encodes the value safely.

Applied `orIlikeValue` to **all 15 unescaped `.or()` search sites**: `partsAccess` (7), `workCentersAccess` (3), `routingsAccess`, `vendorsAccess`, `customerAccess` (2), `jobsAccess`. This also closes a latent **filter-injection** hole (a term like `a%,other_col.ilike.%x` could previously inject an extra OR condition).

## Cleanup / consolidation

Removed the two duplicated private `sanitizeSearchString` helpers:
- `jobsAccess`'s copy was **dead code** once its only caller switched to `orIlikeValue` (it used the wrong shape for `.or()` anyway) → deleted.
- `quotesAccess` now imports the shared `escapeIlikePattern` (identical behavior) for its `.ilike()` calls.

Net: one escaping module, every search caller routed through it, zero duplicated or orphaned code.

## Tests

- New `__tests__/utils/searchFilter.test.ts` covering both exports, incl. the exact reported `F40750-1 (REX-76)` case, parens, commas, wildcards, embedded quotes, and the length cap.
- New regression test in `partsAccess.test.ts` asserting the double-quoted filter for `F40750-1 (REX-76)`.
- Updated existing vendors/customer/workCenters assertions to the new double-quoted output.

## Verification

- `pnpm exec tsc --noEmit -p tsconfig.json` — clean.
- `pnpm test --run` on all 7 affected access-layer suites — **180 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)