### PR TITLE
feat(settings): compact section layout + configurable quote validity

### DIFF
--- a/__tests__/lib/companyDefaults.test.ts
+++ b/__tests__/lib/companyDefaults.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  KNOWN_DEFAULTS,
+  readCompanyDefault,
+  readQuoteValidityDays,
+  readCompanyDefaults,
+} from '@/lib/companyDefaults';
+import { DEFAULT_QUOTE_VALIDITY_DAYS } from '@/types/quote';
+
+describe('companyDefaults: quote_validity_days', () => {
+  it('is registered in KNOWN_DEFAULTS (so the settings card renders a row)', () => {
+    expect(KNOWN_DEFAULTS.map((d) => d.key)).toContain('quote_validity_days');
+  });
+
+  it('falls back to DEFAULT_QUOTE_VALIDITY_DAYS when unset', () => {
+    expect(readQuoteValidityDays({ settings: { defaults: {} } })).toBe(DEFAULT_QUOTE_VALIDITY_DAYS);
+    expect(readQuoteValidityDays({ settings: {} })).toBe(DEFAULT_QUOTE_VALIDITY_DAYS);
+    expect(readQuoteValidityDays(null)).toBe(DEFAULT_QUOTE_VALIDITY_DAYS);
+    expect(readQuoteValidityDays(undefined)).toBe(DEFAULT_QUOTE_VALIDITY_DAYS);
+  });
+
+  it('reads an explicit stored value (number or numeric string)', () => {
+    expect(readQuoteValidityDays({ settings: { defaults: { quote_validity_days: 20 } } })).toBe(20);
+    expect(readQuoteValidityDays({ settings: { defaults: { quote_validity_days: '30' } } })).toBe(30);
+  });
+
+  it('rounds fractional stored values to the nearest integer', () => {
+    expect(readQuoteValidityDays({ settings: { defaults: { quote_validity_days: 14.4 } } })).toBe(14);
+  });
+
+  it('rejects out-of-range / non-numeric values back to the fallback', () => {
+    const fb = DEFAULT_QUOTE_VALIDITY_DAYS;
+    expect(readQuoteValidityDays({ settings: { defaults: { quote_validity_days: 0 } } })).toBe(fb); // < min
+    expect(readQuoteValidityDays({ settings: { defaults: { quote_validity_days: 999 } } })).toBe(fb); // > max
+    expect(readQuoteValidityDays({ settings: { defaults: { quote_validity_days: 'abc' } } })).toBe(fb);
+    expect(readQuoteValidityDays({ settings: { defaults: { quote_validity_days: null } } })).toBe(fb);
+  });
+
+  it('readCompanyDefault throws on an unknown key', () => {
+    // @ts-expect-error — exercising the runtime guard with a bad key
+    expect(() => readCompanyDefault({ settings: {} }, 'nope')).toThrow();
+  });
+
+  it('readCompanyDefaults returns a dense map resolved against fallbacks', () => {
+    const values = readCompanyDefaults({ settings: { defaults: { quote_validity_days: 25 } } });
+    expect(values.quote_validity_days).toBe(25);
+
+    const none = readCompanyDefaults(null);
+    expect(none.quote_validity_days).toBe(DEFAULT_QUOTE_VALIDITY_DAYS);
+  });
+});

--- a/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
+++ b/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
@@ -37,6 +37,7 @@ import {
 import { getJobQuantitiesForQuote } from '@/utils/jobsAccess';
 import { getCompany } from '@/utils/companyAccess';
 import type { Company } from '@/utils/companyAccess';
+import { readQuoteValidityDays } from '@/lib/companyDefaults';
 import QuotePdfPreviewDialog from '@/components/quotes/QuotePdfPreviewDialog';
 import {
   quoteToFormData,
@@ -91,6 +92,15 @@ export default function QuoteDetailPage() {
     onError: (err) =>
       setError(err instanceof Error ? err.message : 'Failed to load quote'),
   });
+
+  // Load the company eagerly so reactivating an expired quote can honor the
+  // company's configured quote-validity window, and the PDF preview can reuse
+  // it without a second fetch. Fallback (still loading / failed) is null, which
+  // readQuoteValidityDays resolves to the default validity.
+  const { data: loadedCompany } = useLoad(
+    () => getCompany(companyId),
+    [companyId],
+  );
 
   // Reflect current job quantities on a converted quote (read-only). A quantity
   // edited on the job after conversion shows here as "now N on the job"; the
@@ -183,7 +193,7 @@ export default function QuoteDetailPage() {
     try {
       // Fetch (or reuse) the company so the preview dialog can render the
       // shop header without doing its own data fetch.
-      const c = company ?? (await getCompany(companyId));
+      const c = company ?? loadedCompany ?? (await getCompany(companyId));
       if (!c) {
         throw new Error('Company info unavailable — cannot generate PDF.');
       }
@@ -289,7 +299,9 @@ export default function QuoteDetailPage() {
     // still-past date leaves it expired (updateQuote derives status from it).
     const initialData = quoteToFormData(quote);
     if (expired) {
-      initialData.expiration_date = defaultExpirationDate();
+      initialData.expiration_date = defaultExpirationDate(
+        readQuoteValidityDays(loadedCompany),
+      );
     }
 
     return (

--- a/app/dashboard/[companyId]/quotes/new/page.tsx
+++ b/app/dashboard/[companyId]/quotes/new/page.tsx
@@ -1,13 +1,42 @@
 'use client';
 
+import { useParams } from 'next/navigation';
 import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import QuoteForm from '@/components/quotes/QuoteForm';
-import { EMPTY_QUOTE_FORM } from '@/types/quote';
+import { EMPTY_QUOTE_FORM, defaultExpirationDate } from '@/types/quote';
+import { getCompany } from '@/utils/companyAccess';
+import { readQuoteValidityDays } from '@/lib/companyDefaults';
+import { useLoad } from '@/hooks/useLoad';
 
 export default function NewQuotePage() {
+  const params = useParams();
+  const companyId = params.companyId as string;
+
+  // Pre-fill the expiration date from the company's configured quote-validity
+  // window (companies.settings.defaults.quote_validity_days). While loading (or
+  // on failure) readQuoteValidityDays falls back to the default validity.
+  const { data: company, loading } = useLoad(
+    () => getCompany(companyId),
+    [companyId],
+  );
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  const initialData = {
+    ...EMPTY_QUOTE_FORM,
+    expiration_date: defaultExpirationDate(readQuoteValidityDays(company)),
+  };
+
   return (
     <Box>
-      <QuoteForm mode="create" initialData={EMPTY_QUOTE_FORM} />
+      <QuoteForm mode="create" initialData={initialData} />
     </Box>
   );
 }

--- a/app/dashboard/[companyId]/settings/page.tsx
+++ b/app/dashboard/[companyId]/settings/page.tsx
@@ -3,12 +3,8 @@
 import { useState } from 'react';
 import { useParams } from 'next/navigation';
 import Box from '@mui/material/Box';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
-import Divider from '@mui/material/Divider';
+import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -17,7 +13,9 @@ import DialogActions from '@mui/material/DialogActions';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useDemoMode } from '@/components/providers/DemoModeProvider';
 import AdminGuard from '@/components/auth/AdminGuard';
+import SettingsSection from '@/components/settings/SettingsSection';
 import CompanyProfileCard from '@/components/settings/CompanyProfileCard';
+import AppDefaultsCard from '@/components/settings/AppDefaultsCard';
 import QuickBooksIntegrationCard from '@/components/settings/QuickBooksIntegrationCard';
 
 export default function SettingsPage() {
@@ -46,68 +44,61 @@ export default function SettingsPage() {
       {/* Shop contact info (header on printed quotes) */}
       <CompanyProfileCard companyId={companyId} />
 
+      {/* Company-configurable business defaults (quote validity, etc.) */}
+      <AppDefaultsCard companyId={companyId} />
+
       {/* QuickBooks Online connection + invoice push settings */}
       <QuickBooksIntegrationCard companyId={companyId} />
 
-      {/* Demo Mode Section */}
-      <Card elevation={2}>
-        <CardContent sx={{ p: 3 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
-            <Typography variant="h6" sx={{ fontWeight: 600 }}>
-              Demo Mode
-            </Typography>
-            {!isLoading && (
-              <Chip
-                label={isDemoMode ? 'Active' : hasDemoCompany ? 'Available' : 'Not set up'}
-                size="small"
-                color={isDemoMode ? 'warning' : 'default'}
-                variant={isDemoMode ? 'filled' : 'outlined'}
-              />
-            )}
-          </Box>
+      {/* Advanced / rarely-used zone — kept last, visually de-emphasized. */}
+      <SettingsSection
+        title="Demo Mode"
+        variant="advanced"
+        statusChip={
+          !isLoading ? (
+            <Chip
+              label={isDemoMode ? 'Active' : hasDemoCompany ? 'Available' : 'Not set up'}
+              size="small"
+              color={isDemoMode ? 'warning' : 'default'}
+              variant={isDemoMode ? 'filled' : 'outlined'}
+            />
+          ) : undefined
+        }
+        description="Explore Jigged with pre-populated sample data — customers, parts, quotes, jobs, and more. Your real company data is never affected."
+      >
+        <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+          {isDemoMode ? (
+            <Button variant="contained" onClick={exitDemoMode}>
+              Back to My Company
+            </Button>
+          ) : (
+            <Button
+              variant="contained"
+              onClick={enterDemoMode}
+              disabled={isCreating || isLoading}
+              startIcon={isCreating ? <CircularProgress size={16} /> : undefined}
+            >
+              {isCreating
+                ? 'Setting up demo…'
+                : hasDemoCompany
+                  ? 'Enter Demo Mode'
+                  : 'Set Up Demo Mode'}
+            </Button>
+          )}
 
-          <Typography variant="body2" sx={{ color: 'text.secondary', mb: 3 }}>
-            Demo mode lets you explore Jigged with pre-populated sample data —
-            customers, parts, quotes, jobs, and more. Your real company data is
-            never affected.
-          </Typography>
-
-          <Divider sx={{ mb: 3 }} />
-
-          <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
-            {isDemoMode ? (
-              <Button variant="contained" onClick={exitDemoMode}>
-                Back to My Company
-              </Button>
-            ) : (
-              <Button
-                variant="contained"
-                onClick={enterDemoMode}
-                disabled={isCreating || isLoading}
-                startIcon={isCreating ? <CircularProgress size={16} /> : undefined}
-              >
-                {isCreating
-                  ? 'Setting up demo…'
-                  : hasDemoCompany
-                    ? 'Enter Demo Mode'
-                    : 'Set Up Demo Mode'}
-              </Button>
-            )}
-
-            {hasDemoCompany && (
-              <Button
-                variant="outlined"
-                color="error"
-                onClick={() => setResetDialogOpen(true)}
-                disabled={isResetting}
-                startIcon={isResetting ? <CircularProgress size={16} /> : undefined}
-              >
-                {isResetting ? 'Resetting…' : 'Reset Demo'}
-              </Button>
-            )}
-          </Box>
-        </CardContent>
-      </Card>
+          {hasDemoCompany && (
+            <Button
+              variant="outlined"
+              color="error"
+              onClick={() => setResetDialogOpen(true)}
+              disabled={isResetting}
+              startIcon={isResetting ? <CircularProgress size={16} /> : undefined}
+            >
+              {isResetting ? 'Resetting…' : 'Reset Demo'}
+            </Button>
+          )}
+        </Box>
+      </SettingsSection>
 
       {/* Reset Confirmation Dialog */}
       <Dialog open={resetDialogOpen} onClose={() => setResetDialogOpen(false)}>

--- a/components/settings/AppDefaultsCard.tsx
+++ b/components/settings/AppDefaultsCard.tsx
@@ -113,7 +113,7 @@ export default function AppDefaultsCard({ companyId }: AppDefaultsCardProps) {
 
   return (
     <SettingsSection
-      title="Quote & Document Defaults"
+      title="App Default Settings"
       description="Default values applied to new records. Changing one doesn't affect records you've already created."
     >
       {error && (

--- a/components/settings/AppDefaultsCard.tsx
+++ b/components/settings/AppDefaultsCard.tsx
@@ -113,7 +113,7 @@ export default function AppDefaultsCard({ companyId }: AppDefaultsCardProps) {
 
   return (
     <SettingsSection
-      title="App Default Settings"
+      title="Company Default Settings"
       description="Default values applied to new records. Changing one doesn't affect records you've already created."
     >
       {error && (

--- a/components/settings/AppDefaultsCard.tsx
+++ b/components/settings/AppDefaultsCard.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+import InputAdornment from '@mui/material/InputAdornment';
+import SaveIcon from '@mui/icons-material/Save';
+import { getCompany, updateCompanyDefaults } from '@/utils/companyAccess';
+import {
+  KNOWN_DEFAULTS,
+  readCompanyDefaults,
+  type CompanyDefaultKey,
+} from '@/lib/companyDefaults';
+import SettingsSection from '@/components/settings/SettingsSection';
+
+interface AppDefaultsCardProps {
+  companyId: string;
+}
+
+type FormState = Record<CompanyDefaultKey, string>;
+
+/** Validate one field's string value against its descriptor's [min, max]. */
+function fieldError(key: CompanyDefaultKey, raw: string): string | null {
+  const descriptor = KNOWN_DEFAULTS.find((d) => d.key === key)!;
+  const trimmed = raw.trim();
+  if (trimmed === '') return 'Required';
+  const n = Number(trimmed);
+  if (!Number.isInteger(n)) return 'Whole number';
+  if (n < descriptor.min || n > descriptor.max) {
+    return `${descriptor.min}–${descriptor.max}`;
+  }
+  return null;
+}
+
+/**
+ * "Quote & Document Defaults" settings block. Renders one editable row per
+ * KNOWN_DEFAULTS entry, so surfacing a new company-configurable default is a
+ * single registry line. Values persist to companies.settings.defaults via
+ * updateCompanyDefaults (feature flags in the sibling `features` block are
+ * preserved).
+ */
+export default function AppDefaultsCard({ companyId }: AppDefaultsCardProps) {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState<FormState>(() => emptyForm());
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const company = await getCompany(companyId);
+        if (cancelled) return;
+        const values = readCompanyDefaults(company);
+        setForm(toFormState(values));
+      } catch {
+        if (!cancelled) setError('Failed to load settings.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [companyId]);
+
+  const handleChange = (key: CompanyDefaultKey) => (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setForm((prev) => ({ ...prev, [key]: e.target.value }));
+    setSuccess(false);
+  };
+
+  const errors = KNOWN_DEFAULTS.reduce<Partial<Record<CompanyDefaultKey, string>>>(
+    (acc, d) => {
+      const err = fieldError(d.key, form[d.key]);
+      if (err) acc[d.key] = err;
+      return acc;
+    },
+    {},
+  );
+  const hasErrors = Object.keys(errors).length > 0;
+
+  const handleSave = async () => {
+    if (hasErrors) {
+      setError('Fix the highlighted fields before saving.');
+      return;
+    }
+    setError(null);
+    setSuccess(false);
+    setSaving(true);
+    try {
+      const patch: Record<string, number> = {};
+      for (const d of KNOWN_DEFAULTS) {
+        patch[d.key] = Number(form[d.key].trim());
+      }
+      await updateCompanyDefaults(companyId, patch);
+      setSuccess(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save settings.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <SettingsSection
+      title="Quote & Document Defaults"
+      description="Default values applied to new records. Changing one doesn't affect records you've already created."
+    >
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+      {success && (
+        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(false)}>
+          Settings saved.
+        </Alert>
+      )}
+
+      {loading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <>
+          {KNOWN_DEFAULTS.map((d, i) => (
+            <Box key={d.key}>
+              {i > 0 && <Divider sx={{ my: 2 }} />}
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 2,
+                  flexWrap: 'wrap',
+                }}
+              >
+                <Box sx={{ flex: '1 1 260px', minWidth: 0 }}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                    {d.label}
+                  </Typography>
+                  <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                    {d.description}
+                  </Typography>
+                </Box>
+                <TextField
+                  value={form[d.key]}
+                  onChange={handleChange(d.key)}
+                  size="small"
+                  type="number"
+                  inputProps={{ min: d.min, max: d.max, step: 1, 'aria-label': d.label }}
+                  error={Boolean(errors[d.key])}
+                  helperText={errors[d.key]}
+                  sx={{ width: 160 }}
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position="end">{d.unit}</InputAdornment>
+                    ),
+                  }}
+                />
+              </Box>
+            </Box>
+          ))}
+
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 3 }}>
+            <Button
+              variant="contained"
+              startIcon={saving ? <CircularProgress size={16} color="inherit" /> : <SaveIcon />}
+              onClick={handleSave}
+              disabled={saving || hasErrors}
+            >
+              Save
+            </Button>
+          </Box>
+        </>
+      )}
+    </SettingsSection>
+  );
+}
+
+function emptyForm(): FormState {
+  const out = {} as FormState;
+  for (const d of KNOWN_DEFAULTS) out[d.key] = String(d.fallback);
+  return out;
+}
+
+function toFormState(values: Record<CompanyDefaultKey, number>): FormState {
+  const out = {} as FormState;
+  for (const d of KNOWN_DEFAULTS) out[d.key] = String(values[d.key]);
+  return out;
+}

--- a/components/settings/CompanyProfileCard.tsx
+++ b/components/settings/CompanyProfileCard.tsx
@@ -2,14 +2,10 @@
 
 import { useState, useEffect } from 'react';
 import Box from '@mui/material/Box';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
-import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
 import SaveIcon from '@mui/icons-material/Save';
 import {
@@ -20,6 +16,7 @@ import {
 import CountrySelect from '@/components/common/CountrySelect';
 import StateSelect from '@/components/common/StateSelect';
 import { isValidEmail, isValidPhone, isValidPostalCode } from '@/lib/validators';
+import SettingsSection from '@/components/settings/SettingsSection';
 
 interface CompanyProfileCardProps {
   companyId: string;
@@ -110,18 +107,10 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
   };
 
   return (
-    <Card elevation={2}>
-      <CardContent sx={{ p: 3 }}>
-        <Typography variant="h6" sx={{ fontWeight: 600, mb: 1 }}>
-          Company Profile
-        </Typography>
-        <Typography variant="body2" sx={{ color: 'text.secondary', mb: 3 }}>
-          Shop contact and address info shown in the FROM block on printed quote
-          PDFs. Leave fields blank to omit them from the PDF.
-        </Typography>
-
-        <Divider sx={{ mb: 3 }} />
-
+    <SettingsSection
+      title="Company Profile"
+      description="Shop contact and address shown on printed quote PDFs. Leave a field blank to omit it."
+    >
         {error && (
           <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
             {error}
@@ -139,10 +128,7 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
           </Box>
         ) : (
           <>
-            <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1.5 }}>
-              Contact
-            </Typography>
-            <Grid container spacing={2} sx={{ mb: 3 }}>
+            <Grid container spacing={2}>
               <Grid size={{ xs: 12, sm: 4 }}>
                 <TextField
                   label="Phone"
@@ -180,12 +166,6 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
                   autoComplete="url"
                 />
               </Grid>
-            </Grid>
-
-            <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1.5 }}>
-              Address
-            </Typography>
-            <Grid container spacing={2}>
               <Grid size={{ xs: 12 }}>
                 <TextField
                   label="Address line 1"
@@ -206,7 +186,7 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
                   autoComplete="address-line2"
                 />
               </Grid>
-              <Grid size={{ xs: 12, sm: 6 }}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <TextField
                   label="City"
                   value={form.city}
@@ -216,7 +196,7 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
                   autoComplete="address-level2"
                 />
               </Grid>
-              <Grid size={{ xs: 12, sm: 6 }}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <StateSelect
                   value={form.state}
                   onChange={(v) => {
@@ -227,7 +207,7 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
                   size="small"
                 />
               </Grid>
-              <Grid size={{ xs: 12, sm: 6 }}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <TextField
                   label="ZIP"
                   value={form.postal_code}
@@ -239,7 +219,7 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
                   helperText={postalInvalid ? 'Invalid for country' : undefined}
                 />
               </Grid>
-              <Grid size={{ xs: 12, sm: 6 }}>
+              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
                 <CountrySelect
                   value={form.country}
                   onChange={(v) => {
@@ -263,7 +243,6 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
             </Box>
           </>
         )}
-      </CardContent>
-    </Card>
+    </SettingsSection>
   );
 }

--- a/components/settings/QuickBooksIntegrationCard.tsx
+++ b/components/settings/QuickBooksIntegrationCard.tsx
@@ -3,13 +3,10 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Box from '@mui/material/Box';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Alert from '@mui/material/Alert';
-import Divider from '@mui/material/Divider';
 import CircularProgress from '@mui/material/CircularProgress';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -22,6 +19,7 @@ import {
   disconnectQuickBooks,
   type QuickBooksStatus,
 } from '@/utils/quickbooksAccess';
+import SettingsSection from '@/components/settings/SettingsSection';
 
 interface QuickBooksIntegrationCardProps {
   companyId: string;
@@ -110,33 +108,26 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
 
   const connected = status?.connected ?? false;
 
+  const statusChip = !loading ? (
+    <>
+      <Chip
+        label={connected ? 'Connected' : 'Not connected'}
+        size="small"
+        color={connected ? 'success' : 'default'}
+        variant={connected ? 'filled' : 'outlined'}
+      />
+      {connected && status?.environment === 'sandbox' && (
+        <Chip label="Sandbox" size="small" color="warning" variant="outlined" />
+      )}
+    </>
+  ) : undefined;
+
   return (
-    <Card elevation={2}>
-      <CardContent sx={{ p: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
-          <Typography variant="h6" sx={{ fontWeight: 600 }}>
-            QuickBooks Online
-          </Typography>
-          {!loading && (
-            <Chip
-              label={connected ? 'Connected' : 'Not connected'}
-              size="small"
-              color={connected ? 'success' : 'default'}
-              variant={connected ? 'filled' : 'outlined'}
-            />
-          )}
-          {connected && status?.environment === 'sandbox' && (
-            <Chip label="Sandbox" size="small" color="warning" variant="outlined" />
-          )}
-        </Box>
-
-        <Typography variant="body2" sx={{ color: 'text.secondary', mb: 3 }}>
-          Connect QuickBooks Online to push converted quotes as invoices. Jigged only
-          sends to QuickBooks — it never changes your QuickBooks data on its own.
-        </Typography>
-
-        <Divider sx={{ mb: 3 }} />
-
+    <SettingsSection
+      title="QuickBooks Online"
+      statusChip={statusChip}
+      description="Connect QuickBooks Online to push converted quotes as invoices. Jigged only sends to QuickBooks — it never changes your QuickBooks data on its own."
+    >
         {error && (
           <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
             {error}
@@ -184,7 +175,6 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
             </Button>
           </>
         )}
-      </CardContent>
 
       <Dialog open={disconnectOpen} onClose={() => setDisconnectOpen(false)}>
         <DialogTitle>Disconnect QuickBooks?</DialogTitle>
@@ -201,6 +191,6 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
           </Button>
         </DialogActions>
       </Dialog>
-    </Card>
+    </SettingsSection>
   );
 }

--- a/components/settings/SettingsSection.tsx
+++ b/components/settings/SettingsSection.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+
+interface SettingsSectionProps {
+  title: string;
+  /** Optional status/label chip rendered inline to the right of the title. */
+  statusChip?: ReactNode;
+  /** One-line helper text under the title. Keep it short. */
+  description?: ReactNode;
+  /**
+   * `default` — a standard settings block (elevation 2).
+   * `advanced` — a de-emphasized block (outlined, muted heading) for rarely
+   * used / destructive zones like Demo Mode, set apart from everyday settings.
+   */
+  variant?: 'default' | 'advanced';
+  children: ReactNode;
+}
+
+/**
+ * Shared wrapper giving every Settings block one compact, consistent header
+ * rhythm — a single title row (with optional status chip), a one-line helper,
+ * and the content — instead of each card re-implementing a heavy header +
+ * divider. Density comes from cutting chrome, not shrinking controls.
+ */
+export default function SettingsSection({
+  title,
+  statusChip,
+  description,
+  variant = 'default',
+  children,
+}: SettingsSectionProps) {
+  const advanced = variant === 'advanced';
+
+  return (
+    <Card
+      elevation={advanced ? 0 : 2}
+      variant={advanced ? 'outlined' : 'elevation'}
+    >
+      <CardContent sx={{ p: 2.5, '&:last-child': { pb: 2.5 } }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: description ? 0.5 : 2 }}>
+          <Typography
+            variant="h6"
+            sx={{ fontWeight: 600, color: advanced ? 'text.secondary' : 'text.primary' }}
+          >
+            {title}
+          </Typography>
+          {statusChip}
+        </Box>
+
+        {description && (
+          <Typography variant="body2" sx={{ color: 'text.secondary', mb: 2 }}>
+            {description}
+          </Typography>
+        )}
+
+        {children}
+      </CardContent>
+    </Card>
+  );
+}

--- a/hooks/useCompanyDefaults.ts
+++ b/hooks/useCompanyDefaults.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { getCompany } from '@/utils/companyAccess';
+import {
+  readCompanyDefaults,
+  type CompanyDefaultKey,
+} from '@/lib/companyDefaults';
+import { useLoad } from '@/hooks/useLoad';
+
+/**
+ * Read the current company's business-default values (quote validity, etc.)
+ * for use in render logic — e.g. pre-filling a new quote's expiration date.
+ *
+ * Returns a dense map keyed by KNOWN_DEFAULTS entries. `loading` is true until
+ * the company row has been fetched the first time; the fallback (no companyId /
+ * fetch failure) is every default's descriptor `fallback`, so a failed load
+ * degrades to the same behavior as the old hard-coded constants rather than
+ * blocking. Mirrors useCompanyFeatures.
+ */
+export function useCompanyDefaults() {
+  const params = useParams();
+  const companyId = params.companyId as string | undefined;
+
+  const { data, loading } = useLoad(
+    async () => {
+      if (!companyId) return FALLBACK_DEFAULTS;
+      try {
+        return readCompanyDefaults(await getCompany(companyId));
+      } catch (err) {
+        console.warn('useCompanyDefaults: failed to load company:', err);
+        return FALLBACK_DEFAULTS;
+      }
+    },
+    [companyId],
+  );
+
+  return { defaults: data ?? FALLBACK_DEFAULTS, loading };
+}
+
+// Stable "all descriptor fallbacks" map — computed once (readCompanyDefaults of
+// an empty company resolves every key to its fallback), shared as the
+// loading/fallback value so consumers don't see a new object identity each render.
+const FALLBACK_DEFAULTS: Record<CompanyDefaultKey, number> = readCompanyDefaults(null);

--- a/lib/companyDefaults.ts
+++ b/lib/companyDefaults.ts
@@ -1,0 +1,115 @@
+/**
+ * Per-tenant business defaults stored in companies.settings (jsonb).
+ *
+ * A sibling of the feature-flag block (see lib/featureFlags.ts): flags live
+ * under `settings.features.<key>`, numeric business defaults live under
+ * `settings.defaults.<key>`. These are values that used to be hard-coded in
+ * source (e.g. a new quote's 10-day validity window) but should be editable
+ * per company from the Settings page.
+ *
+ * Every default is registered once in KNOWN_DEFAULTS; the "Quote & Document
+ * Defaults" settings card renders one editable row per entry, and the read
+ * helpers below resolve a company row against the registry's `fallback` when
+ * no explicit value is stored. Adding a new default is a single registry line.
+ *
+ * Set for a company:
+ *   UPDATE public.companies
+ *      SET settings = jsonb_set(COALESCE(settings, '{}'::jsonb),
+ *                               '{defaults,quote_validity_days}', '20')
+ *    WHERE id = '<company-uuid>';
+ */
+
+import type { Company } from '@/utils/companyAccess';
+import { DEFAULT_QUOTE_VALIDITY_DAYS } from '@/types/quote';
+
+interface SettingsLike {
+  settings?: Record<string, unknown> | null | undefined;
+}
+
+/**
+ * Descriptor for one numeric business default.
+ *
+ * The settings UI renders a labelled number input per descriptor; `min`/`max`
+ * bound both the input and the read-side clamp; `fallback` is returned whenever
+ * a company has no valid stored value.
+ */
+export interface CompanyDefaultDescriptor {
+  key: string;
+  label: string;
+  description: string;
+  unit: string;
+  min: number;
+  max: number;
+  fallback: number;
+}
+
+export const KNOWN_DEFAULTS: readonly CompanyDefaultDescriptor[] = [
+  {
+    key: 'quote_validity_days',
+    label: 'Quote validity',
+    description: 'How long a new quote stays valid before it expires.',
+    unit: 'days',
+    min: 1,
+    max: 365,
+    fallback: DEFAULT_QUOTE_VALIDITY_DAYS,
+  },
+] as const;
+
+export type CompanyDefaultKey = (typeof KNOWN_DEFAULTS)[number]['key'];
+
+/**
+ * Coerce an arbitrary stored value to a whole number within [min, max], or
+ * return null if it isn't a usable number. Accepts numeric strings (jsonb can
+ * round-trip either) and rounds fractional values to the nearest integer.
+ */
+function coerceInt(value: unknown, min: number, max: number): number | null {
+  const n = typeof value === 'string' ? Number(value) : value;
+  if (typeof n !== 'number' || !Number.isFinite(n)) return null;
+  const rounded = Math.round(n);
+  if (rounded < min || rounded > max) return null;
+  return rounded;
+}
+
+/**
+ * Read one default. Returns the descriptor's `fallback` when the company has no
+ * explicit value (missing settings, missing defaults block, missing key) or the
+ * stored value is out of range / non-numeric — an explicit valid value wins.
+ */
+export function readCompanyDefault(
+  company: SettingsLike | null | undefined,
+  key: CompanyDefaultKey,
+): number {
+  const descriptor = KNOWN_DEFAULTS.find((d) => d.key === key);
+  if (!descriptor) {
+    throw new Error(`Unknown company default key: ${key}`);
+  }
+  const settings = company?.settings as Record<string, unknown> | undefined | null;
+  const defaults = settings?.defaults as Record<string, unknown> | undefined;
+  const coerced = coerceInt(defaults?.[key], descriptor.min, descriptor.max);
+  return coerced ?? descriptor.fallback;
+}
+
+/**
+ * Days a new quote stays valid before expiring. Falls back to
+ * DEFAULT_QUOTE_VALIDITY_DAYS when unset.
+ */
+export function readQuoteValidityDays(
+  company: Pick<Company, 'settings'> | null | undefined,
+): number {
+  return readCompanyDefault(company, 'quote_validity_days');
+}
+
+/**
+ * Read the full defaults state for a company — a dense map keyed by
+ * KNOWN_DEFAULTS entries, each resolved against its descriptor's fallback.
+ * Used by the settings card to seed its form.
+ */
+export function readCompanyDefaults(
+  company: SettingsLike | null | undefined,
+): Record<CompanyDefaultKey, number> {
+  const out = {} as Record<CompanyDefaultKey, number>;
+  for (const d of KNOWN_DEFAULTS) {
+    out[d.key] = readCompanyDefault(company, d.key);
+  }
+  return out;
+}

--- a/types/quote.ts
+++ b/types/quote.ts
@@ -366,9 +366,17 @@ export interface CompanyMember {
 export const DEFAULT_QUOTE_LEAD_DAYS = 14;
 export const DEFAULT_QUOTE_VALIDITY_DAYS = 10;
 
-export function defaultExpirationDate(): string {
+/**
+ * Expiration date for a NEW quote: today + `validityDays`. The validity window
+ * is company-configurable (companies.settings.defaults.quote_validity_days,
+ * read via readQuoteValidityDays); callers that don't have the company row pass
+ * nothing and get the DEFAULT_QUOTE_VALIDITY_DAYS fallback.
+ */
+export function defaultExpirationDate(
+  validityDays: number = DEFAULT_QUOTE_VALIDITY_DAYS,
+): string {
   const d = new Date();
-  d.setDate(d.getDate() + DEFAULT_QUOTE_VALIDITY_DAYS);
+  d.setDate(d.getDate() + validityDays);
   return d.toISOString().slice(0, 10);
 }
 

--- a/utils/companyAccess.ts
+++ b/utils/companyAccess.ts
@@ -2,6 +2,7 @@
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type { CompanyMember } from '@/types/quote';
+import type { Json } from '@/types/database';
 
 export interface Company {
   id: string;
@@ -313,5 +314,40 @@ export async function updateCompanyProfile(
   if (error) {
     console.error('Error updating company profile:', error);
     throw new Error(`Failed to update company profile: ${error.message}`);
+  }
+}
+
+/**
+ * Merge numeric business defaults into companies.settings.defaults (jsonb).
+ * Read-modify-write of the whole settings object so the sibling `features`
+ * block (feature flags) is preserved. Keys should be CompanyDefaultKey values;
+ * see lib/companyDefaults.ts for the registry + read helpers.
+ */
+export async function updateCompanyDefaults(
+  companyId: string,
+  patch: Record<string, number>,
+): Promise<void> {
+  const supabase = getSupabase();
+
+  const company = await getCompany(companyId);
+  if (!company) {
+    throw new Error('Company not found.');
+  }
+
+  const settings = (company.settings ?? {}) as Record<string, unknown>;
+  const existingDefaults = (settings.defaults ?? {}) as Record<string, unknown>;
+  const nextSettings = {
+    ...settings,
+    defaults: { ...existingDefaults, ...patch },
+  } as Json;
+
+  const { error } = await supabase
+    .from('companies')
+    .update({ settings: nextSettings, updated_at: new Date().toISOString() })
+    .eq('id', companyId);
+
+  if (error) {
+    console.error('Error updating company defaults:', error);
+    throw new Error(`Failed to update company defaults: ${error.message}`);
   }
 }


### PR DESCRIPTION
## Context

The Settings page was a single scrolling column of three heavy cards (Company Profile, QuickBooks, Demo Mode), each re-implementing the same bulky header (title + chip + long blurb + divider) — oversized for the info it held. It also had no home for hard-coded business defaults a shop owner should be able to change. This redesigns the whole page structure and adds the first configurable default: **quote validity** (previously the hard-coded `DEFAULT_QUOTE_VALIDITY_DAYS = 10`).

Approach informed by settings-page UX research (NN/G et al.): keep one scrolling page (tabs/left-nav are overkill at ~4 sections), order everyday → advanced, and gain density by cutting chrome, not shrinking controls.

## What changed

**Layout** — one page, consistent compact sections via a new shared `SettingsSection` wrapper:
1. **Company Profile** — compacted (one-line blurb, no `Contact`/`Address` subheadings or divider, 4-up City/State/ZIP/Country row)
2. **Quote & Document Defaults** *(new)* — editable **Quote validity** days
3. **QuickBooks Online** — same connect/reconnect/disconnect lifecycle, shared compact header
4. **Demo Mode** — moved to the **bottom**, de-emphasized "advanced" zone (reset-confirm intact)

**Configurable-defaults framework** — mirrors the existing feature-flag pattern, stored in the existing `companies.settings` jsonb, so **no migration**:
- `lib/companyDefaults.ts` — `KNOWN_DEFAULTS` registry + clamped readers
- `hooks/useCompanyDefaults.ts`
- `updateCompanyDefaults()` in `utils/companyAccess.ts` — read-modify-write that preserves the sibling `features` block

Adding the next default (lead time, procurement expiry window, …) is one registry line. Quote validity is now read per company on new quotes and expired-quote reactivation.

## Verification

- `tsc --noEmit` clean; `eslint` clean on touched files
- Unit tests: new `__tests__/lib/companyDefaults.test.ts` (fallback, stored value, rounding, out-of-range clamp, unknown-key guard, dense map) + existing `QuoteForm.test.tsx` — **30 passed**
- Live (local Supabase): set validity 10→20, saved, **reloaded → persisted as 20**; new quote pre-filled expiration to **today + 20 days**; redesigned layout rendered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)