### PR TITLE
fix(auth): local-scope sign-out so one device's logout doesn't force a re-login on others

### DIFF
--- a/__tests__/components/providers/AuthProvider.test.tsx
+++ b/__tests__/components/providers/AuthProvider.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import AuthProvider, { useAuth } from '@/components/providers/AuthProvider';
+
+// Shared Supabase singleton the provider talks to.
+const sharedSupabase = {
+  auth: {
+    getSession: vi.fn(),
+    onAuthStateChange: vi.fn(() => ({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    })),
+    signOut: vi.fn(),
+  },
+};
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => sharedSupabase,
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  setUser: vi.fn(),
+}));
+
+// Minimal consumer that exercises the context signOut with each scope.
+function SignOutHarness() {
+  const { signOut } = useAuth();
+  return (
+    <>
+      <button onClick={() => signOut()}>default</button>
+      <button onClick={() => signOut('global')}>global</button>
+      <button onClick={() => signOut('others')}>others</button>
+    </>
+  );
+}
+
+describe('AuthProvider signOut scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sharedSupabase.auth.getSession.mockResolvedValue({
+      data: { session: { user: { id: 'user-1', email: 'op@example.com' } } },
+    });
+    sharedSupabase.auth.signOut.mockResolvedValue({ error: null });
+  });
+
+  it("defaults to local scope so logging out one device doesn't revoke others", async () => {
+    render(
+      <AuthProvider>
+        <SignOutHarness />
+      </AuthProvider>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'default' }));
+
+    await waitFor(() => {
+      expect(sharedSupabase.auth.signOut).toHaveBeenCalledWith({ scope: 'local' });
+    });
+  });
+
+  it('passes an explicit scope through (global for password reset)', async () => {
+    render(
+      <AuthProvider>
+        <SignOutHarness />
+      </AuthProvider>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'global' }));
+    await userEvent.click(screen.getByRole('button', { name: 'others' }));
+
+    await waitFor(() => {
+      expect(sharedSupabase.auth.signOut).toHaveBeenCalledWith({ scope: 'global' });
+      expect(sharedSupabase.auth.signOut).toHaveBeenCalledWith({ scope: 'others' });
+    });
+  });
+});

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -80,7 +80,9 @@ export default function OperatorLayout({
         .single();
 
       if (!operatorAccess) {
-        await supabase.auth.signOut();
+        // Local scope — only clear this device's bad session; don't revoke the
+        // user's sessions on other devices.
+        await supabase.auth.signOut({ scope: 'local' });
         router.push(`/operator/${companyId}/login`);
         return;
       }

--- a/app/operator/[companyId]/login/page.tsx
+++ b/app/operator/[companyId]/login/page.tsx
@@ -144,7 +144,9 @@ export default function OperatorLoginPage() {
         .single();
 
       if (opError || !operatorAccess) {
-        await supabase.auth.signOut();
+        // Local scope — only clear this device's session; don't revoke the
+        // user's sessions on other devices.
+        await supabase.auth.signOut({ scope: 'local' });
         throw new Error('You do not have access to this company');
       }
 

--- a/app/operator/[companyId]/profile/page.tsx
+++ b/app/operator/[companyId]/profile/page.tsx
@@ -82,7 +82,10 @@ export default function OperatorProfilePage() {
     // OperatorStationContext uses; sessionStorage is no longer the station's home.
     clearStoredStation();
     const supabase = getSupabase();
-    await supabase.auth.signOut();
+    // Local scope — sign out ONLY this device. An operator logging out here must
+    // not revoke their session on their other devices (which surfaced as a
+    // forced re-login when marking a job complete).
+    await supabase.auth.signOut({ scope: 'local' });
     router.push(`/operator/${companyId}/login`);
   };
 

--- a/components/auth/ResetPassword.tsx
+++ b/components/auth/ResetPassword.tsx
@@ -146,8 +146,12 @@ export default function ResetPassword() {
 
       setSuccess(true);
 
-      // Sign out and redirect to login after a short delay
-      await signOut();
+      // Global scope — a password reset must invalidate the user's sessions on
+      // ALL devices (the lost/old device that prompted the reset included), not
+      // just this recovery session. signOut defaults to `local` now, so this
+      // flow passes 'global' explicitly. The flow then redirects to /login for a
+      // fresh sign-in.
+      await signOut('global');
       setTimeout(() => {
         router.push('/login');
       }, 2000);

--- a/components/providers/AuthProvider.tsx
+++ b/components/providers/AuthProvider.tsx
@@ -6,11 +6,20 @@ import type { Session, User, AuthChangeEvent } from '@supabase/supabase-js';
 import { getSupabase } from '@/lib/supabase';
 import { redirectToSessionExpiry } from '@/lib/supabaseErrors';
 
+/**
+ * Sign-out scope. `local` (default) ends only this device's session; `others`
+ * ends every OTHER session but keeps this one; `global` ends them all. Ordinary
+ * logout is `local` so one device signing out never revokes an operator's
+ * session on their other devices (which showed up as a forced re-login on the
+ * shop floor). The password-reset flow opts into `global` explicitly.
+ */
+type SignOutScope = 'local' | 'global' | 'others';
+
 interface AuthContextType {
   session: Session | null;
   user: User | null;
   loading: boolean;
-  signOut: () => Promise<void>;
+  signOut: (scope?: SignOutScope) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType>({
@@ -102,15 +111,16 @@ export default function AuthProvider({ children }: AuthProviderProps) {
     }
   }, [user]);
 
-  const signOut = async () => {
+  const signOut = async (scope: SignOutScope = 'local') => {
     intentionalSignOut.current = true;
     const supabase = getSupabase();
-    // Explicit scope='global' — revokes every session for this user
-    // across all devices. The ResetPassword flow relies on this to
-    // invalidate the lost/old device after an admin-triggered reset.
-    // Do NOT narrow this scope without also updating the password-reset
-    // flow's session-invalidation guarantee.
-    await supabase.auth.signOut({ scope: 'global' });
+    // Default `local` — revokes ONLY this device's session, so logging out on
+    // one device leaves the user signed in everywhere else. Callers that need
+    // to invalidate other devices pass an explicit scope: the password-reset
+    // flow (ResetPassword) passes 'global' to kill lost/old devices, and the
+    // change-password flow calls supabase.auth.signOut({ scope: 'others' })
+    // directly. Do NOT change this default without revisiting those two flows.
+    await supabase.auth.signOut({ scope });
   };
 
   return (


### PR DESCRIPTION
## Problem

Operators are intermittently kicked to the **Operator Sign In** page when they tap **Mark Complete**. They can log back in and finish the job, but it's disruptive on the shop floor.

## Root cause (confirmed against Supabase docs)

The visible redirect comes from the operator layout's auth listener, which does `router.push(.../login)` on any Supabase `SIGNED_OUT` event. `SIGNED_OUT` fires when the browser's refresh token has been revoked server-side — and our own code was revoking it across devices:

In JavaScript, [`supabase.auth.signOut()` defaults to `scope: 'global'`](https://supabase.com/docs/guides/auth/signout), which *terminates every session for the user and destroys all their refresh tokens on all devices*. Operators use individual accounts but often across two devices (e.g. a personal phone **and** a shop tablet). The moment one device tapped **Logout** (global), the **other** device's session was silently killed. That device only discovered it on its next write — Mark Complete — → `SIGNED_OUT` → forced re-login. It's intermittent precisely because it only triggers when the account signed out somewhere else.

## Fix

Move ordinary logout to **`local`** scope (this device only), and keep "sign out my other devices" **only** on the password-change/reset paths.

- **`AuthProvider.signOut`** now takes an optional scope, **defaulting to `local`**. This fixes the dashboard header, admin, and no-access logouts, which all route through it.
- **Operator** profile / layout / login sign-outs pass `{ scope: 'local' }`.
- **ResetPassword** opts back into `signOut('global')` — a password reset must still invalidate the lost/old device that prompted it (then redirects to `/login`).
- **ChangePassword** is unchanged — already `signOut({ scope: 'others' })` (updates password, keeps the current device signed in).
- New **AuthProvider test** locks in the `local` default and explicit `global`/`others` pass-through.

## Testing

- `pnpm exec tsc --noEmit` — clean.
- `pnpm test --run __tests__/components/auth __tests__/components/providers` — 56 passed (incl. the new AuthProvider scope test; ChangePassword's `others` assertion still holds).
- **Manual (the actual bug):** log the same operator account into two sessions, tap **Logout** in one, then tap **Mark Complete** in the other — it now completes without bouncing to login.

## Residual risk / follow-up (not in this PR)

If the intermittent kick still occurs after this, the remaining suspect is a **refresh-token rotation race** between supabase-js's built-in auto-refresh and our custom `refreshSession()` in `lib/supabase.ts` (worsened by mobile tab-backgrounding). The scoped follow-up would be to proactively refresh via `getSession()` at the start of `completeOperation()` and drop its redundant `getUser()` round-trip. Left out here per agreed scope.

Optional config check (Supabase dashboard, not code): confirm **Auth → Sessions → "Enforce single session per user"** is **off**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)