### PR TITLE
copy(marketing): hero subhead unpacks the scope, drops the paperless opener

### DIFF
--- a/lib/constants/marketing.ts
+++ b/lib/constants/marketing.ts
@@ -39,8 +39,16 @@ export const HERO = {
   // quote → floor → shipping → invoicing.
   headlineLead: 'Your whole shop,',
   headlineEmphasis: 'in one place.',
+  // Unpacks the headline rather than repeating it: "whole shop" is abstract, so this says
+  // what it actually spans, then delivers the two benefits (grunt test: subhead = how it
+  // makes life better). Opened "Go paperless" before — the narrow pitch we cut from the
+  // eyebrow, and paperless is a mechanism anyway (the shop-floor section sells it).
+  // "Jigged shows you" made Jigged the actor; the customer is the hero. "Captures the
+  // notes your operators take" → "stay with the part": same fact, the shop's side of the
+  // table. "Next time someone needs it" (not "you run the part") is availability, not just
+  // the owner's own recall.
   subhead:
-    'Go paperless from quote to done. Jigged shows you where every job stands without walking the floor — and captures the notes and photos your operators take at the machine, so the fix your best guy figured out is still there next time you run the part.',
+    'Quoting to invoicing and everything between. See where every job stands without walking the floor — and the notes and photos your operators take at the machine stay with the part, so the fix your best guy figured out is there next time someone needs it.',
   primaryCta: { label: 'Request access', href: '/invite/early-access' },
   secondaryCta: { label: 'See how it works', href: '#how-it-works' },
 };


### PR DESCRIPTION
## Why

The subhead still opened **"Go paperless from quote to done"** — the narrow pitch we just cut from the eyebrow in #572, and "paperless" is a *mechanism*, not a benefit (the shop-floor section already sells it). So the hero read: widened eyebrow → widened headline → **revert to the operator-view framing**.

## What

```
Quoting to invoicing and everything between. See where every job stands without
walking the floor — and the notes and photos your operators take at the machine
stay with the part, so the fix your best guy figured out is there next time
someone needs it.
```

It now **unpacks** the headline rather than repeating it: "whole shop" is abstract, so the subhead says what it actually spans, then delivers the two benefits it owes (visibility + the know-how sticking). Grunt test: headline = what you offer, subhead = how it makes life better.

Three smaller fixes carried along:

| before | after | why |
|---|---|---|
| "**Jigged shows you** where every job stands" | "**See** where every job stands" | The customer is the hero; Jigged isn't the actor. |
| "**captures** the notes and photos your operators take" | those notes "**stay with the part**" | Same fact, from the shop's side of the table. "Capture" is the word that reads as taking what a shop holds dear. |
| "still there next time **you run the part**" | "there next time **someone needs it**" | Availability to whoever needs it next, not just the owner's own recall. |

## Notes

- Length is a wash (252 → 255 chars) — no extra lines in the hero.
- Copy-only, one constant. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)