### PR TITLE
feat(db): adopt Supabase's new Data API default; export grants in the schema snapshot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,12 +105,37 @@ Always create migration files with `supabase migration new <slug>` (NOT by writi
 **How to apply (workflow per change):**
 1. `supabase migration new <slug>` — creates the file with a fresh 14-digit timestamp.
 2. Write the SQL into the new file.
-3. **Verify locally:** `supabase db reset` replays the baseline + migrations + `supabase/seed.sql` on a fresh local DB — run it plus the relevant tests. This is the deterministic check; there is **no staging project to push to anymore** (we run on Supabase Branching now).
-4. **Open a PR.** Supabase Branching auto-creates a preview branch, applies the migration to it, and reports the **required migration status check**; the Vercel preview points at that branch's DB. If the check is red, fix the migration — it blocks merge.
-5. **Merge to `main` deploys to production.** The merge *is* the deploy — Supabase auto-applies new migrations to prod. Do NOT run `supabase db push` (or `supabase link`) against prod manually; the branching pipeline owns it. The human still owns clicking merge.
-6. After the merge has deployed, optionally run `python scripts/export_schema.py` to refresh the `supabase/schema.prod.sql` snapshot.
+3. **If the migration creates a table in `public`, grant it explicitly** — in the same migration, alongside `ENABLE ROW LEVEL SECURITY` and the policies. See "Data API grants" below. Without a `GRANT` the table is invisible to PostgREST/supabase-js and the FastAPI backend.
+4. **Verify locally:** `supabase db reset` replays the baseline + migrations + `supabase/seed.sql` on a fresh local DB — run it plus the relevant tests. This is the deterministic check; there is **no staging project to push to anymore** (we run on Supabase Branching now).
+5. **Open a PR.** Supabase Branching auto-creates a preview branch, applies the migration to it, and reports the **required migration status check**; the Vercel preview points at that branch's DB. If the check is red, fix the migration — it blocks merge.
+6. **Merge to `main` deploys to production.** The merge *is* the deploy — Supabase auto-applies new migrations to prod. Do NOT run `supabase db push` (or `supabase link`) against prod manually; the branching pipeline owns it. The human still owns clicking merge.
+7. After the merge has deployed, optionally run `python scripts/export_schema.py` to refresh the `supabase/schema.prod.sql` snapshot.
 
-The remaining handful of 8-digit-prefixed legacy files (e.g. `20260314_grant_anon_waitlist.sql`) are grandfathered — leave them alone. Never reuse the 8-digit pattern for new files.
+Never use the 8-digit date-only prefix for new files — always let the CLI generate the timestamp.
+
+### Data API grants (new tables in `public`)
+
+**Every new table in `public` needs explicit grants in its own migration.** Nothing is exposed to the Data API automatically any more — [`20260716025048_align_data_api_default_privileges.sql`](supabase/migrations/20260716025048_align_data_api_default_privileges.sql) revoked the default privileges that used to do it for you, matching what Supabase enforces on all projects from 2026-10-30 ([changelog #45329](https://supabase.com/changelog/45329-breaking-change-tables-not-exposed-to-data-and-graphql-api-automatically)).
+
+Bundle the grants with the RLS + policy block, in the same migration as the `CREATE TABLE`:
+
+```sql
+CREATE TABLE public.your_table (...);
+ALTER TABLE public.your_table ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ... ON public.your_table ...;
+
+GRANT SELECT ON public.your_table TO anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.your_table TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.your_table TO service_role;
+```
+
+**Grants and RLS are different layers.** A grant decides whether a role can touch the table *at all*; RLS decides *which rows*. RLS with no matching grant is unreachable, and a grant with no RLS policy is denied — you need both. Tailor the roles to the table:
+
+- Most tables are member-scoped by RLS, and `anon` rarely needs more than `SELECT` (often nothing at all — drop the `anon` line if the table is never read logged-out).
+- Backend-only tables (secrets, tokens) should grant `service_role` **only**, and explicitly `REVOKE` from `anon`/`authenticated` — see [`quickbooks_connections`](supabase/migrations/20260620122700_quickbooks_integration.sql#L50-L51).
+- Do **not** write `REVOKE`-down-from-`ALL` to express intent. That idiom relied on the old permissive default having granted everything first; under the current default it revokes privileges that were never granted, leaving the table exposed to nobody.
+
+**Symptom of a missing grant:** PostgREST returns `42501 permission denied`, and its error hint names the grant to add. Because local now matches prod, this fails in dev rather than only in production.
 
 ### Schema source-of-truth
 

--- a/scripts/export_schema.py
+++ b/scripts/export_schema.py
@@ -717,6 +717,168 @@ class SchemaExporter:
         return "\n".join(lines)
 
     # =========================================================================
+    # GRANTS & DEFAULT PRIVILEGES
+    # =========================================================================
+    # Canonical privilege orders, used to sort output deterministically and to
+    # collapse a full set to `ALL`. MAINTAIN is PG17+; prod runs PG17, which is
+    # the only database this script targets. A privilege outside these lists is
+    # emitted explicitly rather than folded into ALL — verbose on a different
+    # Postgres, but never wrong.
+    TABLE_PRIVILEGE_ORDER = [
+        "SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER",
+        "MAINTAIN",
+    ]
+    SEQUENCE_PRIVILEGE_ORDER = ["USAGE", "SELECT", "UPDATE"]
+    FUNCTION_PRIVILEGE_ORDER = ["EXECUTE"]
+    TYPE_PRIVILEGE_ORDER = ["USAGE"]
+
+    # pg_default_acl.defaclobjtype -> (keyword, canonical privilege order)
+    DEFACL_OBJTYPES = {
+        "r": ("TABLES", TABLE_PRIVILEGE_ORDER),
+        "S": ("SEQUENCES", SEQUENCE_PRIVILEGE_ORDER),
+        "f": ("FUNCTIONS", FUNCTION_PRIVILEGE_ORDER),
+        "T": ("TYPES", TYPE_PRIVILEGE_ORDER),
+    }
+
+    def format_privileges(self, privileges: Set[str], order: List[str]) -> str:
+        """Sort privileges canonically, collapsing an exact full set to ALL."""
+        if privileges == set(order):
+            return "ALL"
+        known = [p for p in order if p in privileges]
+        unknown = sorted(privileges - set(order))
+        return ", ".join(known + unknown)
+
+    def export_grants(self) -> str:
+        """Export GRANT statements and ALTER DEFAULT PRIVILEGES.
+
+        Data API exposure is decided here, not in the RLS sections: a role can
+        reach a table through PostgREST/supabase-js only if it holds a GRANT on
+        it, and RLS then decides which rows. The two layers are independent —
+        RLS with no grant is unreachable, a grant with no policy is denied.
+
+        Supabase is removing the default privileges that used to grant new
+        `public` tables automatically (changelog #45329; enforced on all
+        existing projects 2026-10-30). That makes this section load-bearing:
+        the per-object grants record what is actually exposed today, and the
+        default-privileges block records whether *new* tables will be exposed
+        at all.
+
+        Scoped to `public` to match get_tables(), so the grants listed always
+        correspond to the tables exported above. Cluster-wide default ACLs
+        (defaclnamespace = 0) are out of scope — Supabase sets per-schema ones.
+        """
+        # LEFT JOIN LATERAL, not CROSS JOIN: a relation whose relacl IS NULL has
+        # no explicit grants at all, and that is exactly the state worth seeing
+        # after the revoke. CROSS JOIN would drop those rows silently.
+        # aclexplode reports PUBLIC as grantee = 0.
+        object_sql = """
+            SELECT
+                n.nspname AS schema,
+                c.relname AS name,
+                c.relkind AS relkind,
+                CASE
+                    WHEN a.grantee IS NULL THEN NULL
+                    WHEN a.grantee = 0 THEN 'PUBLIC'
+                    ELSE pg_get_userbyid(a.grantee)
+                END AS grantee,
+                a.privilege_type AS privilege_type
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            LEFT JOIN LATERAL aclexplode(c.relacl) a ON true
+            WHERE n.nspname = ANY(%s)
+                AND c.relkind IN ('r', 'p', 'v', 'm', 'S')
+            ORDER BY n.nspname, c.relname
+        """
+        default_sql = """
+            SELECT
+                pg_get_userbyid(d.defaclrole) AS owner_role,
+                n.nspname AS schema,
+                d.defaclobjtype AS objtype,
+                CASE
+                    WHEN a.grantee = 0 THEN 'PUBLIC'
+                    ELSE pg_get_userbyid(a.grantee)
+                END AS grantee,
+                a.privilege_type AS privilege_type
+            FROM pg_default_acl d
+            JOIN pg_namespace n ON n.oid = d.defaclnamespace
+            CROSS JOIN LATERAL aclexplode(d.defaclacl) a
+            WHERE n.nspname = ANY(%s)
+            ORDER BY 1, 2, 3, 4
+        """
+        object_rows = self.query(object_sql, (['public'],))
+        default_rows = self.query(default_sql, (['public'],))
+
+        if not object_rows and not default_rows:
+            return ""
+
+        lines = ["-- ============================================================",
+                 "-- 12. GRANTS & DEFAULT PRIVILEGES",
+                 "-- ============================================================",
+                 "-- A role reaches a table through the Data API only if it holds a GRANT",
+                 "-- here; RLS then filters rows. Both layers are required.",
+                 "--",
+                 "-- New tables in `public` are NOT granted automatically (Supabase changelog",
+                 "-- #45329). The default privileges at the end of this section decide what,",
+                 "-- if anything, a newly created object is exposed to.",
+                 ""]
+
+        # Group privileges per (object, grantee); track objects with no ACL at all.
+        grants: Dict[Tuple[str, str, str], Set[str]] = defaultdict(set)
+        relkinds: Dict[Tuple[str, str], str] = {}
+        ungranted: List[Tuple[str, str]] = []
+
+        for row in object_rows:
+            key2 = (row["schema"], row["name"])
+            relkinds[key2] = row["relkind"]
+            if row["grantee"] is None:
+                ungranted.append(key2)
+                continue
+            grants[(row["schema"], row["name"], row["grantee"])].add(row["privilege_type"])
+
+        if ungranted:
+            lines.append("-- Objects with no explicit grants — unreachable via the Data API:")
+            for schema, name in sorted(set(ungranted)):
+                lines.append(f"--   {schema}.{name}")
+            lines.append("")
+
+        for (schema, name, grantee) in sorted(grants.keys()):
+            order = (self.SEQUENCE_PRIVILEGE_ORDER
+                     if relkinds.get((schema, name)) == "S"
+                     else self.TABLE_PRIVILEGE_ORDER)
+            privileges = self.format_privileges(grants[(schema, name, grantee)], order)
+            keyword = "SEQUENCE" if relkinds.get((schema, name)) == "S" else "TABLE"
+            full_name = self.format_schema_table(schema, name)
+            # PUBLIC is a keyword, not an identifier — never quote it.
+            target = "PUBLIC" if grantee == "PUBLIC" else self.escape_identifier(grantee)
+            lines.append(f"GRANT {privileges} ON {keyword} {full_name} TO {target};")
+
+        if default_rows:
+            lines.append("")
+            lines.append("-- Default privileges — what a NEWLY created object is granted.")
+            lines.append("-- anon/authenticated/service_role absent from TABLES means new tables")
+            lines.append("-- are invisible to the Data API until granted explicitly.")
+
+            defaults: Dict[Tuple[str, str, str, str], Set[str]] = defaultdict(set)
+            for row in default_rows:
+                key = (row["owner_role"], row["schema"], row["objtype"], row["grantee"])
+                defaults[key].add(row["privilege_type"])
+
+            for (owner_role, schema, objtype, grantee) in sorted(defaults.keys()):
+                if objtype not in self.DEFACL_OBJTYPES:
+                    continue
+                keyword, order = self.DEFACL_OBJTYPES[objtype]
+                privileges = self.format_privileges(defaults[(owner_role, schema, objtype, grantee)], order)
+                target = "PUBLIC" if grantee == "PUBLIC" else self.escape_identifier(grantee)
+                lines.append(
+                    f"ALTER DEFAULT PRIVILEGES FOR ROLE {self.escape_identifier(owner_role)} "
+                    f"IN SCHEMA {self.escape_identifier(schema)} "
+                    f"GRANT {privileges} ON {keyword} TO {target};"
+                )
+
+        lines.append("")
+        return "\n".join(lines)
+
+    # =========================================================================
     # MAIN EXPORT
     # =========================================================================
     def export(self) -> str:
@@ -746,6 +908,7 @@ class SchemaExporter:
             self.export_views(),
             self.export_comments(),
             self.export_storage_buckets(),
+            self.export_grants(),
             "COMMIT;",
             "",
         ]

--- a/supabase/migrations/20260716025048_align_data_api_default_privileges.sql
+++ b/supabase/migrations/20260716025048_align_data_api_default_privileges.sql
@@ -1,0 +1,58 @@
+-- Adopt Supabase's new Data API default ahead of its 2026-10-30 enforcement.
+-- https://supabase.com/changelog/45329-breaking-change-tables-not-exposed-to-data-and-graphql-api-automatically
+--
+-- Supabase is removing the automatic Data API exposure of new tables in `public`.
+-- New projects flipped 2026-05-30; existing projects (ours) flip 2026-10-30. These
+-- are verbatim the statements Supabase publishes for adopting the new behavior
+-- early ("You do not have to wait for October 30").
+--
+-- WHY RUN IT NOW rather than let 2026-10-30 do it:
+--   The baseline (20260527151536_baseline.sql, ~line 6427) asserts
+--     ALTER DEFAULT PRIVILEGES ... GRANT ALL ON TABLES TO anon, authenticated, service_role
+--   Prod is a long-lived database: the baseline already ran there and never runs
+--   again, so Supabase's revoke will stick. But every local `supabase db reset`
+--   replays the baseline, which re-grants the permissive default. After 2026-10-30
+--   that leaves local permissive while prod is restrictive -- so a new table with a
+--   forgotten GRANT would work locally, pass CI, and then 404 through PostgREST in
+--   production only. Running the revoke ourselves keeps every database on the same
+--   behavior, on our schedule, and makes a forgotten grant fail immediately in dev.
+--
+-- SCOPE -- do not broaden these. Being stricter than prod merely inverts the
+-- divergence above:
+--   * No functions revoke. The CLI ships a third `revoke execute on functions`
+--     statement, but both the changelog and discussion #45329 publish only the two
+--     below, and that CLI SQL is project-creation SQL, not the 2026-10-30 SQL for
+--     existing projects. It is moot here regardless: every function in `public` is
+--     already granted explicitly, so the functions default privilege does nothing
+--     for us. Revisit in October if the enforcement turns out to include it.
+--   * jigged_ai_readonly is left alone. It is our own role, Supabase will not
+--     touch it, and its reads already require an explicit per-table
+--     ai_readonly_select policy. (Note: the baseline ~line 6431 asserts a
+--     `GRANT SELECT ON TABLES` default for it, but prod's pg_default_acl has no
+--     such entry -- pre-existing baseline/prod drift, unrelated to this change.
+--     Nothing here touches it either way.)
+--   * Only `FOR ROLE postgres` is revoked, matching Supabase. Prod also carries a
+--     permissive `FOR ROLE supabase_admin` TABLES default, but our migrations
+--     create objects as `postgres`, and Supabase's own revoke targets `postgres`
+--     alone -- so mirroring keeps us aligned rather than clever.
+--   * No sequences exist in `public` today (every PK is gen_random_uuid()); the
+--     sequence statement is included for fidelity with prod and covers the first
+--     `serial` column anyone adds.
+--
+-- ONLY AFFECTS FUTURE OBJECTS. ALTER DEFAULT PRIVILEGES is not retroactive:
+-- every existing table keeps the grants it already has.
+--
+-- From here on, a new table in `public` needs explicit grants in its own
+-- migration, alongside ENABLE ROW LEVEL SECURITY and its policies:
+--
+--   GRANT SELECT ON public.your_table TO anon;
+--   GRANT SELECT, INSERT, UPDATE, DELETE ON public.your_table TO authenticated;
+--   GRANT SELECT, INSERT, UPDATE, DELETE ON public.your_table TO service_role;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLES
+  FROM anon, authenticated, service_role;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  REVOKE USAGE, SELECT ON SEQUENCES
+  FROM anon, authenticated, service_role;


### PR DESCRIPTION
## Why

Supabase is removing automatic Data API exposure for new tables in `public` ([changelog #45329](https://supabase.com/changelog/45329-breaking-change-tables-not-exposed-to-data-and-graphql-api-automatically)). New projects flipped 2026-05-30; **existing projects — ours — flip 2026-10-30.** After that, a new `public` table needs an explicit `GRANT` before PostgREST, supabase-js, or the FastAPI backend can see it (`service_role` is named in the revoke, so this isn't browser-only).

**Nothing currently deployed breaks.** `ALTER DEFAULT PRIVILEGES` is not retroactive, and a read of prod's actual ACLs confirms every existing table already holds explicit grants.

**The risk is a prod-only failure.** `baseline.sql:6427` re-asserts the permissive `GRANT ALL ON TABLES` default. Prod is long-lived — the baseline already ran and never runs again, so Supabase's revoke will stick there. But every local `supabase db reset` replays the baseline and re-grants. So after Oct 30, a table with a forgotten grant would work locally, pass CI, and 404 **only in production** — the `jobs.status` shape CLAUDE.md warns about.

Adopting the revoke now — which Supabase explicitly sanctions (*"You do not have to wait for October 30"*) — puts every database on one behavior and makes a missing grant fail in dev, where PostgREST's `42501` hint names the fix.

## What

| File | Change |
|---|---|
| `supabase/migrations/20260716025048_align_data_api_default_privileges.sql` | The two revoke statements Supabase publishes, + rationale |
| `CLAUDE.md` | Grants step in the migration workflow + a "Data API grants" section |
| `scripts/export_schema.py` | `export_grants()` as section 12 |

**Scope is deliberate.** Only the two statements *both* the changelog and discussion #45329 publish. No functions revoke — the CLI ships a third, but that's project-creation SQL, not the Oct 30 SQL, and it's moot here since every function is already granted explicitly. Only `FOR ROLE postgres` is revoked, matching Supabase. Being stricter than prod would just invert the divergence.

**No CI guardrail.** The migration *is* the guardrail: once local matches prod, a forgotten grant fails in dev with an error naming the grant to add. Supabase recommends updating AI tool prompts for this (for us, that's CLAUDE.md), not adding a linter.

**Why `export_grants()` is here.** The snapshot had **zero** `GRANT` lines and the exporter no privilege handling at all, so a granted table and an ungranted one looked identical — it misled in both directions. The Security Advisor reports nothing about Data API exposure either (verified against both exports). Between them we had no way to see what's exposed. Section 12 now emits per-object grants plus default privileges, so the snapshot states plainly whether new tables are exposed — and will show the Oct 30 flip when it lands.

## Verification

- **Exporter run against prod (read-only):** 219 `GRANT` lines, previously 0. This turned the premise from a changelog quote into direct evidence — prod's table default *is* permissive, and every existing table *is* explicitly granted.
- **`pnpm test --run __tests__/schema/embedCheck.test.ts`:** 9/9 against a snapshot containing the real grants section, confirming it doesn't disturb schema parsing.
- **Not yet verified:** the migration applying. That's the preview branch's required migration check — the real gate. Expect `anon`/`authenticated`/`service_role` gone from the tables and sequences entries of `pg_default_acl`, `jigged_ai_readonly` untouched, and the Vercel preview unaffected (existing tables keep their grants).

## Notes for review

- **Prod is PG17.** The `MAINTAIN` privilege showed up in the export; the canonical list includes it so full sets collapse to `GRANT ALL`.
- **Snapshot regen deliberately excluded.** Prod has ~7 days of unrelated drift (markup-rates removal, procurement tiers, yield costing). Folding that into a grants PR would bury the diff; it belongs to the post-merge refresh, which captures both.
- **Real drift found:** `baseline.sql:6431` asserts a `jigged_ai_readonly` TABLES default that prod does not have. Pre-existing and harmless, but the migration comment records it rather than repeating the prod-false claim.
- **Stale doc removed:** CLAUDE.md's "grandfathered 8-digit legacy files" note — all 53 migrations are 14-digit and the file it named doesn't exist.

## Follow-up (not this PR)

The Security Advisor export flags **28 `SECURITY DEFINER` functions executable by `anon`** — e.g. `accept_invitation` callable unauthenticated via `/rest/v1/rpc/`. `SECURITY DEFINER` runs as the owner, bypassing RLS. Pre-existing and unrelated, but the largest thing in the export; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)