### PR TITLE
fix(dashboard): revenue-in-range 400 from invalid job_last_ship_date computed column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ api/.coverage
 # settings.json is re-included so shared, team-level Claude config can still be committed.
 .claude/*
 !.claude/settings.json
+
+# Blender
+/outputs/

--- a/utils/dashboardAccess.ts
+++ b/utils/dashboardAccess.ts
@@ -290,14 +290,15 @@ async function getRevenueInRange(
   const supabase = getSupabase();
   // "Revenue in range" used to filter jobs.shipped_at — but shipped_at is
   // gone in the dual-status model. Re-anchor on fulfillment_status =
-  // fully_shipped + the new SQL helper job_last_ship_date, which PR 4
-  // wires up to the shipments cascade. PR 3 ships a NULL-returning stub,
-  // so this query returns 0 until shipments exist — that's the truthful
-  // answer because no shipments exist yet.
+  // fully_shipped and use updated_at as the in-range proxy (same shape as
+  // getCompletedJobsInRange below). We sum quote_line_items.total_price and
+  // don't need a per-job ship date here — job_last_ship_date exists only as a
+  // job_last_ship_date(uuid) function, not a jobs-row computed column, so
+  // selecting it as a computed column made PostgREST reject the query with 400.
   const { data, error } = await supabase
     .from('jobs')
     .select(
-      'id, quotes!jobs_quote_id_fkey(quote_line_items(total_price)), last_ship_date:job_last_ship_date',
+      'id, quotes!jobs_quote_id_fkey(quote_line_items(total_price))',
     )
     .eq('company_id', companyId)
     .eq('fulfillment_status', 'fully_shipped')


### PR DESCRIPTION
## Problem

The dashboard "revenue in range" metric returned **HTTP 400**. The failing PostgREST call:

```
GET /rest/v1/jobs?select=id,quotes!jobs_quote_id_fkey(quote_line_items(total_price)),last_ship_date:job_last_ship_date&company_id=eq.<id>&fulfillment_status=eq.fully_shipped&updated_at=gte.<start>&updated_at=lt.<end>
```

**Root cause:** the select aliased `last_ship_date:job_last_ship_date`, asking PostgREST to resolve `job_last_ship_date` as a *computed column* on `jobs`. Computed columns must be functions whose single argument is the table row (`job_last_ship_date(public.jobs)`), but the function is defined only as `job_last_ship_date(p_job_id uuid)`. No such overload exists, so PostgREST rejected the whole select with 400.

The nested embed `quotes!jobs_quote_id_fkey(quote_line_items(total_price))` was never the problem — those FKs are valid.

## Fix

Dropped the `last_ship_date` alias from the select. It was **dead weight**: `getRevenueInRange` sums `quote_line_items.total_price` and its `Row` type never read the ship date. This keeps the query structurally identical to its sibling `getCompletedJobsInRange`, which already uses `updated_at` as the in-range proxy — no migration needed.

Also rewrote the stale in-code comment, which wrongly described the function as a "NULL-returning stub" (the schema shows a real `MAX(ship_date)` implementation over the shipments cascade).

## Verification

Reproduced against a running local Supabase stack:

- **OLD** select → HTTP **400** (bug reproduced)
- **NEW** select → HTTP **200** (fixed)

Plus:
- `pnpm exec tsc --noEmit -p tsconfig.json` — clean
- `pnpm test --run __tests__/utils/dashboardAccess.test.ts` — 5/5 pass

## Note on semantics (not changed here)

The metric still filters on `updated_at` as a ship-date proxy — a pre-existing design choice, consistent with `getCompletedJobsInRange`. Keying revenue off the *actual* last ship date would be a separate semantics change worth its own ticket.

## Unrelated

Bundles a one-line `.gitignore` addition (`/outputs/`) — intentional, added by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
