### PR TITLE
ci: pull Supabase stack images from GHCR to stop ECR rate-limit flakes

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,6 +11,13 @@ jobs:
     name: Playwright E2E (local Supabase)
     timeout-minutes: 25
     runs-on: ubuntu-latest
+    # Pull the Supabase stack from GHCR, not the CLI's default AWS public ECR:
+    # shared GitHub-runner IPs trip public.ecr.aws's anonymous rate limit
+    # ("toomanyrequests"), which flakes `supabase start`. GHCR mirrors the same
+    # images and is effectively unmetered for public pulls from GitHub runners.
+    # Mirrors the backend job in test.yml — keep the two in lockstep. supabase/cli#419.
+    env:
+      SUPABASE_INTERNAL_IMAGE_REGISTRY: ghcr.io
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,16 @@ jobs:
   backend:
     name: Backend Tests
     runs-on: ubuntu-latest
+    # Pull the Supabase stack images (postgres, postgres-meta, gotrue, …) from
+    # GitHub Container Registry instead of the CLI's default AWS public ECR.
+    # Shared GitHub-runner IPs regularly trip public.ecr.aws's anonymous pull
+    # rate limit ("toomanyrequests: Rate exceeded"), which flaked `supabase
+    # start` at the postgres-meta pull. GHCR mirrors the identical images and is
+    # effectively unmetered for public pulls from GitHub-hosted runners.
+    # (docker.io mirrors them too but carries its own anonymous per-IP limit, so
+    # it just trades one throttle for another.) See supabase/cli#419.
+    env:
+      SUPABASE_INTERNAL_IMAGE_REGISTRY: ghcr.io
     defaults:
       run:
         working-directory: ./api


### PR DESCRIPTION
## Problem

Backend (and E2E) CI jobs intermittently fail at **`supabase start`** with:

```
v0.96.1: Pulling from supabase/postgres-meta
docker: toomanyrequests: Rate exceeded
```

`supabase start` pulls the stack images (postgres, **postgres-meta**, gotrue, realtime, storage-api, studio, …) from the CLI's default registry, **AWS public ECR** (`public.ecr.aws`). Public ECR anonymous pulls are rate-limited **per IP**, and GitHub-hosted runners share a pool of egress IPs — so on a busy day the runner's IP is already over the limit and the pull is rejected. It's flaky infra, unrelated to our code, and it's bitten us before.

> Note: a Google AI Overview attributes this to a "Supabase TypeScript rewrite regression where `gen types --local` ignores registry flags." That explanation is fabricated — `gen types --local` doesn't pull images; `supabase start` does. The registry override it lands on is real, though.

## Fix

Set `SUPABASE_INTERNAL_IMAGE_REGISTRY=ghcr.io` as a **job-level env var** in both `test.yml` (backend) and `e2e-tests.yml`. The Supabase CLI then pulls the **identical images** from GitHub Container Registry instead of ECR.

**Why `ghcr.io` and not `docker.io`** (the value most blog posts suggest): Docker Hub anonymous pulls carry their *own* per-IP rate limit, so on shared runner IPs it just trades one throttle for another. GHCR public-image pulls **from GitHub-hosted runners are effectively unmetered** — it's the right target for GitHub Actions specifically.

## Verification

- `SUPABASE_INTERNAL_IMAGE_REGISTRY` confirmed as a real CLI env var; `ghcr.io` is a documented valid value.
- The **exact failing tag** resolves on GHCR — `ghcr.io/supabase/postgres-meta:v0.96.1` → HTTP 200 (manifest check), and on `docker.io` too. The whole `supabase/*` org is mirrored across ECR / GHCR / Docker Hub, so nothing breaks.
- **This PR is the live test:** the `pull_request` trigger runs both workflows with the new registry — green CI here proves `supabase start` pulls cleanly from GHCR.

## Notes

- Pins nothing new; image **tags** are unchanged (still whatever the pinned CLI `2.109.0` requests) — only the *registry host* changes. The types-drift check in `test.yml` is unaffected.
- If GHCR ever throttles too (unlikely for our volume), the next step up is authenticating the pull rather than switching back to ECR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
