### PR TITLE
feat(quotes): search list by customer and part, not just quote number

### DIFF
--- a/app/dashboard/[companyId]/quotes/page.tsx
+++ b/app/dashboard/[companyId]/quotes/page.tsx
@@ -135,10 +135,12 @@ export default function QuotesPage() {
       if (statusFilter !== 'all') filters.status = statusFilter;
       if (customerFilter) filters.customerId = customerFilter;
       if (createdByFilter) filters.createdBy = createdByFilter;
-      if (searchDebounced) filters.search = searchDebounced;
+      // Text search is applied client-side (below) — the list already loads
+      // every quote with its customer + part names, so we filter in memory and
+      // don't refetch per keystroke.
       return getAllQuotes(companyId, filters, sortModel.field, sortModel.sort);
     },
-    [companyId, searchDebounced, statusFilter, customerFilter, createdByFilter, sortModel],
+    [companyId, statusFilter, customerFilter, createdByFilter, sortModel],
     {
       onError: (error) => {
         console.error('Error fetching quotes:', error);
@@ -146,6 +148,24 @@ export default function QuotesPage() {
     },
   );
   const quotes = quotesData ?? EMPTY_QUOTES;
+
+  // Search quotes like jobs — by quote #, customer name, or any line item's part
+  // (name or description). The list query already joins `customers` and
+  // `line_items.parts`, so this needs no DB round-trip; matching in memory keeps
+  // it instant and avoids an RPC (unlike jobs, quotes has no un-joined field).
+  const filteredQuotes = useMemo(() => {
+    const q = searchDebounced.trim().toLowerCase();
+    if (!q) return quotes;
+    return quotes.filter((quote) => {
+      if (quote.quote_number?.toLowerCase().includes(q)) return true;
+      if (quote.customers?.name?.toLowerCase().includes(q)) return true;
+      return (quote.line_items ?? []).some(
+        (li) =>
+          li.parts?.part_name?.toLowerCase().includes(q) ||
+          li.parts?.description?.toLowerCase().includes(q),
+      );
+    });
+  }, [quotes, searchDebounced]);
 
   // Clear selection when search or any filter changes — the rows on screen
   // change, so any ids selected before may no longer be visible. Called from
@@ -157,15 +177,15 @@ export default function QuotesPage() {
 
   // Grid height calculation
   const gridHeight = useMemo(() => {
-    if (loading || quotes.length === 0) return 600;
+    if (loading || filteredQuotes.length === 0) return 600;
 
     const headerHeight = 56;
     const rowHeight = 52;
     const paginationHeight = 56;
-    const displayedRows = Math.min(quotes.length, 25);
+    const displayedRows = Math.min(filteredQuotes.length, 25);
 
     return Math.max(headerHeight + rowHeight * displayedRows + paginationHeight, 400);
-  }, [loading, quotes.length]);
+  }, [loading, filteredQuotes.length]);
 
   const handleGridReady = (event: GridReadyEvent<QuoteWithRelations>) => {
     event.api.applyColumnState({
@@ -331,7 +351,7 @@ export default function QuotesPage() {
         }}
       >
         <TextField
-          placeholder="Search quotes..."
+          placeholder="Quote #, customer, part…"
           value={search}
           onChange={(e) => {
             setSearch(e.target.value);
@@ -430,7 +450,7 @@ export default function QuotesPage() {
       </Box>
 
       {/* Grid or Empty State */}
-      {!loading && quotes.length === 0 ? (
+      {!loading && filteredQuotes.length === 0 ? (
         <Card elevation={2}>
           <CardContent sx={{ p: 6, textAlign: 'center' }}>
             <DescriptionOutlinedIcon
@@ -476,7 +496,7 @@ export default function QuotesPage() {
           >
             <AgGridReact<QuoteWithRelations>
               ref={gridRef}
-              rowData={quotes}
+              rowData={filteredQuotes}
               columnDefs={columnDefs}
               theme={jiggedAgGridTheme}
               defaultColDef={{

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -146,7 +146,7 @@ Each job knows which line item it came from. To list every job spawned from a qu
 
 - Jobs column shows links to every job spawned from the quote (one per converted line item)
 
-- Search box (searches quote number)
+- Search box (matches quote number, customer name, and part name/description — client-side)
 
 - Filter dropdown: Status (All / Active / Expired)
 
@@ -514,7 +514,7 @@ This follows the same pattern as Customers, Parts, and Operations:
 
 - [ ] Can view paginated list of quotes — *(automation-pending)*
 
-- [ ] Can search quotes by number — *(automation-pending)*
+- [ ] Can search quotes by number, customer, or part (name/description) — *(automation-pending)*
 
 - [ ] Can filter by status (active / expired) — *(automation-pending)*
 
@@ -664,7 +664,7 @@ While creating a quote, users can create new entities without leaving the form:
 
 ## Search and Filter
 
-**Search:** Full-text search on quote number (toolbar input)
+**Search:** the toolbar input matches on **quote number, customer name, and any line item's part** (name or description) — mirroring the jobs list. It filters **client-side** over the already-loaded rows (the list query joins `customers` and `line_items.parts`), so it's instant and needs no DB round-trip or RPC. Placeholder: `Quote #, customer, part…`.
 
 **Filters:**
 


### PR DESCRIPTION
## What & why
Jobs search matches job#, PO, customer, part, and packing slip; quotes only matched `quote_number`. Users want to find a quote by customer or part. The quotes list already joins `customers` and `line_items.parts` and loads all rows, so this is a **client-side filter — no query change, no RPC** (unlike jobs, quotes has no un-joined field that would need one).

## Changes
- **`app/dashboard/[companyId]/quotes/page.tsx`** — filter the loaded rows in a `useMemo` over quote number + customer name + part name/description; search no longer hits the server. Placeholder updated to `Quote #, customer, part…`.
- **Docs** — `quotes.md` search section synced.

## Testing
- `tsc` + lint clean; no existing test asserted the old search behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)