### PR TITLE
feat(parts): default to recently-updated + make updated_at accurate

### DIFF
--- a/app/dashboard/[companyId]/parts/page.tsx
+++ b/app/dashboard/[companyId]/parts/page.tsx
@@ -96,9 +96,13 @@ export default function PartsPage() {
   // Completeness = priceable (set up enough to quote). Drives the inline
   // incomplete marker + this filter, replacing the old Pricing column.
   const [completenessFilter, setCompletenessFilter] = useState<CompletenessFilter>('all');
+  // Default to most-recently-updated: users care about the parts they just
+  // worked on (routing/pricing/BOM edits now bump parts.updated_at too — see
+  // migration touch_parts_updated_at_on_satellite_writes), not the alphabetical
+  // top. Alphabetical stays one click away on the Part Name column.
   const [sortModel, setSortModel] = useState<{ field: string; sort: 'asc' | 'desc' }>({
-    field: 'part_name',
-    sort: 'asc',
+    field: 'updated_at',
+    sort: 'desc',
   });
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const gridRef = useRef<AgGridReact<PartRow>>(null);
@@ -191,7 +195,7 @@ export default function PartsPage() {
 
   const handleGridReady = (event: GridReadyEvent<PartRow>) => {
     event.api.applyColumnState({
-      state: [{ colId: 'part_name', sort: 'asc' }],
+      state: [{ colId: 'updated_at', sort: 'desc' }],
       defaultState: { sort: null },
     });
   };
@@ -217,7 +221,8 @@ export default function PartsPage() {
         sort: sortedColumn.sort as 'asc' | 'desc',
       });
     } else {
-      setSortModel({ field: 'part_name', sort: 'asc' });
+      // Clearing the sort falls back to the recency default, not alphabetical.
+      setSortModel({ field: 'updated_at', sort: 'desc' });
     }
   };
 

--- a/components/parts/PartAutocomplete.tsx
+++ b/components/parts/PartAutocomplete.tsx
@@ -154,34 +154,26 @@ export default function PartAutocomplete({
             component="li"
             {...rest}
             key={key as React.Key}
-            // MUI styles the option <li> as display:flex (row), which runs the
-            // part name straight into its description ("ASM-GEARBOXGearbox…").
-            // Stack them so the name sits above its description as a clear label
-            // + subtext.
-            sx={{
-              minWidth: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'flex-start',
-              gap: 0.25,
-            }}
+            // Keep MUI's single-row option layout; the part name and its
+            // description previously ran together ("ASM-GEARBOXGearbox…") because
+            // there was no gap. A gap + a shrinking, truncating description gives
+            // clear demarcation on one line — the name bold, the description muted.
+            sx={{ gap: 1.5, minWidth: 0 }}
           >
             <Typography
+              component="span"
               variant="body2"
-              sx={{ fontWeight: 500, color: isCreate ? 'primary.main' : undefined }}
+              sx={{ fontWeight: 600, flexShrink: 0, color: isCreate ? 'primary.main' : undefined }}
             >
               {option.part_name}
             </Typography>
             {!isCreate && (option as PartSelectOption).description && (
               <Typography
-                variant="caption"
+                component="span"
+                variant="body2"
                 color="text.secondary"
-                sx={{
-                  display: 'block',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
+                noWrap
+                sx={{ minWidth: 0 }}
               >
                 {(option as PartSelectOption).description}
               </Typography>

--- a/components/parts/PartAutocomplete.tsx
+++ b/components/parts/PartAutocomplete.tsx
@@ -150,7 +150,22 @@ export default function PartAutocomplete({
         };
         const isCreate = isCreateNewOption(option);
         return (
-          <Box component="li" {...rest} key={key as React.Key} sx={{ minWidth: 0 }}>
+          <Box
+            component="li"
+            {...rest}
+            key={key as React.Key}
+            // MUI styles the option <li> as display:flex (row), which runs the
+            // part name straight into its description ("ASM-GEARBOXGearbox…").
+            // Stack them so the name sits above its description as a clear label
+            // + subtext.
+            sx={{
+              minWidth: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-start',
+              gap: 0.25,
+            }}
+          >
             <Typography
               variant="body2"
               sx={{ fontWeight: 500, color: isCreate ? 'primary.main' : undefined }}

--- a/docs/modules/parts.md
+++ b/docs/modules/parts.md
@@ -57,7 +57,7 @@ This three-layer split mirrors how real shops already think: cost the part once,
 | preferred_vendor_id | UUID (FK) | No | Default vendor for a bought part's procurement cost |
 | is_location_tracked | Boolean | Yes | Whether stock is tracked per QR-addressable location (default false) |
 | created_at | Timestamp | Yes | Auto-generated |
-| updated_at | Timestamp | Yes | Auto-updated on changes |
+| updated_at | Timestamp | Yes | Auto-updated on changes — **including edits to the part's satellite data** (routing, pricing tiers, BOM, procurement tiers), which bump it via AFTER triggers (`touch_parts_updated_at_on_satellite_writes` migration). Before that, editing a routing/pricing/BOM left `updated_at` stale, so recency-sort missed the parts people actually worked on. |
 
 **Unique Constraint:** `(company_id, part_name)` — part names must be unique within a company. This is the identity key the CSV importer upserts on (`ON CONFLICT (company_id, part_name)`), so re-importing the same export updates parts in place rather than duplicating them.
 
@@ -127,6 +127,8 @@ Engineering files attached to a part — drawings (PDF), CAD models (STEP), and 
 **Features:**
 
 - AG Grid showing: **Part Name** (with an inline ⚠ marker on parts not yet priceable), **Description**, **Source** (Made/Bought chip), **Updated**. There is no Category column (categories were removed) and no Cost column — engineering/cost signals live on the detail page.
+
+- **Default sort is most-recently-updated first** (the Updated column, descending) — users care about the parts they just worked on, not the alphabetical top. Alphabetical is one click away on the Part Name header. Sorting is server-side for the real columns (`part_name`, `source`, `updated_at`). This pairs with the `updated_at` accuracy fix below, so a part whose routing/pricing/BOM was just edited rises to the top.
 
 - Search box (searches part name and description)
 

--- a/docs/modules/routings.md
+++ b/docs/modules/routings.md
@@ -48,7 +48,7 @@ Routings are edited **inline on the part detail page** via the `PartRoutingPanel
 
 - **Internal vs external fields** — an internal work center's editor shows setup minutes, cycle minutes per unit, and an optional labor-rate override (pre-filled from the work center's default). An external work center's editor shows a per-unit vendor price and no setup (external work bills once per part). At least one of setup/cycle (internal) or a unit price (external) is required before the row will save.
 
-- **Auto-save** — Each row-editor save, reorder click, or delete persists the whole operations list immediately via `saveRoutingWithOperations`, then refetches so new temp IDs become real DB IDs. A subtle "Saving…" / "All changes saved" indicator (`SaveStatus`) appears above the list. The first add implicitly creates the routing record if the part doesn't have one yet.
+- **Auto-save** — Each row-editor save, reorder click, or delete persists the whole operations list immediately via `saveRoutingWithOperations`, then refetches so new temp IDs become real DB IDs. A subtle "Saving…" / "All changes saved" indicator (`SaveStatus`) appears above the list. The first add implicitly creates the routing record if the part doesn't have one yet. Each such write also **bumps the owning part's `updated_at`** (via DB triggers, `touch_parts_updated_at_on_satellite_writes`), so a part whose routing was just edited rises to the top of the recency-sorted parts list and picker — see [Parts](parts.md).
 
 - **No minimum** — A routing can be saved with zero operations during editing (it just won't be useful for jobs). The cost breakdown surfaces a `no_operations` warning; the job-creation flow surfaces a missing routing if needed.
 

--- a/supabase/migrations/20260720191253_touch_parts_updated_at_on_satellite_writes.sql
+++ b/supabase/migrations/20260720191253_touch_parts_updated_at_on_satellite_writes.sql
@@ -1,0 +1,93 @@
+-- Bump parts.updated_at when a part's *satellite* data changes.
+--
+-- Why: the parts list and the quote part-picker now default to "most recently
+-- updated", but the existing parts_updated_at trigger only fires on edits to the
+-- parts row itself (name, description, stock, etc.). Editing a part's routing,
+-- pricing tiers, BOM, or procurement cost — which is most of the real
+-- post-creation work — lives in separate tables and never touched
+-- parts.updated_at, so recency-sort would miss the parts people just worked on.
+--
+-- These AFTER triggers bump the owning part's updated_at on any write to its
+-- satellite tables. We do it in the DB (not the access layer) so the importer
+-- and re-import upsert paths are covered too, and so every current and future
+-- writer stays consistent — mirroring how update_updated_at_column already works.
+--
+-- No schema/column change (updated_at already exists), so types/database.ts is
+-- unaffected. SECURITY INVOKER (the default): the bump runs under the caller who
+-- was already allowed to write the satellite row, so parts RLS is respected and
+-- no GRANT is needed (trigger functions don't require EXECUTE to fire).
+
+-- Tables with a direct part_id (routings, part_pricing_tiers, part_procurement_tiers).
+CREATE OR REPLACE FUNCTION public.touch_part_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_part_id uuid;
+BEGIN
+  v_part_id := COALESCE(NEW.part_id, OLD.part_id);
+  IF v_part_id IS NOT NULL THEN
+    UPDATE public.parts SET updated_at = now() WHERE id = v_part_id;
+  END IF;
+  RETURN NULL; -- AFTER trigger: return value is ignored
+END;
+$$;
+
+-- parts_bom: the edited part is the PARENT (its cost/composition changed); the
+-- child part itself is unchanged, so only the parent's updated_at bumps.
+CREATE OR REPLACE FUNCTION public.touch_parent_part_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_part_id uuid;
+BEGIN
+  v_part_id := COALESCE(NEW.parent_part_id, OLD.parent_part_id);
+  IF v_part_id IS NOT NULL THEN
+    UPDATE public.parts SET updated_at = now() WHERE id = v_part_id;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+-- routing_operations link to a routing, not a part — resolve the part via the
+-- routing. If the routing is already gone (e.g. a cascading delete), the lookup
+-- yields nothing and we simply skip (the part is being removed anyway).
+CREATE OR REPLACE FUNCTION public.touch_part_from_routing_operation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_routing_id uuid;
+  v_part_id uuid;
+BEGIN
+  v_routing_id := COALESCE(NEW.routing_id, OLD.routing_id);
+  IF v_routing_id IS NOT NULL THEN
+    SELECT part_id INTO v_part_id FROM public.routings WHERE id = v_routing_id;
+    IF v_part_id IS NOT NULL THEN
+      UPDATE public.parts SET updated_at = now() WHERE id = v_part_id;
+    END IF;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER trg_touch_part_on_routings
+  AFTER INSERT OR UPDATE OR DELETE ON public.routings
+  FOR EACH ROW EXECUTE FUNCTION public.touch_part_updated_at();
+
+CREATE TRIGGER trg_touch_part_on_pricing_tiers
+  AFTER INSERT OR UPDATE OR DELETE ON public.part_pricing_tiers
+  FOR EACH ROW EXECUTE FUNCTION public.touch_part_updated_at();
+
+CREATE TRIGGER trg_touch_part_on_procurement_tiers
+  AFTER INSERT OR UPDATE OR DELETE ON public.part_procurement_tiers
+  FOR EACH ROW EXECUTE FUNCTION public.touch_part_updated_at();
+
+CREATE TRIGGER trg_touch_part_on_bom
+  AFTER INSERT OR UPDATE OR DELETE ON public.parts_bom
+  FOR EACH ROW EXECUTE FUNCTION public.touch_parent_part_updated_at();
+
+CREATE TRIGGER trg_touch_part_on_routing_operations
+  AFTER INSERT OR UPDATE OR DELETE ON public.routing_operations
+  FOR EACH ROW EXECUTE FUNCTION public.touch_part_from_routing_operation();

--- a/supabase/schema.prod.sql
+++ b/supabase/schema.prod.sql
@@ -1,6 +1,6 @@
 -- ============================================================
 -- Jigged Manufacturing Data Platform - Database Schema
--- Generated: 2026-07-16T20:51:51Z
+-- Generated: 2026-07-20T19:19:31Z
 -- Schemas: public, storage
 -- ============================================================
 
@@ -104,6 +104,7 @@ CREATE TABLE IF NOT EXISTS "public"."customers"
     "website" text,
     "created_at" timestamp with time zone DEFAULT now(),
     "updated_at" timestamp with time zone DEFAULT now(),
+    "deleted_at" timestamp with time zone,
     CONSTRAINT "customers_pkey" PRIMARY KEY (id),
     CONSTRAINT "customers_company_name_unique" UNIQUE (company_id, name)
 );
@@ -222,6 +223,7 @@ CREATE TABLE IF NOT EXISTS "public"."quotes"
     "ship_to_address" jsonb,
     "contact_snapshot" jsonb,
     "lead_time_text" text,
+    "deleted_at" timestamp with time zone,
     CONSTRAINT "quotes_pkey" PRIMARY KEY (id),
     CONSTRAINT "quotes_company_id_quote_number_key" UNIQUE (company_id, quote_number),
     CONSTRAINT "quotes_status_check" CHECK ((status = ANY (ARRAY['active'::text, 'expired'::text])))
@@ -252,6 +254,7 @@ CREATE TABLE IF NOT EXISTS "public"."jobs"
     "ship_to_address" jsonb,
     "contact_snapshot" jsonb,
     "invoicing_status" text NOT NULL DEFAULT 'uninvoiced'::text,
+    "deleted_at" timestamp with time zone,
     CONSTRAINT "jobs_pkey" PRIMARY KEY (id),
     CONSTRAINT "jobs_company_id_job_number_key" UNIQUE (company_id, job_number),
     CONSTRAINT "jobs_fulfillment_status_check" CHECK ((fulfillment_status = ANY (ARRAY['unshipped'::text, 'partially_shipped'::text, 'fully_shipped'::text]))),
@@ -430,11 +433,10 @@ CREATE TABLE IF NOT EXISTS "public"."vendors"
     "state" text,
     "postal_code" text,
     "country" text DEFAULT 'USA'::text,
-    "legacy_id" text,
     "created_at" timestamp with time zone NOT NULL DEFAULT now(),
     "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "deleted_at" timestamp with time zone,
     CONSTRAINT "vendors_pkey" PRIMARY KEY (id),
-    CONSTRAINT "vendors_legacy_id_unique_per_company" UNIQUE (company_id, legacy_id),
     CONSTRAINT "vendors_unique_per_company" UNIQUE (company_id, name)
 );
 
@@ -449,14 +451,13 @@ CREATE TABLE IF NOT EXISTS "public"."parts"
     "quantity" numeric NOT NULL DEFAULT 0,
     "reorder_point" numeric,
     "preferred_vendor_id" uuid,
-    "legacy_id" text,
     "created_at" timestamp with time zone NOT NULL DEFAULT now(),
     "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
     "source" text NOT NULL DEFAULT 'made'::text,
     "is_location_tracked" boolean NOT NULL DEFAULT false,
     "costing_batch_quantity" numeric NOT NULL DEFAULT 1,
+    "deleted_at" timestamp with time zone,
     CONSTRAINT "parts_pkey" PRIMARY KEY (id),
-    CONSTRAINT "parts_legacy_id_unique_per_company" UNIQUE (company_id, legacy_id),
     CONSTRAINT "parts_unique_per_company" UNIQUE (company_id, part_name),
     CONSTRAINT "parts_costing_batch_quantity_check" CHECK (((costing_batch_quantity IS NULL) OR (costing_batch_quantity > (0)::numeric))),
     CONSTRAINT "parts_quantity_non_negative" CHECK ((quantity >= (0)::numeric)),
@@ -754,6 +755,7 @@ CREATE TABLE IF NOT EXISTS "public"."work_centers"
     "metadata" jsonb DEFAULT '{}'::jsonb,
     "created_at" timestamp with time zone NOT NULL DEFAULT now(),
     "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+    "deleted_at" timestamp with time zone,
     CONSTRAINT "work_centers_pkey" PRIMARY KEY (id),
     CONSTRAINT "work_centers_unique_per_company" UNIQUE (company_id, name),
     CONSTRAINT "work_centers_external_requires_vendor" CHECK (((kind = 'internal'::text) OR (vendor_id IS NOT NULL))),
@@ -2623,6 +2625,7 @@ CREATE INDEX IF NOT EXISTS idx_customer_addresses_customer ON public.customer_ad
 CREATE UNIQUE INDEX IF NOT EXISTS customer_contacts_one_primary ON public.customer_contacts USING btree (customer_id) WHERE is_primary;
 CREATE INDEX IF NOT EXISTS idx_customer_contacts_customer ON public.customer_contacts USING btree (customer_id);
 CREATE INDEX IF NOT EXISTS idx_customers_company ON public.customers USING btree (company_id);
+CREATE INDEX IF NOT EXISTS idx_customers_live_by_company ON public.customers USING btree (company_id) WHERE (deleted_at IS NULL);
 CREATE INDEX IF NOT EXISTS idx_customers_name ON public.customers USING btree (company_id, name);
 CREATE INDEX IF NOT EXISTS idx_customers_name_trgm ON public.customers USING gin (name gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS inventory_locations_company_parent_idx ON public.inventory_locations USING btree (company_id, parent_id);
@@ -2677,6 +2680,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS part_procurement_tiers_part_id_min_quantity_ke
 CREATE INDEX IF NOT EXISTS idx_parts_company_id ON public.parts USING btree (company_id);
 CREATE INDEX IF NOT EXISTS idx_parts_company_made ON public.parts USING btree (company_id) WHERE (source = 'made'::text);
 CREATE INDEX IF NOT EXISTS idx_parts_company_stocked ON public.parts USING btree (company_id) WHERE is_stocked;
+CREATE INDEX IF NOT EXISTS idx_parts_live_by_company ON public.parts USING btree (company_id) WHERE (deleted_at IS NULL);
 CREATE INDEX IF NOT EXISTS idx_parts_part_name ON public.parts USING btree (company_id, part_name);
 CREATE INDEX IF NOT EXISTS idx_parts_part_name_trgm ON public.parts USING gin (part_name gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS idx_parts_preferred_vendor ON public.parts USING btree (preferred_vendor_id) WHERE (preferred_vendor_id IS NOT NULL);
@@ -2722,10 +2726,12 @@ CREATE INDEX IF NOT EXISTS idx_user_preferences_user_id ON public.user_preferenc
 CREATE INDEX IF NOT EXISTS idx_vendor_contacts_vendor ON public.vendor_contacts USING btree (vendor_id);
 CREATE UNIQUE INDEX IF NOT EXISTS vendor_contacts_one_primary ON public.vendor_contacts USING btree (vendor_id) WHERE is_primary;
 CREATE INDEX IF NOT EXISTS idx_vendors_company ON public.vendors USING btree (company_id);
+CREATE INDEX IF NOT EXISTS idx_vendors_live_by_company ON public.vendors USING btree (company_id) WHERE (deleted_at IS NULL);
 CREATE INDEX IF NOT EXISTS waitlist_created_at_idx ON public.waitlist USING btree (created_at);
 CREATE INDEX IF NOT EXISTS waitlist_email_idx ON public.waitlist USING btree (email);
 CREATE INDEX IF NOT EXISTS idx_work_centers_company ON public.work_centers USING btree (company_id);
 CREATE INDEX IF NOT EXISTS idx_work_centers_company_kind ON public.work_centers USING btree (company_id, kind);
+CREATE INDEX IF NOT EXISTS idx_work_centers_live_by_company ON public.work_centers USING btree (company_id) WHERE (deleted_at IS NULL);
 CREATE INDEX IF NOT EXISTS idx_work_centers_vendor ON public.work_centers USING btree (vendor_id) WHERE (vendor_id IS NOT NULL);
 
 -- ============================================================
@@ -2967,6 +2973,29 @@ BEGIN
 
     SELECT quantity INTO v_rollup FROM public.parts WHERE id = p_part_id;
     RETURN jsonb_build_object('location_balance', p_converted_new_quantity, 'part_quantity', v_rollup);
+END;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.archive_parts(p_ids uuid[])
+ RETURNS void
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+    -- Idempotent: only stamp rows that aren't already archived, so a re-archive keeps the
+    -- original archive time.
+    UPDATE public.parts
+       SET deleted_at = now(),
+           updated_at = now()
+     WHERE id = ANY(p_ids)
+       AND deleted_at IS NULL;
+
+    -- Remove the archived parts from every parent part's BOM so those parents' live cost
+    -- rollups (compute_part_cost_at_qty reads parts_bom) recompute without them.
+    DELETE FROM public.parts_bom
+     WHERE child_part_id = ANY(p_ids);
 END;
 $function$
 
@@ -4794,6 +4823,27 @@ $function$
 
 ;
 
+CREATE OR REPLACE FUNCTION public.parts_deletion_impact(p_ids uuid[])
+ RETURNS TABLE(quotes_count integer, jobs_count integer, bom_parents_count integer)
+ LANGUAGE sql
+ STABLE
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+    SELECT
+        (SELECT count(DISTINCT qli.quote_id)
+           FROM public.quote_line_items qli
+          WHERE qli.part_id = ANY(p_ids))::int,
+        (SELECT count(DISTINCT jp.job_id)
+           FROM public.job_parts jp
+          WHERE jp.part_id = ANY(p_ids))::int,
+        (SELECT count(DISTINCT pb.parent_part_id)
+           FROM public.parts_bom pb
+          WHERE pb.child_part_id = ANY(p_ids)
+            AND pb.parent_part_id <> ALL(p_ids))::int;
+$function$
+
+;
+
 CREATE OR REPLACE FUNCTION public.recompute_job_part_fulfillment_from_line()
  RETURNS trigger
  LANGUAGE plpgsql
@@ -5147,13 +5197,11 @@ BEGIN
             v_new_id := gen_random_uuid();
             v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_new_id::text));
             INSERT INTO vendors (id, company_id, name,
-                                 address_line1, address_line2, city, state, postal_code, country,
-                                 legacy_id)
+                                 address_line1, address_line2, city, state, postal_code, country)
             VALUES (v_new_id, p_company_id, v_item->>'name',
                     v_item->>'address_line1', v_item->>'address_line2',
                     v_item->>'city', v_item->>'state', v_item->>'postal_code',
-                    COALESCE(v_item->>'country', 'USA'),
-                    v_item->>'legacy_id');
+                    COALESCE(v_item->>'country', 'USA'));
 
             IF v_item->'contacts' IS NOT NULL THEN
                 FOR v_contact IN SELECT * FROM jsonb_array_elements(v_item->'contacts') LOOP
@@ -5200,7 +5248,7 @@ BEGIN
             INSERT INTO parts (id, company_id, part_name, description,
                                source, is_stocked,
                                primary_unit, quantity,
-                               reorder_point, preferred_vendor_id, legacy_id)
+                               reorder_point, preferred_vendor_id)
             VALUES (v_new_id, p_company_id,
                     v_item->>'part_name', v_item->>'description',
                     v_part_source,
@@ -5210,8 +5258,7 @@ BEGIN
                     NULLIF(v_item->>'reorder_point', '')::numeric,
                     CASE WHEN v_item->>'preferred_vendor_ref' IS NOT NULL
                          THEN (v_ref_map->>(v_item->>'preferred_vendor_ref'))::uuid
-                         ELSE NULL END,
-                    v_item->>'legacy_id');
+                         ELSE NULL END);
 
             IF v_part_source = 'bought' AND v_part_cost IS NOT NULL AND v_part_cost > 0 THEN
                 INSERT INTO part_procurement_tiers
@@ -6253,6 +6300,9 @@ COMMENT ON COLUMN "public"."customers"."created_at"
 COMMENT ON COLUMN "public"."customers"."updated_at"
     IS 'Timestamp of last update. Auto-updated via trigger.';
 
+COMMENT ON COLUMN "public"."customers"."deleted_at"
+    IS 'Archive marker (see parts.deleted_at). Reads filter deleted_at IS NULL; reusing the name revives the row.';
+
 COMMENT ON COLUMN "public"."demo_data_templates"."id"
     IS 'Primary key. UUID auto-generated.';
 
@@ -6310,6 +6360,9 @@ COMMENT ON COLUMN "public"."job_operations"."routing_operation_id"
 COMMENT ON COLUMN "public"."jobs"."customer_po_number"
     IS 'Customer-issued PO number for this job. Captured at convertQuoteToJob time (or by reorder when applicable). Indexed via the partial unique-per-company index and via pg_trgm for the jobs-list search RPC.';
 
+COMMENT ON COLUMN "public"."jobs"."deleted_at"
+    IS 'Archive marker (see parts.deleted_at). Distinct from the cancelled production_status, which is a shop-floor outcome, not deletion.';
+
 COMMENT ON COLUMN "public"."part_procurement_tiers"."min_quantity"
     IS 'Lower bound (inclusive) of this tier in the part''s primary unit. A row with min_quantity=100 means "this price applies when ordering >= 100 of this part". Combined with the next-larger tier from the same vendor, defines a half-open break range.';
 
@@ -6334,9 +6387,6 @@ COMMENT ON COLUMN "public"."parts"."reorder_point"
 COMMENT ON COLUMN "public"."parts"."preferred_vendor_id"
     IS 'Default supplier for procurement. The presence of any row pointing at a vendor makes that vendor a "supplier" in the derived-role calculation on the Vendors page.';
 
-COMMENT ON COLUMN "public"."parts"."legacy_id"
-    IS 'Source-system identifier from CSV import; allows ON CONFLICT (company_id, legacy_id) DO UPDATE for safe re-import. NULL for hand-created parts.';
-
 COMMENT ON COLUMN "public"."parts"."source"
     IS 'How this part is sourced. ''made'' = produced in-shop (will have a routing); ''bought'' = procured from a vendor. Combined with is_stocked, classifies the part into one of four quadrants (Custom Made / Sub-assembly / Raw Material / Service+Drop-ship). Replaces the prior is_manufacturable boolean — see the 20260504 migration header for the (false,false)→''made'' orphan-default rationale.';
 
@@ -6345,6 +6395,9 @@ COMMENT ON COLUMN "public"."parts"."is_location_tracked"
 
 COMMENT ON COLUMN "public"."parts"."costing_batch_quantity"
     IS 'Standard costing lot size: the production run this part''s cost is amortized over (setup / batch). A made part is always valued at this quantity when it is consumed as a component in another part''s BOM. Default 1. Bought parts ignore it.';
+
+COMMENT ON COLUMN "public"."parts"."deleted_at"
+    IS 'Archive marker. When set, the part is hidden from all lists/search/pickers/dashboards (reads filter deleted_at IS NULL) but the row and its references survive. Reusing part_name (create or import upsert) revives it (clears deleted_at). Archiving a part also detaches it as a BOM child so parents recompute cost — see archive_parts().';
 
 COMMENT ON COLUMN "public"."parts_bom"."quantity"
     IS 'Quantity of child consumed per unit of parent, expressed in `unit`. Cost rollups convert to the child part primary_unit via parts_unit_conversions if `unit` differs.';
@@ -6405,6 +6458,9 @@ COMMENT ON COLUMN "public"."quotes"."ship_to_address"
 
 COMMENT ON COLUMN "public"."quotes"."contact_snapshot"
     IS 'Immutable snapshot of the customer contact { name, email, phone } at quote issue time.';
+
+COMMENT ON COLUMN "public"."quotes"."deleted_at"
+    IS 'Archive marker (see parts.deleted_at). Reads filter deleted_at IS NULL.';
 
 COMMENT ON COLUMN "public"."routing_operations"."sequence"
     IS 'Linear order within the routing. Lower values execute first. Steps of 10 (10, 20, 30...) leave room for inserts.';
@@ -6511,8 +6567,8 @@ COMMENT ON COLUMN "public"."vendor_contacts"."role_label"
 COMMENT ON COLUMN "public"."vendor_contacts"."is_primary"
     IS 'True for the contact treated as the vendor''s primary point of contact. Surfaced on the vendors list page and as a star badge on the vendor detail page. Enforced unique-per-vendor by the vendor_contacts_one_primary partial index.';
 
-COMMENT ON COLUMN "public"."vendors"."legacy_id"
-    IS 'Source-system identifier from CSV import; allows ON CONFLICT (company_id, legacy_id) DO UPDATE for safe re-import.';
+COMMENT ON COLUMN "public"."vendors"."deleted_at"
+    IS 'Archive marker (see parts.deleted_at). Reads filter deleted_at IS NULL; reusing the name revives the row.';
 
 COMMENT ON COLUMN "public"."waitlist"."id"
     IS 'Primary key. UUID auto-generated.';
@@ -6546,6 +6602,9 @@ COMMENT ON COLUMN "public"."work_centers"."vendor_id"
 
 COMMENT ON COLUMN "public"."work_centers"."labor_rate"
     IS 'Default hourly labor rate in dollars; used when kind=internal and no per-routing_operation override is set. Meaningless / typically NULL when kind=external.';
+
+COMMENT ON COLUMN "public"."work_centers"."deleted_at"
+    IS 'Archive marker (see parts.deleted_at). Reads filter deleted_at IS NULL; reusing the name revives the row.';
 
 -- ============================================================
 -- 11. STORAGE BUCKETS

--- a/utils/partsAccess.ts
+++ b/utils/partsAccess.ts
@@ -578,6 +578,12 @@ export interface PartSelectOption {
   source: 'made' | 'bought';
   primary_unit: string | null;
   quantity: number;
+  /**
+   * Present on rows loaded from the DB (used to order pickers most-recently-
+   * updated first). Optional because callers occasionally synthesize a
+   * PartSelectOption for a locally-known part that has no loaded row.
+   */
+  updated_at?: string;
 }
 
 const PART_SELECT_COLUMNS = `
@@ -588,6 +594,7 @@ const PART_SELECT_COLUMNS = `
   source,
   primary_unit,
   quantity,
+  updated_at,
   routings(id)
 `;
 
@@ -602,6 +609,7 @@ function rowToPartSelectOption(p: Record<string, unknown>): PartSelectOption {
     source: p.source as 'made' | 'bought',
     primary_unit: p.primary_unit as string | null,
     quantity: Number(p.quantity ?? 0),
+    updated_at: p.updated_at as string,
   };
 }
 
@@ -646,9 +654,10 @@ export async function getPartsForSelect(
 /**
  * Server-side search variant of `getPartsForSelect` for autocomplete pickers
  * over very large parts tables. Returns at most `limit` rows matching `query`
- * (ILIKE on part_name + description). When `query` is empty, returns the
- * first `limit` parts alphabetically — gives the dropdown something to show
- * on focus without hydrating every row.
+ * (ILIKE on part_name + description), **ordered most-recently-updated first**
+ * (part_name as the tiebreak). When `query` is empty, returns the `limit` most
+ * recently updated parts — so on focus the picker shows the parts the user is
+ * actively working on, not the alphabetical top.
  *
  * Callers should debounce input changes (e.g. 300ms) so we don't fire one
  * request per keystroke.
@@ -661,11 +670,15 @@ export async function searchPartsForSelect(
 ): Promise<PartSelectOption[]> {
   const supabase = getSupabase();
 
+  // Order by most-recently-updated so the picker surfaces the parts the user is
+  // actively working on first (routing/pricing/BOM edits bump parts.updated_at
+  // via DB triggers). part_name is a stable secondary tiebreak.
   let q = supabase
     .from('parts')
     .select(PART_SELECT_COLUMNS)
     .eq('company_id', companyId)
     .is('deleted_at', null)
+    .order('updated_at', { ascending: false })
     .order('part_name', { ascending: true })
     .limit(limit);
 


### PR DESCRIPTION
## What & why
Parts lists sorted alphabetically, but users care about the parts they just worked on. This defaults the parts list **and** the quote part-picker to most-recently-updated.

Crucially, it also makes "recently updated" **meaningful**: `parts.updated_at` only bumped on edits to the parts row itself — editing a part's routing, pricing tiers, BOM, or procurement tiers (separate tables) left it stale, which is most of the real post-creation work.

## Changes
- **`app/dashboard/[companyId]/parts/page.tsx`** — default sort `updated_at` desc (was `part_name` asc); alphabetical stays one header-click away.
- **`utils/partsAccess.ts`** — `searchPartsForSelect` orders by `updated_at` desc with `part_name` tiebreak; `updated_at` added (optional) to `PartSelectOption`.
- **Migration `touch_parts_updated_at_on_satellite_writes`** — AFTER triggers on `routings`, `routing_operations`, `part_pricing_tiers`, `parts_bom` (parent), `part_procurement_tiers` bump the owning part's `updated_at`. DB-trigger approach (not app-layer) so importer/re-import paths are covered too. No column change ⇒ `types/database.ts` unaffected.
- **Docs** — `parts.md` + `routings.md` synced. Refreshed `schema.prod.sql`.

## Testing
- Migration validated locally in a rolled-back transaction (a pricing-tier insert bumps `parts.updated_at` from 2000 → now).
- `partsAccess` / `QuoteForm` / `MaterialRowEditor` tests pass (65); `tsc` + lint clean.
- The preview-branch migration check is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)