### PR TITLE
feat(jobs): Hot job flag — visibility everywhere, hot-first ordering

### DIFF
--- a/__tests__/components/jobs/JobHotBadge.test.tsx
+++ b/__tests__/components/jobs/JobHotBadge.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import jiggedTheme from '@/lib/theme';
+
+import JobHotBadge from '@/components/jobs/JobHotBadge';
+
+const wrap = (ui: React.ReactElement) => (
+  <ThemeProvider theme={jiggedTheme}>{ui}</ThemeProvider>
+);
+
+describe('JobHotBadge', () => {
+  it('renders a HOT chip with the flame icon when the job is hot', () => {
+    render(wrap(<JobHotBadge job={{ is_hot: true }} />));
+    expect(screen.getByText('HOT')).toBeInTheDocument();
+    // The flame icon carries the MUI test id for LocalFireDepartment.
+    expect(screen.getByTestId('LocalFireDepartmentIcon')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the job is not hot', () => {
+    const { container } = render(wrap(<JobHotBadge job={{ is_hot: false }} />));
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when is_hot is null/undefined', () => {
+    const { container } = render(wrap(<JobHotBadge job={{ is_hot: null }} />));
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/__tests__/utils/jobsAccess.test.ts
+++ b/__tests__/utils/jobsAccess.test.ts
@@ -799,6 +799,29 @@ describe('jobsAccess', () => {
       expect(patch.customer_po_number).toBe('PO-1');
     });
 
+    it('sets is_hot true (the Hot toggle) without touching other fields', async () => {
+      mockQueryBuilder.data = { id: 'j1', is_hot: true };
+      await updateJobDetails('j1', 'co-1', { is_hot: true });
+      const patch = (mockQueryBuilder.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(patch.is_hot).toBe(true);
+      expect(patch).not.toHaveProperty('customer_po_number');
+      expect(patch).not.toHaveProperty('due_date');
+    });
+
+    it('clears is_hot when passed false (unmark Hot)', async () => {
+      mockQueryBuilder.data = { id: 'j1', is_hot: false };
+      await updateJobDetails('j1', 'co-1', { is_hot: false });
+      const patch = (mockQueryBuilder.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(patch.is_hot).toBe(false);
+    });
+
+    it('leaves is_hot untouched when the key is omitted', async () => {
+      mockQueryBuilder.data = { id: 'j1' };
+      await updateJobDetails('j1', 'co-1', { customer_po_number: 'PO-1' });
+      const patch = (mockQueryBuilder.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(patch).not.toHaveProperty('is_hot');
+    });
+
     it('throws a friendly (non-raw) error when supabase fails', async () => {
       mockQueryBuilder.error = { message: 'permission denied' };
       await expect(
@@ -842,6 +865,16 @@ describe('jobsAccess', () => {
       expect(mockQueryBuilder.in).toHaveBeenCalledWith('production_status', ['completed']);
       expect(mockQueryBuilder.in).toHaveBeenCalledWith('fulfillment_status', ['fully_shipped']);
       expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'co-1');
+    });
+
+    it('orders hot jobs first (is_hot desc) as a primary tier, before the caller sort', async () => {
+      mockQueryBuilder.data = [];
+      await getAllJobs('co-1', {}, 'created_at', 'desc');
+      const orderCalls = (mockQueryBuilder.order as ReturnType<typeof vi.fn>).mock.calls;
+      // is_hot desc must be requested before the user's chosen column sort so hot
+      // rows float to the top with the sort applied within each tier.
+      expect(orderCalls[0]).toEqual(['is_hot', { ascending: false }]);
+      expect(orderCalls[1]).toEqual(['created_at', { ascending: false }]);
     });
   });
 });

--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -63,6 +63,41 @@ describe('getAllStationsOperatorJobs', () => {
     expect(result).toEqual([]);
   });
 
+  it('carries is_hot onto each row and preserves the RPC hot-first order', async () => {
+    // The RPC orders hot jobs first (ORDER BY is_hot DESC); buildOperatorJobs is
+    // a 1:1 map that preserves that order, and must surface is_hot so the station
+    // card can badge the row.
+    const readyRow = (over: Record<string, unknown>) => ({
+      job_id: 'j-x',
+      job_part_id: 'jp-x',
+      job_operation_id: 'op-x',
+      operation_name: 'Mill',
+      op_status: 'pending',
+      job_number: 'J-100',
+      part_id: 'p-x',
+      part_name: 'Widget',
+      part_description: null,
+      part_quantity: 5,
+      is_hot: false,
+      ...over,
+    });
+    mockSupabase.rpc.mockResolvedValueOnce({
+      data: [
+        readyRow({ job_id: 'j-hot', job_part_id: 'jp-hot', job_operation_id: 'op-hot', job_number: 'J-HOT', is_hot: true }),
+        readyRow({ job_id: 'j-cold', job_part_id: 'jp-cold', job_operation_id: 'op-cold', job_number: 'J-COLD', is_hot: false }),
+      ],
+      error: null,
+    });
+
+    const result = await getAllStationsOperatorJobs('c1', [{ id: 'wc1', name: 'Lathe' }]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].job_number).toBe('J-HOT');
+    expect(result[0].is_hot).toBe(true);
+    expect(result[1].job_number).toBe('J-COLD');
+    expect(result[1].is_hot).toBe(false);
+  });
+
   it('throws (surfaces the error) when the readiness RPC fails, instead of returning []', async () => {
     // Regression guard: a swallowed RPC error used to read as "no work" to
     // operators (the jobs.status column bug). It must propagate so the jobs

--- a/app/dashboard/[companyId]/jobs/[jobId]/page.tsx
+++ b/app/dashboard/[companyId]/jobs/[jobId]/page.tsx
@@ -31,7 +31,13 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import Snackbar from '@mui/material/Snackbar';
 
-import { getJobWithRelations, cancelJob, reopenJob, deleteJob } from '@/utils/jobsAccess';
+import {
+  getJobWithRelations,
+  cancelJob,
+  reopenJob,
+  deleteJob,
+  updateJobDetails,
+} from '@/utils/jobsAccess';
 import { getJobPartShipmentSummaries, countShipmentsForJob } from '@/utils/shipmentsAccess';
 import type { JobWithRelations, JobPartWithRelations } from '@/types/job';
 import type { JobPartShipmentSummary } from '@/types/shipment';
@@ -39,6 +45,9 @@ import type { JobNote } from '@/types/operator';
 import { getJobNotes } from '@/utils/operatorAccess';
 import { OperationsPanel, JobTravelerPreviewDialog, JobBillingShippingCard, JobPartMaterialsCard, JobEditForm, CollapsibleSection, ShipmentsMenu, InvoicesMenu } from '@/components/jobs';
 import JobOverdueBadge from '@/components/jobs/JobOverdueBadge';
+import JobHotBadge from '@/components/jobs/JobHotBadge';
+import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment';
+import LocalFireDepartmentOutlinedIcon from '@mui/icons-material/LocalFireDepartmentOutlined';
 import JobStatusBlock from '@/components/jobs/JobStatusBlock';
 import { CreateShipmentModal } from '@/components/shipments';
 import PackingSlipPreviewDialog from '@/components/shipments/PackingSlipPreviewDialog';
@@ -172,6 +181,20 @@ export default function JobDetailPage() {
       await fetchJob();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to reopen job');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleToggleHot = async () => {
+    if (!job) return;
+    setActionLoading(true);
+    try {
+      const updated = await updateJobDetails(jobId, companyId, { is_hot: !job.is_hot });
+      // Merge onto the hydrated job so we keep the joined relations fetchJob loaded.
+      setJob((prev) => (prev ? { ...prev, is_hot: updated.is_hot } : prev));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update Hot status');
     } finally {
       setActionLoading(false);
     }
@@ -325,10 +348,22 @@ export default function JobDetailPage() {
           >
             {job.job_number}
           </Typography>
+          <JobHotBadge job={job} size="medium" />
           <JobOverdueBadge job={job} size="medium" />
         </Box>
 
         <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+          <Button
+            variant={job.is_hot ? 'contained' : 'outlined'}
+            color="error"
+            startIcon={
+              job.is_hot ? <LocalFireDepartmentOutlinedIcon /> : <LocalFireDepartmentIcon />
+            }
+            onClick={handleToggleHot}
+            disabled={actionLoading}
+          >
+            {job.is_hot ? 'Unmark Hot' : 'Mark Hot'}
+          </Button>
           {parts.length > 0 && (
             <Button
               variant="outlined"

--- a/app/dashboard/[companyId]/jobs/page.tsx
+++ b/app/dashboard/[companyId]/jobs/page.tsx
@@ -41,6 +41,7 @@ import type {
   ICellRendererParams,
   RowClickedEvent,
   CellKeyDownEvent,
+  PostSortRowsParams,
 } from 'ag-grid-community';
 
 ModuleRegistry.registerModules([AllCommunityModule]);
@@ -58,6 +59,7 @@ import ScheduleIcon from '@mui/icons-material/Schedule';
 import AddIcon from '@mui/icons-material/Add';
 import PrecisionManufacturingIcon from '@mui/icons-material/PrecisionManufacturing';
 import AcceptPurchaseOrderModal from '@/components/jobs/AcceptPurchaseOrderModal';
+import JobHotBadge from '@/components/jobs/JobHotBadge';
 import type { JobWithRelations, JobFilters, JobLifecycleStage } from '@/types/job';
 
 /**
@@ -294,6 +296,20 @@ export default function JobsPage() {
     }
   };
 
+  // Hot jobs always float to the top, regardless of which column the user sorts
+  // by. AG Grid's client-side row model re-sorts rows itself, so a server-side
+  // ORDER BY alone wouldn't survive a column-header sort — postSortRows runs
+  // after every sort and stable-partitions hot rows to the top, keeping the
+  // user's chosen sort within each tier.
+  const handlePostSortRows = (params: PostSortRowsParams<JobWithRelations>) => {
+    const nodes = params.nodes;
+    const hot = nodes.filter((n) => n.data?.is_hot);
+    if (hot.length === 0 || hot.length === nodes.length) return;
+    const rest = nodes.filter((n) => !n.data?.is_hot);
+    nodes.length = 0;
+    nodes.push(...hot, ...rest);
+  };
+
   const handleSelectionChanged = (event: SelectionChangedEvent<JobWithRelations>) => {
     const selectedNodes = event.api.getSelectedNodes();
     const selectedData = selectedNodes
@@ -389,7 +405,10 @@ export default function JobsPage() {
         const ms = params.data?.match_source ?? null;
         return (
           <Box sx={{ lineHeight: 1.2 }}>
-            <Box>{params.value}</Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+              <span>{params.value}</span>
+              {params.data && <JobHotBadge job={params.data} size="small" />}
+            </Box>
             {ms && (
               <Box
                 sx={{
@@ -704,6 +723,12 @@ export default function JobsPage() {
               minHeight: 500,
               '& .ag-root-wrapper': { border: 'none' },
               '& .ag-row': { cursor: 'pointer' },
+              // Hot rows get a subtle red wash + left accent bar so the whole row
+              // reads as rush at a glance, echoing pink-paper travelers.
+              '& .ag-row.job-row-hot': {
+                backgroundColor: 'rgba(239, 68, 68, 0.10)',
+                boxShadow: 'inset 3px 0 0 0 #ef4444',
+              },
               '& .ag-cell:focus, & .ag-header-cell:focus': {
                 outline: 'none !important',
                 border: 'none !important',
@@ -736,6 +761,8 @@ export default function JobsPage() {
               suppressPaginationPanel={false}
               domLayout="normal"
               onSortChanged={handleSortChanged}
+              postSortRows={handlePostSortRows}
+              getRowClass={(params) => (params.data?.is_hot ? 'job-row-hot' : '')}
               onGridReady={handleGridReady}
               loading={loading}
               suppressCellFocus={false}

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/page.tsx
@@ -21,6 +21,7 @@ import { getJobPartTraveler } from '@/utils/operatorAccess';
 import { useSetOperatorChrome, useOperatorNav } from '@/components/operator/OperatorChromeContext';
 import JobFeed from '@/components/operator/JobFeed';
 import PartReferenceRow from '@/components/operator/PartReferenceRow';
+import JobHotBadge from '@/components/jobs/JobHotBadge';
 import type { JobTravelerOperation } from '@/types/operator';
 
 const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
@@ -139,17 +140,20 @@ export default function OperatorJobTravelerPage() {
                 {traveler.customer_name || 'No customer'}
               </Typography>
             </Box>
-            <Chip
-              size="small"
-              label={traveler.production_status}
-              color={
-                traveler.production_status === 'in_progress'
-                  ? 'primary'
-                  : traveler.production_status === 'completed'
-                    ? 'success'
-                    : 'default'
-              }
-            />
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 0.5, flexShrink: 0 }}>
+              <JobHotBadge job={traveler} size="medium" />
+              <Chip
+                size="small"
+                label={traveler.production_status}
+                color={
+                  traveler.production_status === 'in_progress'
+                    ? 'primary'
+                    : traveler.production_status === 'completed'
+                      ? 'success'
+                      : 'default'
+                }
+              />
+            </Box>
           </Box>
 
           <Typography variant="h6">{traveler.part_name || 'Part'}</Typography>

--- a/app/operator/[companyId]/jobs/page.tsx
+++ b/app/operator/[companyId]/jobs/page.tsx
@@ -23,6 +23,7 @@ import {
 import { useStationContext } from '@/components/operator/OperatorStationContext';
 import StationSelector from '@/components/operator/StationSelector';
 import { useOperatorNav } from '@/components/operator/OperatorChromeContext';
+import JobHotBadge from '@/components/jobs/JobHotBadge';
 import type { OperatorJob, OperatorPlantJob } from '@/types/operator';
 
 /**
@@ -138,7 +139,16 @@ function OperatorJobsPageContent() {
     <Card
       key={key}
       elevation={2}
-      sx={{ bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' }}
+      sx={{
+        bgcolor: 'rgba(26, 31, 74, 0.55)',
+        backdropFilter: 'blur(8px)',
+        // Hot jobs get a red wash + left accent bar so a rush job is unmissable
+        // at the station, echoing pink-paper travelers.
+        ...(row.is_hot && {
+          bgcolor: 'rgba(239, 68, 68, 0.16)',
+          borderLeft: '4px solid #ef4444',
+        }),
+      }}
     >
       <CardActionArea onClick={() => handlePartClick(row)} sx={{ minHeight: 100 }}>
         <CardContent>
@@ -159,17 +169,22 @@ function OperatorJobsPageContent() {
                 Order qty {row.part_quantity}
               </Typography>
             </Box>
-            {/* Completed rows show WHEN they were finished where the (removed)
-                status chip used to sit; active rows convey state via the bar. */}
-            {row.completed_at && (
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}
-              >
-                Completed {formatCompletedAt(row.completed_at)}
-              </Typography>
-            )}
+            {/* Right slot: the HOT badge (always, when hot) sits above the
+                completed timestamp. Completed rows show WHEN they were finished
+                where the (removed) status chip used to sit; active rows convey
+                state via the bar. */}
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 0.5, flexShrink: 0 }}>
+              <JobHotBadge job={row} size="small" />
+              {row.completed_at && (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ whiteSpace: 'nowrap' }}
+                >
+                  Completed {formatCompletedAt(row.completed_at)}
+                </Typography>
+              )}
+            </Box>
           </Box>
 
           <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>

--- a/components/jobs/AcceptPurchaseOrderModal.tsx
+++ b/components/jobs/AcceptPurchaseOrderModal.tsx
@@ -14,8 +14,11 @@ import CircularProgress from '@mui/material/CircularProgress';
 import TextField from '@mui/material/TextField';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment';
 import SearchableSelect, { type SelectOption } from '@/components/common/SearchableSelect';
 import PartAutocomplete, { type PartSelectOption } from '@/components/parts/PartAutocomplete';
 import AttachmentUploadField from '@/components/jobs/AttachmentUploadField';
@@ -98,6 +101,9 @@ export default function AcceptPurchaseOrderModal({
   const [customerId, setCustomerId] = useState('');
   const [poNumber, setPoNumber] = useState('');
   const [dueDate, setDueDate] = useState('');
+  // "Hot" (rush) marker for the new job. Off by default; toggleable later on the
+  // job detail page.
+  const [hot, setHot] = useState(false);
   const [lines, setLines] = useState<PoLineDraft[]>([emptyLine()]);
   const [attachment, setAttachment] = useState<File | null>(null);
 
@@ -111,6 +117,7 @@ export default function AcceptPurchaseOrderModal({
     setCustomerId('');
     setPoNumber('');
     setDueDate('');
+    setHot(false);
     setLines([emptyLine()]);
     setAttachment(null);
     getCustomersForSelect(companyId)
@@ -245,6 +252,7 @@ export default function AcceptPurchaseOrderModal({
         customer_id: customerId,
         customer_po_number: poNumber,
         due_date: dueDate || null,
+        hot,
         lines: lines
           .filter((l) => l.part)
           .map((l) => ({
@@ -342,6 +350,20 @@ export default function AcceptPurchaseOrderModal({
                 slotProps={{ htmlInput: { min: today }, inputLabel: { shrink: true } }}
               />
             </Box>
+            <FormControlLabel
+              sx={{ mt: 1 }}
+              control={
+                <Checkbox
+                  checked={hot}
+                  onChange={(e) => setHot(e.target.checked)}
+                  disabled={loading}
+                  color="error"
+                  icon={<LocalFireDepartmentIcon />}
+                  checkedIcon={<LocalFireDepartmentIcon />}
+                />
+              }
+              label="Mark as Hot (rush)"
+            />
           </Box>
 
           <Divider sx={{ my: 2 }} />

--- a/components/jobs/JobHotBadge.tsx
+++ b/components/jobs/JobHotBadge.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Chip from '@mui/material/Chip';
+import Tooltip from '@mui/material/Tooltip';
+import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment';
+
+interface JobHotBadgeProps {
+  /** Only `is_hot` is needed; accepts any object carrying it (Job, traveler, operator row). */
+  job: { is_hot?: boolean | null };
+  size?: 'small' | 'medium';
+}
+
+/**
+ * The digital "HOT" (rush) badge — the paperless equivalent of Contour's pink
+ * paper / "HOT" in red pen at the top of a traveler. Renders nothing unless the
+ * job is hot.
+ *
+ * Deliberately distinct from JobOverdueBadge (also color="error"): this one is a
+ * SOLID/filled red chip with a flame icon and uppercase "HOT", so the two read
+ * as different signals when they appear side by side.
+ */
+export default function JobHotBadge({ job, size = 'small' }: JobHotBadgeProps) {
+  if (!job.is_hot) return null;
+
+  return (
+    <Tooltip title="Hot job — rush. Prioritize this work.">
+      <Chip
+        icon={<LocalFireDepartmentIcon sx={{ fontSize: size === 'medium' ? 20 : 16 }} />}
+        label="HOT"
+        size={size}
+        color="error"
+        variant="filled"
+        sx={{ fontWeight: 700, letterSpacing: 0.5 }}
+      />
+    </Tooltip>
+  );
+}

--- a/components/quotes/ConvertToJobModal.tsx
+++ b/components/quotes/ConvertToJobModal.tsx
@@ -17,6 +17,8 @@ import RadioGroup from '@mui/material/RadioGroup';
 import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormLabel from '@mui/material/FormLabel';
+import Checkbox from '@mui/material/Checkbox';
+import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment';
 import type { QuoteLineItem, QuoteWithRelations } from '@/types/quote';
 import { isQuoteExpired } from '@/types/quote';
 import { convertQuoteToJob } from '@/utils/quotesAccess';
@@ -68,6 +70,9 @@ export default function ConvertToJobModal({
   // (migration 20260526), so the modal always starts empty — the quote
   // never carries one. REQUIRED to convert (the work-order authorization).
   const [customerPoInput, setCustomerPoInput] = useState<string>('');
+  // "Hot" (rush) marker for the new job. Off by default; office staff can also
+  // toggle it later on the job detail page.
+  const [hot, setHot] = useState<boolean>(false);
   // Optional PO PDF, staged here and uploaded after the job is created.
   const [attachment, setAttachment] = useState<File | null>(null);
   const [attachmentWarning, setAttachmentWarning] = useState<string | null>(null);
@@ -159,6 +164,7 @@ export default function ConvertToJobModal({
         dueDate: dueDateInput,
         customerPoNumber: customerPoInput,
         selectedLineItemIds,
+        hot,
       });
       // Attach the PO PDF if one was staged — non-fatal. On failure keep the
       // modal open with an "Open Job" action so the new job isn't lost.
@@ -327,6 +333,19 @@ export default function ConvertToJobModal({
               value={customerPoInput}
               onChange={(e) => setCustomerPoInput(e.target.value)}
               disabled={loading}
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={hot}
+                  onChange={(e) => setHot(e.target.checked)}
+                  disabled={loading}
+                  color="error"
+                  icon={<LocalFireDepartmentIcon />}
+                  checkedIcon={<LocalFireDepartmentIcon />}
+                />
+              }
+              label="Mark as Hot (rush)"
             />
             <AttachmentUploadField
               file={attachment}

--- a/supabase/migrations/20260720202151_add_jobs_is_hot.sql
+++ b/supabase/migrations/20260720202151_add_jobs_is_hot.sql
@@ -1,0 +1,13 @@
+-- "Hot" job flag: the digital equivalent of Contour's pink paper / "HOT" in red
+-- pen at the top of a traveler. A rush-job marker that must be impossible to
+-- miss anywhere someone decides what to work on next.
+--
+-- Visibility only — it has NO scheduling, capacity, or due-date behavior, and is
+-- distinct from the production_status/fulfillment_status axes and from
+-- deleted_at. Settable at job creation and toggleable anytime by office staff.
+
+ALTER TABLE public.jobs
+  ADD COLUMN is_hot boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.jobs.is_hot IS
+  'Rush/"Hot" job marker — visibility only, no scheduling behavior. Sorts hot jobs first in the admin list and operator station queue.';

--- a/supabase/migrations/20260720202214_operator_ready_ops_hot_first.sql
+++ b/supabase/migrations/20260720202214_operator_ready_ops_hot_first.sql
@@ -1,0 +1,72 @@
+-- Hot-first ordering for the operator station dispatch queue.
+--
+-- get_ready_operations_for_station returned ready/active operations in
+-- unspecified order (no ORDER BY); the caller
+-- (utils/operatorAccess.ts::buildOperatorJobs) preserves that order 1:1. Now
+-- that jobs carry an is_hot flag, hot jobs must float to the top of every
+-- station's list so operators see rush work first.
+--
+-- Two changes vs 20260707001934:
+--   1. Return the job's is_hot flag (new column in the RETURNS TABLE), carried
+--      through the eligible_jobs CTE, so the UI can badge the row without a
+--      second lookup.
+--   2. ORDER BY is_hot DESC first (hot to top), then job_number for a stable,
+--      deterministic secondary order.
+--
+-- Because the RETURNS TABLE shape gains a column, CREATE OR REPLACE cannot alter
+-- the return type — DROP then CREATE. No views/other functions depend on it
+-- (it's only reached via supabase.rpc), so the drop is safe.
+
+DROP FUNCTION IF EXISTS public.get_ready_operations_for_station(uuid, uuid);
+
+CREATE FUNCTION public.get_ready_operations_for_station(p_company_id uuid, p_work_center_id uuid)
+ RETURNS TABLE(job_id uuid, job_part_id uuid, job_operation_id uuid, operation_name text, op_status text, job_number text, part_id uuid, part_name text, part_description text, part_quantity numeric, is_hot boolean)
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+BEGIN
+    RETURN QUERY
+    WITH eligible_jobs AS (
+        SELECT j.id, j.job_number, j.is_hot FROM jobs j
+        WHERE j.company_id = p_company_id
+          AND j.production_status IN ('not_started', 'in_progress')
+    ),
+    station_ops AS (
+        SELECT jo.id, jo.job_id, jo.job_part_id, jo.operation_name, jo.status, jo.sequence,
+               ej.job_number, ej.is_hot
+        FROM job_operations jo
+        JOIN eligible_jobs ej ON ej.id = jo.job_id
+        WHERE jo.work_center_id = p_work_center_id
+          AND jo.status IN ('pending', 'in_progress')
+    ),
+    ready_or_active AS (
+        SELECT so.id, so.job_id, so.job_part_id, so.operation_name, so.status,
+               so.job_number, so.is_hot
+        FROM station_ops so
+        WHERE so.status = 'in_progress'
+           OR NOT EXISTS (
+               SELECT 1 FROM job_operations prev
+               WHERE prev.job_part_id = so.job_part_id
+                 AND prev.sequence < so.sequence
+                 AND prev.status <> 'completed'
+           )
+    )
+    SELECT
+        ra.job_id,
+        ra.job_part_id,
+        ra.id AS job_operation_id,
+        ra.operation_name,
+        ra.status AS op_status,
+        ra.job_number,
+        jp.part_id,
+        p.part_name,
+        p.description AS part_description,
+        jp.quantity AS part_quantity,
+        ra.is_hot
+    FROM ready_or_active ra
+    JOIN job_parts jp ON jp.id = ra.job_part_id
+    JOIN parts p ON p.id = jp.part_id
+    -- Hot jobs to the top; job_number for a deterministic secondary order.
+    ORDER BY ra.is_hot DESC, ra.job_number;
+END;
+$function$;

--- a/types/database.ts
+++ b/types/database.ts
@@ -1197,6 +1197,7 @@ export type Database = {
           fulfillment_status: string
           id: string
           invoicing_status: string
+          is_hot: boolean
           job_number: string
           production_status: string
           quote_id: string | null
@@ -1223,6 +1224,7 @@ export type Database = {
           fulfillment_status: string
           id?: string
           invoicing_status?: string
+          is_hot?: boolean
           job_number: string
           production_status: string
           quote_id?: string | null
@@ -1249,6 +1251,7 @@ export type Database = {
           fulfillment_status?: string
           id?: string
           invoicing_status?: string
+          is_hot?: boolean
           job_number?: string
           production_status?: string
           quote_id?: string | null
@@ -3038,6 +3041,7 @@ export type Database = {
       get_ready_operations_for_station: {
         Args: { p_company_id: string; p_work_center_id: string }
         Returns: {
+          is_hot: boolean
           job_id: string
           job_number: string
           job_operation_id: string

--- a/types/job.ts
+++ b/types/job.ts
@@ -71,6 +71,10 @@ export interface Job {
   contact_id: string | null;
   production_status: ProductionStatus;
   fulfillment_status: FulfillmentStatus;
+  // "Hot" (rush) marker — the digital pink-paper / red-pen "HOT" signal. Pure
+  // visibility: no scheduling behavior. Sorts hot jobs first in the admin list
+  // and the operator station queue. Set at creation and toggleable by office staff.
+  is_hot: boolean;
   status_changed_at: string | null;
   started_at: string | null;
   completed_at: string | null;

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -33,6 +33,8 @@ export interface OperatorJob {
   customer_name: string | null;
   part_name: string | null;
   part_quantity: number;
+  /** jobs.is_hot — the rush marker. Drives hot-first ordering + the HOT badge. */
+  is_hot: boolean;
   /** job_parts.production_status. */
   production_status: string;
   // Current operation for this station on this part
@@ -142,6 +144,8 @@ export interface JobTraveler {
   due_date: string | null;
   customer_po_number: string | null;
   production_status: string;
+  /** jobs.is_hot — drives the HOT badge on-screen and the grayscale HOT stamp on the PDF. */
+  is_hot: boolean;
   /** Number of parts on the parent job — drives the "all parts" hub link. */
   job_part_count: number;
   operations: JobTravelerOperation[];

--- a/utils/jobTravelerPdf.ts
+++ b/utils/jobTravelerPdf.ts
@@ -143,8 +143,28 @@ export async function generateJobTravelerPdf(
   doc.setTextColor(60);
   doc.text(`Job ${traveler.job_number}`, pageWidth - MARGIN, headerTop + 36, { align: 'right' });
 
+  // ---------- HOT stamp (right, below the Job #) ----------
+  // The paperless equivalent of Contour's pink paper / "HOT" in red pen. A pure
+  // color would vanish in grayscale printing, so this is a SOLID dark rounded
+  // rect with reversed (white) bold text — unmistakable in black-and-white.
+  let hotStampBottom = headerTop + 36;
+  if (traveler.is_hot) {
+    const stampW = 78;
+    const stampH = 24;
+    const stampX = pageWidth - MARGIN - stampW;
+    const stampY = headerTop + 44;
+    doc.setFillColor(20, 20, 20);
+    doc.roundedRect(stampX, stampY, stampW, stampH, 4, 4, 'F');
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(15);
+    doc.setTextColor(255, 255, 255);
+    doc.text('HOT', stampX + stampW / 2, stampY + stampH / 2 + 5, { align: 'center' });
+    doc.setTextColor(30); // restore for subsequent text
+    hotStampBottom = stampY + stampH;
+  }
+
   // No whole-job QR — each operation row carries its own scan-to-complete QR.
-  let cursorY = Math.max(shopBlockBottom, headerTop + 36) + 18;
+  let cursorY = Math.max(shopBlockBottom, hotStampBottom) + 18;
 
   // ---------- Divider ----------
   doc.setDrawColor(210);

--- a/utils/jobsAccess.ts
+++ b/utils/jobsAccess.ts
@@ -120,6 +120,11 @@ export async function getAllJobs(
       `)
       .eq('company_id', companyId)
       .is('deleted_at', null)
+      // Hot jobs float to the top as a primary tier, with the caller's chosen
+      // column sort applied within each tier. Chained .order() calls apply in
+      // sequence, and the batch loop concatenates in query order, so this holds
+      // across the full result set.
+      .order('is_hot', { ascending: false })
       .order(sortField, { ascending: sortDirection === 'asc' })
       .range(offset, offset + BATCH_SIZE - 1);
 
@@ -344,7 +349,7 @@ export async function updateJobAddressContact(
 export async function updateJobDetails(
   jobId: string,
   companyId: string,
-  fields: { customer_po_number?: string | null; due_date?: string | null },
+  fields: { customer_po_number?: string | null; due_date?: string | null; is_hot?: boolean },
 ): Promise<Job> {
   const supabase = getSupabase();
   const toNull = (v: string | null | undefined): string | null | undefined =>
@@ -356,6 +361,10 @@ export async function updateJobDetails(
   }
   if (fields.due_date !== undefined) {
     patch.due_date = toNull(fields.due_date);
+  }
+  // Hot toggle — the office-side "mark/unmark Hot" control writes through here.
+  if (fields.is_hot !== undefined) {
+    patch.is_hot = fields.is_hot;
   }
 
   const { data, error } = await supabase
@@ -390,6 +399,8 @@ export interface CreateJobFromPoInput {
   customer_po_number: string;
   /** Promised ship date (YYYY-MM-DD), or null. Entered directly (no lead time). */
   due_date: string | null;
+  /** Mark the new job "Hot" (rush) at creation. Visibility only. Defaults to false. */
+  hot?: boolean;
   lines: CreateJobFromPoLine[];
 }
 
@@ -536,6 +547,7 @@ export async function createJobFromPurchaseOrder(
     job_number: jobNumber as string,
     production_status: 'not_started',
     fulfillment_status: 'unshipped',
+    is_hot: input.hot ?? false,
     due_date: input.due_date || null,
     customer_po_number: customerPoNumber,
     billing_address_id: billingAddressId,

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -108,6 +108,8 @@ interface ReadyRow {
   part_name: string;
   part_description: string | null;
   part_quantity: number;
+  /** jobs.is_hot — the RPC returns rows already ordered hot-first. */
+  is_hot: boolean;
 }
 
 async function getReadyOperationsForStation(
@@ -253,6 +255,7 @@ async function buildOperatorJobs(readyRows: ReadyRow[]): Promise<OperatorJob[]> 
       customer_name: customerByJob.get(row.job_id) ?? null,
       part_name: row.part_name,
       part_quantity: row.part_quantity,
+      is_hot: row.is_hot ?? false,
       production_status: statusByPart.get(row.job_part_id) ?? 'not_started',
       operation_id: row.job_operation_id,
       operation_name: row.operation_name,
@@ -299,7 +302,7 @@ async function getCompletedOperationRows(
       job_parts!inner(
         quantity, part_id,
         parts(part_name, description),
-        jobs!inner(job_number, company_id)
+        jobs!inner(job_number, company_id, is_hot)
       )
     `)
     .eq('status', 'completed')
@@ -328,13 +331,13 @@ async function getCompletedOperationRows(
           quantity: number;
           part_id: string;
           parts: { part_name: string; description: string | null } | { part_name: string; description: string | null }[] | null;
-          jobs: { job_number: string } | { job_number: string }[] | null;
+          jobs: { job_number: string; is_hot: boolean } | { job_number: string; is_hot: boolean }[] | null;
         }
       | {
           quantity: number;
           part_id: string;
           parts: { part_name: string; description: string | null } | { part_name: string; description: string | null }[] | null;
-          jobs: { job_number: string } | { job_number: string }[] | null;
+          jobs: { job_number: string; is_hot: boolean } | { job_number: string; is_hot: boolean }[] | null;
         }[]
       | null;
   };
@@ -359,6 +362,7 @@ async function getCompletedOperationRows(
         part_name: partsJoin?.part_name ?? '',
         part_description: partsJoin?.description ?? null,
         part_quantity: partJoin?.quantity ?? 0,
+        is_hot: jobJoin?.is_hot ?? false,
       },
       work_center_id: r.work_center_id,
       completed_at: r.completed_at,
@@ -814,7 +818,7 @@ export async function getJobPartTraveler(
     .select(`
       id, job_id, part_id, production_status, quantity,
       parts(part_name, description),
-      jobs!inner(id, job_number, created_at, due_date, customer_po_number, company_id, customers(name))
+      jobs!inner(id, job_number, created_at, due_date, customer_po_number, company_id, is_hot, customers(name))
     `)
     .eq('id', jobPartId)
     .eq('jobs.company_id', companyId)
@@ -835,6 +839,7 @@ export async function getJobPartTraveler(
       created_at: string | null;
       due_date: string | null;
       customer_po_number: string | null;
+      is_hot: boolean;
       customers: { name: string } | { name: string }[] | null;
     } | null;
   };
@@ -898,6 +903,7 @@ export async function getJobPartTraveler(
     due_date: jobJoin?.due_date ?? null,
     customer_po_number: jobJoin?.customer_po_number ?? null,
     production_status: p.production_status,
+    is_hot: jobJoin?.is_hot ?? false,
     job_part_count: jobPartCount ?? 1,
     operations,
   };

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -1014,6 +1014,8 @@ export interface ConvertToJobOptions {
    * resolve to exactly one line per part_id or the conversion is rejected.
    */
   selectedLineItemIds?: string[];
+  /** Mark the new job "Hot" (rush) at conversion. Visibility only. Defaults to false. */
+  hot?: boolean;
 }
 
 export interface ConvertToJobResult {
@@ -1159,6 +1161,7 @@ export async function convertQuoteToJob(
       job_number: jobNumber,
       production_status: 'not_started',
       fulfillment_status: 'unshipped',
+      is_hot: options.hot ?? false,
       due_date: dueDate,
       customer_po_number: customerPoNumber,
       // Carry the quote's billing/shipping address + contact onto the job so


### PR DESCRIPTION
## What

The digital equivalent of Contour's pink paper / "HOT" in red pen: a job can be marked **Hot** (rush), and it stands out anywhere someone decides what to work on next or handles the job's paperwork. **Visibility only** — no scheduling, capacity, due-date, or notification behavior; no priority levels beyond hot / not-hot. Terminology is "Hot" everywhere.

## Data model
- New column `jobs.is_hot boolean NOT NULL DEFAULT false` ([migration](../blob/feature/hot-job-flag/supabase/migrations/20260720202151_add_jobs_is_hot.sql)).
- Recreated `get_ready_operations_for_station` RPC (DROP+CREATE — return shape gained a column) to return `is_hot` and `ORDER BY is_hot DESC, job_number`.
- Regenerated `types/database.ts`; `is_hot` added to `Job` / `OperatorJob` / `JobTraveler`.

## Where Hot is set
- **Creation** checkbox in `ConvertToJobModal` (quote→job) and `AcceptPurchaseOrderModal` (direct PO).
- **Anytime** `Mark Hot` / `Unmark Hot` toggle on the job detail header (via `updateJobDetails`).
- Operators see Hot but cannot set it.

## Surfaces
One shared `JobHotBadge` (filled red flame "HOT" chip, distinct from the outlined Overdue chip):
- Admin AG Grid list: badge in Job # cell + red row wash/accent.
- Admin detail header, operator station card, operator on-screen traveler.
- PDF traveler: **solid dark stamp with reversed white "HOT"** — legible in grayscale, unlike a color that desaturates away.

## Ordering (hot-first, both surfaces)
- Admin list: `.order('is_hot', desc)` in `getAllJobs` **plus** an AG Grid `postSortRows` handler (the client-side grid re-sorts rows itself, so a server ORDER BY alone wouldn't survive a column-header sort). Hot floats to top; the user's column sort applies within.
- Operator station queue: the recreated RPC orders hot-first.

## Tests
`updateJobDetails` is_hot cases, `getAllJobs` hot-first order, `operatorAccess` carries + orders is_hot, `JobHotBadge` render/null. Local: `tsc` clean, targeted Vitest green, `supabase db reset` replays clean, `pnpm gen:db-types` diff is only `is_hot`.

## Notes for review
- The RPC migration's runtime behavior is gated on the **Supabase preview branch** (validated signature + replay locally).
- The single-operation action page intentionally doesn't badge Hot (reachable via the traveler, which does) — easy follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)