### PR TITLE
feat(operator): capture suggestion on completion + unlock camera roll

### DIFF
--- a/__tests__/components/operator/JobFeed.test.tsx
+++ b/__tests__/components/operator/JobFeed.test.tsx
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@/__tests__/test-utils';
+import userEvent from '@testing-library/user-event';
+
+import JobFeed from '@/components/operator/JobFeed';
+import { getJobNotes, addJobNote, getCurrentMember } from '@/utils/operatorAccess';
+import { addJobNoteMedia, getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
+import { compressPhoto } from '@/utils/imageCompression';
+import type { JobNote } from '@/types/operator';
+
+vi.mock('@/utils/operatorAccess', () => ({
+  getJobNotes: vi.fn(),
+  addJobNote: vi.fn(),
+  getCurrentMember: vi.fn(),
+}));
+vi.mock('@/utils/jobNoteMediaAccess', () => ({
+  addJobNoteMedia: vi.fn(),
+  getJobNoteMediaUrl: vi.fn(),
+}));
+vi.mock('@/utils/imageCompression', () => ({ compressPhoto: vi.fn() }));
+
+const mock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
+const OP_CONTEXT = { jobPartId: 'jp1', jobOperationId: 'jo1', operationLabel: 'Op 20 · Mill' };
+const OFFER_TEXT = /add it before you go/i;
+const HINT_TEXT = /talk instead of type/i;
+
+function makeNote(over: Partial<JobNote> = {}): JobNote {
+  return {
+    id: 'n1',
+    job_id: 'job1',
+    job_operation_id: null,
+    operation_label: null,
+    body: 'existing note',
+    note_type: 'user',
+    created_at: '2026-07-01T10:00:00.000Z',
+    author_name: 'Op',
+    media: [],
+    ...over,
+  };
+}
+
+function renderFeed(props: Partial<React.ComponentProps<typeof JobFeed>> = {}) {
+  return render(
+    <JobFeed jobId="job1" companyId="co1" operationContext={OP_CONTEXT} {...props} />,
+  );
+}
+
+// This jsdom env ships no Storage — polyfill a minimal in-memory one (same
+// pattern as OperatorStationContext.test).
+class MemoryStorage {
+  private store = new Map<string, string>();
+  get length() {
+    return this.store.size;
+  }
+  clear() {
+    this.store.clear();
+  }
+  getItem(k: string) {
+    return this.store.has(k) ? this.store.get(k)! : null;
+  }
+  key(i: number) {
+    return Array.from(this.store.keys())[i] ?? null;
+  }
+  removeItem(k: string) {
+    this.store.delete(k);
+  }
+  setItem(k: string, v: string) {
+    this.store.set(k, String(v));
+  }
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, 'localStorage', {
+    value: new MemoryStorage(),
+    configurable: true,
+    writable: true,
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+  mock(getCurrentMember).mockResolvedValue({ id: 'op1', name: 'Op', role: 'operator' });
+  mock(getJobNotes).mockResolvedValue([]);
+  mock(getJobNoteMediaUrl).mockResolvedValue('blob:thumb');
+  mock(compressPhoto).mockResolvedValue({ file: new File(['x'], 'p.jpg', { type: 'image/jpeg' }) });
+  mock(addJobNoteMedia).mockResolvedValue({ id: 'm1' });
+  // Pre-dismiss the mic hint by default so it doesn't collide with offer assertions.
+  window.localStorage.setItem('jigged:composer-mic-hint', JSON.stringify({ shows: 0, dismissed: true }));
+});
+
+describe('JobFeed — post-completion capture offer', () => {
+  it('shows the offer only after a completion signal, and only when nothing is captured', async () => {
+    const { rerender } = renderFeed({ captureOfferSignal: 0 });
+    await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
+
+    // No offer before a completion event.
+    expect(screen.queryByText(OFFER_TEXT)).not.toBeInTheDocument();
+
+    // A new completion signal, empty feed → offer appears.
+    rerender(<JobFeed jobId="job1" companyId="co1" operationContext={OP_CONTEXT} captureOfferSignal={1} />);
+    expect(await screen.findByText(OFFER_TEXT)).toBeInTheDocument();
+  });
+
+  it('does NOT offer when the operator already captured a note or photo', async () => {
+    mock(getJobNotes).mockResolvedValue([makeNote({ body: 'set jaws to 0.5' })]);
+    const { rerender } = renderFeed({ captureOfferSignal: 0 });
+    await waitFor(() => expect(screen.getByText('set jaws to 0.5')).toBeInTheDocument());
+
+    rerender(<JobFeed jobId="job1" companyId="co1" operationContext={OP_CONTEXT} captureOfferSignal={1} />);
+    // Give the effect a chance to run, then assert it stayed closed.
+    await Promise.resolve();
+    expect(screen.queryByText(OFFER_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('still offers when the only note is an auto-logged event note', async () => {
+    mock(getJobNotes).mockResolvedValue([
+      makeNote({ note_type: 'event', body: 'Order qty changed 10 → 12' }),
+    ]);
+    const { rerender } = renderFeed({ captureOfferSignal: 0 });
+    await waitFor(() => expect(screen.getByText('Order qty changed 10 → 12')).toBeInTheDocument());
+
+    rerender(<JobFeed jobId="job1" companyId="co1" operationContext={OP_CONTEXT} captureOfferSignal={1} />);
+    expect(await screen.findByText(OFFER_TEXT)).toBeInTheDocument();
+  });
+
+  it('is one-per-event: Skip dismisses and it only reopens on a new signal', async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderFeed({ captureOfferSignal: 1 });
+    await screen.findByText(OFFER_TEXT);
+
+    await user.click(screen.getByRole('button', { name: 'Skip' }));
+    expect(screen.queryByText(OFFER_TEXT)).not.toBeInTheDocument();
+
+    // Re-render with the SAME signal — stays closed (skip means skip).
+    rerender(<JobFeed jobId="job1" companyId="co1" operationContext={OP_CONTEXT} captureOfferSignal={1} />);
+    expect(screen.queryByText(OFFER_TEXT)).not.toBeInTheDocument();
+
+    // A brand-new completion → a fresh single offer.
+    rerender(<JobFeed jobId="job1" companyId="co1" operationContext={OP_CONTEXT} captureOfferSignal={2} />);
+    expect(await screen.findByText(OFFER_TEXT)).toBeInTheDocument();
+  });
+
+  it('Skip performs no writes — the offer can never affect the (already-committed) completion', async () => {
+    const user = userEvent.setup();
+    renderFeed({ captureOfferSignal: 1 });
+    await screen.findByText(OFFER_TEXT);
+
+    await user.click(screen.getByRole('button', { name: 'Skip' }));
+    expect(addJobNote).not.toHaveBeenCalled();
+    expect(addJobNoteMedia).not.toHaveBeenCalled();
+  });
+
+  it('"Add photo" opens the file picker and closes the offer', async () => {
+    const user = userEvent.setup();
+    const { container } = renderFeed({ captureOfferSignal: 1 });
+    await screen.findByText(OFFER_TEXT);
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const clickSpy = vi.spyOn(fileInput, 'click').mockImplementation(() => {});
+
+    // Offer's "Add photo" is the first (rendered above the composer's button).
+    await user.click(screen.getAllByRole('button', { name: 'Add photo' })[0]);
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(OFFER_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('"Add note" focuses the composer and closes the offer', async () => {
+    const user = userEvent.setup();
+    renderFeed({ captureOfferSignal: 1 });
+    await screen.findByText(OFFER_TEXT);
+
+    await user.click(screen.getByRole('button', { name: 'Add note' }));
+
+    const field = screen.getByPlaceholderText('Add a note or photo for this step…');
+    expect(field).toHaveFocus();
+    expect(screen.queryByText(OFFER_TEXT)).not.toBeInTheDocument();
+  });
+});
+
+describe('JobFeed — camera-roll photos unlocked', () => {
+  it('file input has no capture attribute and still accepts images', async () => {
+    const { container } = renderFeed();
+    await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).not.toHaveAttribute('capture');
+    expect(fileInput).toHaveAttribute('accept', 'image/*');
+  });
+});
+
+describe('JobFeed — dictation hint', () => {
+  const HINT_KEY = 'jigged:composer-mic-hint';
+
+  it('shows on first composer mounts and counts the show', async () => {
+    window.localStorage.removeItem(HINT_KEY);
+    renderFeed();
+    expect(await screen.findByText(HINT_TEXT)).toBeInTheDocument();
+    expect(JSON.parse(window.localStorage.getItem(HINT_KEY)!)).toEqual({ shows: 1, dismissed: false });
+  });
+
+  it('stops showing after the cap is reached', async () => {
+    window.localStorage.setItem(HINT_KEY, JSON.stringify({ shows: 3, dismissed: false }));
+    renderFeed();
+    await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
+    expect(screen.queryByText(HINT_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('hides immediately and persists dismissal when the × is tapped', async () => {
+    const user = userEvent.setup();
+    window.localStorage.removeItem(HINT_KEY);
+    renderFeed();
+    await screen.findByText(HINT_TEXT);
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss tip' }));
+    expect(screen.queryByText(HINT_TEXT)).not.toBeInTheDocument();
+    expect(JSON.parse(window.localStorage.getItem(HINT_KEY)!).dismissed).toBe(true);
+  });
+});

--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -134,6 +134,7 @@ describe('getJobNotes', () => {
         job_id: 'j1',
         job_operation_id: 'op1',
         body: 'looks good',
+        note_type: 'user',
         created_at: '2026-06-23T10:00:00Z',
         author: { name: 'Jane' },
         operation: { operation_name: 'Mill', sequence: 20 },
@@ -155,6 +156,7 @@ describe('getJobNotes', () => {
         job_id: 'j1',
         job_operation_id: null,
         body: null,
+        note_type: 'event',
         created_at: '2026-06-23T09:00:00Z',
         author: null,
         operation: null,
@@ -181,6 +183,29 @@ describe('getJobNotes', () => {
     expect(result[1].operation_label).toBeNull();
     expect(result[1].body).toBeNull();
     expect(result[1].media).toEqual([]);
+
+    // note_type flows through — 'user' vs auto-logged 'event' (drives the
+    // post-completion capture offer's "already captured?" check).
+    expect(result[0].note_type).toBe('user');
+    expect(result[1].note_type).toBe('event');
+  });
+
+  it('defaults an unknown/missing note_type to user', async () => {
+    mockQueryBuilder.data = [
+      {
+        id: 'n3',
+        job_id: 'j1',
+        job_operation_id: null,
+        body: 'hi',
+        note_type: null,
+        created_at: '2026-06-23T08:00:00Z',
+        author: null,
+        operation: null,
+        media: [],
+      },
+    ];
+    const result = await getJobNotes('j1', 'c1');
+    expect(result[0].note_type).toBe('user');
   });
 
   it('throws when the query errors', async () => {

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -57,6 +57,10 @@ export default function OperatorOperationActionPage() {
   const [currentOperatorId, setCurrentOperatorId] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Bumped after each successful completion to trigger JobFeed's one-time
+  // "add a photo/note?" offer. Bumped strictly AFTER completeOperation resolves,
+  // so completion is already durable before any prompt appears.
+  const [captureOfferSignal, setCaptureOfferSignal] = useState(0);
 
   // Header back pops in-app history (nav.goBack). This href is only the deep-link
   // fallback — the part's traveler — for an operation scanned into directly.
@@ -97,6 +101,9 @@ export default function OperatorOperationActionPage() {
     try {
       await completeOperation(jobOperationId);
       await loadJob();
+      // Completion is now persisted. Offer capture last, so a client death at
+      // the prompt cannot un-complete the step.
+      setCaptureOfferSignal((n) => n + 1);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to complete operation');
     } finally {
@@ -320,6 +327,7 @@ export default function OperatorOperationActionPage() {
         <JobFeed
           jobId={jobId}
           companyId={companyId}
+          captureOfferSignal={captureOfferSignal}
           operationContext={{
             jobPartId,
             jobOperationId,

--- a/components/operator/JobFeed.tsx
+++ b/components/operator/JobFeed.tsx
@@ -48,6 +48,47 @@ interface JobFeedProps {
   readOnly?: boolean;
   /** Set on the operation page to show the composer + auto-tag captures. */
   operationContext?: JobFeedOperationContext;
+  /**
+   * Bumped by the operation page each time a step is completed. On a *new*
+   * value, if the composer is active and the operator hasn't captured anything
+   * on this job yet, we show a one-time "add a photo/note?" offer. Completion
+   * has already been persisted before this changes, so the offer is purely
+   * additive and never blocks or risks the completion. Ignored when 0/undefined.
+   */
+  captureOfferSignal?: number;
+}
+
+// --- Dictation (keyboard-mic) hint: a quiet, contextual, capped one-liner. ---
+// Shown in the composer where operators type notes; capped so repeat users don't
+// get nagged (the documented failure mode of built-in tips). Per-device, since
+// the subject is the device's own keyboard mic.
+const MIC_HINT_KEY = 'jigged:composer-mic-hint';
+const MIC_HINT_MAX_SHOWS = 3;
+
+interface MicHintState {
+  shows: number;
+  dismissed: boolean;
+}
+
+function readMicHint(): MicHintState {
+  if (typeof window === 'undefined') return { shows: 0, dismissed: true };
+  try {
+    const raw = window.localStorage.getItem(MIC_HINT_KEY);
+    if (!raw) return { shows: 0, dismissed: false };
+    const parsed = JSON.parse(raw) as Partial<MicHintState>;
+    return { shows: Number(parsed.shows) || 0, dismissed: !!parsed.dismissed };
+  } catch {
+    return { shows: 0, dismissed: false };
+  }
+}
+
+function writeMicHint(state: MicHintState): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(MIC_HINT_KEY, JSON.stringify(state));
+  } catch {
+    /* private mode / quota — the hint is best-effort, never block on it */
+  }
 }
 
 function formatTimestamp(value: string): string {
@@ -74,7 +115,13 @@ interface PendingPhoto {
  * auto-tagged to the step) and read on both the operation page and the traveler.
  * Listing is a plain Supabase read (no AI on mount).
  */
-export default function JobFeed({ jobId, companyId, readOnly, operationContext }: JobFeedProps) {
+export default function JobFeed({
+  jobId,
+  companyId,
+  readOnly,
+  operationContext,
+  captureOfferSignal,
+}: JobFeedProps) {
   const [error, setError] = useState<string | null>(null);
   // Notes posted optimistically (prepended before the next full load). Deduped
   // out of the merged list once they show up in a fresh load by id.
@@ -91,7 +138,17 @@ export default function JobFeed({ jobId, companyId, readOnly, operationContext }
   // Full-size viewer.
   const [viewerUrl, setViewerUrl] = useState<string | null>(null);
 
+  // Post-completion "add a photo/note?" offer + the dictation hint.
+  const [offerOpen, setOfferOpen] = useState(false);
+  const [showMicHint, setShowMicHint] = useState(false);
+  const offerRef = useRef<HTMLDivElement | null>(null);
+  const lastOfferSignal = useRef<number | undefined>(undefined);
+
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const noteFieldRef = useRef<HTMLInputElement | null>(null);
+  // Monotonic id source for pending picks — avoids the id collisions that
+  // Date.now()+filename produced for rapid same-name camera captures.
+  const pendingIdRef = useRef(0);
 
   const showComposer = !readOnly && !!operationContext;
 
@@ -115,6 +172,19 @@ export default function JobFeed({ jobId, companyId, readOnly, operationContext }
     return [...stillPending, ...loadedNotes];
   }, [loadedNotes, pendingNotes]);
 
+  // Has the operator captured anything real on this job yet? Only human 'user'
+  // notes with text or a photo count — auto-logged 'event' notes (e.g. the
+  // order-qty audit trail) must NOT suppress the offer.
+  const hasUserCapture = useMemo(
+    () =>
+      notes.some(
+        (n) =>
+          n.note_type === 'user' &&
+          ((n.body?.trim().length ?? 0) > 0 || n.media.length > 0),
+      ),
+    [notes],
+  );
+
   useEffect(() => {
     if (!showComposer) return;
     let active = true;
@@ -125,6 +195,34 @@ export default function JobFeed({ jobId, companyId, readOnly, operationContext }
       active = false;
     };
   }, [showComposer, companyId]);
+
+  // Post-completion capture offer: fire ONCE per completion event. Only react to
+  // a *new* signal value (ignore the initial undefined/0), and only offer when
+  // the composer is active and nothing has been captured yet. The parent bumps
+  // the signal strictly after completeOperation resolves, so completion is
+  // already durable — a client death while this is open loses nothing.
+  useEffect(() => {
+    if (!captureOfferSignal) return;
+    if (captureOfferSignal === lastOfferSignal.current) return;
+    lastOfferSignal.current = captureOfferSignal;
+    if (showComposer && !hasUserCapture) setOfferOpen(true);
+  }, [captureOfferSignal, showComposer, hasUserCapture]);
+
+  // Scroll the offer into view when it opens (it sits above a composer that may
+  // be below the fold on a phone).
+  useEffect(() => {
+    if (offerOpen) offerRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' });
+  }, [offerOpen]);
+
+  // Decide the dictation hint once per composer mount, counting the show. Shown
+  // while not dismissed and under the cap; increments the stored show count.
+  useEffect(() => {
+    if (!showComposer) return;
+    const state = readMicHint();
+    if (state.dismissed || state.shows >= MIC_HINT_MAX_SHOWS) return;
+    setShowMicHint(true);
+    writeMicHint({ shows: state.shows + 1, dismissed: false });
+  }, [showComposer]);
 
   // Fetch signed URLs for any media we don't already have a URL for.
   useEffect(() => {
@@ -160,19 +258,44 @@ export default function JobFeed({ jobId, companyId, readOnly, operationContext }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handlePickPhotos = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(e.target.files ?? []);
-    e.target.value = '';
+  const handlePickPhotos = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const input = e.target;
+    const files = Array.from(input.files ?? []);
+    input.value = '';
     if (files.length === 0) return;
     setComposerError(null);
-    setPending((prev) => [
-      ...prev,
-      ...files.map((file, i) => ({
-        id: `${Date.now()}-${i}-${file.name}`,
-        file,
-        previewUrl: URL.createObjectURL(file),
-      })),
-    ]);
+
+    // iOS "new photo → nothing attached" mitigation (UNCONFIRMED — see PR notes;
+    // not reproducible on desktop). A camera-origin `File` can become unreadable
+    // by the time it's compressed/uploaded at Post, yielding a zero-byte blob.
+    // Copy the bytes into a stable File *now*, while the reference is fresh, and
+    // drop any pick that reads back empty rather than silently posting nothing.
+    const prepared: PendingPhoto[] = [];
+    for (const file of files) {
+      let stable = file;
+      try {
+        const buf = await file.arrayBuffer();
+        stable = new File([buf], file.name || 'photo.jpg', {
+          type: file.type || 'image/jpeg',
+          lastModified: file.lastModified,
+        });
+      } catch {
+        // Copy failed — fall through with the original reference and the size
+        // guard below decides whether it's usable.
+      }
+      if (stable.size === 0) continue;
+      prepared.push({
+        id: `pp-${pendingIdRef.current++}`,
+        file: stable,
+        previewUrl: URL.createObjectURL(stable),
+      });
+    }
+
+    if (prepared.length === 0) {
+      setComposerError('That photo could not be read. Please try taking or picking it again.');
+      return;
+    }
+    setPending((prev) => [...prev, ...prepared]);
   };
 
   const removePending = (id: string) => {
@@ -181,6 +304,25 @@ export default function JobFeed({ jobId, companyId, readOnly, operationContext }
       if (target) URL.revokeObjectURL(target.previewUrl);
       return prev.filter((p) => p.id !== id);
     });
+  };
+
+  // Offer actions. "Add photo" is the prominent path (the observed failure was
+  // photos stuck in the camera roll): close the offer and open the picker, which
+  // now surfaces the photo library too. "Add note" focuses the composer; "Skip"
+  // just dismisses. All three are terminal for this completion event.
+  const handleOfferAddPhoto = () => {
+    setOfferOpen(false);
+    fileInputRef.current?.click();
+  };
+  const handleOfferAddNote = () => {
+    setOfferOpen(false);
+    noteFieldRef.current?.focus();
+  };
+  const handleOfferSkip = () => setOfferOpen(false);
+
+  const dismissMicHint = () => {
+    setShowMicHint(false);
+    writeMicHint({ ...readMicHint(), dismissed: true });
   };
 
   const canPost = (noteDraft.trim().length > 0 || pending.length > 0) && !saving;
@@ -244,6 +386,50 @@ export default function JobFeed({ jobId, companyId, readOnly, operationContext }
 
         {showComposer && (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mb: 2 }}>
+            {offerOpen && (
+              <Box
+                ref={offerRef}
+                sx={{
+                  p: 1.5,
+                  borderRadius: 1,
+                  border: '1px solid',
+                  borderColor: 'primary.main',
+                  bgcolor: 'rgba(99, 102, 241, 0.10)',
+                }}
+              >
+                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+                  <Typography variant="body2" sx={{ flex: 1 }}>
+                    Step complete. Got a setup photo or a note? Add it before you go —
+                    it stays with the job.
+                  </Typography>
+                  <IconButton
+                    size="small"
+                    aria-label="Dismiss"
+                    onClick={handleOfferSkip}
+                    sx={{ mt: -0.5, mr: -0.5 }}
+                  >
+                    <CloseIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1 }}>
+                  <Button
+                    variant="contained"
+                    startIcon={<PhotoCameraIcon />}
+                    onClick={handleOfferAddPhoto}
+                    sx={{ minHeight: 44 }}
+                  >
+                    Add photo
+                  </Button>
+                  <Button variant="text" onClick={handleOfferAddNote} sx={{ minHeight: 44 }}>
+                    Add note
+                  </Button>
+                  <Box sx={{ flex: 1 }} />
+                  <Button variant="text" color="inherit" onClick={handleOfferSkip} sx={{ minHeight: 44 }}>
+                    Skip
+                  </Button>
+                </Box>
+              </Box>
+            )}
             {operationContext?.operationLabel && (
               <Typography variant="caption" color="text.secondary">
                 Adding to {operationContext.operationLabel}
@@ -255,9 +441,26 @@ export default function JobFeed({ jobId, companyId, readOnly, operationContext }
               placeholder="Add a note or photo for this step…"
               value={noteDraft}
               onChange={(e) => setNoteDraft(e.target.value)}
+              inputRef={noteFieldRef}
               fullWidth
               size="small"
             />
+
+            {showMicHint && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
+                  ※ Tip: tap the 🎤 on your keyboard to talk instead of type.
+                </Typography>
+                <IconButton
+                  size="small"
+                  aria-label="Dismiss tip"
+                  onClick={dismissMicHint}
+                  sx={{ p: 0.25 }}
+                >
+                  <CloseIcon sx={{ fontSize: 14 }} />
+                </IconButton>
+              </Box>
+            )}
 
             {pending.length > 0 && (
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
@@ -296,11 +499,16 @@ export default function JobFeed({ jobId, companyId, readOnly, operationContext }
 
             {composerError && <Alert severity="error">{composerError}</Alert>}
 
+            {/* No `capture` attribute: on iOS/Android this makes the OS present
+                the full native sheet (Photo Library / Take Photo / Choose File),
+                so operators can attach an EXISTING photo from the camera roll —
+                the observed failure mode was setup photos stuck in the roll —
+                not only shoot a new one. `capture="environment"` would force the
+                camera and hide the library. */}
             <input
               ref={fileInputRef}
               type="file"
               accept="image/*"
-              capture="environment"
               multiple
               hidden
               onChange={handlePickPhotos}

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -202,6 +202,13 @@ export interface JobNote {
   operation_label: string | null;
   /** Free text. Null when the note is media-only. */
   body: string | null;
+  /**
+   * 'user' = a human-authored note (typed text and/or attached media).
+   * 'event' = an auto-logged feed entry (e.g. the order-quantity-change audit
+   * trail). Used to distinguish real operator capture from system events — e.g.
+   * the post-completion "add a photo?" offer only counts 'user' notes.
+   */
+  note_type: 'user' | 'event';
   created_at: string;
   /** Author display name (from user_company_access.name); null if unknown. */
   author_name: string | null;

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -983,7 +983,7 @@ export async function getJobPartsOverview(
 // Each note carries its optional step tag (job_operations) and its media so the
 // feed renders thumbnails without a second round-trip.
 const JOB_NOTE_SELECT =
-  'id, job_id, job_operation_id, body, created_at, ' +
+  'id, job_id, job_operation_id, body, note_type, created_at, ' +
   'author:user_company_access(name), ' +
   'operation:job_operations(operation_name, sequence), ' +
   'media:job_note_media(id, note_id, storage_path, thumbnail_path, kind, mime_type, width, height)';
@@ -993,6 +993,7 @@ type JobNoteRow = {
   job_id: string;
   job_operation_id: string | null;
   body: string | null;
+  note_type: string | null;
   created_at: string;
   author: { name: string | null } | { name: string | null }[] | null;
   operation:
@@ -1035,6 +1036,7 @@ function mapJobNoteRow(n: JobNoteRow): JobNote {
     job_operation_id: n.job_operation_id,
     operation_label: operationLabel,
     body: n.body,
+    note_type: n.note_type === 'event' ? 'event' : 'user',
     created_at: n.created_at,
     author_name: author?.name ?? null,
     media,


### PR DESCRIPTION
## Context

Diary-week finding from our design partner's operator: he took setup photos on his phone but they stayed in his **camera roll**, never attached to the job. He suggested this feature himself — *"a little reminder... hey, you didn't write down any notes, would you like to leave notes... you could put a skip if you want."* Completion is the one moment operators reliably touch the app, so completion becomes the capture moment.

**Scoped honestly:** this operator often completed ops after the fact from a desk. This improves capture in the sessions that happen; it does not fix app adoption. Kept lightweight accordingly. **Operator-only** — the admin completion flow has no note composer, so parity is non-trivial and intentionally untouched.

## What's in here

1. **Camera roll unlocked** — dropped `capture="environment"` from the composer file input. With just `accept="image/*"`, iOS/Android present the native sheet (Photo Library / Take Photo / Choose File), so operators can attach existing photos, not only shoot new ones.
2. **Post-completion offer** — the operator operation page bumps `captureOfferSignal` **strictly after** `completeOperation` resolves. `JobFeed` shows a one-time dismissible callout — **Add photo** (prominent), **Add note** (focuses composer), **Skip** — only when the job has no human capture yet. One-per-completion; skip means skip; reopens only on a new completion. Completion is durable before the prompt appears, so a client death at the offer loses nothing.
3. **`note_type` surfaced** through `getJobNotes` so the "already captured?" check counts only human `user` notes (body or media). Auto-logged `event` notes (e.g. order-qty audit) no longer suppress the offer.
4. **Dictation hint** — a quiet, contextual, capped `※ Tip:` one-liner under the composer (≤3 shows or one dismissal, per-device `localStorage`). Research-backed form: contextual + capped is what makes just-in-time tips get used rather than nag.

## July-9 iOS "new photo → nothing attached" bug

**Not reproduced — not claimed fixed.** The desktop dev env can't exercise the iOS camera → WebView-memory-purge path (needs a physical device). Added an **UNCONFIRMED** low-risk mitigation in `handlePickPhotos`: copy each pick's bytes into a stable `File` at pick time and drop zero-byte reads with a visible error. Leading hypotheses are documented in code comments. **Still needs a real-iOS repro session to confirm.**

## Testing

- `__tests__/components/operator/JobFeed.test.tsx` — offer visibility (empty vs captured vs event-only), one-per-event, skip performs no writes, Add photo opens picker + closes, Add note focuses composer, file input has no `capture`, mic-hint lifecycle.
- `__tests__/utils/operatorAccess.test.ts` — `note_type` maps through (`user`/`event`, defaults unknown→`user`).
- **25 tests pass; `tsc` clean.**
- **Eyeballed in the real app** (operator view, local Supabase seed): dictation tip shows, Mark Complete → offer callout renders with correct copy/buttons, offer fires over an existing `event` note (live confirmation), Skip dismisses, file input has no `capture` and `accept=image/*`.

## Still owed
- Manual **iOS device** pass for the photo picker + the Jul-9 repro attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)