### PR TITLE
fix(parts): pricing tier loses Base/unit + Unit price after save

### DIFF
--- a/components/parts/PartPricing.tsx
+++ b/components/parts/PartPricing.tsx
@@ -183,6 +183,11 @@ export default function PartPricing({
   const [tierBaseCosts, setTierBaseCosts] = useState<Map<number, number | null>>(new Map());
   const inFlightTierQtys = useRef<Set<number>>(new Set());
   const tierBaseCostsRef = useRef(tierBaseCosts);
+  // Latest partId, so an in-flight base-cost fetch can tell whether the part
+  // changed under it before persisting its result (guards cross-part staleness
+  // without a per-effect-run `cancelled` flag — see the fetch effect below). Kept
+  // current in the ref-sync effect (refs must not be written during render).
+  const partIdRef = useRef(partId);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saveState, setSaveState] = useState<SaveState>('idle');
@@ -249,10 +254,12 @@ export default function PartPricing({
     loadAll();
   }, [loadAll, refreshKey]);
 
-  // Keep the ref current for loadAll (see tierBaseCostsRef).
+  // Keep the refs current for loadAll (tierBaseCostsRef) and the base-cost fetch
+  // guard (partIdRef) — written here, not during render.
   useEffect(() => {
     tierBaseCostsRef.current = tierBaseCosts;
-  }, [tierBaseCosts]);
+    partIdRef.current = partId;
+  }, [tierBaseCosts, partId]);
 
   // Re-seed the costing-qty field when the persisted part value changes.
   useEffect(() => {
@@ -309,21 +316,27 @@ export default function PartPricing({
     ];
     const missing = qtys.filter((q) => !tierBaseCosts.has(q) && !inFlightTierQtys.current.has(q));
     if (missing.length === 0) return;
-    let cancelled = false;
+    // `tierBaseCosts` is a dependency so a refreshKey-driven cache wipe (below)
+    // re-runs this and refetches every tier. That means resolving ONE qty re-runs
+    // the effect — so we must NOT use a per-run `cancelled` flag to gate the
+    // write: it would cancel the still-in-flight sibling qtys, leaving an
+    // untouched tier permanently without a base cost ("—" + blank Unit price)
+    // after save. Each result is a pure function of (partId, qty); persist it as
+    // long as we're still on the same part (partIdRef guards a real part change).
+    const forPartId = partId;
     const handle = setTimeout(() => {
       for (const q of missing) {
         inFlightTierQtys.current.add(q);
-        getComputedPartCost(partId, q)
+        getComputedPartCost(forPartId, q)
           .catch(() => null)
           .then((base) => {
             inFlightTierQtys.current.delete(q);
-            if (cancelled) return;
+            if (forPartId !== partIdRef.current) return;
             setTierBaseCosts((prev) => new Map(prev).set(q, base));
           });
       }
     }, 300);
     return () => {
-      cancelled = true;
       clearTimeout(handle);
     };
   }, [rows, tierBaseCosts, partId, isBought]);


### PR DESCRIPTION
## The bug

On a part's **Pricing** panel, editing one tier's Markup % and clicking **Save pricing** leaves a *different, untouched* tier with **Base / unit = "—"** and a **blank Unit price** (the Markup value survives). Recurring — reported seen before.

## Root cause

`Base / unit` isn't stored on the tier row; it's fetched per-qty via the canonical engine (`getComputedPartCost` → `compute_part_cost_at_qty`) into a `Map<qty, cost>` (`tierBaseCosts`). On save, `onPricingChanged` bumps `refreshKey`, which **wipes** that cache and makes the fetch effect refetch every tier.

That effect kept `tierBaseCosts` in its dependency array (correct — so the wipe re-triggers it) **and** used a per-run `let cancelled` flag. So when the *first* qty resolved and called `setTierBaseCosts`, the map changed → the effect re-ran → its cleanup set `cancelled = true` on the batch still awaiting the *other* qtys. Those fetches then hit `if (cancelled) return` and were **dropped** — and were already removed from the in-flight set, so nothing ever refetched them. That tier's base cost stayed missing → "—" + blank Unit price. Markup survived because it lives on the row, not in the map.

## Fix

Drop the per-run `cancelled` flag. Each resolved base cost is a pure function of `(partId, qty)`, so persist it as long as we're still on the same part — guarded by a `partIdRef` (updated in the existing ref-sync effect, not during render) instead of a flag that a sibling's resolution flips. `tierBaseCosts` stays in the deps so the `refreshKey` wipe still refetches. Net: no tier's base cost is dropped; cross-part staleness is still guarded.

## Verification
- tsc clean; eslint clean (0 errors — the 2 remaining warnings are pre-existing in this file).
- Traced the save → wipe → out-of-order-resolution sequence: all tiers repopulate; the previously-dropped tier now persists.
- Suggested manual check: part with 3 pricing tiers → edit one Markup → Save → confirm no tier's Base/unit or Unit price goes blank.

Note: a full component regression test would need to mock ~6 access modules plus fake timers and simulate out-of-order promise resolution — effect-timing tests like that tend to be flaky in CI. Happy to add one if you'd like that guard despite the brittleness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)