### PR TITLE
Operator op-page cleanups + button color standard

### DIFF
--- a/__tests__/components/jobs/OperationCard.test.tsx
+++ b/__tests__/components/jobs/OperationCard.test.tsx
@@ -165,9 +165,25 @@ describe('OperationCard — external (outside-vendor) operations', () => {
     expect(onSend).toHaveBeenCalledWith('op-1');
   });
 
-  it('an internal op still shows Complete (no send/receive)', () => {
+  it('an internal op shows Mark Complete (no send/receive) and no Pending chip', () => {
     renderExternal(op({ status: 'pending', work_center: { id: 'wc-i', name: 'Mill', labor_rate: 50, kind: 'internal' } as JobOperation['work_center'] }));
-    expect(screen.getByRole('button', { name: /Complete/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Mark Complete/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Mark Sent Out/i })).not.toBeInTheDocument();
+    // A pending op reads as "not done" from the Mark Complete button, so the
+    // grey "Pending" chip is omitted (it made the row look finished).
+    expect(screen.queryByText(/^Pending$/i)).not.toBeInTheDocument();
+  });
+
+  it('a completed internal op still shows its status chip', () => {
+    renderExternal(
+      op({
+        status: 'completed',
+        completed_at: '2026-07-15T00:00:00Z',
+        work_center: { id: 'wc-i', name: 'Mill', labor_rate: 50, kind: 'internal' } as JobOperation['work_center'],
+      }),
+    );
+    // Only 'pending' is suppressed; real states (Completed / In Progress / At
+    // Vendor) still render their chip.
+    expect(screen.getByText(/^Completed$/i)).toBeInTheDocument();
   });
 });

--- a/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
+++ b/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
@@ -203,7 +203,7 @@ export default function OperatorBinViewPage() {
                     <Button
                       fullWidth
                       variant="contained"
-                      color="success"
+                      color="primary"
                       startIcon={<AddIcon />}
                       onClick={() => setModal({ action: 'add', part })}
                     >

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -263,13 +263,6 @@ export default function OperatorOperationActionPage() {
         </Alert>
       )}
 
-      {!isCompleted && job.predecessors_incomplete && (
-        <Alert severity="warning" sx={{ mb: 2 }}>
-          Earlier steps on this part aren&apos;t complete yet. You can still complete this
-          step if you&apos;re working out of order.
-        </Alert>
-      )}
-
       <Card
         elevation={2}
         sx={{ mb: 3, bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' }}

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -6,6 +6,7 @@ import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
+import ButtonBase from '@mui/material/ButtonBase';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -18,6 +19,7 @@ import UndoIcon from '@mui/icons-material/Undo';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import LocalShippingIcon from '@mui/icons-material/LocalShipping';
 import Inventory2Icon from '@mui/icons-material/Inventory2';
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import {
   getOperatorOperationDetail,
   getCurrentMember,
@@ -34,7 +36,7 @@ import {
   completionConsequenceCaption,
 } from '@/components/operations/operationMath';
 import { useStationContext } from '@/components/operator/OperatorStationContext';
-import { useSetOperatorChrome } from '@/components/operator/OperatorChromeContext';
+import { useSetOperatorChrome, useOperatorNav } from '@/components/operator/OperatorChromeContext';
 import StationSelector from '@/components/operator/StationSelector';
 import JobFeed from '@/components/operator/JobFeed';
 import PartReferenceRow from '@/components/operator/PartReferenceRow';
@@ -68,6 +70,7 @@ export default function OperatorOperationActionPage() {
   const travelerHref = `/operator/${companyId}/jobs/${jobId}/parts/${jobPartId}`;
 
   const { stationId, stationName, initializing } = useStationContext();
+  const nav = useOperatorNav();
 
   const [currentOperatorId, setCurrentOperatorId] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState(false);
@@ -273,9 +276,28 @@ export default function OperatorOperationActionPage() {
       >
         <CardContent>
           <Box sx={{ mb: 2 }}>
-            <Typography variant="h5" component="h1" fontWeight={700}>
-              {job.job_number}
-            </Typography>
+            {/* The job number doubles as the link to this part's traveler — the
+                full step list. It's the way there for an operator who scanned
+                straight into one operation (no in-app history to pop back to);
+                the list icon signals it's tappable. */}
+            <ButtonBase
+              onClick={() => nav.push(travelerHref)}
+              aria-label={`View all steps for job ${job.job_number}`}
+              sx={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 0.75,
+                minHeight: 44,
+                borderRadius: 1,
+                mx: -0.75,
+                px: 0.75,
+              }}
+            >
+              <Typography variant="h5" component="span" fontWeight={700}>
+                {job.job_number}
+              </Typography>
+              <FormatListBulletedIcon fontSize="small" sx={{ color: 'primary.light' }} />
+            </ButtonBase>
             <Typography variant="body2" color="text.secondary">
               {job.customer_name || 'No customer'}
             </Typography>
@@ -295,27 +317,21 @@ export default function OperatorOperationActionPage() {
           </Typography>
 
           {isExternal && (
-            <Box
-              sx={{
-                mt: 1.5,
-                p: 1.5,
-                borderRadius: 1,
-                bgcolor: 'rgba(245, 158, 11, 0.12)',
-                border: '1px solid',
-                borderColor: 'warning.main',
-                display: 'flex',
-                alignItems: 'center',
-                gap: 1,
-              }}
-            >
-              <LocalShippingIcon sx={{ color: 'warning.main' }} />
-              <Box>
-                <Chip size="small" color="warning" label="OUTSIDE PROCESS" sx={{ fontWeight: 700 }} />
-                <Typography variant="body2" sx={{ mt: 0.5 }}>
-                  Performed by {job.operation_vendor_name || 'an outside vendor'}. Send the parts
-                  out, then mark received when they&apos;re back.
-                </Typography>
-              </Box>
+            // Just name the vendor (matches the traveler/admin "Outside · …"
+            // chip). The Mark Sent Out / Mark Received buttons below carry the
+            // "what to do" — no separate instructional banner needed.
+            <Box sx={{ mt: 1.5 }}>
+              <Chip
+                size="small"
+                color="warning"
+                variant="outlined"
+                icon={<LocalShippingIcon />}
+                label={
+                  job.operation_vendor_name
+                    ? `Outside · ${job.operation_vendor_name}`
+                    : 'Outside process'
+                }
+              />
             </Box>
           )}
 

--- a/components/jobs/OperationCard.tsx
+++ b/components/jobs/OperationCard.tsx
@@ -8,7 +8,6 @@ import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import Collapse from '@mui/material/Collapse';
 import Tooltip from '@mui/material/Tooltip';
-import CheckIcon from '@mui/icons-material/Check';
 import UndoIcon from '@mui/icons-material/Undo';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -244,8 +243,7 @@ export default function OperationCard({
                 <Button
                   size="small"
                   variant="contained"
-                  color="success"
-                  startIcon={<CheckIcon />}
+                  color="primary"
                   onClick={() => onComplete(operation.id)}
                   disabled={disabled}
                 >

--- a/components/jobs/OperationCard.tsx
+++ b/components/jobs/OperationCard.tsx
@@ -230,8 +230,11 @@ export default function OperationCard({
           )}
         </Box>
 
-        {/* Status Chip */}
-        <OperationStatusChip status={status} />
+        {/* Status chip — omitted while pending. A pending op already reads as
+            "not done" from its Mark Complete button; the grey "Pending" chip
+            added noise and made the row look finished. Kept for in-progress /
+            completed / at-vendor, where it carries real state. */}
+        {status !== 'pending' && <OperationStatusChip status={status} />}
 
         {/* Action Buttons */}
         <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
@@ -246,7 +249,7 @@ export default function OperationCard({
                   onClick={() => onComplete(operation.id)}
                   disabled={disabled}
                 >
-                  Complete
+                  Mark Complete
                 </Button>
               </span>
             </Tooltip>

--- a/components/jobs/OperationCard.tsx
+++ b/components/jobs/OperationCard.tsx
@@ -277,7 +277,7 @@ export default function OperationCard({
                 <Button
                   size="small"
                   variant="contained"
-                  color="success"
+                  color="primary"
                   startIcon={<Inventory2Icon />}
                   onClick={() => onReceive(operation.id)}
                   disabled={disabled}

--- a/components/jobs/OperationCompleteDialog.tsx
+++ b/components/jobs/OperationCompleteDialog.tsx
@@ -99,7 +99,7 @@ export default function OperationCompleteDialog({
         </Button>
         <Button
           variant="contained"
-          color="success"
+          color="primary"
           onClick={() => onRecord(qty)}
           disabled={busy || !(qty > 0)}
         >

--- a/components/jobs/OutsideWorkPanel.tsx
+++ b/components/jobs/OutsideWorkPanel.tsx
@@ -93,7 +93,7 @@ function OutsideOpRow({
         <Button
           size="small"
           variant="contained"
-          color="success"
+          color="primary"
           startIcon={<Inventory2Icon />}
           disabled={busy}
           onClick={() => onReceive(op)}

--- a/components/parts/PartLocationInventory.tsx
+++ b/components/parts/PartLocationInventory.tsx
@@ -111,7 +111,7 @@ export default function PartLocationInventory({
   return (
     <Box sx={{ textAlign: 'left' }}>
       <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: 'wrap', gap: 1 }}>
-        <Button variant="contained" color="success" startIcon={<AddIcon />} onClick={() => setAction('add')}>
+        <Button variant="contained" color="primary" startIcon={<AddIcon />} onClick={() => setAction('add')}>
           Add
         </Button>
         <Button variant="contained" color="error" startIcon={<RemoveIcon />} onClick={() => setAction('deplete')}>

--- a/components/parts/PartTransactionModal.tsx
+++ b/components/parts/PartTransactionModal.tsx
@@ -363,13 +363,11 @@ export default function PartTransactionModal({
           onClick={handleSubmit}
           disabled={loading || formData.quantity <= 0 || wouldGoNegative}
           startIcon={loading ? <CircularProgress size={20} /> : null}
-          color={
-            formData.type === 'addition'
-              ? 'success'
-              : formData.type === 'depletion'
-              ? 'error'
-              : 'info'
-          }
+          // Primary action = blue; the one exception is depletion (removing
+          // stock), which stays red like every other destructive action. The
+          // mode's semantic color lives on the ToggleButtonGroup above, not on
+          // this action button.
+          color={formData.type === 'depletion' ? 'error' : 'primary'}
         >
           {loading ? 'Processing...' : getTypeLabel(formData.type)}
         </Button>

--- a/components/parts/workspace/tabs/InventoryTab.tsx
+++ b/components/parts/workspace/tabs/InventoryTab.tsx
@@ -84,7 +84,7 @@ export default function InventoryTab({
             <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', mt: 4, flexWrap: 'wrap' }}>
               <Button
                 variant="contained"
-                color="success"
+                color="primary"
                 size="large"
                 startIcon={<AddIcon />}
                 onClick={() => openTxnModal('addition')}

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -160,29 +160,46 @@ Follow Material Design 3 guidelines for consistency, accessibility, and familiar
 
 ### Buttons
 
-Primary Actions (job creation, approvals):
+**Every button answers two questions: what rank is it (→ `variant`), and is it
+destructive (→ `color`)?** Those are the only two axes. Do **not** reach for
+`success` / `warning` / `info` *fills* to brighten an ordinary action — those are
+status-chip colors (see [Status Colors](#status-colors)); on an action button they
+mislead. A green button reads as *already done* — exactly the trap we hit with green
+"Complete" / "Mark Received" buttons.
 
-```javascript
-<Button variant="contained" color="primary" size="large">
-  Create job
-</Button>
+**Rank → variant.** `color` is almost always **omitted** — the theme default is
+`primary` (steel blue). `size="large"` is *not* needed (the theme already floors
+every button at a 48px touch target).
+
+| Rank | Style | Use for |
+|---|---|---|
+| **Primary** | `variant="contained"` (blue) | The main action on the surface: Save, Create, Add, Submit, Convert, Mark Complete, Mark Received, Record |
+| **Secondary** | `variant="outlined"` (white-on-transparent) | Alternate / less-committing actions: Import, Edit, empty-state CTAs |
+| **Tertiary / dismiss** | `variant="text"` | Cancel, Back, Close, Skip, Undo |
+
+```tsx
+<Button variant="contained">Create job</Button>   {/* primary — blue */}
+<Button variant="outlined">Import</Button>          {/* secondary */}
+<Button variant="text">Cancel</Button>             {/* dismiss */}
 ```
 
-**Secondary Actions** (cancel, back):
+**Destructive → `color="error"` (red), always.** Any Delete / Remove / Cancel-job /
+Void / Disconnect / Logout is red — `contained error` for the final confirm,
+`outlined` / `text error` for the at-rest trigger. This is the one button rule we
+**enforce**: use `components/common/DeleteIconButton` for the trash affordance,
+guarded by a CI source-scan (see [interaction-standards.md §1](interaction-standards.md)).
 
-```javascript
-<Button variant="outlined" color="primary">
-  Cancel
-</Button>
-```
+**`success` / `warning` / `info` are for status chips, not action buttons.** The
+only sanctioned exceptions:
 
-**Tertiary Actions** (less important options):
-
-```javascript
-<Button variant="text" color="primary">
-  Skip
-</Button>
-```
+- **Send-to-vendor waypoint** — "Mark Sent Out" is `outlined color="warning"`: a
+  reversible "parts left the shop" step, deliberately amber, paired with a blue
+  primary "Mark Received."
+- **Inventory verbs** — **Remove** is `color="error"` (subtractive); **Adjust** is
+  `variant="outlined"` (secondary); **Add** is a normal blue primary — *not* green.
+- **Segmented mode selectors** (`ToggleButtonGroup`) may color options semantically
+  (add = success / remove = error / adjust = info) — they indicate the *selected
+  mode*, not an action.
 
 **Button Variant Theme Overrides:**
 


### PR DESCRIPTION
## Summary

Started as three shop-floor UX cleanups from operator feedback; grew into codifying the app's **button color standard** after the review surfaced that green "Complete"/"Received" buttons were undocumented one-offs.

### Operator single-operation page
- **Job number → traveler link.** The job number (e.g. `J-0073`) is now tappable (list icon) and opens that part's traveler — the full operation list. Main path there for an operator who scanned straight into one operation. Routed via the operator nav so header-back retraces.
- **Trimmed external-op text.** Removed the amber "OUTSIDE PROCESS" card + "Send the parts out…" sentence (the Mark Sent Out / Mark Received buttons carry that) and the "Earlier steps aren't complete yet…" out-of-order banner. Kept a compact `Outside · <vendor>` chip so the operator still knows which vendor.

### Admin Production rows (`OperationCard`)
- Hid the grey **"Pending"** chip (kept for In Progress / Completed / At Vendor).
- **"Complete" → "Mark Complete"**, and restyled from green + checkmark to **blue primary** (the checkmark read as "already done").

### Button color standard (the bigger fix)
Audited all 450 `<Button>`s. The de-facto standard (blue primary / red destructive / text cancel) was mostly followed, but `design-system.md` was stale and its color legend was written for *chips*, not buttons — so green action buttons drifted in. Converged the deviations and wrote the rule down:
- **Green → blue** for every "complete/received/record" action: `OperationCard` (Mark Complete, Mark Received), `OperationCompleteDialog` (Record), `OutsideWorkPanel` (Mark Received).
- **Inventory Add → blue** (`PartLocationInventory`, `InventoryTab`, operator locations page, `PartTransactionModal` confirm); Remove stays red, Adjust stays outlined, mode `ToggleButtonGroup` keeps its semantic colors.
- **`docs/design-system.md` §Buttons rewritten**: rank→variant table, destructive=red (the one enforced rule), and an explicit "success/warning/info are for status chips, not action buttons" rule with the sanctioned exceptions (Mark Sent Out = outlined warning, inventory Remove, segmented selectors).

## Testing
- `pnpm exec vitest run` on `OperationCard` (12/12) and `OperatorBinView` (3/3) — pass
- `pnpm exec tsc --noEmit` + `eslint` on all touched files — clean

No schema/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)