### PR TITLE
Enforce button color standard + sweep remaining deviations

### DIFF
--- a/__tests__/standards/interactionStandards.test.ts
+++ b/__tests__/standards/interactionStandards.test.ts
@@ -4,6 +4,7 @@ import {
   isValueLikePlaceholder,
   findPlaceholderViolations,
   findGreyDeleteViolations,
+  findButtonColorViolations,
   scanProject,
 } from '../../scripts/interactionStandardsCheck';
 
@@ -52,6 +53,55 @@ describe('interactionStandardsCheck — grey-delete rule', () => {
   it('does not flag a grey non-delete IconButton (e.g. edit)', () => {
     const src = `<IconButton aria-label="Edit" sx={{ color: 'text.secondary' }}><EditIcon /></IconButton>`;
     expect(findGreyDeleteViolations(src, 'Example.tsx')).toHaveLength(0);
+  });
+});
+
+describe('interactionStandardsCheck — button-color rule', () => {
+  it('flags a contained button with a semantic fill color (success/warning/info)', () => {
+    for (const color of ['success', 'warning', 'info']) {
+      const src = `<Button variant="contained" color="${color}">Go</Button>`;
+      const found = findButtonColorViolations(src, 'Example.tsx');
+      expect(found, color).toHaveLength(1);
+      expect(found[0].rule).toBe('button-color');
+    }
+  });
+
+  it('allows contained primary (default/explicit) and contained error (destructive)', () => {
+    for (const src of [
+      `<Button variant="contained">Save</Button>`,
+      `<Button variant="contained" color="primary">Save</Button>`,
+      `<Button variant="contained" color="error">Delete</Button>`,
+    ]) {
+      expect(findButtonColorViolations(src, 'X.tsx'), src).toHaveLength(0);
+    }
+  });
+
+  it('does not flag outlined/text buttons — the theme re-colors them regardless', () => {
+    // "Mark Sent Out" (outlined warning) is the sanctioned exception; text=default.
+    const outlined = `<Button variant="outlined" color="warning">Mark Sent Out</Button>`;
+    const text = `<Button color="warning">Skip</Button>`;
+    expect(findButtonColorViolations(outlined, 'X.tsx')).toHaveLength(0);
+    expect(findButtonColorViolations(text, 'X.tsx')).toHaveLength(0);
+  });
+
+  it('parses a multi-line tag with an arrow onClick without ending the tag early', () => {
+    const src = [
+      '<Button',
+      '  variant="contained"',
+      '  color="success"',
+      '  onClick={() => doThing()}',
+      '>',
+      '  Add',
+      '</Button>',
+    ].join('\n');
+    const found = findButtonColorViolations(src, 'Example.tsx');
+    expect(found).toHaveLength(1);
+    expect(found[0].line).toBe(1);
+  });
+
+  it('matches <Button> only — not ButtonBase / IconButton / ToggleButton', () => {
+    const src = `<ButtonBase color="success" />\n<IconButton color="warning" />\n<ToggleButton value="a" color="success" />`;
+    expect(findButtonColorViolations(src, 'X.tsx')).toHaveLength(0);
   });
 });
 

--- a/components/import/ReassignmentDialog.tsx
+++ b/components/import/ReassignmentDialog.tsx
@@ -42,7 +42,7 @@ export default function ReassignmentDialog({
         <Button onClick={onCancel} color="inherit">
           Cancel
         </Button>
-        <Button onClick={onConfirm} variant="contained" color="warning">
+        <Button onClick={onConfirm} variant="contained">
           Reassign
         </Button>
       </DialogActions>

--- a/components/jobs/OperationCard.tsx
+++ b/components/jobs/OperationCard.tsx
@@ -384,7 +384,7 @@ export default function OperationCard({
                       {!voided && (
                         <Button
                           size="small"
-                          color="inherit"
+                          color="error"
                           disabled={disabled || voidingId === e.id}
                           onClick={() => handleVoidEvent(e.id)}
                           sx={{ minWidth: 0 }}

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -201,6 +201,13 @@ only sanctioned exceptions:
   (add = success / remove = error / adjust = info) — they indicate the *selected
   mode*, not an action.
 
+**Enforced.** A source-scan test fails CI on any `contained` `<Button>` with a
+`success` / `warning` / `info` fill — the `button-color` rule in
+`scripts/interactionStandardsCheck.ts` (the same gate that keeps deletes red).
+`outlined` / `text` buttons are re-colored by the theme regardless of `color`, so
+the sanctioned outlined exceptions pass automatically; `color={expr}` is left to
+review. Genuine exceptions go in that scanner's `ALLOWLIST`.
+
 **Button Variant Theme Overrides:**
 
 The MUI theme includes custom styling for outlined and text button variants to ensure proper contrast against the gradient background:

--- a/scripts/interactionStandardsCheck.ts
+++ b/scripts/interactionStandardsCheck.ts
@@ -1,6 +1,6 @@
 /**
- * interactionStandardsCheck — a source scanner that turns two documented-but-
- * unenforced design rules into a CI gate. Both rules drifted in real PRs because
+ * interactionStandardsCheck — a source scanner that turns documented-but-
+ * unenforced design rules into a CI gate. Each rule drifted in real PRs because
  * docs alone don't stop hand-rolled regressions:
  *
  *   1. Misleading placeholders — a placeholder that looks like real data (bare
@@ -10,6 +10,11 @@
  *      rest, never grey (`color: 'text.secondary'`). See
  *      docs/interaction-standards.md "Destructive actions". Use the shared
  *      components/common/DeleteIconButton so the color can't be set wrong.
+ *   3. Semantic-color button fills — a filled (contained) action <Button> may
+ *      only be primary (blue) or error (red). success/warning/info are status-
+ *      chip colors; on a button fill they mislead (a green button reads as
+ *      "already done"). See docs/design-system.md "Buttons". This is exactly
+ *      how the green "Complete"/"Mark Received" one-offs crept in.
  *
  * Mirrors scripts/schemaEmbedCheck.ts: a pure scan function the test drives,
  * plus a main() for `pnpm exec tsx`.
@@ -20,7 +25,7 @@ import path from 'path';
 export interface StandardsViolation {
   file: string; // relative to repo root
   line: number;
-  rule: 'placeholder' | 'grey-delete';
+  rule: 'placeholder' | 'grey-delete' | 'button-color';
   message: string;
 }
 
@@ -101,10 +106,70 @@ export function findGreyDeleteViolations(source: string, relPath: string): Stand
 // We intentionally do NOT enforce a single glyph here — that's a per-call-site
 // judgment. We DO enforce that no delete is grey (findGreyDeleteViolations).
 
+/**
+ * Slice a JSX opening tag that starts at `source[start]` (the `<`), returning the
+ * text up to and including the tag's own closing `>`. Skips any `>` inside {expr}
+ * braces and string / template literals, so `onClick={() => fn()}` and `sx={{…}}`
+ * don't end the tag early. Heuristic (no escaped-quote handling) — same spirit as
+ * this file's other regex scanners. Returns null if no closer is found.
+ */
+function sliceOpeningTag(source: string, start: number): string | null {
+  let depth = 0;
+  let quote: string | null = null;
+  for (let i = start; i < source.length; i++) {
+    const c = source[i];
+    if (quote) {
+      if (c === quote) quote = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') quote = c;
+    else if (c === '{') depth++;
+    else if (c === '}') {
+      if (depth > 0) depth--;
+    } else if (c === '>' && depth === 0) {
+      return source.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+/**
+ * Find action buttons that carry a semantic FILL color. We flag only
+ * `variant="contained"` with `color="success|warning|info"` — that is the one
+ * case that actually renders the misleading color, because the theme re-colors
+ * outlined (white) and text (primary.light) buttons regardless of the `color`
+ * prop. So the sanctioned outlined exception ("Mark Sent Out" = outlined warning)
+ * passes automatically, and `color="error"` (destructive red) and primary/omitted
+ * stay allowed. Only literal string props are checked; `color={expr}` is left to
+ * review. Matches `<Button` exactly (not ButtonBase / IconButton / ToggleButton).
+ */
+export function findButtonColorViolations(source: string, relPath: string): StandardsViolation[] {
+  const out: StandardsViolation[] = [];
+  const re = /<Button\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(source)) !== null) {
+    const tag = sliceOpeningTag(source, m.index);
+    if (!tag) continue;
+    if (!/\bvariant=["']contained["']/.test(tag)) continue;
+    const cm = tag.match(/\bcolor=["'](success|warning|info)["']/);
+    if (!cm) continue;
+    if (ALLOWLIST.has(`${relPath}::button-color`)) continue;
+    const line = source.slice(0, m.index).split('\n').length;
+    out.push({
+      file: relPath,
+      line,
+      rule: 'button-color',
+      message: `Contained <Button> uses color="${cm[1]}" — a status-chip color. A filled action button is primary (blue) or, if destructive, error (red). See docs/design-system.md "Buttons".`,
+    });
+  }
+  return out;
+}
+
 export function scanSource(source: string, relPath: string): StandardsViolation[] {
   return [
     ...findPlaceholderViolations(source, relPath),
     ...findGreyDeleteViolations(source, relPath),
+    ...findButtonColorViolations(source, relPath),
   ];
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #599 (which documented the button color standard). This turns that standard into a **CI gate** and sweeps the last deviations. Independent of #599, which is already merged — this branches off `main`.

### Enforcement (the main change)
Adds a `button-color` rule to [`scripts/interactionStandardsCheck.ts`](scripts/interactionStandardsCheck.ts) — the existing source-scan gate that already keeps deletes red and blocks value-like placeholders. The rule fails CI on any **`contained` `<Button>` with `color="success" | "warning" | "info"`** (a status-chip color used as a button fill — the exact shape the green "Complete"/"Mark Received" one-offs took).

Why only `contained`: the theme re-colors `outlined` (white) and `text` (primary.light) buttons regardless of `color`, so a colored fill is the only case that actually renders the misleading color. This means the **sanctioned outlined exceptions pass automatically** (e.g. "Mark Sent Out" = `outlined warning`), with no allowlist needed. `color="error"` (destructive red) and primary/omitted stay allowed. `color={expr}` is left to review; genuine exceptions go in the scanner's `ALLOWLIST`.

Covered by 5 new unit tests plus the existing repo-wide "repo is clean" scan.

### Deviations fixed
The scan surfaced exactly one live violation (everything else was already cleared by #599):
- **`ReassignmentDialog` "Reassign"** — `contained warning` → primary (blue).

Plus the one cosmetic convergence from the audit:
- **`OperationCard` per-event "Void"** — grey (`color="inherit"`) → `error` (red), matching the `PackingSlipPreviewDialog` "Void" and the destructive-at-rest standard.

### Deliberately left alone
The **Add Contact / Add Address** contained-vs-outlined "deviation" is intentional: the `contained` button is the **empty-state** CTA and the `outlined` one is the populated-header "add another" — they're mutually exclusive (guarded on `length === 0` / `> 0`) and never render together. Converging them would weaken the empty-state CTA, so it stays.

`docs/design-system.md` §Buttons notes the new enforcement.

## Testing
- `pnpm exec vitest run __tests__/standards/interactionStandards.test.ts __tests__/components/jobs/OperationCard.test.tsx` — 25/25 pass
- `pnpm exec tsc --noEmit` + `eslint` on all touched files — clean

No schema/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)