### PR TITLE
Fix Billing & Shipping contact overflow on the job detail page

### DIFF
--- a/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
+++ b/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
@@ -553,7 +553,7 @@ export default function QuoteDetailPage() {
                       <AddressDisplay address={shippingAddress} />
                     </Grid>
                   )}
-                  <Grid size={{ xs: 12, sm: 6, md: showShippingColumn ? 4 : 6 }}>
+                  <Grid size={{ xs: 12, sm: 6, md: showShippingColumn ? 4 : 6 }} sx={{ minWidth: 0 }}>
                     <Typography variant="body2" color="text.secondary">
                       Contact
                     </Typography>
@@ -563,14 +563,22 @@ export default function QuoteDetailPage() {
                           {quoteContact.name}
                         </Typography>
                         {quoteContact.email && (
-                          <Typography variant="body2" color="text.secondary">
+                          <MuiLink
+                            href={`mailto:${quoteContact.email}`}
+                            variant="body2"
+                            sx={{ display: 'block', overflowWrap: 'anywhere' }}
+                          >
                             {quoteContact.email}
-                          </Typography>
+                          </MuiLink>
                         )}
                         {quoteContact.phone && (
-                          <Typography variant="body2" color="text.secondary">
+                          <MuiLink
+                            href={`tel:${quoteContact.phone}`}
+                            variant="body2"
+                            sx={{ display: 'block' }}
+                          >
                             {quoteContact.phone}
-                          </Typography>
+                          </MuiLink>
                         )}
                       </Box>
                     ) : (

--- a/components/common/AddressDisplay.tsx
+++ b/components/common/AddressDisplay.tsx
@@ -45,7 +45,11 @@ export default function AddressDisplay({ address }: { address: DisplayAddress | 
   return (
     <Box>
       {lines.map((line, i) => (
-        <Typography key={i} variant="body1" sx={{ fontWeight: i === 0 ? 500 : 400 }}>
+        <Typography
+          key={i}
+          variant="body1"
+          sx={{ fontWeight: i === 0 ? 500 : 400, overflowWrap: 'anywhere' }}
+        >
           {line}
         </Typography>
       ))}

--- a/components/jobs/JobBillingShippingCard.tsx
+++ b/components/jobs/JobBillingShippingCard.tsx
@@ -15,6 +15,7 @@ import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Grid from '@mui/material/Grid';
 import InputLabel from '@mui/material/InputLabel';
+import Link from '@mui/material/Link';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
@@ -73,6 +74,12 @@ export default function JobBillingShippingCard({
   const contact = job.contact_snapshot;
   const billingSameAsShipping =
     !!job.shipping_address_id && job.billing_address_id === job.shipping_address_id;
+
+  // Read-only layout: collapse the Billing column when it equals shipping (the
+  // common case) so the remaining columns get room in this half-width card —
+  // mirrors the quote card. An explicit note keeps the "same as shipping" fact.
+  const showBillingColumn = !billingSameAsShipping;
+  const infoColSize = showBillingColumn ? { xs: 12, sm: 4 } : { xs: 12, sm: 6 };
 
   const customerHref = `/dashboard/${companyId}/customers/${job.customer_id}`;
 
@@ -134,7 +141,7 @@ export default function JobBillingShippingCard({
 
         {!editing ? (
           <Grid container spacing={2}>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid size={infoColSize} sx={{ minWidth: 0 }}>
               <Typography variant="body2" color="text.secondary">
                 Contact
               </Typography>
@@ -144,14 +151,22 @@ export default function JobBillingShippingCard({
                     {contact.name}
                   </Typography>
                   {contact.email && (
-                    <Typography variant="body2" color="text.secondary">
+                    <Link
+                      href={`mailto:${contact.email}`}
+                      variant="body2"
+                      sx={{ display: 'block', overflowWrap: 'anywhere' }}
+                    >
                       {contact.email}
-                    </Typography>
+                    </Link>
                   )}
                   {contact.phone && (
-                    <Typography variant="body2" color="text.secondary">
+                    <Link
+                      href={`tel:${contact.phone}`}
+                      variant="body2"
+                      sx={{ display: 'block' }}
+                    >
                       {contact.phone}
-                    </Typography>
+                    </Link>
                   )}
                 </Box>
               ) : (
@@ -160,24 +175,29 @@ export default function JobBillingShippingCard({
                 </Typography>
               )}
             </Grid>
-            <Grid size={{ xs: 12, sm: 4 }}>
+            <Grid size={infoColSize} sx={{ minWidth: 0 }}>
               <Typography variant="body2" color="text.secondary">
                 Shipping address
               </Typography>
               <AddressDisplay address={shippingAddress} />
-            </Grid>
-            <Grid size={{ xs: 12, sm: 4 }}>
-              <Typography variant="body2" color="text.secondary">
-                Billing address
-              </Typography>
-              {billingSameAsShipping ? (
-                <Typography variant="body1" color="text.secondary" sx={{ fontStyle: 'italic' }}>
-                  Same as shipping
+              {!showBillingColumn && (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: 'block', mt: 1, fontStyle: 'italic' }}
+                >
+                  Billing address — same as shipping
                 </Typography>
-              ) : (
-                <AddressDisplay address={billingAddress} />
               )}
             </Grid>
+            {showBillingColumn && (
+              <Grid size={infoColSize} sx={{ minWidth: 0 }}>
+                <Typography variant="body2" color="text.secondary">
+                  Billing address
+                </Typography>
+                <AddressDisplay address={billingAddress} />
+              </Grid>
+            )}
           </Grid>
         ) : (
           <Box>


### PR DESCRIPTION
## Summary

On the job detail page, a long contact email (e.g. `zringler@northernprecisionproducts.com`) overflowed the "Billing & Shipping" card's Contact column and visually collided with the Shipping address next to it.

**Root cause:** the read-only card rendered three fixed `Grid` columns (each `sm: 4`) inside a half-width card, with **no `minWidth: 0`**, and the email as plain `Typography` with **no wrapping** — so a long space-less string could neither shrink its track nor break.

## Changes

**`components/jobs/JobBillingShippingCard.tsx`** (read-only view):
- **Adaptive columns:** collapse the Billing column when it equals shipping (the common case) → two roomier columns + an explicit *"Billing address — same as shipping"* note. Mirrors the quote card's existing adaptive-column pattern.
- **Overflow-proof contact:** `minWidth: 0` on each Grid item; email/phone become `mailto:` / `tel:` `Link`s with `overflowWrap: 'anywhere'`, matching the customer-detail contact pattern. Wrapping (not truncation) is deliberate — a contact email must stay fully readable and clickable.

**`components/common/AddressDisplay.tsx`:** `overflowWrap: 'anywhere'` on address lines (shared hardening; normal addresses with spaces are unaffected).

**`app/dashboard/[companyId]/quotes/[quoteId]/page.tsx`:** the quote detail contact block had the identical latent defect — same parallel fix (`minWidth: 0` + `mailto`/`tel` links + wrap).

## Not included (by decision)
The edit-model question that prompted this ("global Edit vs inline") was researched and we chose to **keep the global Edit button** — Jobs is a documented "Pattern B" workflow/document page (like Quotes) with a single Save; its inline buttons are workflow actions, not field edits, and the financial fields need explicit Save. No edit-model change.

## Testing
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec eslint` on the 3 changed files — clean
- `pnpm exec vitest run __tests__/components/jobs/JobEditForm.test.tsx` — 5/5 pass (same component tree)
- Display-only change; behavior is deterministic CSS (`minWidth:0` + `overflowWrap`) + simple conditional rendering.

No schema/migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)