### PR TITLE
feat(billing): self-serve Stripe subscription billing with DB-enforced entitlement

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -34,3 +34,19 @@ QUICKBOOKS_MINOR_VERSION=75
 # Production-only keys, added once Intuit approves the app for production:
 # QUICKBOOKS_PROD_CLIENT_ID=your-production-client-id
 # QUICKBOOKS_PROD_CLIENT_SECRET=your-production-client-secret
+
+# ── Stripe subscription billing ──────────────────────────────────────────────
+# Backend only — no NEXT_PUBLIC_STRIPE_* (Checkout + Portal are server-created
+# redirect URLs; there is no Stripe.js on the client). Prefer a restricted key
+# (rk_...) over a secret key. Use separate keys per environment (test vs live).
+STRIPE_SECRET_KEY=rk_test_your-restricted-or-secret-key
+# The DEFAULT monthly Price id ($300) — chosen server-side for every self-serve
+# signup. The frontend never names a price.
+STRIPE_PRICE_ID=price_your-default-300-price-id
+# The reserved founder-customer Price id ($250). NOT read by the app directly —
+# it's the value you put in a company's company_billing.override_price_id
+# (service-role) to give that one customer the founder rate.
+STRIPE_FOUNDING_PRICE_ID=price_your-founder-250-price-id
+# Webhook signing secret. LOCAL: the `whsec_...` printed by `stripe listen`.
+# DEPLOYED: the signing secret of the Dashboard webhook endpoint (they differ!).
+STRIPE_WEBHOOK_SECRET=whsec_your-webhook-signing-secret

--- a/.env.local.example
+++ b/.env.local.example
@@ -37,9 +37,10 @@ QUICKBOOKS_MINOR_VERSION=75
 
 # ── Stripe subscription billing ──────────────────────────────────────────────
 # Backend only — no NEXT_PUBLIC_STRIPE_* (Checkout + Portal are server-created
-# redirect URLs; there is no Stripe.js on the client). Prefer a restricted key
-# (rk_...) over a secret key. Use separate keys per environment (test vs live).
-STRIPE_SECRET_KEY=rk_test_your-restricted-or-secret-key
+# redirect URLs; there is no Stripe.js on the client). The app reads a RESTRICTED
+# key (rk_...) — least-privilege, and it matches the var the Stripe Dashboard /
+# Vercel label. Use separate keys per environment (test vs live).
+STRIPE_RESTRICTED_KEY=rk_test_your-restricted-key
 # The DEFAULT monthly Price id ($300) — chosen server-side for every self-serve
 # signup. The frontend never names a price.
 STRIPE_PRICE_ID=price_your-default-300-price-id

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ api/.coverage
 
 # Blender
 /outputs/
+
+#Agents
+.agents/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,15 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON public.your_table TO service_role;
 
 **Symptom of a missing grant:** PostgREST returns `42501 permission denied`, and its error hint names the grant to add. Because local now matches prod, this fails in dev rather than only in production.
 
+### Billing write-gate (new tenant tables)
+
+Entitlement is enforced at the DB layer: every browser-writable tenant table carries `billing_gate_*` restrictive RLS policies that call `company_can_write(company_id)`, so a lapsed/unsubscribed shop can't write (reads stay open). RLS is per-table — **a new `company_id` table without the gate silently bypasses billing.** When you add a tenant table:
+
+- Gate it in the same migration (direct-`company_id` tables): `SELECT public.apply_billing_write_gate('public.your_table');` (parent-resolved child tables need hand-written policies resolving the parent's company — see the `stripe_write_enforcement` migration).
+- Or, if it's genuinely exempt (identity/bootstrap or service-role-only), add it to the exempt list in `tenant_tables_missing_write_gate()`.
+
+The CI test [`test_no_tenant_table_left_ungated`](api/tests/integration/test_billing_enforcement.py) fails if any `company_id` table is neither gated nor exempt — so a forgotten gate is a red build, not silent tech debt. Full standard: [docs/modules/billing.md](docs/modules/billing.md) §4. If you change the entitlement rule, change **both** `lib/entitlement.ts` `getEntitlement` and the SQL `company_can_write` (parity is tested).
+
 ### Schema source-of-truth
 
 Two artifacts describe the database schema. They serve different purposes:
@@ -628,6 +637,7 @@ See [docs/modules/](docs/modules/) for detailed module specs:
 - [Operator View](docs/modules/operator-view.md)
 - [Invitation System](docs/modules/invitation-system.md)
 - [Data Import](docs/modules/data-import.md) (guided onboarding import; [Phase 2 design](docs/modules/data-import-phase2-design.md))
+- [Billing & Subscriptions](docs/modules/billing.md) (Stripe-hosted checkout/portal; DB-enforced entitlement)
 
 ### Testing Documentation
 

--- a/__tests__/lib/entitlement.test.ts
+++ b/__tests__/lib/entitlement.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getEntitlement,
+  isWriteAllowed,
+  GRACE_DAYS,
+  type BillingRow,
+  type Entitlement,
+} from '@/lib/entitlement';
+
+// A fixed "now" so grace-window math is deterministic.
+const NOW = new Date('2026-07-25T12:00:00.000Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+function row(overrides: Partial<BillingRow> = {}): BillingRow {
+  return {
+    billing_exempt: false,
+    subscription_status: null,
+    current_period_end: null,
+    cancel_at: null,
+    ended_at: null,
+    ...overrides,
+  };
+}
+
+/** ISO string for `days` days before/after NOW (negative = past). */
+function iso(daysFromNow: number): string {
+  return new Date(NOW.getTime() + daysFromNow * DAY).toISOString();
+}
+
+/**
+ * The parity contract shared with the SQL `company_can_write()` function
+ * (scripts/verify_billing_parity.sql runs these exact cases through the DB).
+ * `isWriteAllowed(entitlement)` MUST equal the SQL boolean for each row.
+ */
+export interface GoldenCase {
+  name: string;
+  isDemo: boolean;
+  billing: BillingRow | null;
+  expected: Entitlement;
+}
+
+export const GOLDEN_CASES: GoldenCase[] = [
+  { name: 'demo, no billing row', isDemo: true, billing: null, expected: 'full' },
+  { name: 'demo, lapsed billing (ignored)', isDemo: true, billing: row({ subscription_status: 'canceled', ended_at: iso(-30) }), expected: 'full' },
+  { name: 'grandfathered (exempt), no sub', isDemo: false, billing: row({ billing_exempt: true }), expected: 'full' },
+  { name: 'trialing', isDemo: false, billing: row({ subscription_status: 'trialing', trial_end: iso(20) }), expected: 'full' },
+  { name: 'active', isDemo: false, billing: row({ subscription_status: 'active', current_period_end: iso(20) }), expected: 'full' },
+  { name: 'past_due', isDemo: false, billing: row({ subscription_status: 'past_due' }), expected: 'past_due' },
+  { name: 'canceled within grace (ended 2d ago)', isDemo: false, billing: row({ subscription_status: 'canceled', ended_at: iso(-2) }), expected: 'full' },
+  { name: 'canceled past grace (ended 30d ago)', isDemo: false, billing: row({ subscription_status: 'canceled', ended_at: iso(-30) }), expected: 'read_only' },
+  { name: 'unpaid within grace', isDemo: false, billing: row({ subscription_status: 'unpaid', ended_at: iso(-1) }), expected: 'full' },
+  { name: 'unpaid past grace', isDemo: false, billing: row({ subscription_status: 'unpaid', ended_at: iso(-10) }), expected: 'read_only' },
+  { name: 'canceled, grace anchored on cancel_at', isDemo: false, billing: row({ subscription_status: 'canceled', cancel_at: iso(-1) }), expected: 'full' },
+  { name: 'canceled, grace anchored on current_period_end', isDemo: false, billing: row({ subscription_status: 'canceled', current_period_end: iso(-1) }), expected: 'full' },
+  { name: 'canceled, no anchor at all', isDemo: false, billing: row({ subscription_status: 'canceled' }), expected: 'read_only' },
+  { name: 'paused', isDemo: false, billing: row({ subscription_status: 'paused' }), expected: 'read_only' },
+  { name: 'incomplete', isDemo: false, billing: row({ subscription_status: 'incomplete' }), expected: 'must_subscribe' },
+  { name: 'incomplete_expired', isDemo: false, billing: row({ subscription_status: 'incomplete_expired' }), expected: 'must_subscribe' },
+  { name: 'no billing row, not demo', isDemo: false, billing: null, expected: 'must_subscribe' },
+  { name: 'row exists, status null, not exempt', isDemo: false, billing: row(), expected: 'must_subscribe' },
+];
+
+describe('getEntitlement', () => {
+  for (const c of GOLDEN_CASES) {
+    it(`maps: ${c.name} → ${c.expected}`, () => {
+      expect(getEntitlement(c.isDemo, c.billing, NOW)).toBe(c.expected);
+    });
+  }
+
+  it('demo short-circuits regardless of billing state', () => {
+    expect(getEntitlement(true, row({ subscription_status: 'incomplete' }), NOW)).toBe('full');
+  });
+
+  it('grace boundary: exactly GRACE_DAYS ago is still full; just past is read_only', () => {
+    const justInside = row({ subscription_status: 'canceled', ended_at: iso(-GRACE_DAYS) });
+    const justPast = row({
+      subscription_status: 'canceled',
+      ended_at: new Date(NOW.getTime() - GRACE_DAYS * DAY - 1000).toISOString(),
+    });
+    expect(getEntitlement(false, justInside, NOW)).toBe('full');
+    expect(getEntitlement(false, justPast, NOW)).toBe('read_only');
+  });
+});
+
+describe('isWriteAllowed', () => {
+  it('full and past_due may write; read_only and must_subscribe may not', () => {
+    expect(isWriteAllowed('full')).toBe(true);
+    expect(isWriteAllowed('past_due')).toBe(true);
+    expect(isWriteAllowed('read_only')).toBe(false);
+    expect(isWriteAllowed('must_subscribe')).toBe(false);
+  });
+
+  it('every golden case: write-allowed is derivable from entitlement', () => {
+    // This is the TS half of the TS↔SQL parity (scenario 29). The SQL half runs
+    // the same GOLDEN_CASES through company_can_write in verify_billing_parity.sql.
+    for (const c of GOLDEN_CASES) {
+      const e = getEntitlement(c.isDemo, c.billing, NOW);
+      const writeAllowed = isWriteAllowed(e);
+      expect(typeof writeAllowed).toBe('boolean');
+      // Sanity: full/past_due write; the rest don't.
+      expect(writeAllowed).toBe(e === 'full' || e === 'past_due');
+    }
+  });
+});

--- a/api/index.py
+++ b/api/index.py
@@ -74,6 +74,7 @@ from routes.admin_routes import router as system_admin_router
 from routes.quote_email_routes import router as quote_email_router
 from routes.quickbooks_routes import router as quickbooks_router
 from routes.data_import_routes import router as data_import_router
+from routes.stripe_routes import router as stripe_router
 
 app.include_router(import_router)
 app.include_router(parts_import_router)
@@ -87,6 +88,7 @@ app.include_router(system_admin_router)
 app.include_router(quote_email_router)
 app.include_router(quickbooks_router)
 app.include_router(data_import_router)
+app.include_router(stripe_router)
 
 
 # For local development

--- a/api/models/stripe_models.py
+++ b/api/models/stripe_models.py
@@ -1,0 +1,64 @@
+"""Request/response models for the Stripe billing endpoints."""
+from __future__ import annotations
+
+from pydantic import BaseModel, field_validator
+
+
+def _require_uuid_like(v: str, field: str) -> str:
+    v = (v or "").strip()
+    if not v:
+        raise ValueError(f"{field} is required")
+    return v
+
+
+class CheckoutRequest(BaseModel):
+    """Start a subscription Checkout. Body carries ONLY company_id — the price and
+    trial are chosen server-side (frontend never names a price)."""
+
+    company_id: str
+
+    @field_validator("company_id")
+    @classmethod
+    def _validate_company_id(cls, v: str) -> str:
+        return _require_uuid_like(v, "company_id")
+
+
+class PortalRequest(BaseModel):
+    """Open the Stripe Customer Portal for a company."""
+
+    company_id: str
+
+    @field_validator("company_id")
+    @classmethod
+    def _validate_company_id(cls, v: str) -> str:
+        return _require_uuid_like(v, "company_id")
+
+
+class CheckoutSyncRequest(BaseModel):
+    """Reconcile the billing cache from a completed Checkout Session (success-page
+    fallback for the webhook race)."""
+
+    company_id: str
+    session_id: str
+
+    @field_validator("company_id")
+    @classmethod
+    def _validate_company_id(cls, v: str) -> str:
+        return _require_uuid_like(v, "company_id")
+
+    @field_validator("session_id")
+    @classmethod
+    def _validate_session_id(cls, v: str) -> str:
+        return _require_uuid_like(v, "session_id")
+
+
+class UrlResponse(BaseModel):
+    """A hosted Stripe URL (Checkout or Portal) for the client to redirect to."""
+
+    url: str
+
+
+class SyncResponse(BaseModel):
+    """Result of a checkout/sync reconcile."""
+
+    status: str | None = None

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -9,6 +9,7 @@ markers =
     unit: Unit tests (no external dependencies)
     integration: Integration tests (requires DB)
     slow: Slow tests
+    stripe_live: Hits the real Stripe test sandbox (needs STRIPE_* creds; not run in CI)
 filterwarnings =
     # Ignore deprecation warnings from third-party packages
     ignore::DeprecationWarning:pyiceberg.*

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -20,6 +20,10 @@ google-genai>=0.3.0
 # Error monitoring
 sentry-sdk[fastapi]>=2.0.0
 
+# Subscription billing (Stripe-hosted Checkout + Customer Portal + webhooks).
+# Pin the SDK line that supports API version 2026-06-24.dahlia.
+stripe>=12.0.0
+
 # Outbound email (quote-to-customer, future invitation emails)
 resend>=0.17.0
 # Outbound HTTP for the QuickBooks OAuth + API calls (also present transitively

--- a/api/routes/stripe_routes.py
+++ b/api/routes/stripe_routes.py
@@ -52,9 +52,16 @@ LIVE_STATUSES = ("trialing", "active", "past_due")
 
 # ───────────────────────── config helpers ─────────────────────────
 def _stripe():
-    key = os.getenv("STRIPE_SECRET_KEY")
+    # Use a RESTRICTED key (rk_...) — least-privilege by design, and it maps
+    # 1:1 to the var the Stripe Dashboard/Vercel label "STRIPE_RESTRICTED_KEY".
+    # We deliberately do NOT fall back to STRIPE_SECRET_KEY: a single
+    # authoritative var avoids someone later editing the (unused) secret key and
+    # wondering why nothing changed.
+    key = os.getenv("STRIPE_RESTRICTED_KEY")
     if not key:
-        raise HTTPException(status_code=503, detail="Stripe not configured (STRIPE_SECRET_KEY)")
+        raise HTTPException(
+            status_code=503, detail="Stripe not configured (STRIPE_RESTRICTED_KEY)"
+        )
     stripe.api_key = key
     stripe.api_version = STRIPE_API_VERSION
     return stripe

--- a/api/routes/stripe_routes.py
+++ b/api/routes/stripe_routes.py
@@ -1,0 +1,557 @@
+"""
+Stripe self-serve subscription billing.
+
+Design: maximum delegation to Stripe. We create hosted Checkout Sessions and
+Customer Portal sessions (server-side, returned as redirect URLs) and consume
+webhooks. Stripe is the sole source of truth; `company_billing` is a webhook-fed
+read cache. No card data touches our stack; no Stripe.js on the client.
+
+Auth model (mirrors quickbooks_routes):
+  - /checkout, /portal, /checkout/sync are company-scoped and require the caller's
+    Supabase JWT + the 'admin' role on the company.
+  - /webhook has NO bearer token (Stripe calls it); its trust signal is the
+    Stripe-Signature header verified against STRIPE_WEBHOOK_SECRET.
+
+All cache writes go through the SECURITY DEFINER RPC `apply_stripe_subscription`
+(guarded upsert, monotonic by event time) using the service-role key.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+import string
+import time
+from datetime import datetime, timezone
+
+import sentry_sdk
+import stripe
+from fastapi import APIRouter, HTTPException, Request
+from supabase import Client, create_client
+
+from models.stripe_models import (
+    CheckoutRequest,
+    CheckoutSyncRequest,
+    PortalRequest,
+    SyncResponse,
+    UrlResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/stripe", tags=["stripe"])
+
+# Pin the API version explicitly — Stripe's 2025 billing changes moved
+# current_period_end onto the subscription item and the invoice→subscription
+# reference onto invoice.parent; we read the version-correct fields below.
+STRIPE_API_VERSION = "2026-06-24.dahlia"
+
+# Statuses that count as a live paying/trialing relationship.
+LIVE_STATUSES = ("trialing", "active", "past_due")
+
+
+# ───────────────────────── config helpers ─────────────────────────
+def _stripe():
+    key = os.getenv("STRIPE_SECRET_KEY")
+    if not key:
+        raise HTTPException(status_code=503, detail="Stripe not configured (STRIPE_SECRET_KEY)")
+    stripe.api_key = key
+    stripe.api_version = STRIPE_API_VERSION
+    return stripe
+
+
+def _service_client() -> Client:
+    url = os.getenv("NEXT_PUBLIC_SUPABASE_URL") or os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SECRET_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    if not url or not key:
+        raise HTTPException(status_code=503, detail="Database not configured")
+    return create_client(url, key)
+
+
+def _default_price_id() -> str:
+    """The default monthly price every self-serve company gets. The reserved
+    founder-customer price is applied per-company via company_billing.override_price_id."""
+    pid = os.getenv("STRIPE_PRICE_ID")
+    if not pid:
+        raise HTTPException(status_code=503, detail="STRIPE_PRICE_ID not configured")
+    return pid
+
+
+def _webhook_secret() -> str:
+    s = os.getenv("STRIPE_WEBHOOK_SECRET")
+    if not s:
+        raise HTTPException(status_code=503, detail="STRIPE_WEBHOOK_SECRET not configured")
+    return s
+
+
+def _app_base_url() -> str:
+    explicit = os.getenv("APP_BASE_URL") or os.getenv("NEXT_PUBLIC_APP_URL")
+    if explicit:
+        return explicit.rstrip("/")
+    origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000")
+    first = next((o.strip() for o in origins.split(",") if o.strip()), "http://localhost:3000")
+    return first.rstrip("/")
+
+
+def _integration_identifier() -> str:
+    suffix = "".join(secrets.choice(string.ascii_letters) for _ in range(8))
+    return f"jigged-selfserve-{suffix}"
+
+
+def _billing_url(base: str, company_id: str) -> str:
+    # Billing lives as a card on the main Settings page (the checkout success page
+    # handles the ?session_id reconcile).
+    return f"{base}/dashboard/{company_id}/settings"
+
+
+# ───────────────────────── auth (mirrors quickbooks) ─────────────────────────
+async def _verify_company_admin(request: Request, company_id: str) -> str:
+    """Verify the caller's Supabase JWT and require the 'admin' role on company_id."""
+    token = request.headers.get("Authorization", "").replace("Bearer ", "")
+    if not token:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    client = _service_client()
+    try:
+        user_response = client.auth.get_user(token)
+        if not user_response or not user_response.user:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        user_id = user_response.user.id
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Token verification failed: %s", exc)
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+    access = (
+        client.table("user_company_access")
+        .select("role")
+        .eq("user_id", user_id)
+        .eq("company_id", company_id)
+        .limit(1)
+        .execute()
+    )
+    if not access.data:
+        raise HTTPException(status_code=403, detail="No access to this company")
+    if access.data[0].get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin role required")
+    return user_id
+
+
+# ───────────────────────── db + stripe helpers ─────────────────────────
+def _get_company(client: Client, company_id: str) -> dict:
+    res = (
+        client.table("companies")
+        .select("id, is_demo, email")
+        .eq("id", company_id)
+        .limit(1)
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Company not found")
+    return res.data[0]
+
+
+def _get_billing(client: Client, company_id: str) -> dict | None:
+    res = (
+        client.table("company_billing")
+        .select("*")
+        .eq("company_id", company_id)
+        .limit(1)
+        .execute()
+    )
+    return res.data[0] if res.data else None
+
+
+def _g(obj, key, default=None):
+    """Field access that works on both Stripe objects and plain dicts.
+
+    stripe-python's StripeObject supports attribute + bracket access but NOT the
+    dict `.get()` method, so `stripe_obj.get("x")` raises AttributeError. This
+    normalizes both: dicts use `.get`, Stripe objects use `getattr`.
+    """
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _resolve_company_from_customer(client: Client, customer_id: str | None) -> str | None:
+    if not customer_id:
+        return None
+    res = (
+        client.table("company_billing")
+        .select("company_id")
+        .eq("stripe_customer_id", customer_id)
+        .limit(1)
+        .execute()
+    )
+    return res.data[0]["company_id"] if res.data else None
+
+
+def _iso_from_unix(unix: int | None) -> str | None:
+    if not unix:
+        return None
+    return datetime.fromtimestamp(int(unix), tz=timezone.utc).isoformat()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _sub_price_id(sub) -> str | None:
+    data = _g(_g(sub, "items"), "data") or []
+    if not data:
+        return None
+    return _g(_g(data[0], "price"), "id")
+
+
+def _sub_period_end(sub) -> int | None:
+    # 2025 billing changes: current_period_end lives on the subscription item on
+    # newer API versions; fall back to the subscription-level field for safety.
+    data = _g(_g(sub, "items"), "data") or []
+    if data:
+        cpe = _g(data[0], "current_period_end")
+        if cpe:
+            return cpe
+    return _g(sub, "current_period_end")
+
+
+def _apply_subscription(client: Client, company_id: str, sub, event_at_iso: str) -> None:
+    """Overwrite the company_billing cache from a fresh subscription object,
+    guarded (monotonic) and grandfather-clearing, via the SECURITY DEFINER RPC."""
+    client.rpc(
+        "apply_stripe_subscription",
+        {
+            "p_company_id": company_id,
+            "p_stripe_customer_id": _g(sub, "customer"),
+            "p_stripe_subscription_id": _g(sub, "id"),
+            "p_status": _g(sub, "status"),
+            "p_price_id": _sub_price_id(sub),
+            "p_current_period_end": _iso_from_unix(_sub_period_end(sub)),
+            "p_cancel_at": _iso_from_unix(_g(sub, "cancel_at")),
+            "p_canceled_at": _iso_from_unix(_g(sub, "canceled_at")),
+            "p_ended_at": _iso_from_unix(_g(sub, "ended_at")),
+            "p_trial_end": _iso_from_unix(_g(sub, "trial_end")),
+            "p_event_at": event_at_iso,
+        },
+    ).execute()
+
+
+def _clear_subscription_cache(client: Client, company_id: str) -> None:
+    """Null out the cached subscription fields (keeps stripe_customer_id + any
+    overrides / billing_exempt). Used when Stripe reports no live subscription."""
+    client.table("company_billing").update(
+        {
+            "subscription_status": None,
+            "stripe_subscription_id": None,
+            "subscription_price_id": None,
+            "current_period_end": None,
+            "cancel_at": None,
+            "canceled_at": None,
+            "ended_at": None,
+            "trial_end": None,
+            "subscription_event_at": None,
+        }
+    ).eq("company_id", company_id).execute()
+
+
+def _sync_customer(s, client: Client, company_id: str, customer_id: str) -> str | None:
+    """The ONE function that writes subscription state (Stripe's recommended
+    "single source of truth" sync). Fetch the customer's current subscription from
+    Stripe and overwrite the cache with its ACTUAL status — trialing / active /
+    past_due / canceled / unpaid / paused — so a canceled sub still surfaces its
+    grace window. Clears the cache only when the customer has NO subscription at
+    all. Returns the cached status (or None).
+
+    The webhook and every reconcile path call this, so behaviour is identical
+    everywhere and no code has to parse event payloads. May raise
+    stripe.error.StripeError (callers map it to a 502)."""
+    subs = s.Subscription.list(customer=customer_id, status="all", limit=100)
+    data = _g(subs, "data") or []
+    if not data:
+        _clear_subscription_cache(client, company_id)
+        return None
+    # Prefer a live subscription; else the most recent (Stripe returns newest first).
+    chosen = next((x for x in data if _g(x, "status") in LIVE_STATUSES), data[0])
+    _apply_subscription(client, company_id, chosen, _now_iso())
+    return _g(chosen, "status")
+
+
+def _resolve_company_for_event(s, client: Client, obj, customer_id: str | None) -> str | None:
+    """Resolve our company from any webhook object: the cached stripe_customer_id
+    (fast, no Stripe call), else the object's client_reference_id (checkout) or
+    metadata (subscriptions), else the Customer's metadata."""
+    company_id = _resolve_company_from_customer(client, customer_id)
+    if company_id:
+        return company_id
+    company_id = _g(obj, "client_reference_id") or _g(_g(obj, "metadata"), "company_id")
+    if company_id:
+        return company_id
+    if customer_id:
+        try:
+            cust = s.Customer.retrieve(customer_id)
+            return _g(_g(cust, "metadata"), "company_id")
+        except stripe.error.StripeError:
+            return None
+    return None
+
+
+# ───────────────────────── endpoints ─────────────────────────
+@router.post("/checkout", response_model=UrlResponse)
+async def create_checkout(body: CheckoutRequest, request: Request):
+    """Start a subscription Checkout. Price + trial are chosen server-side."""
+    await _verify_company_admin(request, body.company_id)
+    client = _service_client()
+    company = _get_company(client, body.company_id)
+    if company.get("is_demo"):
+        raise HTTPException(status_code=400, detail="Demo companies cannot subscribe")
+
+    s = _stripe()
+    billing = _get_billing(client, body.company_id)
+
+    # Double-subscribe guard. The local cache is the fast path, but it can be stale
+    # (e.g. the webhook hasn't been delivered yet — or isn't running locally), so a
+    # company with an existing Stripe Customer is verified AUTHORITATIVELY against
+    # Stripe before we ever create a second subscription.
+    if billing and billing.get("subscription_status") in LIVE_STATUSES:
+        raise HTTPException(
+            status_code=409,
+            detail="This company already has an active subscription. Use Manage Billing.",
+        )
+
+    # One Stripe Customer per company (reliable event→company resolution key).
+    customer_id = billing.get("stripe_customer_id") if billing else None
+    if customer_id:
+        try:
+            existing = s.Subscription.list(customer=customer_id, status="all", limit=100)
+        except stripe.error.StripeError as e:
+            sentry_sdk.capture_exception(e)
+            raise HTTPException(status_code=502, detail="Stripe error checking subscriptions")
+        for sub in _g(existing, "data") or []:
+            if _g(sub, "status") in LIVE_STATUSES:
+                raise HTTPException(
+                    status_code=409,
+                    detail="This company already has an active subscription. Use Manage Billing.",
+                )
+    else:
+        try:
+            customer = s.Customer.create(
+                email=company.get("email") or None,
+                metadata={"company_id": body.company_id},
+                idempotency_key=f"customer-{body.company_id}",
+            )
+        except stripe.error.StripeError as e:
+            sentry_sdk.capture_exception(e)
+            raise HTTPException(status_code=502, detail="Stripe error creating customer")
+        customer_id = _g(customer, "id")
+        client.table("company_billing").upsert(
+            {"company_id": body.company_id, "stripe_customer_id": customer_id},
+            on_conflict="company_id",
+        ).execute()
+
+    # Server-side price + trial selection (frontend never names a price).
+    override_price = billing.get("override_price_id") if billing else None
+    price_id = override_price or _default_price_id()
+    override_trial = billing.get("override_trial_days") if billing else None
+    trial_days = 30 if override_trial is None else int(override_trial)
+
+    subscription_data: dict = {"metadata": {"company_id": body.company_id}}
+    if trial_days > 0:
+        subscription_data["trial_period_days"] = trial_days
+        # A card is always collected upfront, so this should never fire; defensive.
+        subscription_data["trial_settings"] = {
+            "end_behavior": {"missing_payment_method": "cancel"}
+        }
+
+    base = _app_base_url()
+    try:
+        session = s.checkout.Session.create(
+            mode="subscription",
+            customer=customer_id,
+            line_items=[{"price": price_id, "quantity": 1}],
+            subscription_data=subscription_data,
+            client_reference_id=body.company_id,
+            success_url=f"{_billing_url(base, body.company_id)}?session_id={{CHECKOUT_SESSION_ID}}",
+            cancel_url=_billing_url(base, body.company_id),
+            integration_identifier=_integration_identifier(),
+            idempotency_key=f"checkout-{body.company_id}-{int(time.time() // 10)}",
+        )
+    except stripe.error.StripeError as e:
+        sentry_sdk.capture_exception(e)
+        raise HTTPException(status_code=502, detail="Stripe error creating checkout session")
+
+    return UrlResponse(url=_g(session, "url"))
+
+
+@router.post("/portal", response_model=UrlResponse)
+async def create_portal(body: PortalRequest, request: Request):
+    """Open the Stripe-hosted Customer Portal for self-service billing management."""
+    await _verify_company_admin(request, body.company_id)
+    client = _service_client()
+    company = _get_company(client, body.company_id)
+    if company.get("is_demo"):
+        raise HTTPException(status_code=400, detail="Demo companies have no billing portal")
+
+    billing = _get_billing(client, body.company_id)
+    customer_id = billing.get("stripe_customer_id") if billing else None
+    if not customer_id:
+        sentry_sdk.capture_message(
+            f"Portal requested for company {body.company_id} with no stripe_customer_id"
+        )
+        raise HTTPException(status_code=409, detail="No billing customer for this company")
+
+    s = _stripe()
+
+    # Self-heal a stale cache before opening the portal: if there's no live
+    # subscription (e.g. a missed customer.subscription.deleted webhook), clear the
+    # cache and 409 so the client flips to "Subscribe" instead of opening an empty,
+    # unactionable portal.
+    try:
+        status = _sync_customer(s, client, body.company_id, customer_id)
+    except stripe.error.StripeError as e:
+        sentry_sdk.capture_exception(e)
+        raise HTTPException(status_code=502, detail="Stripe error checking subscriptions")
+    if status not in LIVE_STATUSES:
+        raise HTTPException(
+            status_code=409, detail="No active subscription to manage. Please subscribe."
+        )
+
+    base = _app_base_url()
+    try:
+        session = s.billing_portal.Session.create(
+            customer=customer_id,
+            return_url=_billing_url(base, body.company_id),
+        )
+    except stripe.error.StripeError as e:
+        sentry_sdk.capture_exception(e)
+        raise HTTPException(status_code=502, detail="Stripe error creating portal session")
+
+    return UrlResponse(url=_g(session, "url"))
+
+
+@router.post("/checkout/sync", response_model=SyncResponse)
+async def checkout_sync(body: CheckoutSyncRequest, request: Request):
+    """Success-page reconcile: pull the just-completed session's subscription and
+    overwrite the cache immediately (backstops a delayed/lost webhook)."""
+    await _verify_company_admin(request, body.company_id)
+    s = _stripe()
+    client = _service_client()
+
+    try:
+        session = s.checkout.Session.retrieve(body.session_id)
+    except stripe.error.StripeError as e:
+        sentry_sdk.capture_exception(e)
+        raise HTTPException(status_code=404, detail="Checkout session not found")
+
+    # Ownership: the session MUST belong to the authenticated company. Without this
+    # an admin could pass another company's session_id and adopt its subscription.
+    owner = _g(session, "client_reference_id")
+    if not owner:
+        owner = _resolve_company_from_customer(client, _g(session, "customer"))
+    if owner != body.company_id:
+        sentry_sdk.capture_message(
+            f"checkout/sync ownership mismatch: session {body.session_id} owner {owner} "
+            f"!= {body.company_id}"
+        )
+        raise HTTPException(status_code=403, detail="Session does not belong to this company")
+
+    customer_id = _g(session, "customer")
+    if not customer_id:
+        return SyncResponse(status=None)
+    try:
+        status = _sync_customer(s, client, body.company_id, customer_id)
+    except stripe.error.StripeError as e:
+        sentry_sdk.capture_exception(e)
+        raise HTTPException(status_code=502, detail="Stripe error syncing subscription")
+    return SyncResponse(status=status)
+
+
+@router.post("/reconcile", response_model=SyncResponse)
+async def reconcile(body: PortalRequest, request: Request):
+    """Refresh the cache from Stripe's live state and return the current status.
+    Called when the billing card is VIEWED (a deliberate settings visit, not every
+    page load), so the card is accurate even if a webhook was missed. Bounded to at
+    most one Stripe read per view, and skipped entirely when there's no customer."""
+    await _verify_company_admin(request, body.company_id)
+    client = _service_client()
+    company = _get_company(client, body.company_id)
+    if company.get("is_demo"):
+        return SyncResponse(status=None)  # demo: never billed
+
+    billing = _get_billing(client, body.company_id)
+    customer_id = billing.get("stripe_customer_id") if billing else None
+    if not customer_id:
+        return SyncResponse(status=None)  # never subscribed — nothing to reconcile
+
+    s = _stripe()
+    try:
+        status = _sync_customer(s, client, body.company_id, customer_id)
+    except stripe.error.StripeError as e:
+        sentry_sdk.capture_exception(e)
+        raise HTTPException(status_code=502, detail="Stripe error reconciling subscription")
+    return SyncResponse(status=status)
+
+
+@router.post("/webhook")
+async def webhook(request: Request):
+    """Stripe webhook. Verifies the signature, resolves the company, refetches the
+    subscription (source of truth), and overwrites the cache (guarded)."""
+    payload = await request.body()
+    sig = request.headers.get("Stripe-Signature", "")
+    s = _stripe()
+
+    try:
+        event = s.Webhook.construct_event(payload, sig, _webhook_secret())
+    except ValueError as e:  # malformed payload
+        sentry_sdk.capture_exception(e)
+        raise HTTPException(status_code=400, detail="Invalid payload")
+    except stripe.error.SignatureVerificationError as e:
+        sentry_sdk.capture_exception(e)
+        raise HTTPException(status_code=400, detail="Invalid signature")
+
+    try:
+        _handle_event(s, event)
+    except Exception as e:  # noqa: BLE001  — real errors → 500 so Stripe retries
+        logger.error("Webhook handler error for %s: %s", _g(event, "type"), e)
+        sentry_sdk.capture_exception(e)
+        raise HTTPException(status_code=500, detail="Webhook handler error")
+
+    return {"received": True}
+
+
+# Events that mean "this customer's subscription state may have changed". On any
+# of them we simply re-sync the customer from Stripe — the event only tells us
+# WHICH customer to refetch, never what to write.
+_HANDLED_EVENTS = frozenset(
+    {
+        "checkout.session.completed",
+        "customer.subscription.created",
+        "customer.subscription.updated",
+        "customer.subscription.deleted",
+        "invoice.paid",
+        "invoice.payment_failed",
+    }
+)
+
+
+def _handle_event(s, event) -> None:
+    """Single-sync dispatch. For any subscription-relevant event, resolve the
+    customer + company and re-sync from Stripe (no payload parsing). Unresolvable
+    references are captured to Sentry and acknowledged — never silently defaulted."""
+    etype = _g(event, "type")
+    if etype not in _HANDLED_EVENTS:
+        return
+    obj = _g(_g(event, "data"), "object")
+    customer_id = _g(obj, "customer")
+    if not customer_id:
+        return  # e.g. a subscription-less invoice — nothing to sync
+    client = _service_client()
+    company_id = _resolve_company_for_event(s, client, obj, customer_id)
+    if not company_id:
+        sentry_sdk.capture_message(
+            f"Stripe {etype}: unresolvable company for customer {customer_id}"
+        )
+        return
+    _sync_customer(s, client, company_id, customer_id)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -265,6 +265,19 @@ def seeded_user_b(supabase_admin: Client) -> Generator[dict, None, None]:
     _teardown_seeded_user(supabase_admin, seeded)
 
 
+@pytest.fixture
+def billing_user(supabase_admin: Client) -> Generator[dict, None, None]:
+    """Function-scoped fresh company + admin user + user-JWT client for billing
+    write-gate tests. The company starts with NO company_billing row (→
+    must_subscribe / write-blocked); each test sets the state it needs via
+    supabase_admin. Function scope keeps state changes isolated per test."""
+    seeded = _create_seeded_user(supabase_admin, "billing")
+    try:
+        yield seeded
+    finally:
+        _teardown_seeded_user(supabase_admin, seeded)
+
+
 @pytest.fixture(scope="session")
 def seeded_company_b_graph(
     supabase_admin: Client, seeded_user_b: dict

--- a/api/tests/integration/test_billing_enforcement.py
+++ b/api/tests/integration/test_billing_enforcement.py
@@ -1,0 +1,173 @@
+"""Integration tests for the DB-layer billing write-gate (no Stripe needed).
+
+These are the D10/D11 scenarios: entitlement is enforced by RLS, so a lapsed /
+never-subscribed company genuinely cannot write while an exempt / active / demo
+company can. Assertions run as the `authenticated` role through a real user-JWT
+client (the same path the app uses); a blocked write must fail with the RLS
+policy (42501), not some other error. Billing states are seeded directly with the
+service role.
+
+Requires a local Supabase with all migrations applied (TEST_SUPABASE_URL /
+TEST_SUPABASE_PUBLISHABLE_KEY / TEST_SUPABASE_SECRET_KEY). Skipped without it.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+GRACE_DAYS = 7  # mirrors lib/entitlement.GRACE_DAYS + company_can_write()
+
+
+def _iso(days_from_now: float) -> str:
+    return (datetime.now(timezone.utc) + timedelta(days=days_from_now)).isoformat()
+
+
+def _set_billing(admin, company_id: str, **fields) -> None:
+    admin.table("company_billing").upsert(
+        {"company_id": company_id, **fields}, on_conflict="company_id"
+    ).execute()
+
+
+def _clear_billing(admin, company_id: str) -> None:
+    admin.table("company_billing").delete().eq("company_id", company_id).execute()
+
+
+def _try_write(user_client, company_id: str):
+    """Attempt a customers INSERT as the authenticated user (customers is a gated
+    tenant table). Returns the response, or raises on RLS rejection."""
+    return (
+        user_client.table("customers")
+        .insert({"company_id": company_id, "name": "billing-gate-test"})
+        .execute()
+    )
+
+
+def _assert_rls_blocked(exc: Exception) -> None:
+    msg = str(exc).lower()
+    assert "42501" in msg or "row-level security" in msg, (
+        f"expected an RLS (42501) rejection, got: {exc}"
+    )
+
+
+# ── golden cases: (label, billing fields | None, is_demo, write allowed?) ──────
+# Mirrors __tests__/lib/entitlement.test.ts GOLDEN_CASES + verify_billing_parity.sql.
+CASES = [
+    ("no_row", None, False, False),
+    ("exempt", {"billing_exempt": True}, False, True),
+    ("trialing", {"subscription_status": "trialing"}, False, True),
+    ("active", {"subscription_status": "active"}, False, True),
+    ("past_due", {"subscription_status": "past_due"}, False, True),
+    ("canceled_in_grace", {"subscription_status": "canceled", "ended_at": _iso(-2)}, False, True),
+    ("canceled_past_grace", {"subscription_status": "canceled", "ended_at": _iso(-30)}, False, False),
+    ("unpaid_past_grace", {"subscription_status": "unpaid", "ended_at": _iso(-10)}, False, False),
+    ("paused", {"subscription_status": "paused"}, False, False),
+    ("incomplete", {"subscription_status": "incomplete"}, False, False),
+    ("demo_no_row", None, True, True),
+]
+
+
+@pytest.mark.parametrize("label,fields,is_demo,allowed", CASES, ids=[c[0] for c in CASES])
+def test_write_gate_enforced_by_rls(supabase_admin, billing_user, label, fields, is_demo, allowed):
+    """The RLS gate allows/blocks a real authenticated-client write per billing state."""
+    company_id = billing_user["company_id"]
+    user_client = billing_user["client"]
+
+    if is_demo:
+        supabase_admin.table("companies").update({"is_demo": True}).eq("id", company_id).execute()
+    if fields is None:
+        _clear_billing(supabase_admin, company_id)
+    else:
+        _set_billing(supabase_admin, company_id, **fields)
+
+    if allowed:
+        res = _try_write(user_client, company_id)
+        assert res.data and res.data[0]["name"] == "billing-gate-test"
+        supabase_admin.table("customers").delete().eq("id", res.data[0]["id"]).execute()
+    else:
+        with pytest.raises(Exception) as exc:
+            _try_write(user_client, company_id)
+        _assert_rls_blocked(exc.value)
+
+
+def test_select_still_works_when_write_blocked(supabase_admin, billing_user):
+    """Read-only, never a hard lockout: a lapsed company can still SELECT."""
+    company_id = billing_user["company_id"]
+    _set_billing(supabase_admin, company_id, subscription_status="canceled", ended_at=_iso(-30))
+    # A row seeded via service role (bypasses RLS); the user can still read it.
+    supabase_admin.table("customers").insert(
+        {"company_id": company_id, "name": "readable"}
+    ).execute()
+
+    read = billing_user["client"].table("customers").select("name").eq(
+        "company_id", company_id
+    ).execute()
+    assert any(r["name"] == "readable" for r in read.data)
+
+    # …but a write is rejected.
+    with pytest.raises(Exception) as exc:
+        _try_write(billing_user["client"], company_id)
+    _assert_rls_blocked(exc.value)
+
+
+def test_company_can_write_parity(supabase_admin, billing_user):
+    """The SQL company_can_write() matches the entitlement rule for every golden
+    case — the DB half of the getEntitlement <-> company_can_write parity."""
+    company_id = billing_user["company_id"]
+    for label, fields, is_demo, allowed in CASES:
+        supabase_admin.table("companies").update({"is_demo": is_demo}).eq("id", company_id).execute()
+        # Clear first so a prior case's columns (e.g. billing_exempt) never leak
+        # into this one via upsert.
+        _clear_billing(supabase_admin, company_id)
+        if fields is not None:
+            _set_billing(supabase_admin, company_id, **fields)
+
+        got = supabase_admin.rpc("company_can_write", {"check_company_id": company_id}).execute()
+        assert got.data is allowed, f"company_can_write parity failed for {label}: {got.data}"
+
+
+def test_apply_stripe_subscription_monotonic_and_exempt_clear(supabase_admin, billing_user):
+    """The webhook sync RPC: stale events are rejected; exempt clears on active but
+    NOT on trialing (Amendment 4)."""
+    company_id = billing_user["company_id"]
+    _clear_billing(supabase_admin, company_id)
+
+    def apply(status, event_at):
+        supabase_admin.rpc(
+            "apply_stripe_subscription",
+            {
+                "p_company_id": company_id, "p_stripe_customer_id": "cus_test",
+                "p_stripe_subscription_id": "sub_test", "p_status": status,
+                "p_price_id": "price_test", "p_current_period_end": None,
+                "p_cancel_at": None, "p_canceled_at": None, "p_ended_at": None,
+                "p_trial_end": None, "p_event_at": event_at,
+            },
+        ).execute()
+
+    def row():
+        return supabase_admin.table("company_billing").select("*").eq(
+            "company_id", company_id
+        ).single().execute().data
+
+    apply("trialing", "2026-01-01T00:00:00+00:00")
+    assert row()["subscription_status"] == "trialing"
+    apply("active", "2025-12-31T00:00:00+00:00")  # stale → rejected by monotonic guard
+    assert row()["subscription_status"] == "trialing"
+    apply("active", "2026-01-02T00:00:00+00:00")  # newer → applies
+    assert row()["subscription_status"] == "active"
+
+    # Exempt clears only on active/past_due, not trialing.
+    _set_billing(supabase_admin, company_id, billing_exempt=True)
+    apply("trialing", "2026-02-01T00:00:00+00:00")
+    assert row()["billing_exempt"] is True
+    apply("active", "2026-02-02T00:00:00+00:00")
+    assert row()["billing_exempt"] is False
+
+
+def test_no_tenant_table_left_ungated(supabase_admin):
+    """The tech-debt guard: every browser-writable tenant table is gated or
+    explicitly exempt. A new tenant table left un-gated fails this test."""
+    res = supabase_admin.rpc("tenant_tables_missing_write_gate", {}).execute()
+    assert res.data == [], f"tenant tables missing the billing write-gate: {res.data}"

--- a/api/tests/integration/test_billing_stripe_lifecycle.py
+++ b/api/tests/integration/test_billing_stripe_lifecycle.py
@@ -1,0 +1,166 @@
+"""Stripe-sandbox lifecycle tests for the billing sync (REAL Stripe, not mocked).
+
+These exercise `_sync_customer` against **real Stripe test-mode objects**, which is
+what catches the class of bug the unit tests (plain dicts) can't — e.g. stripe
+StripeObject has no `.get()`. They drive the Stripe SDK directly and call the sync
+function, so they do NOT require `stripe listen` or the FastAPI server running —
+only sandbox creds + a local Supabase.
+
+NOT run in CI by default (CI can't hold your Stripe sandbox secrets). To run:
+
+    cd /path/to/Jigged
+    supabase start                                  # local DB
+    eval "$(supabase status -o env)"
+    export TEST_SUPABASE_URL=$API_URL \
+           TEST_SUPABASE_PUBLISHABLE_KEY=$ANON_KEY \
+           TEST_SUPABASE_SECRET_KEY=$SERVICE_ROLE_KEY
+    cd api && conda run -n jigged python -m pytest \
+        tests/integration/test_billing_stripe_lifecycle.py -m stripe_live -q
+
+STRIPE_SECRET_KEY / STRIPE_PRICE_ID / STRIPE_FOUNDING_PRICE_ID are read from the
+repo's .env.local. The suite skips if STRIPE_SECRET_KEY is not a TEST key. Every
+test creates and then deletes its own Stripe test Customer.
+"""
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+from dotenv import load_dotenv
+
+import routes.stripe_routes as sr
+
+pytestmark = [pytest.mark.integration, pytest.mark.stripe_live]
+
+# Load the repo .env.local so STRIPE_* are available (as the backend does).
+load_dotenv(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".env.local"))
+
+_STRIPE_KEY = os.getenv("STRIPE_SECRET_KEY", "")
+_DEFAULT_PRICE = os.getenv("STRIPE_PRICE_ID")
+_FOUNDER_PRICE = os.getenv("STRIPE_FOUNDING_PRICE_ID")
+
+# Guard: only run against a TEST-mode key, never live.
+if not _STRIPE_KEY.startswith(("sk_test", "rk_test")):
+    pytest.skip(
+        "STRIPE_SECRET_KEY is not a test key — skipping live Stripe lifecycle tests.",
+        allow_module_level=True,
+    )
+if not _DEFAULT_PRICE or not _FOUNDER_PRICE:
+    pytest.skip("STRIPE_PRICE_ID / STRIPE_FOUNDING_PRICE_ID not set.", allow_module_level=True)
+
+
+@pytest.fixture
+def stripe_sdk():
+    import stripe
+
+    stripe.api_key = _STRIPE_KEY
+    stripe.api_version = sr.STRIPE_API_VERSION
+    return stripe
+
+
+@pytest.fixture
+def sandbox_customer(stripe_sdk, billing_user):
+    """A real Stripe test Customer with a default test card, tied to a fresh
+    company. Deleted (which cancels its subscriptions) on teardown."""
+    customer = stripe_sdk.Customer.create(
+        metadata={"company_id": billing_user["company_id"]},
+        payment_method="pm_card_visa",
+        invoice_settings={"default_payment_method": "pm_card_visa"},
+    )
+    yield {"customer_id": customer["id"], "company_id": billing_user["company_id"]}
+    try:
+        stripe_sdk.Customer.delete(customer["id"])
+    except Exception:
+        pass
+
+
+def _billing_row(supabase_admin, company_id):
+    res = (
+        supabase_admin.table("company_billing")
+        .select("*")
+        .eq("company_id", company_id)
+        .execute()
+    )
+    return res.data[0] if res.data else None
+
+
+def _sync(stripe_sdk, supabase_admin, sandbox_customer):
+    return sr._sync_customer(
+        stripe_sdk, supabase_admin, sandbox_customer["company_id"], sandbox_customer["customer_id"]
+    )
+
+
+def test_sync_reflects_real_trial_subscription(stripe_sdk, supabase_admin, sandbox_customer):
+    """A real trialing subscription syncs into the cache with the version-correct
+    fields (status, price, item current_period_end)."""
+    stripe_sdk.Subscription.create(
+        customer=sandbox_customer["customer_id"],
+        items=[{"price": _DEFAULT_PRICE}],
+        trial_period_days=30,
+    )
+    status = _sync(stripe_sdk, supabase_admin, sandbox_customer)
+    assert status == "trialing"
+    row = _billing_row(supabase_admin, sandbox_customer["company_id"])
+    assert row["subscription_status"] == "trialing"
+    assert row["subscription_price_id"] == _DEFAULT_PRICE
+    assert row["current_period_end"] is not None  # read off the subscription item
+    assert row["trial_end"] is not None
+    assert row["billing_exempt"] is False
+
+
+def test_founder_override_no_trial_charges_immediately(stripe_sdk, supabase_admin, sandbox_customer):
+    """The reserved $250 / no-trial path lands 'active' (immediate charge), no trial."""
+    stripe_sdk.Subscription.create(
+        customer=sandbox_customer["customer_id"],
+        items=[{"price": _FOUNDER_PRICE}],
+        # no trial_period_days → immediate charge with the default test card
+    )
+    status = _sync(stripe_sdk, supabase_admin, sandbox_customer)
+    assert status == "active"
+    row = _billing_row(supabase_admin, sandbox_customer["company_id"])
+    assert row["subscription_status"] == "active"
+    assert row["subscription_price_id"] == _FOUNDER_PRICE
+    assert row["trial_end"] is None
+
+
+def test_cancel_at_period_end_is_reflected(stripe_sdk, supabase_admin, sandbox_customer):
+    """Canceling at period end keeps the sub live with cancel_at set (the 'Canceling'
+    UI state)."""
+    sub = stripe_sdk.Subscription.create(
+        customer=sandbox_customer["customer_id"],
+        items=[{"price": _DEFAULT_PRICE}],
+        trial_period_days=30,
+    )
+    stripe_sdk.Subscription.modify(sub["id"], cancel_at_period_end=True)
+    status = _sync(stripe_sdk, supabase_admin, sandbox_customer)
+    assert status == "trialing"  # still live until the period ends
+    row = _billing_row(supabase_admin, sandbox_customer["company_id"])
+    assert row["cancel_at"] is not None
+
+
+def test_immediate_cancel_then_no_subscription(stripe_sdk, supabase_admin, sandbox_customer):
+    """Canceling immediately → the sub is canceled; a later sync with no live sub
+    still surfaces the canceled state (grace), then clearing when truly gone."""
+    sub = stripe_sdk.Subscription.create(
+        customer=sandbox_customer["customer_id"],
+        items=[{"price": _DEFAULT_PRICE}],
+        trial_period_days=30,
+    )
+    stripe_sdk.Subscription.cancel(sub["id"])
+    status = _sync(stripe_sdk, supabase_admin, sandbox_customer)
+    assert status == "canceled"
+    row = _billing_row(supabase_admin, sandbox_customer["company_id"])
+    assert row["subscription_status"] == "canceled"
+    assert row["ended_at"] is not None
+
+
+def test_sync_clears_cache_when_customer_has_no_subscription(
+    stripe_sdk, supabase_admin, sandbox_customer
+):
+    """A customer that never subscribed → the cache is cleared to no-subscription."""
+    status = _sync(stripe_sdk, supabase_admin, sandbox_customer)
+    assert status is None
+    row = _billing_row(supabase_admin, sandbox_customer["company_id"])
+    # Row may not exist, or exists with null status — either is "no subscription".
+    assert row is None or row["subscription_status"] is None

--- a/api/tests/integration/test_billing_stripe_lifecycle.py
+++ b/api/tests/integration/test_billing_stripe_lifecycle.py
@@ -17,9 +17,9 @@ NOT run in CI by default (CI can't hold your Stripe sandbox secrets). To run:
     cd api && conda run -n jigged python -m pytest \
         tests/integration/test_billing_stripe_lifecycle.py -m stripe_live -q
 
-STRIPE_SECRET_KEY / STRIPE_PRICE_ID / STRIPE_FOUNDING_PRICE_ID are read from the
-repo's .env.local. The suite skips if STRIPE_SECRET_KEY is not a TEST key. Every
-test creates and then deletes its own Stripe test Customer.
+STRIPE_RESTRICTED_KEY / STRIPE_PRICE_ID / STRIPE_FOUNDING_PRICE_ID are read from
+the repo's .env.local. The suite skips if STRIPE_RESTRICTED_KEY is not a TEST key.
+Every test creates and then deletes its own Stripe test Customer.
 """
 from __future__ import annotations
 
@@ -36,14 +36,14 @@ pytestmark = [pytest.mark.integration, pytest.mark.stripe_live]
 # Load the repo .env.local so STRIPE_* are available (as the backend does).
 load_dotenv(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".env.local"))
 
-_STRIPE_KEY = os.getenv("STRIPE_SECRET_KEY", "")
+_STRIPE_KEY = os.getenv("STRIPE_RESTRICTED_KEY", "")
 _DEFAULT_PRICE = os.getenv("STRIPE_PRICE_ID")
 _FOUNDER_PRICE = os.getenv("STRIPE_FOUNDING_PRICE_ID")
 
 # Guard: only run against a TEST-mode key, never live.
 if not _STRIPE_KEY.startswith(("sk_test", "rk_test")):
     pytest.skip(
-        "STRIPE_SECRET_KEY is not a test key — skipping live Stripe lifecycle tests.",
+        "STRIPE_RESTRICTED_KEY is not a test key — skipping live Stripe lifecycle tests.",
         allow_module_level=True,
     )
 if not _DEFAULT_PRICE or not _FOUNDER_PRICE:

--- a/api/tests/unit/test_stripe_routes.py
+++ b/api/tests/unit/test_stripe_routes.py
@@ -1,0 +1,361 @@
+"""Unit tests for the Stripe billing routes.
+
+Covers the version-drift field readers (scenario 12), the demo-reject guard
+(scenario 22), the /checkout/sync ownership check (scenario 9b), and the webhook
+signature-failure path (scenario 7). Stripe + Supabase are mocked; no network, no
+DB.
+"""
+import asyncio
+
+import pytest
+import stripe
+from stripe import StripeObject
+
+from fastapi import HTTPException
+
+import routes.stripe_routes as sr
+from models.stripe_models import CheckoutRequest, CheckoutSyncRequest, PortalRequest
+
+pytestmark = pytest.mark.unit
+
+
+def _stripe_obj(data: dict) -> StripeObject:
+    """A real StripeObject (which, unlike a dict, has NO .get() method) so tests
+    exercise the same accessor path as live Stripe responses."""
+    return StripeObject.construct_from(data, "sk_test")
+
+
+# ───────────────────────── accessor helper vs real StripeObject ─────────────────────────
+def test_g_works_on_stripe_object_and_dict():
+    # Regression guard: StripeObject has no .get(); _g must still read it.
+    obj = _stripe_obj({"status": "active", "cancel_at": None})
+    assert not hasattr(obj, "get")  # documents the SDK behavior that broke us
+    assert sr._g(obj, "status") == "active"
+    assert sr._g(obj, "cancel_at", "x") is None  # present but null
+    assert sr._g(obj, "missing", "default") == "default"
+    assert sr._g({"a": 1}, "a") == 1
+    assert sr._g(None, "a", "d") == "d"
+
+
+def test_accessor_helpers_on_stripe_object():
+    sub = _stripe_obj({
+        "id": "sub_1", "status": "trialing", "customer": "cus_1",
+        "metadata": {"company_id": "c-123"},
+        "items": {"data": [{"current_period_end": 111, "price": {"id": "price_x"}}]},
+    })
+    assert sr._sub_price_id(sub) == "price_x"
+    assert sr._sub_period_end(sub) == 111
+    assert sr._g(sr._g(sub, "metadata"), "company_id") == "c-123"
+
+
+# ───────────────────────── pure helpers ─────────────────────────
+def test_iso_from_unix_roundtrip_and_none():
+    assert sr._iso_from_unix(None) is None
+    assert sr._iso_from_unix(0) is None  # falsy → treated as absent
+    iso = sr._iso_from_unix(1_700_000_000)
+    assert iso is not None and iso.startswith("2023-11-14T")
+
+
+def test_sub_period_end_prefers_item_then_falls_back():
+    # newer API: current_period_end lives on the subscription item
+    sub_item = {"items": {"data": [{"current_period_end": 111}]}, "current_period_end": 999}
+    assert sr._sub_period_end(sub_item) == 111
+    # older API: only the subscription-level field
+    sub_legacy = {"items": {"data": [{}]}, "current_period_end": 999}
+    assert sr._sub_period_end(sub_legacy) == 999
+    # nothing → None
+    assert sr._sub_period_end({"items": {"data": []}}) is None
+
+
+def test_sub_price_id():
+    assert sr._sub_price_id({"items": {"data": [{"price": {"id": "price_x"}}]}}) == "price_x"
+    assert sr._sub_price_id({"items": {"data": []}}) is None
+    assert sr._sub_price_id({}) is None
+
+
+# ───────────────────────── fakes ─────────────────────────
+class _Result:
+    def __init__(self, data):
+        self.data = data
+
+
+class _Chain:
+    def __init__(self, data):
+        self._data = data
+
+    def select(self, *a, **k):
+        return self
+
+    def eq(self, *a, **k):
+        return self
+
+    def limit(self, *a, **k):
+        return self
+
+    def update(self, *a, **k):
+        return self
+
+    def upsert(self, *a, **k):
+        return self
+
+    def insert(self, *a, **k):
+        return self
+
+    def execute(self):
+        return _Result(self._data)
+
+
+class FakeClient:
+    def __init__(self, tables):
+        self._tables = tables
+
+    def table(self, name):
+        return _Chain(self._tables.get(name, []))
+
+    def rpc(self, name, params):
+        return _Chain([])
+
+
+class FakeRequest:
+    def __init__(self, body=b"", headers=None):
+        self._body = body
+        self.headers = headers or {}
+
+    async def body(self):
+        return self._body
+
+
+async def _noop_admin(request, company_id):
+    return "user-123"
+
+
+# ───────────────────────── checkout: demo reject ─────────────────────────
+def test_checkout_rejects_demo_company(monkeypatch):
+    monkeypatch.setattr(sr, "_verify_company_admin", _noop_admin)
+    monkeypatch.setattr(
+        sr,
+        "_service_client",
+        lambda: FakeClient({"companies": [{"id": "c1", "is_demo": True, "email": None}]}),
+    )
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(sr.create_checkout(CheckoutRequest(company_id="c1"), FakeRequest()))
+    assert exc.value.status_code == 400
+    assert "demo" in exc.value.detail.lower()
+
+
+def test_checkout_blocks_second_subscription_via_stripe(monkeypatch):
+    """Even if the local cache is stale (no status), an existing Stripe
+    subscription must block a second one (authoritative double-subscribe guard)."""
+    monkeypatch.setattr(sr, "_verify_company_admin", _noop_admin)
+    monkeypatch.setattr(
+        sr, "_service_client",
+        lambda: FakeClient({
+            "companies": [{"id": "c1", "is_demo": False, "email": None}],
+            "company_billing": [{"stripe_customer_id": "cus_x", "subscription_status": None}],
+        }),
+    )
+
+    class _FakeSubs:
+        @staticmethod
+        def list(customer=None, status=None, limit=None):
+            # cache says "no sub", but Stripe has a live one
+            return _stripe_obj({"data": [{"id": "sub_live", "status": "active"}]})
+
+    class _FakeStripe:
+        Subscription = _FakeSubs
+
+    monkeypatch.setattr(sr, "_stripe", lambda: _FakeStripe())
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(sr.create_checkout(CheckoutRequest(company_id="c1"), FakeRequest()))
+    assert exc.value.status_code == 409
+
+
+# ───────────────────────── portal: self-heal reconcile ─────────────────────────
+def _portal_client():
+    return FakeClient({
+        "companies": [{"id": "c1", "is_demo": False, "email": None}],
+        "company_billing": [{"stripe_customer_id": "cus_x", "subscription_status": "trialing"}],
+    })
+
+
+def test_portal_no_live_subscription_clears_and_409(monkeypatch):
+    """Stale cache says trialing but Stripe has no live sub → clear + 409."""
+    monkeypatch.setattr(sr, "_verify_company_admin", _noop_admin)
+    monkeypatch.setattr(sr, "_service_client", _portal_client)
+
+    class _FakeSubs:
+        @staticmethod
+        def list(customer=None, status=None, limit=None):
+            return _stripe_obj({"data": [{"id": "sub_dead", "status": "canceled"}]})
+
+    class _FakeStripe:
+        Subscription = _FakeSubs
+
+    monkeypatch.setattr(sr, "_stripe", lambda: _FakeStripe())
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(sr.create_portal(PortalRequest(company_id="c1"), FakeRequest()))
+    assert exc.value.status_code == 409
+    assert "subscribe" in exc.value.detail.lower()
+
+
+def test_portal_with_live_subscription_opens(monkeypatch):
+    monkeypatch.setattr(sr, "_verify_company_admin", _noop_admin)
+    monkeypatch.setattr(sr, "_service_client", _portal_client)
+    monkeypatch.setattr(sr, "_apply_subscription", lambda *a, **k: None)
+
+    class _FakeSubs:
+        @staticmethod
+        def list(customer=None, status=None, limit=None):
+            return _stripe_obj({"data": [{"id": "sub_live", "status": "active"}]})
+
+    class _FakePortal:
+        @staticmethod
+        def create(customer=None, return_url=None):
+            return _stripe_obj({"url": "https://billing.stripe.com/session/xyz"})
+
+    class _FakeStripe:
+        Subscription = _FakeSubs
+        billing_portal = type("_B", (), {"Session": _FakePortal})
+
+    monkeypatch.setattr(sr, "_stripe", lambda: _FakeStripe())
+
+    resp = asyncio.run(sr.create_portal(PortalRequest(company_id="c1"), FakeRequest()))
+    assert resp.url.startswith("https://billing.stripe.com/")
+
+
+# ───────────────────────── checkout/sync: ownership check ─────────────────────────
+def test_checkout_sync_rejects_cross_company_session(monkeypatch):
+    monkeypatch.setattr(sr, "_verify_company_admin", _noop_admin)
+    # company_billing lookup (customer→company) returns nothing.
+    monkeypatch.setattr(sr, "_service_client", lambda: FakeClient({"company_billing": []}))
+
+    class _FakeSessions:
+        @staticmethod
+        def retrieve(session_id, expand=None):
+            # A real StripeObject (no .get()) belonging to a DIFFERENT company.
+            return _stripe_obj({
+                "client_reference_id": "other-company",
+                "customer": "cus_x",
+                "subscription": "sub_x",
+            })
+
+    class _FakeStripe:
+        checkout = type("_C", (), {"Session": _FakeSessions})
+
+    monkeypatch.setattr(sr, "_stripe", lambda: _FakeStripe())
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            sr.checkout_sync(
+                CheckoutSyncRequest(company_id="c1", session_id="cs_test_1"),
+                FakeRequest(),
+            )
+        )
+    assert exc.value.status_code == 403
+
+
+def test_checkout_sync_syncs_owned_session(monkeypatch):
+    """Positive path: a session that belongs to the caller syncs that customer."""
+    monkeypatch.setattr(sr, "_verify_company_admin", _noop_admin)
+    monkeypatch.setattr(sr, "_service_client", lambda: FakeClient({}))
+
+    synced = {}
+    monkeypatch.setattr(
+        sr, "_sync_customer",
+        lambda s, client, company_id, customer_id: (
+            synced.update({"company_id": company_id, "customer_id": customer_id}) or "trialing"
+        ),
+    )
+
+    class _FakeSessions:
+        @staticmethod
+        def retrieve(session_id, **kwargs):
+            return _stripe_obj({"client_reference_id": "c1", "customer": "cus_x"})
+
+    class _FakeStripe:
+        checkout = type("_C", (), {"Session": _FakeSessions})
+
+    monkeypatch.setattr(sr, "_stripe", lambda: _FakeStripe())
+
+    resp = asyncio.run(
+        sr.checkout_sync(CheckoutSyncRequest(company_id="c1", session_id="cs_1"), FakeRequest())
+    )
+    assert resp.status == "trialing"
+    assert synced == {"company_id": "c1", "customer_id": "cus_x"}
+
+
+# ───────────────────────── _sync_customer: single source-of-truth ─────────────────────────
+def test_sync_customer_applies_canceled_not_clears(monkeypatch):
+    """A canceled sub is cached as 'canceled' (keeps its grace window), NOT wiped."""
+    applied, cleared = {}, {"called": False}
+    monkeypatch.setattr(sr, "_apply_subscription",
+                        lambda c, cid, sub, at: applied.update({"status": sr._g(sub, "status")}))
+    monkeypatch.setattr(sr, "_clear_subscription_cache",
+                        lambda c, cid: cleared.update({"called": True}))
+
+    class _FakeSubs:
+        @staticmethod
+        def list(customer=None, status=None, limit=None):
+            return _stripe_obj({"data": [{"id": "s1", "status": "canceled"}]})
+
+    s = type("_S", (), {"Subscription": _FakeSubs})()
+    out = sr._sync_customer(s, FakeClient({}), "c1", "cus_x")
+    assert out == "canceled"
+    assert applied == {"status": "canceled"}
+    assert cleared["called"] is False
+
+
+def test_sync_customer_clears_when_no_subscriptions(monkeypatch):
+    cleared = {"called": False}
+    monkeypatch.setattr(sr, "_clear_subscription_cache",
+                        lambda c, cid: cleared.update({"called": True}))
+
+    class _FakeSubs:
+        @staticmethod
+        def list(customer=None, status=None, limit=None):
+            return _stripe_obj({"data": []})
+
+    s = type("_S", (), {"Subscription": _FakeSubs})()
+    out = sr._sync_customer(s, FakeClient({}), "c1", "cus_x")
+    assert out is None
+    assert cleared["called"] is True
+
+
+def test_webhook_event_syncs_resolved_customer(monkeypatch):
+    """A subscription event resolves the company from the cache and re-syncs."""
+    monkeypatch.setattr(
+        sr, "_service_client",
+        lambda: FakeClient({"company_billing": [{"company_id": "c1", "stripe_customer_id": "cus_x"}]}),
+    )
+    synced = {}
+    monkeypatch.setattr(
+        sr, "_sync_customer",
+        lambda s, client, company_id, customer_id: synced.update(
+            {"company_id": company_id, "customer_id": customer_id}
+        ),
+    )
+    event = _stripe_obj({
+        "type": "customer.subscription.updated",
+        "data": {"object": {"id": "sub_x", "customer": "cus_x", "status": "active"}},
+    })
+    sr._handle_event(object(), event)
+    assert synced == {"company_id": "c1", "customer_id": "cus_x"}
+
+
+# ───────────────────────── webhook: signature failure ─────────────────────────
+def test_webhook_rejects_bad_signature(monkeypatch):
+    def _construct_event(payload, sig, secret):
+        raise stripe.error.SignatureVerificationError("bad sig", sig)
+
+    class _FakeStripe:
+        Webhook = type("_W", (), {"construct_event": staticmethod(_construct_event)})
+
+    monkeypatch.setattr(sr, "_stripe", lambda: _FakeStripe())
+    monkeypatch.setattr(sr, "_webhook_secret", lambda: "whsec_test")
+
+    req = FakeRequest(body=b"{}", headers={"Stripe-Signature": "t=1,v1=deadbeef"})
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(sr.webhook(req))
+    assert exc.value.status_code == 400

--- a/app/dashboard/[companyId]/jobs/page.tsx
+++ b/app/dashboard/[companyId]/jobs/page.tsx
@@ -27,6 +27,7 @@ import ListItemText from '@mui/material/ListItemText';
 import OutlinedInput from '@mui/material/OutlinedInput';
 import Divider from '@mui/material/Divider';
 import Chip from '@mui/material/Chip';
+import StatusChip from '@/components/common/StatusChip';
 import SearchIcon from '@mui/icons-material/Search';
 import CancelIcon from '@mui/icons-material/Cancel';
 import WorkIcon from '@mui/icons-material/Work';
@@ -492,7 +493,7 @@ export default function JobsPage() {
         const atVendor = atVendorJobIds.has(params.data.id);
         return (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
-            <Chip label={cfg.label} color={cfg.color} size="small" />
+            <StatusChip label={cfg.label} color={cfg.color} />
             {atVendor && (
               <Tooltip title="Parts are out at an outside vendor">
                 <Chip

--- a/app/dashboard/[companyId]/layout.tsx
+++ b/app/dashboard/[companyId]/layout.tsx
@@ -10,6 +10,8 @@ import { PageTitleProvider } from '@/components/layout/PageTitleProvider';
 import { AuthGuard } from '@/components/auth';
 import DemoModeProvider from '@/components/providers/DemoModeProvider';
 import DemoModeBanner from '@/components/demo/DemoModeBanner';
+import SubscriptionProvider from '@/components/providers/SubscriptionProvider';
+import BillingBanner from '@/components/billing/BillingBanner';
 import { useMobileDrawer } from '@/hooks/useMobileDrawer';
 import FeedbackFab, { useFeedbackDialog } from '@/components/feedback/FeedbackFab';
 
@@ -31,6 +33,7 @@ export default function DashboardLayout({
   return (
     <AuthGuard companyId={companyId} requireCompany>
       <DemoModeProvider>
+        <SubscriptionProvider>
         <PageTitleProvider>
         <Box sx={{ position: 'relative', minHeight: '100vh' }}>
           {/* Ambient shop-floor backdrop — sits behind the workspace, above the theme base */}
@@ -40,6 +43,7 @@ export default function DashboardLayout({
             <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', ml: { xs: 0, md: '240px' }, minWidth: 0 }}>
               <Header isMobile={isMobile} onMenuClick={openDrawer} />
               <DemoModeBanner />
+              <BillingBanner />
               <Box component="main" sx={{ flex: 1, p: { xs: 2, md: 3 }, overflow: 'auto' }}>
                 {children}
               </Box>
@@ -55,6 +59,7 @@ export default function DashboardLayout({
           onSnackbarClose={feedback.closeSnackbar}
         />
         </PageTitleProvider>
+        </SubscriptionProvider>
       </DemoModeProvider>
     </AuthGuard>
   );

--- a/app/dashboard/[companyId]/settings/page.tsx
+++ b/app/dashboard/[companyId]/settings/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState } from 'react';
-import { useParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
 import Box from '@mui/material/Box';
-import Chip from '@mui/material/Chip';
+import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -12,15 +12,21 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogActions from '@mui/material/DialogActions';
 import CircularProgress from '@mui/material/CircularProgress';
 import { useDemoMode } from '@/components/providers/DemoModeProvider';
+import { useSubscription } from '@/components/providers/SubscriptionProvider';
+import { syncCheckout } from '@/lib/billingApi';
 import AdminGuard from '@/components/auth/AdminGuard';
+import StatusChip from '@/components/common/StatusChip';
 import SettingsSection from '@/components/settings/SettingsSection';
 import CompanyProfileCard from '@/components/settings/CompanyProfileCard';
 import AppDefaultsCard from '@/components/settings/AppDefaultsCard';
 import QuickBooksIntegrationCard from '@/components/settings/QuickBooksIntegrationCard';
+import BillingCard from '@/components/settings/BillingCard';
 
 export default function SettingsPage() {
   const params = useParams();
+  const router = useRouter();
   const companyId = params.companyId as string;
+  const { refresh } = useSubscription();
   const {
     isDemoMode,
     hasDemoCompany,
@@ -32,20 +38,55 @@ export default function SettingsPage() {
     isLoading,
   } = useDemoMode();
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
+  const [justSubscribed, setJustSubscribed] = useState(false);
 
   const handleReset = async () => {
     setResetDialogOpen(false);
     await resetDemo();
   };
 
+  // Checkout success lands here with ?session_id=… (before the webhook may have
+  // arrived). Reconcile the billing cache immediately from the live session, then
+  // refresh entitlement and drop the query param so a reload doesn't re-sync.
+  useEffect(() => {
+    const sessionId = new URLSearchParams(window.location.search).get('session_id');
+    if (!sessionId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        await syncCheckout(companyId, sessionId);
+        if (!cancelled) {
+          setJustSubscribed(true);
+          await refresh();
+          router.replace(`/dashboard/${companyId}/settings`);
+        }
+      } catch {
+        // Non-fatal: the webhook will reconcile the cache shortly regardless.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [companyId]);
+
   return (
     <AdminGuard message="You don't have permission to access settings.">
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      {justSubscribed && (
+        <Alert severity="success" onClose={() => setJustSubscribed(false)}>
+          You&apos;re all set — welcome aboard! Your subscription is active.
+        </Alert>
+      )}
+
       {/* Shop contact info (header on printed quotes) */}
       <CompanyProfileCard companyId={companyId} />
 
       {/* Company-configurable business defaults (quote validity, etc.) */}
       <AppDefaultsCard companyId={companyId} />
+
+      {/* Subscription status + Subscribe / Manage billing (hidden in demo mode) */}
+      <BillingCard />
 
       {/* QuickBooks Online connection + invoice push settings */}
       <QuickBooksIntegrationCard companyId={companyId} />
@@ -56,11 +97,9 @@ export default function SettingsPage() {
         variant="advanced"
         statusChip={
           !isLoading ? (
-            <Chip
+            <StatusChip
               label={isDemoMode ? 'Active' : hasDemoCompany ? 'Available' : 'Not set up'}
-              size="small"
               color={isDemoMode ? 'warning' : 'default'}
-              variant={isDemoMode ? 'filled' : 'outlined'}
             />
           ) : undefined
         }

--- a/app/dashboard/[companyId]/team/page.tsx
+++ b/app/dashboard/[companyId]/team/page.tsx
@@ -19,7 +19,7 @@ import Snackbar from '@mui/material/Snackbar';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import SearchIcon from '@mui/icons-material/Search';
-import Chip from '@mui/material/Chip';
+import StatusChip from '@/components/common/StatusChip';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
@@ -587,9 +587,9 @@ export default function TeamPage() {
   // Status cell renderer
   const StatusCellRenderer = useCallback((params: { value: string }) => {
     if (params.value === 'pending') {
-      return <Chip label="Pending" color="warning" size="small" variant="outlined" />;
+      return <StatusChip label="Pending" color="warning" />;
     }
-    return <Chip label="Active" color="success" size="small" variant="outlined" />;
+    return <StatusChip label="Active" color="success" />;
   }, []);
 
   // Actions cell renderer for pending invitation rows

--- a/components/billing/BillingBanner.tsx
+++ b/components/billing/BillingBanner.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Snackbar from '@mui/material/Snackbar';
+import { useParams } from 'next/navigation';
+import { useSubscription } from '@/components/providers/SubscriptionProvider';
+import { startCheckout, openBillingPortal } from '@/lib/billingApi';
+
+/**
+ * Persistent, app-wide billing banner rendered below the header (sibling of the
+ * demo banner). Shows for `past_due`, `read_only`, and `must_subscribe`; renders
+ * nothing for `full` and demo companies. This is the always-visible signal; the
+ * DB is the actual write gate.
+ */
+export default function BillingBanner() {
+  const params = useParams();
+  const companyId = params.companyId as string;
+  const { entitlement, isPastDue, isReadOnly, mustSubscribe, hasCustomer, refresh } =
+    useSubscription();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isPastDue && !isReadOnly && !mustSubscribe) return null;
+
+  // Past-due / lapsed-with-a-customer manage billing in the Portal; a
+  // never-subscribed (or customer-less) company starts a new Checkout.
+  const useCheckout = mustSubscribe || !hasCustomer;
+
+  const config = {
+    past_due: {
+      severity: 'warning' as const,
+      message:
+        "Your last payment didn't go through. Update your payment method to keep your shop running.",
+    },
+    read_only: {
+      severity: 'error' as const,
+      message:
+        'Your subscription has ended — your account is read-only. Resubscribe to make changes again.',
+    },
+    must_subscribe: {
+      severity: 'info' as const,
+      message: 'Start your subscription to unlock Jigged for your shop.',
+    },
+    full: { severity: 'info' as const, message: '' },
+  }[entitlement];
+
+  const actionLabel = useCheckout ? 'Subscribe' : 'Manage billing';
+
+  const handleAction = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const url = useCheckout
+        ? await startCheckout(companyId)
+        : await openBillingPortal(companyId);
+      window.location.href = url;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong. Please try again.');
+      setBusy(false);
+      // A stale-cache "Manage billing" attempt may have reconciled the cache
+      // server-side — refresh so the banner/button corrects.
+      void refresh();
+    }
+  };
+
+  return (
+    <>
+      <Alert
+        severity={config.severity}
+        sx={{
+          borderRadius: 0,
+          py: 0.5,
+          '& .MuiAlert-message': {
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+            gap: 2,
+          },
+        }}
+      >
+        {config.message}
+        <Button
+          size="small"
+          variant="contained"
+          color="inherit"
+          onClick={handleAction}
+          disabled={busy}
+          startIcon={busy ? <CircularProgress size={16} color="inherit" /> : undefined}
+          sx={{ flexShrink: 0 }}
+        >
+          {busy ? 'Redirecting…' : actionLabel}
+        </Button>
+      </Alert>
+
+      <Snackbar
+        open={Boolean(error)}
+        autoHideDuration={6000}
+        onClose={() => setError(null)}
+      >
+        <Alert severity="error" onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}

--- a/components/common/StatusChip.tsx
+++ b/components/common/StatusChip.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { forwardRef } from 'react';
+import Chip, { type ChipProps } from '@mui/material/Chip';
+
+export type StatusChipColor = NonNullable<ChipProps['color']>;
+
+export interface StatusChipProps extends Omit<ChipProps, 'variant' | 'color'> {
+  /** Semantic status color. `default` (the neutral fallback) renders outlined. */
+  color?: StatusChipColor;
+}
+
+/**
+ * The standard status / state indicator chip. ONE variant rule, enforced here so
+ * it can't drift across the app:
+ *
+ *   - a SEMANTIC color (info / success / warning / error / primary / secondary)
+ *     renders FILLED — it draws the eye (Active, Connected, Trial, Overdue…);
+ *   - the neutral `default` color renders OUTLINED — de-emphasized for "off"
+ *     states (No subscription, Not connected, Not set up).
+ *
+ * Always `size="small"` by default. Use this for any on/off/lifecycle status
+ * badge instead of a raw <Chip variant=…>. Forwards a ref so it works inside
+ * Tooltip and other ref-requiring wrappers. See docs/design-system.md →
+ * "Status Badges".
+ */
+const StatusChip = forwardRef<HTMLDivElement, StatusChipProps>(function StatusChip(
+  { color = 'default', size = 'small', ...rest },
+  ref,
+) {
+  return (
+    <Chip
+      ref={ref}
+      color={color}
+      size={size}
+      variant={color === 'default' ? 'outlined' : 'filled'}
+      {...rest}
+    />
+  );
+});
+
+export default StatusChip;

--- a/components/jobs/JobOverdueBadge.tsx
+++ b/components/jobs/JobOverdueBadge.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import Chip from '@mui/material/Chip';
 import Tooltip from '@mui/material/Tooltip';
 import ScheduleIcon from '@mui/icons-material/Schedule';
+import StatusChip from '@/components/common/StatusChip';
 import { isJobOverdue } from '@/types/job';
 import type { Job } from '@/types/job';
 
@@ -18,7 +18,7 @@ export default function JobOverdueBadge({ job, size = 'small' }: JobOverdueBadge
 
   return (
     <Tooltip title={`Was due ${dueDate}`}>
-      <Chip
+      <StatusChip
         icon={<ScheduleIcon sx={{ fontSize: size === 'medium' ? 18 : 14 }} />}
         label="Overdue"
         size={size}

--- a/components/jobs/JobStatusChip.tsx
+++ b/components/jobs/JobStatusChip.tsx
@@ -1,4 +1,4 @@
-import Chip from '@mui/material/Chip';
+import StatusChip from '@/components/common/StatusChip';
 import type { ProductionStatus, FulfillmentStatus } from '@/types/job';
 import { PRODUCTION_STATUS_CONFIG, FULFILLMENT_STATUS_CONFIG } from '@/types/job';
 
@@ -19,13 +19,7 @@ export function ProductionStatusChip({
     color: 'default' as const,
   };
   return (
-    <Chip
-      label={config.label}
-      color={config.color}
-      size={size}
-      variant="filled"
-      sx={{ fontWeight: 500 }}
-    />
+    <StatusChip label={config.label} color={config.color} size={size} sx={{ fontWeight: 500 }} />
   );
 }
 
@@ -46,13 +40,7 @@ export function FulfillmentStatusChip({
     color: 'default' as const,
   };
   return (
-    <Chip
-      label={config.label}
-      color={config.color}
-      size={size}
-      variant="outlined"
-      sx={{ fontWeight: 500 }}
-    />
+    <StatusChip label={config.label} color={config.color} size={size} sx={{ fontWeight: 500 }} />
   );
 }
 

--- a/components/jobs/OperationStatusChip.tsx
+++ b/components/jobs/OperationStatusChip.tsx
@@ -1,4 +1,4 @@
-import Chip from '@mui/material/Chip';
+import StatusChip from '@/components/common/StatusChip';
 import type { OperationStatus } from '@/types/job';
 import { OPERATION_STATUS_CONFIG } from '@/types/job';
 
@@ -11,12 +11,6 @@ export default function OperationStatusChip({ status, size = 'small' }: Operatio
   const config = OPERATION_STATUS_CONFIG[status] || { label: status, color: 'default' as const };
 
   return (
-    <Chip
-      label={config.label}
-      color={config.color}
-      size={size}
-      variant="filled"
-      sx={{ fontWeight: 500 }}
-    />
+    <StatusChip label={config.label} color={config.color} size={size} sx={{ fontWeight: 500 }} />
   );
 }

--- a/components/layout/AlertBadge.tsx
+++ b/components/layout/AlertBadge.tsx
@@ -6,6 +6,7 @@ import { useLoad } from '@/hooks/useLoad';
 import Badge from '@mui/material/Badge';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
+import StatusChip from '@/components/common/StatusChip';
 import Collapse from '@mui/material/Collapse';
 import IconButton from '@mui/material/IconButton';
 import List from '@mui/material/List';
@@ -148,9 +149,8 @@ export default function AlertBadge({ companyId }: AlertBadgeProps) {
                               <Typography variant="body2" sx={{ fontWeight: 600 }}>
                                 {job.job_number}
                               </Typography>
-                              <Chip
+                              <StatusChip
                                 label={job.severity}
-                                size="small"
                                 color={severityColor(job.severity)}
                                 sx={{ height: 18, fontSize: '0.7rem' }}
                               />
@@ -206,9 +206,8 @@ export default function AlertBadge({ companyId }: AlertBadgeProps) {
                               <Typography variant="body2" sx={{ fontWeight: 600 }}>
                                 {alert.item_name}
                               </Typography>
-                              <Chip
+                              <StatusChip
                                 label={alert.severity}
-                                size="small"
                                 color={severityColor(alert.severity)}
                                 sx={{ height: 18, fontSize: '0.7rem' }}
                               />

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
-import Chip from '@mui/material/Chip';
+import StatusChip from '@/components/common/StatusChip';
 import LogoutIcon from '@mui/icons-material/Logout';
 import MenuIcon from '@mui/icons-material/Menu';
 import { useAuth } from '@/components/providers/AuthProvider';
@@ -198,9 +198,8 @@ export default function Header({ isMobile = false, onMenuClick }: HeaderProps) {
           {pageTitle}
         </Typography>
         {isDemoMode && (
-          <Chip
+          <StatusChip
             label="DEMO"
-            size="small"
             color="warning"
             sx={{ fontWeight: 600, letterSpacing: 0.5 }}
           />

--- a/components/parts/workspace/tabs/HistoryTab.tsx
+++ b/components/parts/workspace/tabs/HistoryTab.tsx
@@ -10,6 +10,7 @@ import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Alert from '@mui/material/Alert';
 import Chip from '@mui/material/Chip';
+import StatusChip from '@/components/common/StatusChip';
 import CircularProgress from '@mui/material/CircularProgress';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -306,7 +307,7 @@ function FeedPrimary({ ev }: { ev: PartActivityEvent }) {
         <Typography variant="body2">
           {TXN_VERB[ev.txn.type] ?? ev.txn.type} {ev.txn.quantity} {ev.txn.unit}
         </Typography>
-        {ev.txn.has_discrepancy && <Chip size="small" color="warning" label="Discrepancy" />}
+        {ev.txn.has_discrepancy && <StatusChip color="warning" label="Discrepancy" />}
       </Box>
     );
   }

--- a/components/providers/SubscriptionProvider.tsx
+++ b/components/providers/SubscriptionProvider.tsx
@@ -58,7 +58,9 @@ export default function SubscriptionProvider({ children }: { children: ReactNode
 
   const fetchBilling = useCallback(async () => {
     if (!companyId) return;
-    setIsLoading(true);
+    // Note: no synchronous setIsLoading(true) here. `isLoading` starts true, so
+    // the first load shows the spinner; all state writes below happen after the
+    // await (async), which keeps the calling effect free of synchronous setState.
     try {
       const row = await getCompanyBilling(companyId);
       setBilling(row);
@@ -75,29 +77,36 @@ export default function SubscriptionProvider({ children }: { children: ReactNode
 
   useEffect(() => {
     if (demoLoading) return; // wait until we know whether this is a demo company
-    if (isDemoMode) {
-      // Demo companies are never billing-gated — skip the fetch entirely.
-      setBilling(null);
-      setIsLoading(false);
-      return;
+    if (isDemoMode) return; // demo companies are never billing-gated — skip the fetch
+    // Inline async wrapper (mirrors DemoModeProvider) so the effect body doesn't
+    // directly invoke a setState-bearing callback — react-hooks/set-state-in-effect.
+    async function load() {
+      await fetchBilling();
     }
-    fetchBilling();
+    load();
   }, [companyId, isDemoMode, demoLoading, fetchBilling]);
 
-  const entitlement = getEntitlement(isDemoMode, billing);
+  // Demo companies never fetch billing; treat their cache as empty and resolved.
+  // Deriving these (rather than setting state inside the effect) keeps the effect
+  // free of synchronous setState and gives the same result — getEntitlement
+  // short-circuits is_demo → full regardless of the row.
+  const effectiveBilling = isDemoMode ? null : billing;
+  const loading = demoLoading || (!isDemoMode && isLoading);
+
+  const entitlement = getEntitlement(isDemoMode, effectiveBilling);
 
   return (
     <SubscriptionContext.Provider
       value={{
         entitlement,
-        billing,
+        billing: effectiveBilling,
         isDemo: isDemoMode,
         isPastDue: entitlement === 'past_due',
         isReadOnly: entitlement === 'read_only',
         mustSubscribe: entitlement === 'must_subscribe',
         canWrite: isWriteAllowed(entitlement),
-        hasCustomer: Boolean(billing?.stripe_customer_id),
-        isLoading: isLoading || demoLoading,
+        hasCustomer: Boolean(effectiveBilling?.stripe_customer_id),
+        isLoading: loading,
         refresh: fetchBilling,
       }}
     >

--- a/components/providers/SubscriptionProvider.tsx
+++ b/components/providers/SubscriptionProvider.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+  type ReactNode,
+} from 'react';
+import { useParams } from 'next/navigation';
+import * as Sentry from '@sentry/nextjs';
+import { useDemoMode } from '@/components/providers/DemoModeProvider';
+import { getCompanyBilling, type CompanyBilling } from '@/utils/companyAccess';
+import {
+  getEntitlement,
+  isWriteAllowed,
+  type Entitlement,
+} from '@/lib/entitlement';
+
+/**
+ * Reads the company's billing cache (via RLS — zero Stripe calls) and derives
+ * entitlement. Demo companies short-circuit to `full` and never render billing
+ * UI (D11). This is the UI twin of the DB `company_can_write()` gate; it drives
+ * banners, not enforcement — the DB blocks writes regardless.
+ */
+interface SubscriptionContextType {
+  entitlement: Entitlement;
+  billing: CompanyBilling | null;
+  isDemo: boolean;
+  isPastDue: boolean;
+  isReadOnly: boolean;
+  mustSubscribe: boolean;
+  canWrite: boolean;
+  /** Whether a Stripe customer exists (→ "Manage billing" vs "Subscribe"). */
+  hasCustomer: boolean;
+  isLoading: boolean;
+  refresh: () => Promise<void>;
+}
+
+const SubscriptionContext = createContext<SubscriptionContextType | null>(null);
+
+export function useSubscription(): SubscriptionContextType {
+  const context = useContext(SubscriptionContext);
+  if (!context) {
+    throw new Error('useSubscription must be used within a SubscriptionProvider');
+  }
+  return context;
+}
+
+export default function SubscriptionProvider({ children }: { children: ReactNode }) {
+  const params = useParams();
+  const companyId = params.companyId as string;
+  const { isDemoMode, isLoading: demoLoading } = useDemoMode();
+
+  const [billing, setBilling] = useState<CompanyBilling | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchBilling = useCallback(async () => {
+    if (!companyId) return;
+    setIsLoading(true);
+    try {
+      const row = await getCompanyBilling(companyId);
+      setBilling(row);
+    } catch (err) {
+      // Billing path: surface loudly, never silently default to full. Leaving
+      // billing null resolves to `must_subscribe` (a banner, not a block), and the
+      // DB still enforces writes regardless of this UI read.
+      Sentry.captureException(err);
+      setBilling(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [companyId]);
+
+  useEffect(() => {
+    if (demoLoading) return; // wait until we know whether this is a demo company
+    if (isDemoMode) {
+      // Demo companies are never billing-gated — skip the fetch entirely.
+      setBilling(null);
+      setIsLoading(false);
+      return;
+    }
+    fetchBilling();
+  }, [companyId, isDemoMode, demoLoading, fetchBilling]);
+
+  const entitlement = getEntitlement(isDemoMode, billing);
+
+  return (
+    <SubscriptionContext.Provider
+      value={{
+        entitlement,
+        billing,
+        isDemo: isDemoMode,
+        isPastDue: entitlement === 'past_due',
+        isReadOnly: entitlement === 'read_only',
+        mustSubscribe: entitlement === 'must_subscribe',
+        canWrite: isWriteAllowed(entitlement),
+        hasCustomer: Boolean(billing?.stripe_customer_id),
+        isLoading: isLoading || demoLoading,
+        refresh: fetchBilling,
+      }}
+    >
+      {children}
+    </SubscriptionContext.Provider>
+  );
+}

--- a/components/quotes/QuoteStatusChip.tsx
+++ b/components/quotes/QuoteStatusChip.tsx
@@ -1,4 +1,4 @@
-import Chip from '@mui/material/Chip';
+import StatusChip from '@/components/common/StatusChip';
 import type { QuoteStatus } from '@/types/quote';
 import { QUOTE_STATUS_CONFIG } from '@/types/quote';
 
@@ -11,12 +11,6 @@ export default function QuoteStatusChip({ status, size = 'small' }: QuoteStatusC
   const config = QUOTE_STATUS_CONFIG[status] || { label: status, color: 'default' as const };
 
   return (
-    <Chip
-      label={config.label}
-      color={config.color}
-      size={size}
-      variant="filled"
-      sx={{ fontWeight: 500 }}
-    />
+    <StatusChip label={config.label} color={config.color} size={size} sx={{ fontWeight: 500 }} />
   );
 }

--- a/components/settings/BillingCard.tsx
+++ b/components/settings/BillingCard.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import SettingsSection from '@/components/settings/SettingsSection';
+import StatusChip from '@/components/common/StatusChip';
+import { useSubscription } from '@/components/providers/SubscriptionProvider';
+import { GRACE_DAYS } from '@/lib/entitlement';
+import { startCheckout, openBillingPortal, reconcileBilling } from '@/lib/billingApi';
+
+type ChipColor = 'success' | 'warning' | 'error' | 'default' | 'info';
+
+// Statuses that represent a live subscription you'd manage in the Portal (vs.
+// starting a new one via Checkout).
+const MANAGEABLE = ['trialing', 'active', 'past_due', 'paused'];
+
+/**
+ * When access ends for a canceled/unpaid subscription: the grace anchor
+ * (ended_at ?? cancel_at ?? current_period_end) + GRACE_DAYS. Mirrors the grace
+ * math in lib/entitlement so the displayed date matches when read-only kicks in.
+ */
+function graceEndMs(
+  billing: { current_period_end: string | null; cancel_at: string | null; ended_at: string | null } | null,
+): number | null {
+  if (!billing) return null;
+  const anchor = billing.ended_at ?? billing.cancel_at ?? billing.current_period_end;
+  if (!anchor) return null;
+  const ms = new Date(anchor).getTime();
+  if (Number.isNaN(ms)) return null;
+  return ms + GRACE_DAYS * 24 * 60 * 60 * 1000;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+/**
+ * The card shows the true SUBSCRIPTION STATUS — independent of entitlement.
+ * Grandfathered (billing_exempt) and demo companies have full *access* but no
+ * active *subscription*, so they honestly read "No subscription" rather than
+ * masking it as "full access". Entitlement (banners / write-gating) is handled
+ * separately by BillingBanner + the DB.
+ */
+export default function BillingCard() {
+  const params = useParams();
+  const companyId = params.companyId as string;
+  const { billing, isDemo, isLoading, refresh } = useSubscription();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const reconciledFor = useRef<string | null>(null);
+
+  // Reconcile from Stripe once when the billing card is viewed, so the status is
+  // accurate even if a webhook was missed. This is a single Stripe read on a
+  // deliberate settings visit — NOT a poll, and not on every page load. Skipped
+  // server-side for demo / never-subscribed companies.
+  useEffect(() => {
+    if (!companyId || isDemo) return;
+    if (reconciledFor.current === companyId) return;
+    reconciledFor.current = companyId;
+    reconcileBilling(companyId)
+      .then(() => refresh())
+      .catch(() => {
+        /* non-fatal — the cache stays as-is and the webhook will catch up */
+      });
+  }, [companyId, isDemo, refresh]);
+
+  const status = billing?.subscription_status ?? null;
+  const graceEnd = graceEndMs(billing);
+  const withinGrace = graceEnd !== null && graceEnd >= Date.now();
+  const readOnly = (status === 'canceled' || status === 'unpaid') && !withinGrace;
+  // A still-live subscription (trial/active/past_due) that's set to cancel at
+  // period end: Stripe keeps it live with cancel_at set. Surface the pending
+  // cancellation instead of "renews"/"billing begins".
+  const cancelAt = billing?.cancel_at ?? null;
+  const canceling = Boolean(cancelAt) && MANAGEABLE.includes(status ?? '');
+
+  const chip: { label: string; color: ChipColor } = (() => {
+    if (canceling) return { label: 'Canceling', color: 'warning' };
+    switch (status) {
+      case 'trialing':
+        return { label: 'Trial', color: 'info' };
+      case 'active':
+        return { label: 'Active', color: 'success' };
+      case 'past_due':
+        return { label: 'Payment failed', color: 'warning' };
+      case 'canceled':
+      case 'unpaid':
+        return readOnly ? { label: 'Ended', color: 'error' } : { label: 'Ending', color: 'warning' };
+      case 'paused':
+        return { label: 'Paused', color: 'warning' };
+      default:
+        return { label: 'No subscription', color: 'default' };
+    }
+  })();
+
+  const detail: string = (() => {
+    if (canceling) {
+      const when = formatDate(cancelAt);
+      return status === 'trialing'
+        ? `Set to cancel${when ? ` ${when}` : ''} — your trial ends and you won't be charged.`
+        : `Set to cancel${when ? ` ${when}` : ''} — you keep access until then, then it won't renew.`;
+    }
+    switch (status) {
+      case 'trialing':
+        return billing?.trial_end
+          ? `Free trial — billing begins ${formatDate(billing.trial_end)}.`
+          : 'You are on a free trial.';
+      case 'active':
+        return billing?.current_period_end
+          ? `Active — renews ${formatDate(billing.current_period_end)}.`
+          : 'Your subscription is active.';
+      case 'past_due':
+        return 'Your last payment failed. Update your payment method to avoid interruption.';
+      case 'canceled':
+      case 'unpaid':
+        if (readOnly) return 'Your subscription has ended — read-only until you resubscribe.';
+        return graceEnd
+          ? `Access ends ${formatDate(new Date(graceEnd).toISOString())} — resubscribe to keep it.`
+          : 'Your subscription is ending — resubscribe to keep full access.';
+      case 'paused':
+        return 'Your subscription is paused.';
+      default:
+        // No active subscription.
+        if (isDemo) return 'This is a demo sandbox — billing applies to your real company, not the demo.';
+        return "You don't have an active subscription yet.";
+    }
+  })();
+
+  const useCheckout = !MANAGEABLE.includes(status ?? '');
+  const actionLabel = useCheckout ? 'Subscribe' : 'Manage billing';
+
+  const handleAction = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const url = useCheckout
+        ? await startCheckout(companyId)
+        : await openBillingPortal(companyId);
+      window.location.href = url;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong. Please try again.');
+      setBusy(false);
+      // A stale-cache "Manage billing" attempt may have just reconciled the cache
+      // server-side (e.g. cleared a deleted subscription) — refresh so the button
+      // corrects (e.g. to "Subscribe").
+      void refresh();
+    }
+  };
+
+  return (
+    <SettingsSection
+      title="Billing & Subscription"
+      statusChip={
+        !isLoading ? <StatusChip label={chip.label} color={chip.color} /> : undefined
+      }
+      description={isLoading ? undefined : detail}
+    >
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 1 }}>
+          <CircularProgress size={24} />
+        </Box>
+      ) : isDemo ? (
+        // Demo sandboxes can't subscribe (/checkout rejects them) — informational only.
+        null
+      ) : (
+        <>
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+              {error}
+            </Alert>
+          )}
+          <Button
+            variant="contained"
+            onClick={handleAction}
+            disabled={busy}
+            startIcon={busy ? <CircularProgress size={16} color="inherit" /> : undefined}
+          >
+            {busy ? 'Redirecting…' : actionLabel}
+          </Button>
+        </>
+      )}
+    </SettingsSection>
+  );
+}

--- a/components/settings/BillingCard.tsx
+++ b/components/settings/BillingCard.tsx
@@ -51,7 +51,7 @@ function formatDate(iso: string | null): string {
 export default function BillingCard() {
   const params = useParams();
   const companyId = params.companyId as string;
-  const { billing, isDemo, isLoading, refresh } = useSubscription();
+  const { billing, isDemo, isLoading, refresh, isReadOnly } = useSubscription();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const reconciledFor = useRef<string | null>(null);
@@ -73,8 +73,12 @@ export default function BillingCard() {
 
   const status = billing?.subscription_status ?? null;
   const graceEnd = graceEndMs(billing);
-  const withinGrace = graceEnd !== null && graceEnd >= Date.now();
-  const readOnly = (status === 'canceled' || status === 'unpaid') && !withinGrace;
+  // "Ended" (read-only) vs "Ending" (still in grace) comes from the provider's
+  // entitlement rather than recomputing the grace boundary here — that keeps a
+  // single source of truth and avoids calling Date.now() during render (impure).
+  // It also correctly accounts for billing_exempt / demo, which a local
+  // status+grace check would miss.
+  const readOnly = isReadOnly;
   // A still-live subscription (trial/active/past_due) that's set to cancel at
   // period end: Stripe keeps it live with cancel_at set. Surface the pending
   // cancellation instead of "renews"/"billing begins".

--- a/components/settings/QuickBooksIntegrationCard.tsx
+++ b/components/settings/QuickBooksIntegrationCard.tsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
+import StatusChip from '@/components/common/StatusChip';
 import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
 import Dialog from '@mui/material/Dialog';
@@ -110,12 +111,11 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
 
   const statusChip = !loading ? (
     <>
-      <Chip
+      <StatusChip
         label={connected ? 'Connected' : 'Not connected'}
-        size="small"
         color={connected ? 'success' : 'default'}
-        variant={connected ? 'filled' : 'outlined'}
       />
+      {/* Secondary environment tag — kept outlined to sit quietly next to status. */}
       {connected && status?.environment === 'sandbox' && (
         <Chip label="Sandbox" size="small" color="warning" variant="outlined" />
       )}

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -331,25 +331,34 @@ This rule is enforced by [`__tests__/standards/interactionStandards.test.ts`](..
 
 ### Status Badges
 
-```javascript
-<Chip 
-  label="In Progress" 
-  color="info" 
-  size="small"
-/>
+**Use `StatusChip` (`components/common/StatusChip.tsx`) for every on/off/lifecycle
+status badge — never a hand-rolled `<Chip variant=…>`.** It enforces the one
+variant rule so status chips look identical everywhere (this was previously
+inconsistent — QuickBooks "Connected" was filled while Billing "Active" was
+outlined):
 
-<Chip 
-  label="Complete" 
-  color="success" 
-  size="small"
-/>
+- a **semantic color** (`info` / `success` / `warning` / `error` / `primary`) →
+  **filled** (draws the eye: Active, Connected, Trial, Overdue…);
+- the neutral **`default`** color → **outlined** (de-emphasized "off" states: No
+  subscription, Not connected, Not set up).
 
-<Chip 
-  label="Overdue" 
-  color="error" 
-  size="small"
-/>
+Always `size="small"`. Pass the semantic `color`; the variant is derived for you.
+
+```jsx
+import StatusChip from '@/components/common/StatusChip';
+
+<StatusChip label="In Progress" color="info" />       {/* filled */}
+<StatusChip label="Complete"    color="success" />    {/* filled */}
+<StatusChip label="Overdue"     color="error" />      {/* filled */}
+<StatusChip label="Not set up" />                     {/* default → outlined */}
 ```
+
+**Exempt (intentionally custom, do not force onto `StatusChip`):** chips with a
+bespoke palette for a domain reason — stock level (`StockStatusChip`), part
+classification (`PartClassificationChips`), customer active state
+(`CustomerStatusChip`), work-center kind — and the `HOT` rush badge
+(`JobHotBadge`), which deliberately mutes to outlined for historical jobs. These
+use custom hex/rgba, not the semantic palette, and are not on/off status badges.
 
 ### Tabs vs. segmented toggles (role-based)
 

--- a/docs/modules/billing.md
+++ b/docs/modules/billing.md
@@ -191,9 +191,12 @@ Payment failed · Paused.
 
 ## 10. Environment variables
 
-Backend only (no `NEXT_PUBLIC_STRIPE_*`). Prefer a restricted key (`rk_`). See
+Backend only (no `NEXT_PUBLIC_STRIPE_*`). The app reads a **restricted key**
+(`rk_`) from `STRIPE_RESTRICTED_KEY` — least-privilege, and it matches the var
+the Stripe Dashboard / Vercel label (so the unused `STRIPE_SECRET_KEY` /
+`STRIPE_PUBLISHABLE_KEY` can't be edited by mistake and silently take effect). See
 `.env.local.example`:
-`STRIPE_SECRET_KEY`, `STRIPE_PRICE_ID`, `STRIPE_FOUNDING_PRICE_ID`,
+`STRIPE_RESTRICTED_KEY`, `STRIPE_PRICE_ID`, `STRIPE_FOUNDING_PRICE_ID`,
 `STRIPE_WEBHOOK_SECRET`. **Local** webhook secret = the `whsec_…` from
 `stripe listen`; **prod** = the Dashboard endpoint's secret (they differ). The
 backend loads env at startup — restart `python api/index.py` after changing them

--- a/docs/modules/billing.md
+++ b/docs/modules/billing.md
@@ -1,0 +1,223 @@
+# Billing & Subscriptions
+
+> **As-built reference** for the self-serve subscription billing feature. This
+> describes what shipped (which diverged from the original implementation plan as
+> decisions were made) — not a forward-looking PRD. When code and this doc
+> disagree, fix whichever is wrong; keep them in sync.
+
+## 1. Overview
+
+Jigged bills each shop (company) a monthly subscription. **Maximum delegation to
+Stripe, minimum custom code:** Stripe-hosted Checkout + Customer Portal (both are
+server-created redirect URLs — **no Stripe.js, no publishable key on the
+client**), Stripe-managed receipts, retries, and dunning. No card data touches our
+stack.
+
+- **Stripe is the sole source of truth** for billing state.
+- **Supabase holds a read-cache** (`company_billing`, 1:1 with `companies`), kept
+  current by webhooks.
+- **Entitlement is enforced at the database layer** (RLS), not just the UI, so a
+  lapsed shop genuinely cannot write even if the frontend is bypassed — while
+  reads stay open (read-only, never a hard lockout, never deletion).
+
+Every self-serve signup gets a **30-day trial, card collected upfront**, billing
+begins day 31. One reserved customer (Contour) gets a **$250 price with no trial**
+via per-company overrides.
+
+## 2. Data model — `company_billing`
+
+Dedicated 1:1 satellite of `companies` (migration `stripe_billing_cache`). It is a
+**cache**, not the source of truth. Key columns:
+
+| Column | Meaning |
+|---|---|
+| `company_id` (PK/FK) | the shop |
+| `billing_exempt` | grandfathered → full access without a subscription (see §7) |
+| `stripe_customer_id` (unique) | one Stripe Customer per company |
+| `stripe_subscription_id`, `subscription_status`, `subscription_price_id` | cached sub state |
+| `current_period_end`, `cancel_at`, `canceled_at`, `ended_at`, `trial_end` | cached timestamps |
+| `override_price_id`, `override_trial_days` | reserved-customer checkout overrides (§6) |
+| `subscription_event_at` | monotonic write-guard stamp (§5) |
+
+**Why a separate table, not columns on `companies`:** `companies` grants
+`GRANT ALL … TO authenticated` at the table level and its INSERT policy is
+`WITH CHECK (true)`. A column-level `REVOKE` there is a Postgres no-op, so writable
+billing columns on `companies` would let any admin self-stamp `active` from the
+browser. `company_billing` grants members **`SELECT` only**; the **service-role
+webhook is the sole writer**. Entitlement is *derived* from the cache, never
+stored.
+
+## 3. Entitlement — one rule, two encodings (KEEP IN PARITY)
+
+The rule "may this company write?" lives in **two places that must agree**:
+
+- `lib/entitlement.ts` → `getEntitlement(isDemo, billing)` → `full | past_due |
+  read_only | must_subscribe` (drives banners + the UI).
+- `public.company_can_write(company_id)` (SQL, `SECURITY DEFINER STABLE`) →
+  boolean (the actual RLS enforcement).
+
+`isWriteAllowed(entitlement)` (∈ {full, past_due}) must equal `company_can_write`
+for every case. Mapping:
+
+| State | Entitlement | Can write? |
+|---|---|---|
+| `is_demo` | full | yes |
+| `billing_exempt` | full | yes |
+| `trialing`, `active` | full | yes |
+| `past_due` | past_due (banner) | yes |
+| `canceled`/`unpaid`, within 7-day grace | full | yes |
+| `canceled`/`unpaid`, past grace | read_only | **no** |
+| `paused` | read_only | **no** |
+| `incomplete`/`incomplete_expired` | must_subscribe | **no** |
+| no row / no sub, not exempt | must_subscribe | **no** |
+
+- **Grace window = `GRACE_DAYS` (7)**, anchored on `ended_at ?? cancel_at ??
+  current_period_end`. The same constant feeds the UI and the SQL, so the date the
+  card shows ("Access ends …") is exactly when the DB flips to read-only.
+- **Parity is tested both ways** — `__tests__/lib/entitlement.test.ts` (TS) and
+  `test_company_can_write_parity` (SQL) run the same golden cases.
+
+## 4. Write enforcement (RLS) — and the new-table invariant
+
+Members write directly through the browser Supabase client, so enforcement is in
+Postgres. Because RLS is **per-table** (no global write hook), every
+browser-writable tenant table carries **additive `AS RESTRICTIVE`** policies
+(`billing_gate_insert/update/delete`) that AND `company_can_write(company_id)` onto
+the existing membership policy. **SELECT is never gated.** `service_role` and
+`SECURITY DEFINER` functions bypass RLS, so the webhook, importers, and demo
+seeder are unaffected.
+
+> ### ⚠ Invariant: every new tenant table must be billing-gated
+> A new `company_id` table without the gate **silently bypasses billing**. To make
+> that a *loud CI failure* instead of tech debt:
+> - Gate a new direct-`company_id` table in one line, in its migration:
+>   `SELECT public.apply_billing_write_gate('public.your_table');`
+>   (Parent-resolved child tables — no `company_id` — still need hand-written
+>   policies that resolve the parent's company; see the
+>   `stripe_write_enforcement` migration for the pattern.)
+> - The CI test **`test_no_tenant_table_left_ungated`** calls
+>   `public.tenant_tables_missing_write_gate()` and fails if any `company_id` table
+>   is neither gated nor on the explicit exempt list. Add a genuinely-exempt table
+>   (identity/bootstrap or service-role-only) to that function's list — a conscious
+>   one-line decision.
+
+**Storage:** the private `attachments` bucket's `storage.objects` INSERT/DELETE
+policies also call `company_can_write` (company derived from the first path
+segment), so a lapsed shop can't upload; SELECT stays open.
+
+## 5. Webhook + sync — single source-of-truth pattern
+
+**One function writes subscription state:** `_sync_customer(customer_id)` in
+`api/routes/stripe_routes.py` fetches the customer's current subscription from
+Stripe and overwrites the cache with its **actual** status (so a `canceled` sub
+keeps its grace window; the cache is cleared only when the customer has no
+subscription at all). Everything calls it, so behaviour is identical everywhere and
+no code parses event payloads.
+
+Writes go through the `apply_stripe_subscription(...)` RPC (guarded upsert):
+- **Monotonic guard** on `subscription_event_at` (webhooks stamp `event.created`;
+  `/checkout/sync` and reconcile stamp `now()`) — concurrent/out-of-order Vercel
+  lambdas can't lose-update each other.
+- **Grandfather auto-clear:** `billing_exempt` clears only on `active`/`past_due`
+  (a real paying relationship), **never on `trialing`** — so a grandfathered shop
+  that starts a trial and cancels mid-trial keeps its free access.
+
+**Endpoints** (`/api/stripe/*`, admin-only except the webhook):
+- `POST /checkout` — server picks the price (`override_price_id` else
+  `STRIPE_PRICE_ID`) + trial (`override_trial_days` else 30); rejects demo (400) and
+  double-subscribe (409, checked against Stripe, not just the cache).
+- `POST /portal` — self-heals a stale cache first (§8); 409 → "subscribe" if no live
+  sub.
+- `POST /webhook` — verifies signature; resolves the customer → company → sync.
+- `POST /checkout/sync` — success-page reconcile with an **ownership check** (403 if
+  the session isn't the caller's company).
+- `POST /reconcile` — called when the billing card is *viewed*, so it's accurate even
+  if a webhook was missed (one bounded Stripe read on a settings visit, not a poll).
+
+**Webhook subscription set:** `checkout.session.completed`,
+`customer.subscription.{created,updated,deleted}`, `invoice.{paid,payment_failed}`.
+
+## 6. Prices & the reserved customer
+
+- **`STRIPE_PRICE_ID`** = the default $300 monthly price every self-serve company
+  gets. The frontend never names a price.
+- **`STRIPE_FOUNDING_PRICE_ID`** = the reserved $250 founder price id. **Not read by
+  the app** — it's the value you copy into a company's `override_price_id`.
+- To put a company on the reserved deal (e.g. Contour), set two columns
+  (service-role): `override_price_id = <$250 price id>`, `override_trial_days = 0`.
+  Then they self-serve via Settings → Subscribe → $250, no trial. Overrides are
+  service-role-write-only, so $250 is unreachable by self-serve.
+
+Future price changes are **new Price objects** — never mutate/migrate an existing
+subscription's price.
+
+## 7. Rollout: grandfathering existing shops
+
+The `stripe_billing_cache` migration backfills `billing_exempt = true` for every
+existing **real** company (demo excluded), so nobody is locked out on day one.
+New companies have no row until they check out → `must_subscribe`. When a
+grandfathered shop subscribes and reaches `active`, the webhook auto-clears its
+exempt flag → it's gated by its real subscription thereafter.
+
+**Enforcement was sequenced last** (after the backfill + Contour onboarding) so
+every pre-existing company was `exempt`/`active`/`demo` at flip time — zero
+lockouts.
+
+## 8. UI states & self-healing
+
+The billing card (`components/settings/BillingCard.tsx`, on the Settings page) shows
+the **subscription status**, not entitlement, so a grandfathered/demo company
+honestly reads "No subscription" rather than "full access". States: No subscription
+· Trial · Active · **Canceling** (set to cancel at period end — shows the date) ·
+**Ending** (canceled, in grace — shows the date access ends) · Ended (read-only) ·
+Payment failed · Paused.
+
+- **Reconcile-on-view + portal self-heal:** viewing the card, or clicking "Manage
+  billing", re-syncs from Stripe, so a missed webhook self-corrects (a stale
+  "trialing" from a deleted sub flips to "Subscribe" instead of opening a dead
+  portal).
+- **Demo** companies never show billing UI and are never gated (D11).
+- Chips use the shared `StatusChip` (see design-system.md → Status Badges).
+
+## 9. Dashboard configuration (delegate, don't build)
+
+- **Customer Portal:** enable cancellation; **disable plan switching** (prices are
+  new-Price-only) and **disable pause** (`paused` stays in the map defensively but
+  isn't self-serve-reachable); enable update-payment-method + invoice history.
+- **Billing settings:** enable Smart Retries + failed-payment (dunning) emails +
+  receipt emails. These are the retries/dunning/receipts the app relies on.
+- **Tax:** not collected (conscious deferral — no `automatic_tax`). Revisit via a
+  Dashboard registration + `automatic_tax` when there's nexus.
+
+## 10. Environment variables
+
+Backend only (no `NEXT_PUBLIC_STRIPE_*`). Prefer a restricted key (`rk_`). See
+`.env.local.example`:
+`STRIPE_SECRET_KEY`, `STRIPE_PRICE_ID`, `STRIPE_FOUNDING_PRICE_ID`,
+`STRIPE_WEBHOOK_SECRET`. **Local** webhook secret = the `whsec_…` from
+`stripe listen`; **prod** = the Dashboard endpoint's secret (they differ). The
+backend loads env at startup — restart `python api/index.py` after changing them
+(`--reload` watches `.py`, not `.env.local`).
+
+## 11. Testing
+
+- **DB-only (CI, no Stripe):** `api/tests/integration/test_billing_enforcement.py` —
+  the RLS write-gate across every state, read-still-works, TS↔SQL parity, the
+  `apply_stripe_subscription` guard, and the completeness check.
+  `__tests__/lib/entitlement.test.ts` (Vitest) + `scripts/verify_billing_parity.sql`
+  cover the entitlement rule. `api/tests/unit/test_stripe_routes.py` covers endpoint
+  logic (mocked Stripe).
+- **Stripe sandbox (local/manual):**
+  `api/tests/integration/test_billing_stripe_lifecycle.py` — the real-Stripe
+  lifecycle (checkout, override no-trial, cancel, webhook sync). Needs
+  `stripe listen` forwarding + sandbox creds; **not run in CI** (CI can't hold your
+  sandbox secrets). See its module docstring to run it.
+
+## 12. Local dev
+
+Seed + E2E grandfather their companies (`billing_exempt`) so dev/test flows stay
+writable. To exercise the *gated* states or lifecycle transitions locally, run
+`stripe listen --forward-to localhost:8000/api/stripe/webhook` (put the printed
+`whsec_…` in `STRIPE_WEBHOOK_SECRET`, restart the backend) and drive it with
+`stripe trigger` / test clocks — or set `company_billing.subscription_status`
+directly via SQL on a throwaway company.

--- a/e2e/billing-card.spec.ts
+++ b/e2e/billing-card.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import { navigateTo } from './helpers/navigation';
+
+/**
+ * E2E happy-path smoke for the billing UI. The full Checkout flow can't complete
+ * in CI (external Stripe-hosted page + the FastAPI backend), so this verifies the
+ * piece that runs entirely in-app: the SubscriptionProvider reads company_billing
+ * via Supabase (no Stripe/backend needed) and the BillingCard renders the right
+ * state + action on Settings.
+ *
+ * The seeded E2E company is grandfathered (billing_exempt, no subscription — see
+ * e2e/global-setup.ts ensureCompanyBilling), so the card shows "No subscription"
+ * and prompts to Subscribe. The reconcile-on-view call to /api/stripe/reconcile
+ * fails silently without the backend, so the card still renders from the cache.
+ */
+test.describe('Billing card', () => {
+  test('renders on Settings with a subscribe action', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/dashboard\//, { timeout: 30_000 });
+
+    await navigateTo(page, 'Settings');
+
+    // The billing section renders from the company_billing cache.
+    await expect(page.getByText('Billing & Subscription')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/don't have an active subscription/i)).toBeVisible();
+
+    // A grandfathered / unsubscribed company is prompted to subscribe.
+    await expect(page.getByRole('button', { name: 'Subscribe' })).toBeVisible();
+
+    // No past-due / read-only banner for a company with full access.
+    await expect(page.getByText(/read-only|payment failed/i)).toHaveCount(0);
+  });
+});

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -142,6 +142,20 @@ async function ensureCompany(supabase: SupabaseClient): Promise<string> {
   return data.id;
 }
 
+// Billing enforcement (company_can_write RLS gate) blocks writes for companies
+// with no billing row. The grandfather backfill runs on an empty DB before any
+// test company exists, so grandfather the test company here — otherwise every
+// app-driven write in the specs would be rejected by RLS.
+async function ensureCompanyBilling(
+  supabase: SupabaseClient,
+  companyId: string,
+): Promise<void> {
+  const { error } = await supabase
+    .from('company_billing')
+    .upsert({ company_id: companyId, billing_exempt: true }, { onConflict: 'company_id' });
+  if (error) throw new Error(`company_billing upsert failed: ${error.message}`);
+}
+
 async function ensureUserCompanyAccess(
   supabase: SupabaseClient,
   userId: string,
@@ -480,6 +494,7 @@ export default async function globalSetup(): Promise<void> {
   const user = await ensureAuthUser(supabase);
   const companyId = await ensureCompany(supabase);
   await ensureUserCompanyAccess(supabase, user.id, companyId);
+  await ensureCompanyBilling(supabase, companyId);
 
   const vendorId = await ensureVendor(supabase, companyId);
   const wcInternalId = await ensureWorkCenter(

--- a/lib/billingApi.ts
+++ b/lib/billingApi.ts
@@ -1,0 +1,75 @@
+/**
+ * Thin client for the FastAPI Stripe endpoints. Checkout and Portal return
+ * Stripe-hosted URLs; the caller redirects the browser to them (no Stripe.js).
+ */
+import { getSupabase } from '@/lib/supabase';
+import { API_BASE_URL } from '@/lib/api';
+
+async function authToken(): Promise<string> {
+  const supabase = getSupabase();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    throw new Error('Your session has expired. Please sign in again.');
+  }
+  return session.access_token;
+}
+
+async function postJson<T>(path: string, body: unknown): Promise<T> {
+  const token = await authToken();
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    let detail = `Request failed (${res.status})`;
+    try {
+      const b = await res.json();
+      if (typeof b?.detail === 'string') detail = b.detail;
+    } catch {
+      /* keep default */
+    }
+    throw new Error(detail);
+  }
+  return res.json() as Promise<T>;
+}
+
+/** Create a Checkout Session and return its hosted URL. */
+export async function startCheckout(companyId: string): Promise<string> {
+  const { url } = await postJson<{ url: string }>('/api/stripe/checkout', {
+    company_id: companyId,
+  });
+  return url;
+}
+
+/** Create a Customer Portal session and return its hosted URL. */
+export async function openBillingPortal(companyId: string): Promise<string> {
+  const { url } = await postJson<{ url: string }>('/api/stripe/portal', {
+    company_id: companyId,
+  });
+  return url;
+}
+
+/** Reconcile the cache from a completed Checkout Session (success-page fallback). */
+export async function syncCheckout(
+  companyId: string,
+  sessionId: string,
+): Promise<{ status: string | null }> {
+  return postJson<{ status: string | null }>('/api/stripe/checkout/sync', {
+    company_id: companyId,
+    session_id: sessionId,
+  });
+}
+
+/**
+ * Refresh the billing cache from Stripe's live state (called when the billing
+ * card is viewed) so it's accurate even if a webhook was missed. A no-op server
+ * side when the company has no Stripe customer.
+ */
+export async function reconcileBilling(companyId: string): Promise<{ status: string | null }> {
+  return postJson<{ status: string | null }>('/api/stripe/reconcile', {
+    company_id: companyId,
+  });
+}

--- a/lib/billingApi.ts
+++ b/lib/billingApi.ts
@@ -2,11 +2,11 @@
  * Thin client for the FastAPI Stripe endpoints. Checkout and Portal return
  * Stripe-hosted URLs; the caller redirects the browser to them (no Stripe.js).
  */
-import { getSupabase } from '@/lib/supabase';
+import { getTypedSupabase } from '@/lib/supabase';
 import { API_BASE_URL } from '@/lib/api';
 
 async function authToken(): Promise<string> {
-  const supabase = getSupabase();
+  const supabase = getTypedSupabase();
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/lib/entitlement.ts
+++ b/lib/entitlement.ts
@@ -1,0 +1,104 @@
+/**
+ * Billing entitlement — the single rule that decides what a company may do based
+ * on its cached Stripe state.
+ *
+ * This is the UI-facing twin of the SQL function `public.company_can_write()`
+ * (see migration `stripe_write_enforcement`). The DB function is the real
+ * enforcement (RLS on every tenant write); this function drives banners, the
+ * subscribe funnel, and disabled write affordances. They are two encodings of one
+ * rule and MUST agree on write-allowed — a parity test asserts this
+ * (`__tests__/lib/entitlement.parity.test.ts`). If you change one, change both.
+ *
+ * Entitlement is DERIVED, never stored. Every Stripe status is mapped explicitly;
+ * there is no permissive default — an unknown state resolves to the most
+ * restrictive `must_subscribe`, never `full`.
+ */
+
+/** Days of continued full access after a subscription ends before read-only. */
+export const GRACE_DAYS = 7;
+
+/** The Stripe subscription statuses we cache (matches the DB CHECK constraint). */
+export type SubscriptionStatus =
+  | 'trialing'
+  | 'active'
+  | 'past_due'
+  | 'canceled'
+  | 'unpaid'
+  | 'incomplete'
+  | 'incomplete_expired'
+  | 'paused';
+
+/**
+ * Entitlement levels:
+ * - `full`           — full read/write.
+ * - `past_due`       — full read/write, plus a persistent "update billing" banner.
+ * - `read_only`      — reads only; writes blocked at the DB (never a hard lockout).
+ * - `must_subscribe` — new / never-subscribed company; gated to the subscribe funnel.
+ */
+export type Entitlement = 'full' | 'past_due' | 'read_only' | 'must_subscribe';
+
+/** The subset of the `company_billing` row entitlement depends on. */
+export interface BillingRow {
+  billing_exempt: boolean;
+  subscription_status: string | null;
+  current_period_end: string | null;
+  cancel_at: string | null;
+  ended_at: string | null;
+}
+
+/** True while a canceled/unpaid subscription is still inside the grace window. */
+function withinGrace(billing: BillingRow, now: Date): boolean {
+  // Same anchor precedence as the SQL: immediate-cancel/unpaid uses ended_at,
+  // cancel-at-period-end uses cancel_at, else the period end.
+  const anchor = billing.ended_at ?? billing.cancel_at ?? billing.current_period_end;
+  if (!anchor) return false;
+  const anchorMs = new Date(anchor).getTime();
+  if (Number.isNaN(anchorMs)) return false;
+  return anchorMs + GRACE_DAYS * 24 * 60 * 60 * 1000 >= now.getTime();
+}
+
+/**
+ * Derive the entitlement for a company.
+ *
+ * @param isDemo  `companies.is_demo` — demo sandboxes are never billing-gated,
+ *                even when they have no billing row (they're excluded from the
+ *                grandfather backfill). Checked first, so it applies regardless.
+ * @param billing the company's `company_billing` row, or `null` if it has none
+ *                (a new, never-subscribed company).
+ * @param now     injected for testing; defaults to the current time.
+ */
+export function getEntitlement(
+  isDemo: boolean,
+  billing: BillingRow | null,
+  now: Date = new Date(),
+): Entitlement {
+  if (isDemo) return 'full';
+  if (!billing) return 'must_subscribe';
+  if (billing.billing_exempt) return 'full';
+
+  switch (billing.subscription_status) {
+    case 'trialing':
+    case 'active':
+      return 'full';
+    case 'past_due':
+      return 'past_due';
+    case 'canceled':
+    case 'unpaid':
+      return withinGrace(billing, now) ? 'full' : 'read_only';
+    case 'paused':
+      return 'read_only';
+    // incomplete / incomplete_expired / no-subscription-yet (null) / anything
+    // unexpected: never grant access — send them to the subscribe funnel.
+    default:
+      return 'must_subscribe';
+  }
+}
+
+/**
+ * The write-allowed projection of entitlement — the exact boolean the DB
+ * `company_can_write()` returns. `full` and `past_due` may write; `read_only`
+ * and `must_subscribe` may not.
+ */
+export function isWriteAllowed(entitlement: Entitlement): boolean {
+  return entitlement === 'full' || entitlement === 'past_due';
+}

--- a/scripts/verify_billing_parity.sql
+++ b/scripts/verify_billing_parity.sql
@@ -1,0 +1,111 @@
+-- TS↔SQL entitlement parity — the SQL half (test scenario 29).
+--
+-- Runs the same golden cases as __tests__/lib/entitlement.test.ts through the DB
+-- function company_can_write() and RAISEs on any mismatch. isWriteAllowed(entitlement)
+-- in TS must equal company_can_write() here for every case.
+--
+-- Run against a DB with the billing migrations applied:
+--   psql "$DATABASE_URL" -f scripts/verify_billing_parity.sql
+-- Wrapped in a transaction that ROLLBACKs, so it leaves no data behind.
+
+BEGIN;
+
+INSERT INTO public.companies (id, name, is_demo) VALUES
+  ('00000000-0000-0000-0000-0000000000a1', 'parity-real', false),
+  ('00000000-0000-0000-0000-0000000000a2', 'parity-demo', true)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE FUNCTION pg_temp.assert_write(p_company uuid, p_expected boolean, p_label text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE got boolean;
+BEGIN
+  got := public.company_can_write(p_company);
+  IF got IS DISTINCT FROM p_expected THEN
+    RAISE EXCEPTION 'PARITY FAIL [%]: company_can_write=%, expected=%', p_label, got, p_expected;
+  END IF;
+END;
+$$;
+
+CREATE FUNCTION pg_temp.set_billing(
+  p_exempt boolean, p_status text,
+  p_ended timestamptz, p_cancel timestamptz, p_period timestamptz
+) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  INSERT INTO public.company_billing
+    (company_id, billing_exempt, subscription_status, ended_at, cancel_at, current_period_end)
+  VALUES ('00000000-0000-0000-0000-0000000000a1', p_exempt, p_status, p_ended, p_cancel, p_period)
+  ON CONFLICT (company_id) DO UPDATE SET
+    billing_exempt = EXCLUDED.billing_exempt,
+    subscription_status = EXCLUDED.subscription_status,
+    ended_at = EXCLUDED.ended_at,
+    cancel_at = EXCLUDED.cancel_at,
+    current_period_end = EXCLUDED.current_period_end;
+END;
+$$;
+
+-- demo short-circuits (with and without a lapsed billing row)
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a2', true, 'demo, no row');
+INSERT INTO public.company_billing (company_id, billing_exempt, subscription_status, ended_at)
+VALUES ('00000000-0000-0000-0000-0000000000a2', false, 'canceled', now() - interval '30 days')
+ON CONFLICT (company_id) DO UPDATE SET subscription_status='canceled', ended_at=now()-interval '30 days';
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a2', true, 'demo, lapsed billing (ignored)');
+
+-- no billing row, not demo
+DELETE FROM public.company_billing WHERE company_id='00000000-0000-0000-0000-0000000000a1';
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', false, 'no billing row, not demo');
+
+SELECT pg_temp.set_billing(true, NULL, NULL, NULL, NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', true, 'grandfathered (exempt)');
+
+SELECT pg_temp.set_billing(false, 'trialing', NULL, NULL, now() + interval '20 days');
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', true, 'trialing');
+
+SELECT pg_temp.set_billing(false, 'active', NULL, NULL, now() + interval '20 days');
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', true, 'active');
+
+SELECT pg_temp.set_billing(false, 'past_due', NULL, NULL, NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', true, 'past_due');
+
+SELECT pg_temp.set_billing(false, 'canceled', now() - interval '2 days', NULL, NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', true, 'canceled within grace');
+
+SELECT pg_temp.set_billing(false, 'canceled', now() - interval '30 days', NULL, NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', false, 'canceled past grace');
+
+SELECT pg_temp.set_billing(false, 'unpaid', now() - interval '1 days', NULL, NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', true, 'unpaid within grace');
+
+SELECT pg_temp.set_billing(false, 'unpaid', now() - interval '10 days', NULL, NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', false, 'unpaid past grace');
+
+SELECT pg_temp.set_billing(false, 'canceled', NULL, now() - interval '1 days', NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', true, 'canceled, anchored on cancel_at');
+
+SELECT pg_temp.set_billing(false, 'canceled', NULL, NULL, now() - interval '1 days');
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', true, 'canceled, anchored on current_period_end');
+
+SELECT pg_temp.set_billing(false, 'canceled', NULL, NULL, NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', false, 'canceled, no anchor');
+
+SELECT pg_temp.set_billing(false, 'paused', NULL, NULL, NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', false, 'paused');
+
+SELECT pg_temp.set_billing(false, 'incomplete', NULL, NULL, NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', false, 'incomplete');
+
+SELECT pg_temp.set_billing(false, 'incomplete_expired', NULL, NULL, NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', false, 'incomplete_expired');
+
+SELECT pg_temp.set_billing(false, NULL, NULL, NULL, NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', false, 'row exists, status null, not exempt');
+
+-- grace boundary: exactly 7 days is still inside; one second past is out
+SELECT pg_temp.set_billing(false, 'canceled', now() - interval '7 days', NULL, NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', true, 'grace boundary: exactly 7 days');
+
+SELECT pg_temp.set_billing(false, 'canceled', now() - interval '7 days 1 second', NULL, NULL);
+SELECT pg_temp.assert_write('00000000-0000-0000-0000-0000000000a1', false, 'grace boundary: just past 7 days');
+
+\echo '== ALL PARITY CASES PASSED =='
+
+ROLLBACK;

--- a/supabase/migrations/20260725205821_stripe_billing_cache.sql
+++ b/supabase/migrations/20260725205821_stripe_billing_cache.sql
@@ -1,0 +1,90 @@
+-- Stripe self-serve subscription billing: minimal read-cache of Stripe state.
+--
+-- Stripe is the sole source of truth for billing; this table is a webhook-fed
+-- read cache. It is a dedicated 1:1 satellite of `companies` (NOT columns on
+-- `companies`) because `companies` grants `GRANT ALL ... TO authenticated` at the
+-- table level and its INSERT policy is `WITH CHECK (true)`. In PostgreSQL a
+-- column-level REVOKE cannot remove a privilege already held at the table level,
+-- so putting writable billing columns on `companies` would let any admin (or any
+-- authenticated user via INSERT) self-stamp subscription_status='active'. Here
+-- members get SELECT only; the service-role webhook is the sole writer.
+--
+-- Entitlement is DERIVED from this cache (see lib/entitlement.ts and, in a later
+-- migration, the company_can_write() SQL function) — never stored.
+
+CREATE TABLE IF NOT EXISTS public.company_billing (
+  company_id             uuid PRIMARY KEY REFERENCES public.companies(id) ON DELETE CASCADE,
+  -- Grandfather flag: existing companies at launch are exempt (full access) until
+  -- they subscribe; the webhook auto-clears this on their first active/past_due.
+  billing_exempt         boolean NOT NULL DEFAULT false,
+  -- Cached Stripe state (overwritten wholesale on each handled webhook event).
+  stripe_customer_id     text UNIQUE,
+  stripe_subscription_id text,
+  subscription_status    text,
+  subscription_price_id  text,
+  current_period_end     timestamptz,
+  cancel_at              timestamptz,
+  canceled_at            timestamptz,
+  ended_at               timestamptz,
+  trial_end              timestamptz,
+  -- Reserved-customer checkout-time overrides (service-role-set only). NULL =>
+  -- founding $300 price / 30-day trial. The $300/$250 price ids live in backend
+  -- env, never in this table.
+  override_price_id      text,
+  override_trial_days    integer,
+  -- Monotonic write guard: webhooks stamp event.created, /checkout/sync stamps
+  -- now(). A write only applies when its stamp is >= the stored one, so
+  -- concurrent/out-of-order Vercel lambdas can't lose-update each other.
+  subscription_event_at  timestamptz,
+  synced_at              timestamptz NOT NULL DEFAULT now(),
+  created_at             timestamptz NOT NULL DEFAULT now(),
+  updated_at             timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT company_billing_status_check CHECK (
+    subscription_status IS NULL OR subscription_status IN (
+      'trialing', 'active', 'past_due', 'canceled', 'unpaid',
+      'incomplete', 'incomplete_expired', 'paused'
+    )
+  )
+);
+
+COMMENT ON TABLE public.company_billing IS
+  'Webhook-fed read cache of Stripe subscription state, 1:1 with companies. Stripe is source of truth; members read-only, service_role is sole writer. Entitlement is derived, not stored.';
+COMMENT ON COLUMN public.company_billing.billing_exempt IS
+  'Grandfathered (existing at launch) => full access until they subscribe; webhook auto-clears on first active/past_due.';
+COMMENT ON COLUMN public.company_billing.override_price_id IS
+  'Service-role-set reserved-customer price id (else backend founding price). Frontend never names a price.';
+COMMENT ON COLUMN public.company_billing.override_trial_days IS
+  'Service-role-set reserved-customer trial length (else 30). 0 => no trial.';
+COMMENT ON COLUMN public.company_billing.subscription_event_at IS
+  'Monotonic write guard: webhooks use event.created, /checkout/sync uses now().';
+
+-- Keep updated_at fresh (matches the companies_updated_at trigger convention).
+DROP TRIGGER IF EXISTS company_billing_updated_at ON public.company_billing;
+CREATE TRIGGER company_billing_updated_at
+  BEFORE UPDATE ON public.company_billing
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+ALTER TABLE public.company_billing ENABLE ROW LEVEL SECURITY;
+
+-- Members may READ their company's billing state (drives the UI). Nobody but
+-- service_role writes — there is deliberately NO insert/update/delete policy for
+-- authenticated, and (below) no write grant either.
+DROP POLICY IF EXISTS "Members can view their company billing" ON public.company_billing;
+CREATE POLICY "Members can view their company billing"
+  ON public.company_billing FOR SELECT
+  USING (company_id IN (SELECT get_user_company_ids()));
+
+-- Data API grants (house style: every new public table needs explicit grants).
+-- SELECT only for members; full CRUD for the service-role webhook/backfill.
+GRANT SELECT ON public.company_billing TO anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.company_billing TO service_role;
+
+-- Day-1 grandfather backfill: every existing REAL company gets full access until
+-- it chooses to subscribe. Demo companies are excluded — they are never
+-- billing-gated (see the is_demo short-circuit in a later migration) and
+-- reset_demo_company could wipe an attached row.
+INSERT INTO public.company_billing (company_id, billing_exempt)
+SELECT id, true
+FROM public.companies
+WHERE is_demo = false
+ON CONFLICT (company_id) DO NOTHING;

--- a/supabase/migrations/20260725210136_stripe_write_enforcement.sql
+++ b/supabase/migrations/20260725210136_stripe_write_enforcement.sql
@@ -1,0 +1,170 @@
+-- Stripe billing: DATA-LAYER write enforcement.
+--
+-- Entitlement is enforced where writes actually happen — in Postgres — not only
+-- in the UI. Members write directly through the browser Supabase client under
+-- RLS, so a lapsed (canceled/unpaid past grace) company must be unable to
+-- INSERT/UPDATE/DELETE even if the frontend is bypassed, while SELECT stays open
+-- (read-only, never a hard lockout).
+--
+-- Implementation note: rather than rewrite each of ~80 existing permissive
+-- membership policies (high variance, high risk), we add ADDITIVE `AS RESTRICTIVE`
+-- policies. PostgreSQL AND-combines restrictive policies with the permissive ones
+-- for the same command+role, so the effective rule becomes
+--   (existing membership check) AND company_can_write(...)
+-- with the existing policies untouched. We add restrictive policies only for
+-- INSERT/UPDATE/DELETE — never SELECT — so reads remain open. service_role and
+-- SECURITY DEFINER functions (webhook, importers, demo seeder/reset) have
+-- BYPASSRLS, so they are unaffected.
+--
+-- SEQUENCING: this runs AFTER the grandfather backfill (20260725205821) and after
+-- Contour onboarding, so every pre-existing real company is billing_exempt or
+-- active, and demo companies short-circuit — zero lockouts at flip time.
+
+-- ─────────────────────────── write-guard function ───────────────────────────
+-- Mirrors lib/entitlement.ts getEntitlement()'s write-allowed set + the 7-day
+-- grace anchor. Returns true for demo companies, billing_exempt, live statuses,
+-- or canceled/unpaid within grace; false otherwise (including a missing row).
+CREATE OR REPLACE FUNCTION public.company_can_write(check_company_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    -- Demo sandboxes are never billing-gated. Checked on the ACTIVE company_id
+    -- being written to, so a real company's lapse never cascades to its paired
+    -- demo. The storage.objects policies call this same function, so demo uploads
+    -- are covered here too.
+    EXISTS (
+      SELECT 1 FROM public.companies c
+      WHERE c.id = check_company_id AND c.is_demo
+    )
+    OR COALESCE((
+      SELECT
+        cb.billing_exempt
+        OR cb.subscription_status IN ('trialing', 'active', 'past_due')
+        OR (
+          cb.subscription_status IN ('canceled', 'unpaid')
+          AND COALESCE(cb.ended_at, cb.cancel_at, cb.current_period_end)
+              + interval '7 days' >= now()
+        )
+      FROM public.company_billing cb
+      WHERE cb.company_id = check_company_id
+    ), false);   -- missing row => false (new, never-subscribed companies)
+$$;
+
+COMMENT ON FUNCTION public.company_can_write(uuid) IS
+  'Billing write-gate for RLS. True if the company may write now (demo, exempt, live sub, or canceled/unpaid within 7-day grace); false otherwise incl. missing row. Mirrors lib/entitlement.ts.';
+
+GRANT EXECUTE ON FUNCTION public.company_can_write(uuid) TO authenticated;
+
+-- ─────────────── restrictive write gates: direct company_id tables ───────────────
+-- Each gains INSERT/UPDATE/DELETE restrictive policies keyed on its own
+-- company_id column. SELECT is untouched.
+DO $$
+DECLARE
+  t text;
+  direct_tables text[] := ARRAY[
+    'customers', 'vendors', 'parts', 'part_pricing_tiers', 'part_attachments',
+    'part_notes', 'quotes', 'quote_line_items', 'quote_materials',
+    'quote_operations', 'jobs', 'job_parts', 'job_attachments', 'job_notes',
+    'job_note_media', 'routings', 'shipments', 'work_centers',
+    'inventory_locations', 'inventory_transactions', 'company_custom_units',
+    'ai_chat_queries', 'ai_config'
+  ];
+BEGIN
+  FOREACH t IN ARRAY direct_tables LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', 'billing_gate_insert', t);
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', 'billing_gate_update', t);
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', 'billing_gate_delete', t);
+
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I AS RESTRICTIVE FOR INSERT TO authenticated '
+      'WITH CHECK (public.company_can_write(company_id))',
+      'billing_gate_insert', t);
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I AS RESTRICTIVE FOR UPDATE TO authenticated '
+      'USING (public.company_can_write(company_id)) '
+      'WITH CHECK (public.company_can_write(company_id))',
+      'billing_gate_update', t);
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I AS RESTRICTIVE FOR DELETE TO authenticated '
+      'USING (public.company_can_write(company_id))',
+      'billing_gate_delete', t);
+  END LOOP;
+END $$;
+
+-- ─────────────── restrictive write gates: parent-resolved child tables ───────────
+-- These have no company_id column; resolve the parent's company and gate on it.
+DO $$
+DECLARE
+  rec record;
+BEGIN
+  FOR rec IN
+    SELECT * FROM (VALUES
+      ('customer_addresses',    'customers', 'customer_id'),
+      ('customer_contacts',     'customers', 'customer_id'),
+      ('vendor_contacts',       'vendors',   'vendor_id'),
+      ('parts_bom',             'parts',     'parent_part_id'),
+      ('parts_unit_conversions','parts',     'part_id'),
+      ('part_procurement_tiers','parts',     'part_id'),
+      ('job_materials',         'jobs',      'job_id'),
+      ('job_operations',        'jobs',      'job_id'),
+      ('routing_operations',    'routings',  'routing_id'),
+      ('shipment_line_items',   'shipments', 'shipment_id')
+    ) AS m(child, parent, fk)
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', 'billing_gate_insert', rec.child);
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', 'billing_gate_update', rec.child);
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', 'billing_gate_delete', rec.child);
+
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I AS RESTRICTIVE FOR INSERT TO authenticated '
+      'WITH CHECK (public.company_can_write((SELECT p.company_id FROM public.%I p WHERE p.id = %I.%I)))',
+      'billing_gate_insert', rec.child, rec.parent, rec.child, rec.fk);
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I AS RESTRICTIVE FOR UPDATE TO authenticated '
+      'USING (public.company_can_write((SELECT p.company_id FROM public.%I p WHERE p.id = %I.%I))) '
+      'WITH CHECK (public.company_can_write((SELECT p.company_id FROM public.%I p WHERE p.id = %I.%I)))',
+      'billing_gate_update', rec.child, rec.parent, rec.child, rec.fk, rec.parent, rec.child, rec.fk);
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I AS RESTRICTIVE FOR DELETE TO authenticated '
+      'USING (public.company_can_write((SELECT p.company_id FROM public.%I p WHERE p.id = %I.%I)))',
+      'billing_gate_delete', rec.child, rec.parent, rec.child, rec.fk);
+  END LOOP;
+END $$;
+
+-- ─────────────────────────── Supabase Storage ───────────────────────────
+-- Tenant uploads go to the private `attachments` bucket, path-namespaced
+-- {companyId}/... , written directly from the browser under RLS. Amend the
+-- existing INSERT + DELETE policies (recreate with the guard); leave SELECT
+-- untouched so existing files stay readable (read-only). These policies existed
+-- only in the prod schema dump (dashboard-created); this brings them under
+-- migration control. The bucket_id = 'attachments' filter is evaluated before the
+-- ::uuid cast, so non-attachments / non-uuid paths never reach the cast.
+DROP POLICY IF EXISTS "Users can upload files to their company folder" ON storage.objects;
+CREATE POLICY "Users can upload files to their company folder"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'attachments'
+    AND (storage.foldername(name))[1] IN (
+      SELECT (user_company_access.company_id)::text
+      FROM user_company_access
+      WHERE user_company_access.user_id = auth.uid()
+    )
+    AND public.company_can_write(((storage.foldername(name))[1])::uuid)
+  );
+
+DROP POLICY IF EXISTS "Users can delete files from their company folder" ON storage.objects;
+CREATE POLICY "Users can delete files from their company folder"
+  ON storage.objects FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'attachments'
+    AND (storage.foldername(name))[1] IN (
+      SELECT (user_company_access.company_id)::text
+      FROM user_company_access
+      WHERE user_company_access.user_id = auth.uid()
+    )
+    AND public.company_can_write(((storage.foldername(name))[1])::uuid)
+  );

--- a/supabase/migrations/20260725211116_stripe_billing_sync_fn.sql
+++ b/supabase/migrations/20260725211116_stripe_billing_sync_fn.sql
@@ -1,0 +1,80 @@
+-- Stripe billing: atomic, monotonically-guarded sync of a subscription into the
+-- company_billing cache.
+--
+-- The webhook and /checkout/sync both call this. It is an UPSERT (a brand-new
+-- company that signs up after launch has no billing row — the grandfather backfill
+-- only covered companies that existed at launch), guarded by a monotonic
+-- timestamp so concurrent / out-of-order Vercel lambdas can't lose-update each
+-- other (D5). PostgREST can't express `ON CONFLICT DO UPDATE ... WHERE`, so this
+-- lives in SQL and is called via .rpc() with the service-role key.
+--
+-- Grandfather auto-clear: billing_exempt is cleared ONLY when the company becomes
+-- a real paying customer (status active/past_due), never on trialing — so a
+-- grandfathered company that starts a trial and cancels mid-trial keeps its free
+-- access.
+
+CREATE OR REPLACE FUNCTION public.apply_stripe_subscription(
+  p_company_id             uuid,
+  p_stripe_customer_id     text,
+  p_stripe_subscription_id text,
+  p_status                 text,
+  p_price_id               text,
+  p_current_period_end     timestamptz,
+  p_cancel_at              timestamptz,
+  p_canceled_at            timestamptz,
+  p_ended_at               timestamptz,
+  p_trial_end              timestamptz,
+  p_event_at               timestamptz
+)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  INSERT INTO public.company_billing AS cb (
+    company_id, stripe_customer_id, stripe_subscription_id, subscription_status,
+    subscription_price_id, current_period_end, cancel_at, canceled_at, ended_at,
+    trial_end, subscription_event_at, synced_at, billing_exempt
+  ) VALUES (
+    p_company_id, p_stripe_customer_id, p_stripe_subscription_id, p_status,
+    p_price_id, p_current_period_end, p_cancel_at, p_canceled_at, p_ended_at,
+    p_trial_end, p_event_at, now(),
+    -- A brand-new billing row created by a subscription event is a paying/trialing
+    -- company, never grandfathered.
+    false
+  )
+  ON CONFLICT (company_id) DO UPDATE SET
+    stripe_customer_id     = EXCLUDED.stripe_customer_id,
+    stripe_subscription_id = EXCLUDED.stripe_subscription_id,
+    subscription_status    = EXCLUDED.subscription_status,
+    subscription_price_id  = EXCLUDED.subscription_price_id,
+    current_period_end     = EXCLUDED.current_period_end,
+    cancel_at              = EXCLUDED.cancel_at,
+    canceled_at            = EXCLUDED.canceled_at,
+    ended_at               = EXCLUDED.ended_at,
+    trial_end              = EXCLUDED.trial_end,
+    subscription_event_at  = EXCLUDED.subscription_event_at,
+    synced_at              = now(),
+    billing_exempt         = CASE
+      WHEN EXCLUDED.subscription_status IN ('active', 'past_due') THEN false
+      ELSE cb.billing_exempt
+    END
+  -- Monotonic guard: only apply if this event is newer than the last one we
+  -- recorded. A stale/duplicate delivery is a no-op (neither inserts nor updates).
+  WHERE cb.subscription_event_at IS NULL
+     OR cb.subscription_event_at <= EXCLUDED.subscription_event_at;
+$$;
+
+COMMENT ON FUNCTION public.apply_stripe_subscription IS
+  'Guarded upsert of a Stripe subscription into company_billing (webhook + /checkout/sync). Monotonic by p_event_at; clears billing_exempt only on active/past_due.';
+
+-- Backend-only: the webhook/sync call it with the service-role key. Never exposed
+-- to browser clients.
+REVOKE ALL ON FUNCTION public.apply_stripe_subscription(
+  uuid, text, text, text, text, timestamptz, timestamptz, timestamptz,
+  timestamptz, timestamptz, timestamptz
+) FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.apply_stripe_subscription(
+  uuid, text, text, text, text, timestamptz, timestamptz, timestamptz,
+  timestamptz, timestamptz, timestamptz
+) TO service_role;

--- a/supabase/migrations/20260726033616_stripe_write_gate_helper.sql
+++ b/supabase/migrations/20260726033616_stripe_write_gate_helper.sql
@@ -1,0 +1,84 @@
+-- Billing write-gate: maintenance helpers.
+--
+-- Postgres RLS is per-table (no global write hook), so every browser-writable
+-- tenant table needs the billing_gate_* restrictive policies that call
+-- company_can_write(). To keep that a one-liner (not hand-copied policy SQL) and
+-- to make a forgotten table a LOUD CI failure instead of silent tech debt, this
+-- migration adds:
+--   1. apply_billing_write_gate(regclass) — attach the gate to a direct-company_id
+--      table in one call. Use it in the migration for any new tenant table.
+--   2. tenant_tables_missing_write_gate() — lists any public table with a
+--      company_id column that is neither gated nor on the exempt list. A CI test
+--      asserts this is empty (see api/tests/integration/test_billing_enforcement.py).
+
+-- ── 1. one-line gate for a new direct-company_id tenant table ──────────────────
+CREATE OR REPLACE FUNCTION public.apply_billing_write_gate(p_table regclass)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  EXECUTE format('DROP POLICY IF EXISTS billing_gate_insert ON %s', p_table);
+  EXECUTE format('DROP POLICY IF EXISTS billing_gate_update ON %s', p_table);
+  EXECUTE format('DROP POLICY IF EXISTS billing_gate_delete ON %s', p_table);
+  EXECUTE format(
+    'CREATE POLICY billing_gate_insert ON %s AS RESTRICTIVE FOR INSERT TO authenticated '
+    'WITH CHECK (public.company_can_write(company_id))', p_table);
+  EXECUTE format(
+    'CREATE POLICY billing_gate_update ON %s AS RESTRICTIVE FOR UPDATE TO authenticated '
+    'USING (public.company_can_write(company_id)) WITH CHECK (public.company_can_write(company_id))',
+    p_table);
+  EXECUTE format(
+    'CREATE POLICY billing_gate_delete ON %s AS RESTRICTIVE FOR DELETE TO authenticated '
+    'USING (public.company_can_write(company_id))', p_table);
+END;
+$$;
+
+COMMENT ON FUNCTION public.apply_billing_write_gate(regclass) IS
+  'Attach the billing write-gate (restrictive INSERT/UPDATE/DELETE policies calling company_can_write) to a tenant table with a direct company_id column. Call in the migration for any new tenant table. Parent-resolved child tables (no company_id) still need hand-written policies. See docs/modules/billing.md.';
+
+-- ── 2. completeness check (powers the CI guard) ───────────────────────────────
+-- Any public table with a company_id column must be either gated or explicitly
+-- exempt. The exempt set = identity/bootstrap tables + service-role-only /
+-- SELECT-only tables (whose writes never come from the browser, so RLS can't gate
+-- them anyway). Adding a NEW exempt table is a conscious one-line edit here.
+CREATE OR REPLACE FUNCTION public.tenant_tables_missing_write_gate()
+RETURNS TABLE(table_name text)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT c.relname::text
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  JOIN pg_attribute a
+    ON a.attrelid = c.oid AND a.attname = 'company_id' AND NOT a.attisdropped
+  WHERE n.nspname = 'public'
+    AND c.relkind = 'r'
+    AND c.relname NOT IN (
+      -- identity / bootstrap (gating would block signup / team / preferences)
+      'companies', 'user_company_access', 'user_preferences', 'system_admins',
+      'invitations', 'demo_data_templates', 'waitlist', 'saved_insights', 'feedback',
+      'company_billing',
+      -- service-role-only / SELECT-only (writes never come from the browser)
+      'auth_audit_log', 'job_fulfillment_audit', 'part_location_stock',
+      'company_order_counters', 'quickbooks_connections', 'quickbooks_customer_map',
+      'quickbooks_invoice_links', 'quickbooks_invoice_line_items'
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_policies p
+      WHERE p.schemaname = 'public'
+        AND p.tablename = c.relname
+        AND p.policyname = 'billing_gate_insert'
+    )
+  ORDER BY 1;
+$$;
+
+COMMENT ON FUNCTION public.tenant_tables_missing_write_gate() IS
+  'Lists public tables with a company_id column that are neither billing-gated nor exempt. A CI test asserts this returns no rows, so a new tenant table left un-gated fails the build instead of silently bypassing billing.';
+
+GRANT EXECUTE ON FUNCTION public.tenant_tables_missing_write_gate() TO service_role;
+
+-- ── 3. gate a tenant table the earlier enforcement migration missed ───────────
+-- job_operation_completions (company_id, browser-writable) was added after the
+-- write-enforcement migration's table list was built, so it shipped un-gated.
+-- The completeness check above flags it; gate it here via the new helper.
+SELECT public.apply_billing_write_gate('public.job_operation_completions');

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -74,6 +74,15 @@ insert into public.companies (id, name, settings) values
    '{"features": {"data_import": true}}'::jsonb)
 on conflict (id) do nothing;
 
+-- Billing cache: the grandfather backfill in the stripe_billing_cache migration
+-- runs on an empty DB (before this seed), so the seeded company gets no row and
+-- would be write-blocked once billing enforcement is on. Grandfather it here so
+-- dev / preview / E2E have a fully writable company (entitlement = full, no
+-- billing banner). Devs can still exercise Checkout in Stripe test mode.
+insert into public.company_billing (company_id, billing_exempt) values
+  ('22222222-2222-2222-2222-222222222222', true)
+on conflict (company_id) do nothing;
+
 insert into public.user_company_access (id, user_id, company_id, role, name) values
   ('23000000-0000-0000-0000-000000000001',
    '11111111-1111-1111-1111-111111111111',

--- a/types/database.ts
+++ b/types/database.ts
@@ -237,6 +237,74 @@ export type Database = {
           },
         ]
       }
+      company_billing: {
+        Row: {
+          billing_exempt: boolean
+          cancel_at: string | null
+          canceled_at: string | null
+          company_id: string
+          created_at: string
+          current_period_end: string | null
+          ended_at: string | null
+          override_price_id: string | null
+          override_trial_days: number | null
+          stripe_customer_id: string | null
+          stripe_subscription_id: string | null
+          subscription_event_at: string | null
+          subscription_price_id: string | null
+          subscription_status: string | null
+          synced_at: string
+          trial_end: string | null
+          updated_at: string
+        }
+        Insert: {
+          billing_exempt?: boolean
+          cancel_at?: string | null
+          canceled_at?: string | null
+          company_id: string
+          created_at?: string
+          current_period_end?: string | null
+          ended_at?: string | null
+          override_price_id?: string | null
+          override_trial_days?: number | null
+          stripe_customer_id?: string | null
+          stripe_subscription_id?: string | null
+          subscription_event_at?: string | null
+          subscription_price_id?: string | null
+          subscription_status?: string | null
+          synced_at?: string
+          trial_end?: string | null
+          updated_at?: string
+        }
+        Update: {
+          billing_exempt?: boolean
+          cancel_at?: string | null
+          canceled_at?: string | null
+          company_id?: string
+          created_at?: string
+          current_period_end?: string | null
+          ended_at?: string | null
+          override_price_id?: string | null
+          override_trial_days?: number | null
+          stripe_customer_id?: string | null
+          stripe_subscription_id?: string | null
+          subscription_event_at?: string | null
+          subscription_price_id?: string | null
+          subscription_status?: string | null
+          synced_at?: string
+          trial_end?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "company_billing_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: true
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       company_custom_units: {
         Row: {
           company_id: string
@@ -2997,7 +3065,31 @@ export type Database = {
         }
         Returns: Json
       }
+      apply_billing_write_gate: {
+        Args: { p_table: unknown }
+        Returns: undefined
+      }
+      apply_stripe_subscription: {
+        Args: {
+          p_cancel_at: string
+          p_canceled_at: string
+          p_company_id: string
+          p_current_period_end: string
+          p_ended_at: string
+          p_event_at: string
+          p_price_id: string
+          p_status: string
+          p_stripe_customer_id: string
+          p_stripe_subscription_id: string
+          p_trial_end: string
+        }
+        Returns: undefined
+      }
       archive_parts: { Args: { p_ids: string[] }; Returns: undefined }
+      company_can_write: {
+        Args: { check_company_id: string }
+        Returns: boolean
+      }
       compute_job_fulfillment_status: {
         Args: { p_job_id: string }
         Returns: string
@@ -3191,6 +3283,12 @@ export type Database = {
       sync_demo_access: {
         Args: { p_demo_company_id: string; p_source_company_id: string }
         Returns: undefined
+      }
+      tenant_tables_missing_write_gate: {
+        Args: never
+        Returns: {
+          table_name: string
+        }[]
       }
       transfer_stock: {
         Args: {

--- a/utils/companyAccess.ts
+++ b/utils/companyAccess.ts
@@ -269,6 +269,50 @@ export async function getCompany(companyId: string): Promise<Company | null> {
 }
 
 /**
+ * The webhook-fed Stripe billing cache row for a company. Read-only on the
+ * client (only the service-role webhook writes it). Entitlement is derived from
+ * this via `getEntitlement` in `lib/entitlement.ts`.
+ */
+export interface CompanyBilling {
+  company_id: string;
+  billing_exempt: boolean;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
+  subscription_status: string | null;
+  subscription_price_id: string | null;
+  current_period_end: string | null;
+  cancel_at: string | null;
+  canceled_at: string | null;
+  ended_at: string | null;
+  trial_end: string | null;
+}
+
+/**
+ * Read a company's Stripe billing cache. Returns `null` when the company has no
+ * billing row (a new, never-subscribed company → the subscribe funnel). Throws
+ * on a genuine read error so the caller can surface it to Sentry rather than
+ * silently defaulting entitlement — this is a billing path. Reads via RLS; touches
+ * Stripe zero times, so it is safe on mount.
+ */
+export async function getCompanyBilling(companyId: string): Promise<CompanyBilling | null> {
+  const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from('company_billing')
+    .select(
+      'company_id, billing_exempt, stripe_customer_id, stripe_subscription_id, subscription_status, subscription_price_id, current_period_end, cancel_at, canceled_at, ended_at, trial_end'
+    )
+    .eq('company_id', companyId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to read company_billing for ${companyId}: ${error.message}`);
+  }
+
+  return (data as CompanyBilling | null) ?? null;
+}
+
+/**
  * Update the company's logo storage path (or clear it by passing null).
  * The caller is responsible for uploading/removing the file in storage.
  */


### PR DESCRIPTION
## Summary

Self-serve **Stripe subscription billing** for Jigged. Maximum delegation to Stripe: hosted **Checkout + Customer Portal** (server-created redirect URLs — **no Stripe.js, no publishable key on the client**), Stripe-managed receipts/retries/dunning. No card data touches our stack.

- **Stripe is the source of truth.** A `company_billing` cache (1:1 with `companies`) is kept current by a **single-sync webhook** (`_sync_customer`) — one function writes subscription state; nothing parses event payloads.
- **Entitlement is enforced at the DB layer** (RLS), not just the UI: a lapsed shop genuinely can't write while reads stay open (read-only, never a hard lockout). `company_can_write()` (SQL) mirrors `getEntitlement()` (TS); parity is tested both ways.
- **Grandfathered** (`billing_exempt`) and **demo** companies are exempt. One reserved customer gets a **$250 / no-trial** price via per-company `override_*` columns; everyone else gets the $300 default + 30-day trial, selected server-side (frontend never names a price).

Full design: [`docs/modules/billing.md`](docs/modules/billing.md).

## The new-table invariant (worth a look in review)

RLS is per-table, so every browser-writable tenant table carries `billing_gate_*` restrictive policies calling `company_can_write`. To keep that from becoming silent tech debt:
- `apply_billing_write_gate('table')` gates a new table in one line.
- `tenant_tables_missing_write_gate()` + the CI test **`test_no_tenant_table_left_ungated`** fail the build if any `company_id` table is neither gated nor exempt. **This already caught + fixed a real gap** (`job_operation_completions`, added after the enforcement list was built).

## Migrations (4)
1. `company_billing` cache + grandfather backfill (demo excluded).
2. `company_can_write()` + restrictive write policies on 33 tenant tables + `attachments` storage.
3. `apply_stripe_subscription` guarded-upsert RPC (monotonic guard; exempt auto-clears on `active`/`past_due`, not `trialing`).
4. `apply_billing_write_gate()` helper + completeness check (+ gates the missed table).

## Testing
| Suite | Where | Runs |
|---|---|---|
| `entitlement.test.ts` (22) + `verify_billing_parity.sql` | Vitest / psql | **CI** |
| `test_stripe_routes.py` (15, mocked) | pytest unit | **CI** |
| `test_billing_enforcement.py` (15 — RLS gate every state, parity, RPC guard, completeness) | pytest integration | **CI** (local Supabase, no Stripe) |
| `test_billing_stripe_lifecycle.py` (5 — real Stripe objects) | pytest `stripe_live` | **local** (skips without test creds) |
| `billing-card.spec.ts` | Playwright | **CI** |

No regressions (unit + existing RLS: 213 passing).

## Config needed to run (not in code)
- Env: `STRIPE_RESTRICTED_KEY` (restricted `rk_`; app reads this var only — matches the Dashboard/Vercel name), `STRIPE_PRICE_ID` ($300 default), `STRIPE_FOUNDING_PRICE_ID` ($250 reserved), `STRIPE_WEBHOOK_SECRET`.
- Stripe Dashboard: Customer Portal — enable cancellation, **disable plan-switching + pause**; enable Smart Retries + dunning + receipt emails. Tax intentionally deferred.
- Reserved customer (Contour): set `override_price_id` + `override_trial_days = 0` on their `company_billing` row (service-role).

## Deliberately out of scope / follow-ups
- Live Stripe lifecycle tests run **locally / not per-PR CI** by policy (external-integration smoke tier). Nightly CI wiring is a future option — secrets can be added then.
- Sales tax (Stripe Tax) deferred.
- Write-rejection UX polish (turn a raw `42501` into a friendly "resubscribe" toast) is a small follow-up; the DB gate + banner already cover the requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
