### PR TITLE
fix(billing): don't flash the subscribe banner while billing is loading

### DIFF
--- a/components/billing/BillingBanner.tsx
+++ b/components/billing/BillingBanner.tsx
@@ -18,10 +18,17 @@ import { startCheckout, openBillingPortal } from '@/lib/billingApi';
 export default function BillingBanner() {
   const params = useParams();
   const companyId = params.companyId as string;
-  const { entitlement, isPastDue, isReadOnly, mustSubscribe, hasCustomer, refresh } =
+  const { entitlement, isLoading, isPastDue, isReadOnly, mustSubscribe, hasCustomer, refresh } =
     useSubscription();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Render nothing until billing is known. While the cache is still loading,
+  // `billing` is null → entitlement resolves to `must_subscribe`, which would
+  // flash the "Start your subscription" banner for a split second before the
+  // fetch confirms the shop is exempt/subscribed. Default to hidden; only show
+  // once we've actually resolved that a subscription is needed.
+  if (isLoading) return null;
 
   if (!isPastDue && !isReadOnly && !mustSubscribe) return null;
 


### PR DESCRIPTION
## Problem

On dashboard refresh, the **"Start your subscription to unlock Jigged for your shop."** banner flashes for a split second, then disappears — even for exempt/subscribed shops.

## Cause

While the `company_billing` cache is still being fetched, `billing` is `null`, and `getEntitlement(isDemo, null)` maps a missing row to `must_subscribe`. `BillingBanner` renders on `mustSubscribe` without checking whether billing has actually loaded yet — so it shows, then vanishes once the fetch resolves the shop as `billing_exempt`/`active`.

## Fix

Default to **hidden**: `BillingBanner` now returns `null` while `isLoading` (already exposed by `SubscriptionProvider`). The banner only appears once billing is *known* and a subscription is genuinely needed — the inverse of the buggy behavior. One-line guard, no logic change to the entitlement rule itself.

- No flash for exempt/subscribed shops (the common case).
- A genuinely never-subscribed company still sees the banner — just after load resolves, not as a flicker.
- Also removes the accompanying layout jump.

tsc clean; lint 0 errors (17 warnings, all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)