### PR TITLE
One QR per job traveler, a compact header, and two seed data-at-rest fixes

### DIFF
--- a/__tests__/utils/jobTravelerPdf.test.ts
+++ b/__tests__/utils/jobTravelerPdf.test.ts
@@ -27,7 +27,7 @@ const { jsPDFCtor, autoTableFn, addImageMock, qrMock } = vi.hoisted(() => {
     return docInstance;
   });
   const autoTableFn = vi.fn();
-  // Deterministic QR per URL so we can assert which op's code lands on which row.
+  // Deterministic QR per URL so we can assert what the single header code encodes.
   const qrMock = vi.fn().mockImplementation((url: string) => Promise.resolve(`QR::${url}`));
   return { jsPDFCtor, autoTableFn, addImageMock, qrMock };
 });
@@ -104,16 +104,16 @@ async function renderAndGetOpsTable(t: JobTraveler) {
   );
   if (!call) throw new Error('operations autoTable not found');
   return call[1] as {
+    head: string[][];
     body: string[][];
     didParseCell: (d: unknown) => void;
-    didDrawCell: (d: unknown) => void;
+    didDrawCell?: (d: unknown) => void;
   };
 }
 
-// traveler ops table columns: Step, WC, Operation/Instructions, Notes, Done, Scan
+// traveler ops table columns: Step, WC, Operation/Instructions, Notes, Done
 const DETAIL_COL = 2;
 const NOTES_COL = 3;
-const SCAN_COL = 5;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -159,27 +159,6 @@ describe('generateJobTravelerPdf — external (outside) operations', () => {
     expect(parse(0, DETAIL_COL)).toEqual({});
   });
 
-  it('maps each QR to the correct op id by identity (mixed routing, not by position)', async () => {
-    const opts = await renderAndGetOpsTable(
-      traveler([
-        op({ id: 'op-0', work_center_kind: 'internal' }),
-        op({ id: 'op-1', work_center_kind: 'external', vendor_name: 'AcmeCoat' }),
-      ]),
-    );
-    const drawScan = (rowIndex: number) =>
-      opts.didDrawCell({
-        section: 'body',
-        row: { index: rowIndex },
-        column: { index: SCAN_COL },
-        cell: { x: 0, y: 0, width: 80, height: 80 },
-      });
-    drawScan(0);
-    drawScan(1);
-    const drawnUrls = addImageMock.mock.calls.map((c) => c[0] as string);
-    expect(drawnUrls[0]).toContain('operation=op-0');
-    expect(drawnUrls[1]).toContain('operation=op-1');
-  });
-
   it('renders a no-vendor external op without throwing (still flagged OUTSIDE)', async () => {
     const opts = await renderAndGetOpsTable(
       traveler([op({ id: 'op-1', work_center_kind: 'external', vendor_name: null })]),
@@ -196,10 +175,46 @@ describe('generateJobTravelerPdf — external (outside) operations', () => {
       opts.didParseCell({ section: 'body', row: { index: 0 }, column: { index: DETAIL_COL }, cell }),
     ).not.toThrow();
     expect(cell.styles).toEqual({});
-    expect(() =>
-      opts.didDrawCell({ section: 'body', row: { index: 0 }, column: { index: SCAN_COL }, cell: { x: 0, y: 0, width: 80, height: 80 } }),
-    ).not.toThrow();
-    // No QR drawn for the placeholder row.
+  });
+});
+
+describe('generateJobTravelerPdf — single traveler QR', () => {
+  it('generates exactly one QR, pointing at the part traveler (no operation param)', async () => {
+    await generateJobTravelerPdf({
+      traveler: traveler([
+        op({ id: 'op-0', sequence: 10 }),
+        op({ id: 'op-1', sequence: 20 }),
+        op({ id: 'op-2', sequence: 30 }),
+      ]),
+      company,
+      bom: [],
+      companyId: 'c1',
+      baseUrl: 'https://app.test',
+      supabase: null,
+    });
+
+    // One code for the whole sheet, regardless of how many operations it lists.
+    expect(qrMock).toHaveBeenCalledTimes(1);
+    const url = qrMock.mock.calls[0][0] as string;
+    expect(url).toBe('https://app.test/operator/c1/login?job=job-1&part=jp-1');
+    expect(url).not.toContain('operation=');
+
+    // ...and it's the only image drawn (no logo on this company).
+    expect(addImageMock).toHaveBeenCalledTimes(1);
+    expect(addImageMock.mock.calls[0][0]).toBe(`QR::${url}`);
+  });
+
+  it('drops the per-operation Scan column from the operations table', async () => {
+    const opts = await renderAndGetOpsTable(traveler([op({ id: 'op-0' })]));
+    expect(opts.head[0]).toEqual(['Step', 'Work Center', 'Operation / Instructions', 'Notes', 'Done']);
+    expect(opts.body[0]).toHaveLength(5);
+    expect(opts.didDrawCell).toBeUndefined();
+  });
+
+  it('still renders the sheet when QR generation fails', async () => {
+    qrMock.mockRejectedValueOnce(new Error('qr boom'));
+    const opts = await renderAndGetOpsTable(traveler([op({ id: 'op-0' })]));
+    expect(opts.body).toHaveLength(1);
     expect(addImageMock).not.toHaveBeenCalled();
   });
 });

--- a/app/operator/[companyId]/login/page.tsx
+++ b/app/operator/[companyId]/login/page.tsx
@@ -38,11 +38,12 @@ export default function OperatorLoginPage() {
   const locationId = searchParams.get('location') || undefined;
 
   // Where to land after auth, given the scanned QR's params. A location QR
-  // (printed on a bin/cabinet label) opens that location's bin view; a
-  // per-operation QR (job + part + operation) jumps straight to that step's
-  // action view; a per-part QR (legacy travelers) to the part traveler;
-  // anything else — incl. a job-only scan, which we no longer print — falls back
-  // to the station jobs list.
+  // (printed on a bin/cabinet label) opens that location's bin view; the
+  // traveler QR (job + part) opens that part's traveler, where the operator
+  // picks the step; a job + part + operation QR (printed on older travelers,
+  // still in circulation on the floor) jumps straight to that step's action
+  // view; anything else — incl. a job-only scan — falls back to the station
+  // jobs list.
   const postLoginPath = () => {
     if (locationId) return `/operator/${companyId}/inventory/locations/${locationId}`;
     if (jobId && partId && operationId) {

--- a/components/jobs/JobTravelerPreviewDialog.tsx
+++ b/components/jobs/JobTravelerPreviewDialog.tsx
@@ -35,10 +35,10 @@ export interface JobTravelerPreviewDialogProps {
 
 /**
  * Per-part job-traveler preview. Re-renders the PDF from the job_part on
- * every open. The traveler carries one QR PER OPERATION (generated inside
- * generateJobTravelerPdf), each deep-linking the operator to
- * /operator/{companyId}/login?job=&part=&operation= and, post-login, straight
- * to that exact step's action view.
+ * every open. The traveler carries a SINGLE QR (generated inside
+ * generateJobTravelerPdf) that links to /operator/{companyId}/login?job=&part=
+ * and, post-login, to that part's traveler page — where the operator picks the
+ * step they're working.
  */
 export default function JobTravelerPreviewDialog({
   open,

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -91,15 +91,19 @@ tagged to a step via `job_operation_id`. Captured on the operation page (text + 
 
 - **Station placard** (per work center): selects the station and opens its job list. Posted at
   the machine, printed once; bulk-print all from the work-centers list.
-- **Per-operation traveler QR** (`utils/jobTravelerPdf.ts`): deep-links to a specific step's
-  action view. An **optional accelerator** for shops mid-transition — not required under the
-  paperless-preferred model. **Outside (external-vendor) steps are flagged with a heavy black
-  outline + bold text (border only, no fill)** on the printed traveler — unmistakable and
+- **Traveler QR** (`utils/jobTravelerPdf.ts`): **exactly one per traveler sheet**, in the header
+  beside the Job #, captioned "Scan to open this traveler". It opens that part's traveler page,
+  where the operator taps the step they're working. An **optional accelerator** for shops
+  mid-transition — not required under the paperless-preferred model.
+  *A previous revision printed a QR on every operation row; operators couldn't tell which code
+  they were pointing their phone at, so the sheet is back to one unambiguous target. The
+  `?job=&part=&operation=` deep link still resolves for sheets printed under that revision.*
+- The printed traveler's other shop-floor conventions: **outside (external-vendor) steps are
+  flagged with a heavy black outline + bold text (border only, no fill)** — unmistakable and
   grayscale-safe, but essentially no extra toner (earlier gray/solid fills drew a shop-owner ink
-  complaint). The traveler's merged **Notes** column carries the "OUTSIDE — ship to {vendor}"
-  cue for outside steps (and the setup/cycle estimates for internal steps), and the **Completed
-  (of N)** column is a blank write-in for a count or tick. The Scan cell
-  stays white so its QR remains scannable inside the banner.
+  complaint). The merged **Notes** column carries the "OUTSIDE — ship to {vendor}" cue for
+  outside steps (and the setup/cycle estimates for internal steps), and the **Done** column is a
+  blank write-in for a count or tick.
 
 ## Admin
 
@@ -126,7 +130,7 @@ Each bullet is a Given/When/Then scenario carrying a verification clause — a p
 
 - [ ] **Given** an operator scans a station placard, **when** they open `…/login?station={workCenterId}` and sign in with email/password, **then** the station is written to `sessionStorage` (`jigged_operator_station`) and they land on that station's job list — *write path verified by `__tests__/components/operations/StationQRCode.test.tsx > 'StationQRCode' > 'renders the QR code with the operator-login URL'`; login/session-persist E2E automation-pending (`OperatorLoginPage`)*.
 - [ ] **Given** a signed-in user with `role='operator'`, **when** `getPostLoginRoute` runs, **then** they are routed to `/operator/{companyId}` (office roles go to `/dashboard/{companyId}`) — *automation-pending (`getPostLoginRoute` in `utils/companyAccess.ts`)*.
-- [ ] **Given** a per-operation QR (`?job=&part=&operation=`), **when** the operator signs in, **then** they jump straight to that step's action view; a `?location=` QR opens that bin, and a bare scan falls back to the station jobs list — *automation-pending (`OperatorLoginPage.postLoginPath`)*.
+- [ ] **Given** the traveler QR (`?job=&part=`) — the one code printed on a job traveler — **when** the operator signs in, **then** they land on that part's traveler page and pick the step themselves; a `?job=&part=&operation=` QR (older travelers still on the floor) jumps straight to that step's action view, a `?location=` QR opens that bin, and a bare scan falls back to the station jobs list — *automation-pending (`OperatorLoginPage.postLoginPath`); the traveler's single-QR contract is verified by `__tests__/utils/jobTravelerPdf.test.ts > 'generateJobTravelerPdf — single traveler QR'`*.
 
 **Station selection (work centers)**
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -149,7 +149,7 @@ Flow 1: job Happy Path
 
 3. Salesperson/Owner converts quote directly into a job (job.due_date = entered manually at conversion)
 
-4. Operator scans the station QR placard (or a job's per-operation QR), opens the step, and taps Mark Complete (part → In Progress)
+4. Operator scans the station QR placard (or the single QR on a job traveler, which opens that part's step list), opens the step, and taps Mark Complete (part → In Progress)
 
 5. Operator completes work, logs output
 

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -67,8 +67,18 @@ insert into auth.identities (
 ) on conflict do nothing;
 
 -- ── Company + access ─────────────────────────────────────────────────────────
-insert into public.companies (id, name, settings) values
+-- The address / phone / email / website columns are NOT decoration: every
+-- generated document (job traveler, packing slip, quote, invoice) builds its
+-- letterhead from them via buildShopHeaderLines(). Left null, each PDF prints a
+-- company name floating over a block of empty paper, which reads as a layout bug
+-- rather than as missing profile data — so dev and preview branches were tuning
+-- print layouts against a shop that doesn't exist. Keep these populated.
+insert into public.companies (
+  id, name, address_line1, city, state, postal_code, country, phone, email, website, settings
+) values
   ('22222222-2222-2222-2222-222222222222', 'Vanguard Precision Works',
+   '1420 Rand Drive', 'Detroit', 'MI', '48211', 'USA',
+   '(313) 555-0142', 'shop@vanguardprecision.test', 'vanguardprecision.test',
    -- Enable the opt-in data-import tool in dev + preview branches so
    -- it's visible while the feature rolls out. Seed is local/preview-only, never prod.
    '{"features": {"data_import": true}}'::jsonb)
@@ -454,12 +464,50 @@ begin
   return v_jp;
 end $$;
 
+-- Record the completion event behind an advanced operation. Outside
+-- (external-vendor) ops are skipped: compute_job_operation_status() returns their
+-- stored status untouched because they move through the send/receive lifecycle,
+-- so a quantity event there would be meaningless noise. (The seeded routings are
+-- all-internal today; the guard keeps this correct if an outside step is added.)
+create function pg_temp.record_completion(
+  p_op uuid, p_jp uuid, p_qty numeric, p_at timestamptz, p_note text)
+returns void language plpgsql as $$
+begin
+  if exists (
+    select 1 from public.job_operations o
+    join public.work_centers wc on wc.id = o.work_center_id
+    where o.id = p_op and wc.kind = 'external'
+  ) then
+    return;
+  end if;
+  insert into public.job_operation_completions
+    (company_id, job_operation_id, job_part_id, quantity_good, completed_by, completed_at, created_at, note)
+  values ('22222222-2222-2222-2222-222222222222', p_op, p_jp, p_qty,
+          '11111111-1111-1111-1111-111111111111', p_at, p_at, p_note);
+end $$;
+
 -- Progress a job's parts + operations (job status rolls up via trigger).
+--
+-- job_operations.status is DERIVED, not authoritative: job_operation_completions
+-- is the append-only source of truth and
+-- recompute_job_operation_status_from_completion() computes the status from
+-- SUM(quantity_good) vs the ordered qty. So every op this helper advances also
+-- gets the completion event the app itself would have written. Without it the
+-- seed shipped "completed" ops with no history behind them — the operator
+-- completion feed was empty, and completeJobOperation() would compute
+-- `remaining = quantity - 0` and offer to re-complete the whole order as though
+-- the work had never happened.
+--
+-- ORDERING IS LOAD-BEARING: the status UPDATE comes first, the event second. The
+-- recompute trigger only writes when the computed status differs from the stored
+-- one, so seeding the status first makes the event a no-op transition and the
+-- backdated completed_at / completed_by survive. Insert the event first and the
+-- trigger stamps both with now(), flattening the seed's dated history.
 create function pg_temp.progress_job(p_job uuid, p_status text, p_anchor int)
 returns void language plpgsql as $$
-declare jp record; op record; n int; i int;
+declare jp record; op record; n int; i int; v_at timestamptz;
 begin
-  for jp in select id from public.job_parts where job_id = p_job loop
+  for jp in select id, quantity from public.job_parts where job_id = p_job loop
     if p_status = 'cancelled' then
       update public.job_parts set production_status='cancelled', status_changed_at = now() - (p_anchor||' days')::interval where id = jp.id;
       continue;
@@ -469,16 +517,32 @@ begin
     for op in select id from public.job_operations where job_part_id = jp.id order by sequence loop
       i := i + 1;
       if p_status = 'completed' then
+        v_at := now() - ((p_anchor + (n - i + 1)*2 - 1)||' days')::interval;
         update public.job_operations set status='completed',
-          completed_at = now() - ((p_anchor + (n - i + 1)*2 - 1)||' days')::interval,
+          completed_at = v_at,
           completed_by = '11111111-1111-1111-1111-111111111111' where id = op.id;
+        perform pg_temp.record_completion(op.id, jp.id, jp.quantity, v_at, 'Seed: full run complete');
       elsif p_status = 'in_progress' then
         if i = 1 then
+          v_at := now() - ((p_anchor+2)||' days')::interval;
           update public.job_operations set status='completed',
-            completed_at = now() - ((p_anchor+2)||' days')::interval,
+            completed_at = v_at,
             completed_by='11111111-1111-1111-1111-111111111111' where id = op.id;
+          perform pg_temp.record_completion(op.id, jp.id, jp.quantity, v_at, 'Seed: full run complete');
         elsif i = 2 then
           update public.job_operations set status='in_progress' where id = op.id;
+          -- Half the order booked: 0 < good < target is exactly what
+          -- compute_job_operation_status() reads back as 'in_progress', so the
+          -- derived status agrees with the one set above and the op carries a
+          -- real good-piece count for the partial-completion UI to show.
+          -- Floor it so a discrete part reads as whole pieces (2 of 5, not 2.5);
+          -- only fall back to the raw half when flooring would hit 0 and the
+          -- status would collapse to 'pending'.
+          perform pg_temp.record_completion(
+            op.id, jp.id,
+            case when floor(jp.quantity / 2) >= 1 then floor(jp.quantity / 2)
+                 else jp.quantity / 2 end,
+            now() - ((p_anchor+1)||' days')::interval, 'Seed: partial run');
         end if;
       end if;
     end loop;

--- a/utils/jobTravelerPdf.ts
+++ b/utils/jobTravelerPdf.ts
@@ -44,15 +44,22 @@ const MARGIN = 40;
  * Side of the single header QR (points).
  *
  * The scan URL is ~156 chars (origin + two UUIDs), which lands the code at
- * version 8 — 49x49 modules, plus 2 quiet-zone modules a side = 53 across. At
- * 64pt (22.6mm) that is ~0.43mm per module: fine for a phone held close to a
- * clean laser print, and sized to the title + Job # stack beside it rather than
- * towering over it. Do not shrink further without shortening the URL — below
- * ~0.4mm/module a greasy or lightly-smudged sheet starts failing to scan, which
- * defeats the whole point of the code. Shortening the URL is the lever that buys
- * a smaller code for free: fewer chars -> lower version -> fewer, fatter modules.
+ * version 8 — 49x49 modules, plus a 2-module quiet zone a side = 53 across. At
+ * 56pt (19.8mm) that works out to ~0.37mm per module.
+ *
+ * That number is set by precedent, not by a generic spec: the per-operation QRs
+ * this sheet used to print were also 56pt but carried a THIRD uuid (203 chars,
+ * version 9, 53x53) for ~0.35mm per module. This code is strictly less dense
+ * than what the traveler already shipped, at the same physical size. Caveat
+ * worth keeping in mind — the paperless operator flow was built but paper won by
+ * habit, so 0.35mm is an accepted precedent rather than a proven field result.
+ *
+ * If a shop ever reports a scan failing off a greasy or smudged sheet, do NOT
+ * just enlarge this. Shorten the URL instead: a `/t/{jobPartId}` redirect route
+ * (~60 chars) drops the code to version 4 / 33x33, which at this same 56pt is
+ * ~0.53mm per module — nearly half again more robust, with no layout change.
  */
-const QR_SIZE = 64;
+const QR_SIZE = 56;
 
 function formatMinutes(value: number | null | undefined): string {
   if (value === null || value === undefined || Number.isNaN(Number(value))) return '—';
@@ -210,8 +217,8 @@ export async function generateJobTravelerPdf(
   }
 
   // Header height is whichever column runs longest. The HOT stamp MUST be in
-  // this max: it hangs 8pt below a 64pt QR, so leaving it out draws the divider
-  // straight through the stamp on every hot job.
+  // this max: its bottom sits 16pt below a 56pt QR, so leaving it out draws the
+  // divider straight through the stamp on every hot job.
   let cursorY = Math.max(shopBlockBottom, qrBlockBottom, hotStampBottom) + 16;
 
   // ---------- Divider ----------

--- a/utils/jobTravelerPdf.ts
+++ b/utils/jobTravelerPdf.ts
@@ -10,11 +10,15 @@
  * which one they were pointing at, so the sheet is back to a single
  * unambiguous target.
  *
- * Layout:
- *   - Header: company logo (top-left) + return address; "JOB TRAVELER"
- *     title + Job # (top-right) with the traveler QR beneath it.
- *   - Info block: Customer / Part Number / Description / Quantity /
- *     Customer PO / Order Date (jobs.created_at) / Due Date.
+ * Layout — kept tight on purpose. The header used to stack title over QR over a
+ * caption and ran ~165pt, pushing the Operations table 40% down the page with a
+ * void beside it for any shop that hasn't filled in an address:
+ *   - Header (~82pt): company logo (top-left) + return address; the traveler QR
+ *     at the far right, top-aligned, with "JOB TRAVELER" + Job # right-aligned
+ *     to ITS left — so header height is the QR, not the sum of the stack.
+ *   - Info block: Customer / Part Number / Quantity / Customer PO / Order Date
+ *     (jobs.created_at) / Due Date, in two label/value columns, closed by a
+ *     divider. Description spans full width beneath.
  *   - Operations table: Step / Work Center / Operation · Instructions / Notes
  *     (setup·cycle for internal, "OUTSIDE — ship to {vendor}" for outside) /
  *     Done (blank write-in). Outside rows are flagged with a heavy black
@@ -125,47 +129,46 @@ export async function generateJobTravelerPdf(
 
   const shopLines = buildShopHeaderLines(company);
   doc.setFont('helvetica', 'normal');
-  doc.setFontSize(10);
-  doc.setTextColor(80);
+  doc.setFontSize(9.5);
+  doc.setTextColor(90);
   shopLines.forEach((line, i) => {
-    doc.text(line, shopNameX, headerTop + 30 + i * 12);
+    doc.text(line, shopNameX, headerTop + 30 + i * 11.5);
   });
-  const shopBlockBottom = Math.max(logoBottom, headerTop + 30 + shopLines.length * 12);
+  const shopBlockBottom = Math.max(
+    logoBottom,
+    headerTop + (shopLines.length ? 30 + shopLines.length * 11.5 : 18),
+  );
 
-  // ---------- Header: title + QR (right) ----------
-  doc.setFont('helvetica', 'bold');
-  doc.setFontSize(24);
-  doc.setTextColor(30);
-  doc.text('JOB TRAVELER', pageWidth - MARGIN, headerTop + 18, { align: 'right' });
-
-  doc.setFont('helvetica', 'bold');
-  doc.setFontSize(12);
-  doc.setTextColor(60);
-  doc.text(`Job ${traveler.job_number}`, pageWidth - MARGIN, headerTop + 36, { align: 'right' });
-
-  // ---------- Header: the traveler QR (far right, under the Job #) ----------
-  // One code, one meaning: "open this traveler". Captioned so nobody has to guess
-  // what scanning it does.
+  // ---------- Header: the traveler QR (far right, top-aligned) ----------
+  // The QR sits BESIDE the title, not under it, so header height is the QR's
+  // 82pt rather than title + QR + caption stacked to ~165pt. No caption — a QR
+  // already reads as "scan me", and the old line just cost a row of paper.
   const qrX = pageWidth - MARGIN - QR_SIZE;
-  const qrY = headerTop + 46;
-  let qrBlockBottom = headerTop + 36;
+  const qrY = headerTop;
+  let qrBlockBottom = headerTop;
   if (travelerQrDataUrl) {
     try {
       doc.addImage(travelerQrDataUrl, 'PNG', qrX, qrY, QR_SIZE, QR_SIZE);
-      doc.setFont('helvetica', 'normal');
-      doc.setFontSize(8);
-      doc.setTextColor(110);
-      doc.text('Scan to open this traveler', pageWidth - MARGIN, qrY + QR_SIZE + 11, {
-        align: 'right',
-      });
-      doc.setTextColor(30);
-      qrBlockBottom = qrY + QR_SIZE + 11;
+      qrBlockBottom = qrY + QR_SIZE;
     } catch {
       // Skip silently — the rest of the traveler is still useful.
     }
   }
 
-  // ---------- HOT stamp (left of the QR) ----------
+  // ---------- Header: title + Job # (right, left of the QR) ----------
+  // Right-aligned to the QR's left edge so the two never collide.
+  const titleRight = qrX - 16;
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(21);
+  doc.setTextColor(30);
+  doc.text('JOB TRAVELER', titleRight, headerTop + 18, { align: 'right' });
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(12);
+  doc.setTextColor(70);
+  doc.text(`Job ${traveler.job_number}`, titleRight, headerTop + 36, { align: 'right' });
+
+  // ---------- HOT stamp (under the Job #, left of the QR) ----------
   // The paperless equivalent of Contour's pink paper / "HOT" in red pen. Drawn as
   // an OUTLINED "rubber stamp" — a heavy black border with bold black "HOT" on
   // white, NO filled background. That mirrors the physical HOT rubber stamp,
@@ -176,9 +179,10 @@ export async function generateJobTravelerPdf(
   if (traveler.is_hot) {
     const stampW = 82;
     const stampH = 26;
-    // Sits beside the QR, not under it — the QR owns the right column now.
-    const stampX = qrX - 14 - stampW;
-    const stampY = qrY + (QR_SIZE - stampH) / 2;
+    // Tucked into the gap under the Job #, right-aligned to the title. It fits
+    // inside the QR's height, so a hot job costs no extra header rows.
+    const stampX = titleRight - stampW;
+    const stampY = headerTop + 46;
     doc.setDrawColor(0);
     doc.setLineWidth(2);
     doc.roundedRect(stampX, stampY, stampW, stampH, 4, 4, 'S');
@@ -193,10 +197,10 @@ export async function generateJobTravelerPdf(
     doc.setLineWidth(0.75);
   }
 
-  let cursorY = Math.max(shopBlockBottom, qrBlockBottom) + 18;
+  let cursorY = Math.max(shopBlockBottom, qrBlockBottom) + 16;
 
   // ---------- Divider ----------
-  doc.setDrawColor(210);
+  doc.setDrawColor(205);
   doc.setLineWidth(0.75);
   doc.line(MARGIN, cursorY, pageWidth - MARGIN, cursorY);
   cursorY += 20;
@@ -205,9 +209,11 @@ export async function generateJobTravelerPdf(
   // Short label/value pairs in two columns; each row advances by the taller
   // of its two cells. Description spans the full width below the grid so a
   // long description wraps cleanly instead of colliding with the next row.
+  // labelGap is the label -> value gutter: wide enough that values line up in a
+  // column, narrow enough not to leave a channel of white down the page.
   const colWidth = (pageWidth - MARGIN * 2) / 2;
   const lineHeight = 13;
-  const labelGap = 80;
+  const labelGap = 66;
 
   const drawPair = (label: string, value: string, x: number, y: number, maxWidth: number): number => {
     doc.setFont('helvetica', 'normal');
@@ -239,7 +245,8 @@ export async function generateJobTravelerPdf(
   gridRows.forEach(([left, right]) => {
     const ll = drawPair(left[0], left[1], MARGIN, cursorY, cellWidth);
     const rl = drawPair(right[0], right[1], MARGIN + colWidth, cursorY, cellWidth);
-    cursorY += Math.max(ll, rl) * lineHeight + 4;
+    // Single-line rows advance 16pt; a wrapped value still gets its full height.
+    cursorY += Math.max(ll, rl) * lineHeight + 3;
   });
 
   // Description — full width so it never overlaps the adjacent column.
@@ -250,7 +257,15 @@ export async function generateJobTravelerPdf(
     cursorY,
     pageWidth - MARGIN * 2 - labelGap,
   );
-  cursorY += descLines * lineHeight + 16;
+  cursorY += descLines * lineHeight + 4;
+
+  // ---------- Divider ----------
+  // Closes the info block so it reads as a band rather than trailing off into
+  // the Operations heading.
+  doc.setDrawColor(205);
+  doc.setLineWidth(0.75);
+  doc.line(MARGIN, cursorY, pageWidth - MARGIN, cursorY);
+  cursorY += 22;
 
   // ---------- Operations table ----------
   doc.setFont('helvetica', 'bold');

--- a/utils/jobTravelerPdf.ts
+++ b/utils/jobTravelerPdf.ts
@@ -40,8 +40,19 @@ import {
 } from '@/utils/packingSlipPdf';
 
 const MARGIN = 40;
-/** Side of the single header QR (points) — big enough to scan off a taped-up sheet. */
-const QR_SIZE = 90;
+/**
+ * Side of the single header QR (points).
+ *
+ * The scan URL is ~156 chars (origin + two UUIDs), which lands the code at
+ * version 8 — 49x49 modules, plus 2 quiet-zone modules a side = 53 across. At
+ * 64pt (22.6mm) that is ~0.43mm per module: fine for a phone held close to a
+ * clean laser print, and sized to the title + Job # stack beside it rather than
+ * towering over it. Do not shrink further without shortening the URL — below
+ * ~0.4mm/module a greasy or lightly-smudged sheet starts failing to scan, which
+ * defeats the whole point of the code. Shortening the URL is the lever that buys
+ * a smaller code for free: fewer chars -> lower version -> fewer, fatter modules.
+ */
+const QR_SIZE = 64;
 
 function formatMinutes(value: number | null | undefined): string {
   if (value === null || value === undefined || Number.isNaN(Number(value))) return '—';
@@ -140,8 +151,8 @@ export async function generateJobTravelerPdf(
   );
 
   // ---------- Header: the traveler QR (far right, top-aligned) ----------
-  // The QR sits BESIDE the title, not under it, so header height is the QR's
-  // 82pt rather than title + QR + caption stacked to ~165pt. No caption — a QR
+  // The QR sits BESIDE the title, not under it, so header height is one element
+  // tall rather than title + QR + caption stacked to ~165pt. No caption — a QR
   // already reads as "scan me", and the old line just cost a row of paper.
   const qrX = pageWidth - MARGIN - QR_SIZE;
   const qrY = headerTop;
@@ -176,13 +187,14 @@ export async function generateJobTravelerPdf(
   // of the toner a solid-black fill would (the earlier reversed-white-on-black
   // version was flagged as too ink-heavy). A double rule gives it stamp presence
   // without adding meaningful ink.
+  let hotStampBottom = headerTop;
   if (traveler.is_hot) {
     const stampW = 82;
     const stampH = 26;
-    // Tucked into the gap under the Job #, right-aligned to the title. It fits
-    // inside the QR's height, so a hot job costs no extra header rows.
+    // Tucked into the gap under the Job #, right-aligned to the title.
     const stampX = titleRight - stampW;
     const stampY = headerTop + 46;
+    hotStampBottom = stampY + stampH;
     doc.setDrawColor(0);
     doc.setLineWidth(2);
     doc.roundedRect(stampX, stampY, stampW, stampH, 4, 4, 'S');
@@ -197,7 +209,10 @@ export async function generateJobTravelerPdf(
     doc.setLineWidth(0.75);
   }
 
-  let cursorY = Math.max(shopBlockBottom, qrBlockBottom) + 16;
+  // Header height is whichever column runs longest. The HOT stamp MUST be in
+  // this max: it hangs 8pt below a 64pt QR, so leaving it out draws the divider
+  // straight through the stamp on every hot job.
+  let cursorY = Math.max(shopBlockBottom, qrBlockBottom, hotStampBottom) + 16;
 
   // ---------- Divider ----------
   doc.setDrawColor(205);

--- a/utils/jobTravelerPdf.ts
+++ b/utils/jobTravelerPdf.ts
@@ -3,19 +3,22 @@
  *
  * Modeled on utils/packingSlipPdf.ts — same jsPDF + jspdf-autotable
  * letter format, margins, logo embedding, and footer. One traveler is
- * unique to a single job_part. Each OPERATION row carries its own QR code,
- * which deep-links the operator straight to that exact step's action view
- * (a per-operation "scan to complete"). There is no single whole-job QR.
+ * unique to a single job_part and carries exactly ONE QR code, in the header:
+ * scanning it opens that part's traveler page, where every step is listed and
+ * the operator taps the one they're working. Earlier revisions printed a QR on
+ * every operation row; a column of codes an inch apart left operators unsure
+ * which one they were pointing at, so the sheet is back to a single
+ * unambiguous target.
  *
  * Layout:
  *   - Header: company logo (top-left) + return address; "JOB TRAVELER"
- *     title + Job # (top-right).
+ *     title + Job # (top-right) with the traveler QR beneath it.
  *   - Info block: Customer / Part Number / Description / Quantity /
  *     Customer PO / Order Date (jobs.created_at) / Due Date.
  *   - Operations table: Step / Work Center / Operation · Instructions / Notes
  *     (setup·cycle for internal, "OUTSIDE — ship to {vendor}" for outside) /
- *     Done (blank write-in) / Scan (per-operation QR). Outside rows are flagged
- *     with a heavy black outline + bold text (border only, low ink).
+ *     Done (blank write-in). Outside rows are flagged with a heavy black
+ *     outline + bold text (border only, low ink).
  *   - Footer (every page): page numbers.
  */
 
@@ -33,11 +36,8 @@ import {
 } from '@/utils/packingSlipPdf';
 
 const MARGIN = 40;
-// Side of the per-operation QR drawn inside each table row (points). Sized
-// generously and paired with a quiet zone (toDataURL margin) + tall rows
-// (bodyStyles.minCellHeight) so adjacent QR codes are far enough apart that a
-// phone camera locks onto a single one instead of getting confused by neighbors.
-const OP_QR_SIZE = 56;
+/** Side of the single header QR (points) — big enough to scan off a taped-up sheet. */
+const QR_SIZE = 90;
 
 function formatMinutes(value: number | null | undefined): string {
   if (value === null || value === undefined || Number.isNaN(Number(value))) return '—';
@@ -68,9 +68,9 @@ export interface JobTravelerPdfContext {
   company: Company;
   /** The part's bill of materials (parts_bom), quantities per unit. */
   bom: BomLineWithChildPart[];
-  /** Company id — used to build each operation's deep-link QR URL. */
+  /** Company id — used to build the traveler's deep-link QR URL. */
   companyId: string;
-  /** Absolute origin (e.g. window.location.origin) the scan URLs resolve against. */
+  /** Absolute origin (e.g. window.location.origin) the scan URL resolves against. */
   baseUrl: string;
   /** Optional Supabase client to resolve the logo signed URL. */
   supabase?: SupabaseLike | null;
@@ -81,24 +81,22 @@ export async function generateJobTravelerPdf(
 ): Promise<jsPDF> {
   const { traveler, company, bom, companyId, baseUrl } = ctx;
 
-  // One QR per operation: scanning it deep-links to that exact step's action
-  // view (via the operator login passthrough). Generated up front as PNG data
-  // URLs and drawn into each row by the autotable didDrawCell hook below.
-  const qrByOpId = new Map<string, string>();
-  await Promise.all(
-    traveler.operations.map(async (op) => {
-      const url =
-        `${baseUrl}/operator/${companyId}/login` +
-        `?job=${traveler.job_id}&part=${traveler.job_part_id}&operation=${op.id}`;
-      try {
-        // margin: 2 = a white quiet zone baked into the image so the scanner
-        // can isolate this code from its neighbors on the sheet.
-        qrByOpId.set(op.id, await QRCode.toDataURL(url, { margin: 2, width: 220, errorCorrectionLevel: 'M' }));
-      } catch {
-        // Skip this row's QR; the rest of the traveler is still useful.
-      }
-    }),
-  );
+  // The one QR on the sheet: it opens this job_part's traveler page (via the
+  // operator login passthrough), which lists every step for the operator to
+  // pick from. No `operation=` param — the sheet no longer targets a step.
+  const travelerUrl =
+    `${baseUrl}/operator/${companyId}/login` +
+    `?job=${traveler.job_id}&part=${traveler.job_part_id}`;
+  let travelerQrDataUrl: string | null = null;
+  try {
+    travelerQrDataUrl = await QRCode.toDataURL(travelerUrl, {
+      margin: 2,
+      width: 320,
+      errorCorrectionLevel: 'M',
+    });
+  } catch {
+    // Skip the QR; the printed traveler is still useful without it.
+  }
 
   const doc = new jsPDF({ unit: 'pt', format: 'letter' });
   const pageWidth = doc.internal.pageSize.getWidth();
@@ -145,7 +143,29 @@ export async function generateJobTravelerPdf(
   doc.setTextColor(60);
   doc.text(`Job ${traveler.job_number}`, pageWidth - MARGIN, headerTop + 36, { align: 'right' });
 
-  // ---------- HOT stamp (right, below the Job #) ----------
+  // ---------- Header: the traveler QR (far right, under the Job #) ----------
+  // One code, one meaning: "open this traveler". Captioned so nobody has to guess
+  // what scanning it does.
+  const qrX = pageWidth - MARGIN - QR_SIZE;
+  const qrY = headerTop + 46;
+  let qrBlockBottom = headerTop + 36;
+  if (travelerQrDataUrl) {
+    try {
+      doc.addImage(travelerQrDataUrl, 'PNG', qrX, qrY, QR_SIZE, QR_SIZE);
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(8);
+      doc.setTextColor(110);
+      doc.text('Scan to open this traveler', pageWidth - MARGIN, qrY + QR_SIZE + 11, {
+        align: 'right',
+      });
+      doc.setTextColor(30);
+      qrBlockBottom = qrY + QR_SIZE + 11;
+    } catch {
+      // Skip silently — the rest of the traveler is still useful.
+    }
+  }
+
+  // ---------- HOT stamp (left of the QR) ----------
   // The paperless equivalent of Contour's pink paper / "HOT" in red pen. Drawn as
   // an OUTLINED "rubber stamp" — a heavy black border with bold black "HOT" on
   // white, NO filled background. That mirrors the physical HOT rubber stamp,
@@ -153,12 +173,12 @@ export async function generateJobTravelerPdf(
   // of the toner a solid-black fill would (the earlier reversed-white-on-black
   // version was flagged as too ink-heavy). A double rule gives it stamp presence
   // without adding meaningful ink.
-  let hotStampBottom = headerTop + 36;
   if (traveler.is_hot) {
     const stampW = 82;
     const stampH = 26;
-    const stampX = pageWidth - MARGIN - stampW;
-    const stampY = headerTop + 44;
+    // Sits beside the QR, not under it — the QR owns the right column now.
+    const stampX = qrX - 14 - stampW;
+    const stampY = qrY + (QR_SIZE - stampH) / 2;
     doc.setDrawColor(0);
     doc.setLineWidth(2);
     doc.roundedRect(stampX, stampY, stampW, stampH, 4, 4, 'S');
@@ -171,11 +191,9 @@ export async function generateJobTravelerPdf(
     // Restore stroke/text state for the elements drawn afterwards (divider, etc.).
     doc.setTextColor(30);
     doc.setLineWidth(0.75);
-    hotStampBottom = stampY + stampH;
   }
 
-  // No whole-job QR — each operation row carries its own scan-to-complete QR.
-  let cursorY = Math.max(shopBlockBottom, hotStampBottom) + 18;
+  let cursorY = Math.max(shopBlockBottom, qrBlockBottom) + 18;
 
   // ---------- Divider ----------
   doc.setDrawColor(210);
@@ -248,12 +266,11 @@ export async function generateJobTravelerPdf(
   // "Done" (not "Completed (of N)", which wrapped) — a short, single-line write-in
   // for a good-piece count or a tick; the order qty already sits in the header.
   const head = [[
-    'Step', 'Work Center', 'Operation / Instructions', 'Notes', 'Done', 'Scan',
+    'Step', 'Work Center', 'Operation / Instructions', 'Notes', 'Done',
   ]];
-  // Explicit row -> operation map, built alongside `body` so both the QR draw and
-  // the external-op restyle resolve the op by identity, never by a fragile
-  // positional index into traveler.operations (the empty-ops placeholder row maps
-  // to null). A wrong QR under a flagged row would send a scan to the wrong step.
+  // Explicit row -> operation map, built alongside `body` so the external-op
+  // restyle resolves the op by identity, never by a fragile positional index
+  // into traveler.operations (the empty-ops placeholder row maps to null).
   const rowOps: (JobTravelerOperation | null)[] = [];
   const body = traveler.operations.map((op) => {
     rowOps.push(op);
@@ -280,17 +297,15 @@ export async function generateJobTravelerPdf(
       workCenter,
       detail,
       notes,
-      '', // Completed — blank write-in
-      '', // Scan — QR drawn in didDrawCell
+      '', // Done — blank write-in
     ];
   });
 
   if (body.length === 0) {
-    body.push(['—', 'No operations on this part', '', '', '', '']);
+    body.push(['—', 'No operations on this part', '', '', '']);
     rowOps.push(null);
   }
 
-  const SCAN_COL = 5;
   autoTable(doc, {
     startY: cursorY,
     margin: { left: MARGIN, right: MARGIN },
@@ -311,17 +326,16 @@ export async function generateJobTravelerPdf(
       lineWidth: 0.5,
     },
     bodyStyles: {
-      // Tall rows put vertical whitespace between adjacent QR codes so a phone
-      // camera doesn't see two codes at once.
-      minCellHeight: OP_QR_SIZE + 30,
+      // Enough row height to hand-write a piece count in the Done column,
+      // without the QR-spacing bloat the per-operation codes used to need.
+      minCellHeight: 32,
     },
     columnStyles: {
       0: { cellWidth: 38, halign: 'center' },
-      1: { cellWidth: 100, fontStyle: 'bold' },
+      1: { cellWidth: 110, fontStyle: 'bold' },
       2: { cellWidth: 'auto' },
-      3: { cellWidth: 132 },
-      4: { cellWidth: 52, halign: 'center' },
-      5: { cellWidth: OP_QR_SIZE + 18, halign: 'center' },
+      3: { cellWidth: 140 },
+      4: { cellWidth: 60, halign: 'center' },
     },
     // Flag external (outside-vendor) rows with a heavy black OUTLINE + bold black
     // text only — no fill. Unmistakable and grayscale-safe (contrast, not hue),
@@ -336,21 +350,6 @@ export async function generateJobTravelerPdf(
       data.cell.styles.textColor = [20, 20, 20];
       data.cell.styles.lineWidth = 1.2;
       data.cell.styles.lineColor = [20, 20, 20];
-    },
-    // Draw each operation's QR centered in its Scan cell (op resolved by the
-    // explicit rowOps map, not by position).
-    didDrawCell: (data) => {
-      if (data.section !== 'body' || data.column.index !== SCAN_COL) return;
-      const op = rowOps[data.row.index];
-      const dataUrl = op ? qrByOpId.get(op.id) : undefined;
-      if (!dataUrl) return;
-      const x = data.cell.x + (data.cell.width - OP_QR_SIZE) / 2;
-      const y = data.cell.y + (data.cell.height - OP_QR_SIZE) / 2;
-      try {
-        doc.addImage(dataUrl, 'PNG', x, y, OP_QR_SIZE, OP_QR_SIZE);
-      } catch {
-        // Skip silently — the row's text is still printed.
-      }
     },
     theme: 'grid',
   });


### PR DESCRIPTION
## Why

The traveler printed **a QR on every operation row**. Stacked an inch apart in the Scan column, operators couldn't tell which code their phone was aimed at — the exact confusion the per-step deep link was meant to remove. Fixing that exposed a layout problem, and fixing *that* exposed two gaps in the seed.

## What changed

### 1. One QR per traveler (`utils/jobTravelerPdf.ts`)

A single code in the header, encoding `…/operator/{companyId}/login?job=&part=` — the part's traveler page, where every step is listed and the operator taps the one they're on.

- The **Scan** column is gone, along with the `minCellHeight: 86` that existed only to keep adjacent QR codes from confusing a phone camera. Rows are back to 32pt.
- No routing change was needed — the login passthrough already routed `job + part` to the part traveler.
- The `?operation=` deep link **stays supported**: sheets printed under the old revision are hanging on shop floors and must keep working.

### 2. Compact header

The header stacked title over QR over a "Scan to open this traveler" caption and ran ~165pt. For a shop with no address on file the left half of that band was empty, so the sheet opened with a void and pushed Operations 40% down the page.

| | Before | After |
|---|---|---|
| Header height | ~165pt | ~96pt |
| Operations begins at | y=315 | y=245 |

The QR now sits at the far right top-aligned with the title and Job # right-aligned to *its* left, so header height is one element tall rather than the sum of the stack. The caption is gone (a QR already reads as "scan me"), the label/value gutter drops 80pt → 66pt, and a divider closes the info block.

### 3. QR sized down 90pt → 56pt

The QR kept its old 90pt size when it moved beside the title, so it towered over the 21pt heading next to it. **56pt (19.8mm)** is a 38% linear / 61% area reduction.

That size is set by this repo's own precedent rather than a generic rule of thumb — an important correction, because the first pass at this used a "0.5mm per module" guideline and landed too conservative:

| | chars | version | modules | size | mm/module |
|---|---|---|---|---|---|
| **Old per-operation QR (shipped)** | 203 | 9 | 53×53 | 56pt | **0.347** |
| Traveler QR before this PR | 156 | 8 | 49×49 | 90pt | 0.599 |
| **Traveler QR now** | 156 | 8 | 49×49 | **56pt** | **0.373** |
| `/t/{jobPartId}` redirect (not built) | 60 | 4 | 33×33 | 56pt | 0.534 |

The per-operation codes this sheet used to print were already 56pt while carrying a *third* UUID. The new code is the same physical size and slightly **less** dense than what shipped.

Caveat recorded in the code: that's a precedent, not a field result. The paperless operator flow was built but paper won by habit, so those codes were never punished by a greasy bench. **If a scan ever does fail, the fix is to shorten the URL, not grow the code** — see the follow-up below.

**This also fixed a latent bug.** Header height was `max(shopBlockBottom, qrBlockBottom)` and ignored the HOT stamp. The stamp's bottom sits 16pt below a 56pt QR, so on every hot job the divider would have been drawn straight through it — it only looked fine at 90pt because the taller QR masked the stamp. The hot sheet now genuinely exercises that path.

### 4. Seed: two data-at-rest fixes (`supabase/seed.sql`)

**Company profile was entirely null** — no address, city, state, zip, phone, email or website. Every generated document builds its letterhead from those via `buildShopHeaderLines()`, so the packing slip, quote and invoice PDFs had the same empty block. We were tuning print layouts against a shop that doesn't exist.

**`job_operations.status` had no completion events behind it.** `job_operation_completions` is the append-only source of truth and `recompute_job_operation_status_from_completion()` derives status from `SUM(quantity_good)` vs ordered qty. The seed set `status` directly, so 11 "completed" ops had zero history: the operator completion feed was empty, and `completeJobOperation()` computes `remaining = quantity - 0` — it would offer to re-book the entire order as if nothing had been made.

The fix works *with* the trigger: the status UPDATE stays first and the event goes second, because the trigger only writes on a real transition. That ordering makes the event a no-op for status and preserves the seed's backdated `completed_at` instead of flattening it to `now()`. External ops are skipped — they move through send/receive, and `compute_job_operation_status()` returns their stored status untouched.

## Verification

- `pnpm exec vitest run __tests__/utils/jobTravelerPdf.test.ts` — 7 passed. Replaced the per-row QR-mapping test with three asserting exactly one QR is generated, that it carries no `operation=` param, that the head row is 5 columns, and that the sheet still renders if QR generation throws.
- `pnpm exec tsc --noEmit` — clean.
- **Two `supabase db reset` cycles**, diffing a full job/part/op status fingerprint before vs after: all 20 seeded rows **byte-identical**, 0 derived-vs-stored status mismatches, all 11 `completed_at` still backdated (none stamped `now()`), partials land on whole pieces below target.
- `test_operator_ready_ops_rpc` passes (the one test that reads the seed).
- Rendered the PDF at every step — normal, addressed, address-less, and hot — and eyeballed it rather than trusting the numbers.

No migrations in this branch.

## Follow-up worth considering

**Shorten the scan URL.** It's the real lever on QR size, and the right response if a scan ever fails on the floor. A `/t/{jobPartId}` redirect resolving to company + job cuts ~156 chars to ~60, dropping the code to version 4 / 33×33 — ~0.53mm per module at the same 56pt, i.e. *more* robust than the original 90pt code while staying visually small.

Not built here, and it isn't free: the scanner isn't logged in yet, so the route needs a `SECURITY DEFINER` lookup granted to `anon` (hence a migration), it's a permanent second entry point since printed sheets must keep resolving the long URL, and it adds a failure mode the self-contained URL doesn't have.

## Known gaps left open (deliberately)

- **`quote_operations` / `quote_materials` are empty for all 12 seeded quotes**, so the cost-breakdown view is blank. The snapshots come from `calculateRoutingCost`, recursive TS cost math — reproducing it in SQL would duplicate the cost engine, the exact risk that got the batch cost RPC deferred in #68. Wants a post-seed script calling the real path; that's a design decision, not a seed tweak.
- `quickbooks_invoice_line_items` empty despite 2 `quickbooks_invoice_links`; `job_fulfillment_audit` empty despite 5 shipments (worth confirming whether it's app-written or should be trigger-populated).
- `part_notes`, `inventory_locations` / `part_location_stock`, `company_custom_units`, `parts_unit_conversions`, `ai_config` all empty — cheap to seed if we want those surfaces populated.
- The E2E company is also address-less (`e2e/global-setup.ts` inserts `{ name }` only).

## Docs

`docs/modules/operator-view.md` and `docs/prd.md` updated — both described the per-operation QR as the traveler's scanning model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)