### PR TITLE
feat(notes): durable note subject + view logging (attribution loop, Iteration A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -573,8 +573,55 @@ worktree:
   gen:db-types` introspects the shared `--local` stack, so it has the same
   hazard. Prefer letting **CI regenerate + diff-check** types on the PR (the
   backend job already fails on a mismatch), or regenerate against a throwaway
-  DB — don't `db reset` the shared stack mid-flight just to gen types. A
-  hand-edited `types/database.ts` is a valid stopgap that CI will validate.
+  DB — don't `db reset` the shared stack mid-flight just to gen types. Do **not**
+  hand-edit the file: the drift check diffs a byte-exact regen, so a hand-edit
+  fails CI even when every column is right.
+
+  The generator accepts `--db-url`, so a throwaway container works:
+
+  ```bash
+  docker run -d --rm --name migcheck -e POSTGRES_PASSWORD=x -p 55499:5432 postgres:17-alpine
+  # create the db, apply Supabase-platform stubs (roles anon/authenticated/
+  # service_role/jigged_ai_readonly, schemas auth/storage, auth.uid(),
+  # storage.objects + storage.foldername), then replay supabase/migrations/ in order
+  npx --yes supabase@2.109.0 gen types typescript \
+    --db-url "postgresql://postgres:x@127.0.0.1:55499/jigged" > types/database.ts
+  ```
+
+  **Gotcha that costs a red CI run:** a bare Postgres has no `pg_graphql`, so the
+  generator silently omits the `graphql_public` schema — in **two** places, the
+  schema block *and* the trailing `Constants` export. Splice both back from
+  `main` (this migration never touches them), then diff against `main` and
+  confirm only your intended tables/functions changed. Keep the generator version
+  matching the one pinned in `gen:db-types`.
+
+### Visual verification on a Vercel preview (worktrees, agents)
+
+Preview deployments sit behind Deployment Protection, so an agent gets a login
+page. The project has a **Protection Bypass for Automation** secret; it lives in
+`.env.local` as `VERCEL_AUTOMATION_BYPASS_SECRET` (gitignored — copy `.env.local`
+from the primary checkout in a fresh worktree, and re-copy if it was added after
+your worktree was created).
+
+Pass it as **headers**, not query params, so the secret never lands in a URL,
+shell history, or an agent transcript. `x-vercel-set-bypass-cookie` sets a cookie
+so in-app navigation after the first load keeps working:
+
+```bash
+export S=$(grep '^VERCEL_AUTOMATION_BYPASS_SECRET=' .env.local | cut -d= -f2- | tr -d '"'"'"' \r')
+export HDRS=$(python3 -c "import json,os;print(json.dumps({'x-vercel-protection-bypass':os.environ['S'],'x-vercel-set-bypass-cookie':'true'}))")
+agent-browser open "$PREVIEW_URL/login" --headers "$HDRS"
+```
+
+Then sign in with the seed account (`dev@jigged.test` / `jigged-dev-1234`) — the
+preview branch runs `supabase/seed.sql`, so it has the full Vanguard Precision
+Works data graph. Get `$PREVIEW_URL` from the PR's Vercel comment or
+`gh pr view <n> --json comments`.
+
+Notes: `agent-browser get text` needs a selector (`get text body`); prefer
+`snapshot -i -c` or `eval` since a not-yet-hydrated App Router page returns raw
+RSC payload. Docs:
+<https://vercel.com/docs/deployment-protection/automated-agent-access>
 - **Merge → local:** merging to `main` auto-applies the migration to **prod**
   (branching pipeline), but your **local** stack only picks it up when you
   `git pull` in the primary and `supabase db reset` again. Merge→prod is

--- a/__tests__/utils/dashboardAccess.test.ts
+++ b/__tests__/utils/dashboardAccess.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Per-table Supabase mock: each supabase.from(table) returns its own thenable
 // builder that resolves to table-specific fixture data, so the UNION-on-read
-// across jobs/quotes/shipments/job_notes/job_operations can be exercised.
+// across jobs/quotes/shipments/notes/job_operations can be exercised.
 const DATA: Record<string, unknown[]> & { error?: unknown } = {
   jobsCreated: [],
   jobsCompleted: [],
@@ -21,7 +21,7 @@ function resolveData(state: { table: string; completedFilter: boolean }) {
       return { data: DATA.quotes, error: null };
     case 'shipments':
       return { data: DATA.shipments, error: null };
-    case 'job_notes':
+    case 'notes':
       return { data: DATA.notes, error: null };
     case 'job_operations':
       return { data: DATA.operations, error: null };

--- a/__tests__/utils/jobNoteMediaAccess.test.ts
+++ b/__tests__/utils/jobNoteMediaAccess.test.ts
@@ -131,7 +131,7 @@ describe('getJobNoteMediaUrl', () => {
 describe('deleteJobNoteMedia', () => {
   it('deletes the row first, then the file (row-first)', async () => {
     await deleteJobNoteMedia({ id: 'media-1', storage_path: 'c1/jobs/j1/x.jpg' });
-    expect(mockSupabase.from).toHaveBeenCalledWith('job_note_media');
+    expect(mockSupabase.from).toHaveBeenCalledWith('note_media');
     expect(mockQueryBuilder.delete).toHaveBeenCalled();
     expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'media-1');
     expect(mockDeleteFileFromStorage).toHaveBeenCalledWith('c1/jobs/j1/x.jpg');
@@ -154,8 +154,8 @@ describe('deleteJobNote', () => {
     ];
     await deleteJobNote('n1');
 
-    expect(mockSupabase.from).toHaveBeenCalledWith('job_note_media');
-    expect(mockSupabase.from).toHaveBeenCalledWith('job_notes');
+    expect(mockSupabase.from).toHaveBeenCalledWith('note_media');
+    expect(mockSupabase.from).toHaveBeenCalledWith('notes');
     expect(mockQueryBuilder.eq).toHaveBeenCalledWith('note_id', 'n1');
     expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'n1');
     expect(mockDeleteFileFromStorage).toHaveBeenCalledWith('c1/jobs/j1/a.jpg');

--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // --- Chainable Supabase mock (same shape as partAttachmentsAccess.test.ts) ---
 const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
   const builder: Record<string, ReturnType<typeof vi.fn> | unknown> = {};
-  const chainMethods = ['from', 'select', 'insert', 'update', 'delete', 'eq', 'neq', 'in', 'is', 'not', 'order', 'limit', 'single'];
+  const chainMethods = ['from', 'select', 'insert', 'update', 'delete', 'eq', 'neq', 'in', 'is', 'not', 'or', 'order', 'limit', 'single'];
   chainMethods.forEach((m) => {
     builder[m] = vi.fn().mockImplementation(() => builder);
   });
@@ -228,9 +228,13 @@ describe('getJobNotes', () => {
 
     const result = await getJobNotes('j1', 'c1');
 
-    expect(mockSupabase.from).toHaveBeenCalledWith('job_notes');
-    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('job_id', 'j1');
+    expect(mockSupabase.from).toHaveBeenCalledWith('notes');
     expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'c1');
+    // The feed unions job-subject notes with DURABLE part-subject notes captured
+    // on this job. Filtering on job_id alone would drop every new capture.
+    expect(mockQueryBuilder.or).toHaveBeenCalledWith(
+      'job_id.eq.j1,captured_job_id.eq.j1',
+    );
     expect(mockQueryBuilder.order).toHaveBeenCalledWith('created_at', { ascending: false });
 
     // Operation-scoped note rolls up with a readable step label + mapped media.
@@ -294,7 +298,7 @@ describe('addJobNote', () => {
       jobOperationId: 'op1',
     });
 
-    expect(mockSupabase.from).toHaveBeenCalledWith('job_notes');
+    expect(mockSupabase.from).toHaveBeenCalledWith('notes');
     expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
       expect.objectContaining({
         company_id: 'c1',

--- a/__tests__/utils/operatorNoteSubject.test.ts
+++ b/__tests__/utils/operatorNoteSubject.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The behaviour change this whole workstream rests on.
+//
+// Before: every note was job-scoped (job_notes.job_id NOT NULL), so a note an
+// operator wrote at the machine died with the job, and the next person running
+// the part depended on a read-time heuristic that walked prior jobs.
+//
+// Now: when the step the operator is standing at has a routing link, the note's
+// SUBJECT is the durable (part, routing step) and the job is recorded only as
+// provenance. The operator is never asked to classify anything — the access layer
+// decides from the step.
+//
+// These tests pin that decision, both branches, and the provenance that keeps the
+// note visible in the capturing job's feed.
+
+const OPERATION: { data: unknown; error: unknown } = { data: null, error: null };
+const INSERTED: { row: Record<string, unknown> | null } = { row: null };
+
+/** Row shape the note insert reads back (JOB_NOTE_SELECT). */
+const NOTE_ROW = {
+  id: 'n1',
+  subject_kind: 'part',
+  job_id: null,
+  job_operation_id: null,
+  captured_job_id: 'job-1',
+  captured_job_operation_id: 'op-1',
+  part_id: 'part-1',
+  routing_operation_id: 'ro-1',
+  viewer_count: 0,
+  usage_count: 0,
+  body: 'watch the bore',
+  note_type: 'user',
+  created_at: '2026-07-27T10:00:00Z',
+  author: { name: 'Kurtis' },
+  operation: null,
+  captured_operation: { operation_name: 'Mill', sequence: 20 },
+  media: [],
+};
+
+function makeBuilder(table: string) {
+  const b: Record<string, unknown> = {};
+  const ret = () => b;
+  b.select = vi.fn(ret);
+  b.eq = vi.fn(ret);
+  b.or = vi.fn(ret);
+  b.order = vi.fn(ret);
+  b.single = vi.fn(ret);
+  b.insert = vi.fn((row: Record<string, unknown>) => {
+    INSERTED.row = row;
+    return b;
+  });
+  b.then = (resolve: (v: unknown) => void) =>
+    resolve(
+      table === 'job_operations'
+        ? OPERATION
+        : { data: INSERTED.row ? NOTE_ROW : null, error: null },
+    );
+  return b;
+}
+
+const mockSupabase = { from: vi.fn((t: string) => makeBuilder(t)), rpc: vi.fn() };
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+vi.mock('@/lib/supabaseErrors', () => ({
+  friendlyErrorMessage: (_e: unknown, o?: { fallback?: string }) => o?.fallback ?? 'error',
+}));
+
+import { addJobNote } from '@/utils/operatorAccess';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  OPERATION.data = null;
+  OPERATION.error = null;
+  INSERTED.row = null;
+});
+
+describe('addJobNote — subject selection', () => {
+  it('anchors to the PART and routing step when the step has a routing link', async () => {
+    OPERATION.data = { routing_operation_id: 'ro-1', job_part: { part_id: 'part-1' } };
+
+    await addJobNote('job-1', 'c1', 'acc-1', 'watch the bore', {
+      jobPartId: 'jp-1',
+      jobOperationId: 'op-1',
+    });
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('notes');
+    expect(INSERTED.row).toMatchObject({
+      subject_kind: 'part',
+      part_id: 'part-1',
+      routing_operation_id: 'ro-1',
+      author_id: 'acc-1',
+      body: 'watch the bore',
+    });
+    // The job is PROVENANCE, never the subject — that is what lets the note
+    // outlive the job while still showing in this job's feed.
+    expect(INSERTED.row).toMatchObject({
+      captured_job_id: 'job-1',
+      captured_job_operation_id: 'op-1',
+    });
+    expect(INSERTED.row).not.toHaveProperty('job_id');
+  });
+
+  it('falls back to a JOB subject when the step has no routing link', async () => {
+    // An ad-hoc step added to one job has nothing durable to anchor to. This is a
+    // genuine subject difference, not a silent fallback papering over bad data.
+    OPERATION.data = { routing_operation_id: null, job_part: { part_id: 'part-1' } };
+
+    await addJobNote('job-1', 'c1', 'acc-1', 'one-off', {
+      jobPartId: 'jp-1',
+      jobOperationId: 'op-1',
+    });
+
+    expect(INSERTED.row).toMatchObject({
+      subject_kind: 'job',
+      job_id: 'job-1',
+      job_part_id: 'jp-1',
+      job_operation_id: 'op-1',
+    });
+    expect(INSERTED.row).not.toHaveProperty('part_id');
+    expect(INSERTED.row).not.toHaveProperty('routing_operation_id');
+  });
+
+  it('falls back to a JOB subject when there is no step at all', async () => {
+    await addJobNote('job-1', 'c1', 'acc-1', 'job-level note');
+
+    expect(INSERTED.row).toMatchObject({ subject_kind: 'job', job_id: 'job-1' });
+    // No step means no job_operations lookup is even attempted.
+    expect(mockSupabase.from).not.toHaveBeenCalledWith('job_operations');
+  });
+
+  it('keeps auto-logged event notes job-scoped even on a routed step', async () => {
+    // A machine-generated audit line (e.g. the order-quantity trail) is not
+    // durable part knowledge and must never land in the Playbook.
+    OPERATION.data = { routing_operation_id: 'ro-1', job_part: { part_id: 'part-1' } };
+
+    await addJobNote('job-1', 'c1', 'acc-1', 'qty changed 10 -> 12', {
+      jobPartId: 'jp-1',
+      jobOperationId: 'op-1',
+      noteType: 'event',
+    });
+
+    expect(INSERTED.row).toMatchObject({ subject_kind: 'job', note_type: 'event' });
+    expect(mockSupabase.from).not.toHaveBeenCalledWith('job_operations');
+  });
+
+  it('trims the body and stores null for a media-only note', async () => {
+    OPERATION.data = { routing_operation_id: 'ro-1', job_part: { part_id: 'part-1' } };
+
+    await addJobNote('job-1', 'c1', 'acc-1', '   ', {
+      jobPartId: 'jp-1',
+      jobOperationId: 'op-1',
+    });
+
+    expect(INSERTED.row).toMatchObject({ body: null });
+  });
+
+  it('labels a durable note with the step it was captured at', async () => {
+    // The note has no job_operation_id of its own (its step is the routing step),
+    // so the feed row falls back to the capturing step for a readable label.
+    OPERATION.data = { routing_operation_id: 'ro-1', job_part: { part_id: 'part-1' } };
+
+    const note = await addJobNote('job-1', 'c1', 'acc-1', 'watch the bore', {
+      jobPartId: 'jp-1',
+      jobOperationId: 'op-1',
+    });
+
+    expect(note.operation_label).toBe('Op 20 · Mill');
+    expect(note.subject_kind).toBe('part');
+    // The feed still resolves it to the capturing job, so it renders in J-0041.
+    expect(note.job_id).toBe('job-1');
+  });
+});

--- a/__tests__/utils/operatorPartPreviousNotes.test.ts
+++ b/__tests__/utils/operatorPartPreviousNotes.test.ts
@@ -1,49 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Per-table Supabase mock so the multi-query flow (job_parts → job_notes →
-// job_operations) can return distinct data per source.
-const DATA: {
-  jobParts: unknown[];
-  notes: unknown[];
-  curOp: unknown;
-  priorOps: unknown[];
-  error?: unknown;
-} = { jobParts: [], notes: [], curOp: null, priorOps: [] };
+// getPartPreviousNotes used to fan out across job_parts -> job_notes ->
+// job_operations, up to 22 round trips for the default 10 prior runs. It is now
+// ONE part_playbook_notes RPC, because a note's subject is the durable
+// (part, routing step) rather than the job it happened to be written on.
+//
+// These tests assert the CONTRACT — which RPC, with which arguments, and how the
+// rows map — not the internals of the SQL, which belongs to the migration and its
+// integration tests.
 
-function resolveData(state: { table: string; single: boolean }) {
-  if (DATA.error) return { data: null, error: DATA.error };
-  switch (state.table) {
-    case 'job_parts':
-      return { data: DATA.jobParts, error: null };
-    case 'job_notes':
-      return { data: DATA.notes, error: null };
-    case 'job_operations':
-      return { data: state.single ? DATA.curOp : DATA.priorOps, error: null };
-    default:
-      return { data: [], error: null };
-  }
-}
+const STEP: { data: unknown; error: unknown } = { data: null, error: null };
+const RPC: { data: unknown; error: unknown } = { data: [], error: null };
 
-function makeBuilder(table: string) {
-  const state = { table, single: false };
+function makeBuilder() {
   const b: Record<string, unknown> = {};
   const ret = () => b;
   b.select = vi.fn(ret);
   b.eq = vi.fn(ret);
-  b.in = vi.fn(ret);
-  b.not = vi.fn(ret);
-  b.order = vi.fn(ret);
-  b.limit = vi.fn(ret);
-  b.lt = vi.fn(ret);
-  b.single = vi.fn(() => {
-    state.single = true;
-    return b;
-  });
-  b.then = (resolve: (v: unknown) => void) => resolve(resolveData(state));
+  b.single = vi.fn(ret);
+  b.then = (resolve: (v: unknown) => void) => resolve(STEP);
   return b;
 }
 
-const mockSupabase = { from: vi.fn((t: string) => makeBuilder(t)) };
+const mockRpc = vi.fn(async () => RPC);
+const mockSupabase = { from: vi.fn(() => makeBuilder()), rpc: mockRpc };
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
@@ -55,83 +35,109 @@ vi.mock('@/lib/supabaseErrors', () => ({
 
 import { getPartPreviousNotes } from '@/utils/operatorAccess';
 
-function note(over: Record<string, unknown>) {
+/** One row in the shape part_playbook_notes returns. */
+function row(over: Record<string, unknown> = {}) {
   return {
-    id: 'n',
-    job_id: 'jNew',
-    job_operation_id: null,
-    body: 'x',
+    id: 'n1',
+    body: 'back the feed off on the last pass',
     created_at: '2026-06-10T00:00:00Z',
-    author: null,
-    operation: null,
+    note_type: 'user',
+    subject_kind: 'part',
+    routing_operation_id: 'ro1',
+    corrects_note_id: null,
+    viewer_count: 4,
+    usage_count: 11,
+    author_name: 'Kurtis',
+    job_number: 'J-0041',
+    operation_label: 'Op 20 · Mill',
     media: [],
+    reactions: [],
     ...over,
   };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  DATA.jobParts = [];
-  DATA.notes = [];
-  DATA.curOp = null;
-  DATA.priorOps = [];
-  delete DATA.error;
+  STEP.data = null;
+  STEP.error = null;
+  RPC.data = [];
+  RPC.error = null;
 });
 
 describe('getPartPreviousNotes', () => {
-  it('returns prior-run notes tagged with the source job number, excluding the current job', async () => {
-    DATA.jobParts = [
-      { job_id: 'jNew', completed_at: '2026-06-10T00:00:00Z', jobs: { id: 'jNew', job_number: 'J-NEW' } },
-      { job_id: 'jCur', completed_at: '2026-06-15T00:00:00Z', jobs: { id: 'jCur', job_number: 'J-CUR' } },
-    ];
-    DATA.notes = [note({ id: 'n1', body: 'setup notes' })];
+  it('reads the whole part in ONE rpc call when no step is given', async () => {
+    RPC.data = [row()];
 
     const notes = await getPartPreviousNotes('part-1', 'c1', { excludeJobId: 'jCur' });
 
-    // Only the non-excluded run is fetched; each note carries its source job number.
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+    expect(mockRpc).toHaveBeenCalledWith(
+      'part_playbook_notes',
+      expect.objectContaining({ p_part_id: 'part-1', p_exclude_job_id: 'jCur' }),
+    );
+    // No step given -> no step scoping is requested.
+    const args = mockRpc.mock.calls[0][1] as Record<string, unknown>;
+    expect(args.p_routing_operation_id).toBeUndefined();
     expect(notes).toHaveLength(1);
-    expect(notes[0].body).toBe('setup notes');
-    expect(notes[0].job_number).toBe('J-NEW');
+    expect(notes[0].body).toBe('back the feed off on the last pass');
+    expect(notes[0].job_number).toBe('J-0041');
   });
 
-  it('returns [] when the only completed run is the current job', async () => {
-    DATA.jobParts = [
-      { job_id: 'jCur', completed_at: '2026-06-15T00:00:00Z', jobs: { id: 'jCur', job_number: 'J-CUR' } },
-    ];
-    expect(await getPartPreviousNotes('part-1', 'c1', { excludeJobId: 'jCur' })).toEqual([]);
-  });
+  it('scopes to a step by ROUTING operation, with the name as the legacy fallback', async () => {
+    // The durable anchor is the routing (template) step; operation_name only
+    // matters for pre-migration notes whose job step had no routing link.
+    STEP.data = { routing_operation_id: 'ro1', operation_name: 'Mill' };
+    RPC.data = [row()];
 
-  it('returns [] when there are no completed prior runs', async () => {
-    DATA.jobParts = [];
-    expect(await getPartPreviousNotes('part-1', 'c1', {})).toEqual([]);
-  });
-
-  it('filters notes to the same step across runs via routing_operation_id', async () => {
-    DATA.jobParts = [
-      { job_id: 'jNew', completed_at: '2026-06-10T00:00:00Z', jobs: { id: 'jNew', job_number: 'J-NEW' } },
-    ];
-    DATA.curOp = { routing_operation_id: 'ro1', operation_name: 'Mill' };
-    DATA.priorOps = [
-      { id: 'opPrior', routing_operation_id: 'ro1', operation_name: 'Mill' },
-      { id: 'opOther', routing_operation_id: 'ro2', operation_name: 'Saw' },
-    ];
-    DATA.notes = [
-      note({ id: 'n1', job_operation_id: 'opPrior', body: 'this step' }),
-      note({ id: 'n2', job_operation_id: 'opOther', body: 'other step' }),
-      note({ id: 'n3', job_operation_id: null, body: 'general' }),
-    ];
-
-    const notes = await getPartPreviousNotes('part-1', 'c1', {
+    await getPartPreviousNotes('part-1', 'c1', {
       excludeJobId: 'jCur',
       jobOperationId: 'opCur',
     });
 
-    expect(notes).toHaveLength(1);
-    expect(notes[0].body).toBe('this step');
+    expect(mockRpc).toHaveBeenCalledWith(
+      'part_playbook_notes',
+      expect.objectContaining({
+        p_part_id: 'part-1',
+        p_routing_operation_id: 'ro1',
+        p_operation_name: 'Mill',
+      }),
+    );
   });
 
-  it('returns [] when the job_parts query errors', async () => {
-    DATA.error = { message: 'boom' };
+  it('surfaces both counters, so a card can say "used on N jobs by N people"', async () => {
+    // viewer_count saturates near shop size; usage_count is the one that keeps
+    // growing and distinguishes a load-bearing note from a curiosity.
+    RPC.data = [row({ viewer_count: 4, usage_count: 11 })];
+
+    const notes = await getPartPreviousNotes('part-1', 'c1', {});
+
+    expect(notes[0].viewer_count).toBe(4);
+    expect(notes[0].usage_count).toBe(11);
+    expect(notes[0].subject_kind).toBe('part');
+  });
+
+  it('maps a legacy job-subject note without pretending it is durable', async () => {
+    RPC.data = [row({ subject_kind: 'job', routing_operation_id: null })];
+
+    const notes = await getPartPreviousNotes('part-1', 'c1', {});
+
+    expect(notes[0].subject_kind).toBe('job');
+  });
+
+  it('defaults an unknown note_type to user', async () => {
+    RPC.data = [row({ note_type: null })];
+    const notes = await getPartPreviousNotes('part-1', 'c1', {});
+    expect(notes[0].note_type).toBe('user');
+  });
+
+  it('returns [] when the rpc errors, rather than surfacing a partial feed', async () => {
+    RPC.data = null;
+    RPC.error = { message: 'boom' };
+    expect(await getPartPreviousNotes('part-1', 'c1', {})).toEqual([]);
+  });
+
+  it('returns [] when the part has nothing recorded yet', async () => {
+    RPC.data = [];
     expect(await getPartPreviousNotes('part-1', 'c1', {})).toEqual([]);
   });
 });

--- a/__tests__/utils/partsAccess.test.ts
+++ b/__tests__/utils/partsAccess.test.ts
@@ -237,7 +237,7 @@ describe('partsAccess utilities', () => {
 
       const notes = await getPartNotes('p1', 'c1');
 
-      expect(mockSupabase.from).toHaveBeenCalledWith('part_notes');
+      expect(mockSupabase.from).toHaveBeenCalledWith('part_comments');
       expect(notes[0]).toMatchObject({ id: 'n1', body: 'first', author_id: 'a1', author_name: 'Sam' });
       expect(notes[1]).toMatchObject({ id: 'n2', author_id: null, author_name: 'Pat' });
     });
@@ -276,7 +276,7 @@ describe('partsAccess utilities', () => {
   describe('deletePartNote', () => {
     it('deletes by id (RLS enforces author/admin)', async () => {
       await deletePartNote('n1');
-      expect(mockSupabase.from).toHaveBeenCalledWith('part_notes');
+      expect(mockSupabase.from).toHaveBeenCalledWith('part_comments');
       expect(mockQueryBuilder.delete).toHaveBeenCalled();
       expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'n1');
     });
@@ -308,7 +308,7 @@ describe('partsAccess utilities', () => {
     it('merges notes + transactions into one newest-first feed (job/quote dropped)', async () => {
       (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) => {
         switch (table) {
-          case 'part_notes':
+          case 'part_comments':
             return makeResult([
               {
                 id: 'n2', part_id: 'p1', body: 'Pricing updated', created_at: '2026-04-01T00:00:00Z',
@@ -345,7 +345,7 @@ describe('partsAccess utilities', () => {
     it('throws if any source errors (no silent partial feed)', async () => {
       (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) => {
         const b = makeResult([]);
-        if (table === 'part_notes') b.error = { message: 'boom' };
+        if (table === 'part_comments') b.error = { message: 'boom' };
         return b;
       });
       await expect(getPartActivity('p1', 'c1')).rejects.toBeTruthy();

--- a/api/tests/integration/test_note_views_rls.py
+++ b/api/tests/integration/test_note_views_rls.py
@@ -343,9 +343,13 @@ def test_non_author_gets_no_names(shop):
     assert shop["reader2"]["client"].rpc("note_viewers", {"p_note_id": note_id}).execute().data == []
 
 
-def test_admin_gets_no_names_even_on_a_note_they_authored(shop):
-    """Closes the bait-note bypass: an admin authors a must-read note, then
-    harvests a named read list entirely legitimately."""
+def test_attribution_does_not_depend_on_the_authors_role(shop):
+    """An admin author sees names exactly like an operator author does.
+
+    Roles are fluid in a shop this size — an operator promoted to lead must not
+    silently lose the feedback loop on notes they already wrote. The rule has no
+    role branch: you see who used YOUR notes, nobody sees who used anyone else's.
+    """
     note_id = (
         shop["admin"]
         .table("notes")
@@ -365,9 +369,28 @@ def test_admin_gets_no_names_even_on_a_note_they_authored(shop):
         "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
     ).execute()
 
-    assert shop["boss"]["client"].rpc("note_viewers", {"p_note_id": note_id}).execute().data == []
-    # ...but the aggregate count is still visible, as designed.
+    rows = shop["boss"]["client"].rpc("note_viewers", {"p_note_id": note_id}).execute().data
+    assert [r["viewer_name"] for r in rows] == ["Dana"]
     assert _counts(shop, note_id)[0] == 1
+
+
+def test_role_change_does_not_change_what_an_author_can_see(shop):
+    """The concrete regression the role branch would have caused: promote the
+    author, and their view of their own notes must be identical."""
+    note_id = _make_note(shop)
+    shop["reader"]["client"].rpc(
+        "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+    ).execute()
+
+    before = shop["author"]["client"].rpc("note_viewers", {"p_note_id": note_id}).execute().data
+
+    shop["admin"].table("user_company_access").update({"role": "admin"}).eq(
+        "id", shop["author"]["access_id"]
+    ).execute()
+
+    after = shop["author"]["client"].rpc("note_viewers", {"p_note_id": note_id}).execute().data
+    assert after == before
+    assert [r["viewer_name"] for r in after] == ["Dana"]
 
 
 def test_counters_never_fall_when_a_member_is_deleted(shop):

--- a/api/tests/integration/test_note_views_rls.py
+++ b/api/tests/integration/test_note_views_rls.py
@@ -1,0 +1,526 @@
+"""Integration tests for note view-logging: dedupe, exclusions, and the privacy rules.
+
+These are the acceptance criteria for the attribution loop, written against a real
+database because every one of them is enforced in Postgres rather than in the app:
+
+  - dedupe is a UNIQUE constraint, not application logic;
+  - "never the author" and "never an excluded account" live inside a SECURITY
+    DEFINER function, so the browser cannot opt out;
+  - "everyone else sees counts only" is the ABSENCE of a SELECT grant, which no
+    frontend test could observe.
+
+The product rule underneath all of it: if a shop owner can audit who reads notes,
+reading becomes an admission of ignorance and the read side dies. So the strongest
+assertions here are the negative ones.
+
+Requires a local Supabase with all migrations applied (TEST_SUPABASE_URL /
+TEST_SUPABASE_PUBLISHABLE_KEY / TEST_SUPABASE_SECRET_KEY). Skipped without it.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from supabase import create_client
+
+pytestmark = pytest.mark.integration
+
+
+def _publishable_key() -> str:
+    return os.environ.get("TEST_SUPABASE_PUBLISHABLE_KEY") or os.environ["TEST_SUPABASE_ANON_KEY"]
+
+
+def _add_member(admin, company_id: str, label: str, role: str = "operator") -> dict:
+    """A company member with their own signed-in client.
+
+    Deliberately defaults to `operator`, not `admin`: note_viewers() blocks admins
+    outright (an admin could otherwise author a must-read note and legitimately
+    harvest a named read list), so an admin-by-default cast would make the core
+    author-sees-names test silently vacuous.
+    """
+    email = f"nv-{label}-{os.urandom(4).hex()}@test.jigged.local"
+    password = "test-password-note-views"
+    created = admin.auth.admin.create_user(
+        {"email": email, "password": password, "email_confirm": True}
+    )
+    access = (
+        admin.table("user_company_access")
+        .insert(
+            {
+                "user_id": created.user.id,
+                "company_id": company_id,
+                "role": role,
+                "name": label.title(),
+            }
+        )
+        .execute()
+    )
+    client = create_client(os.environ["TEST_SUPABASE_URL"], _publishable_key())
+    client.auth.sign_in_with_password({"email": email, "password": password})
+    return {
+        "user_id": created.user.id,
+        "access_id": access.data[0]["id"],
+        "name": label.title(),
+        "client": client,
+    }
+
+
+@pytest.fixture
+def shop(supabase_admin):
+    """A company with an author, two readers, an admin, a routed part, and two jobs."""
+    admin = supabase_admin
+    company_id = (
+        admin.table("companies")
+        .insert({"name": f"nv-{os.urandom(3).hex()}"})
+        .execute()
+        .data[0]["id"]
+    )
+    # Demo company => company_can_write() is true without a billing row, so the
+    # billing gate never masks an RLS result we are actually trying to assert.
+    admin.table("companies").update({"is_demo": True}).eq("id", company_id).execute()
+
+    author = _add_member(admin, company_id, "kurtis")
+    reader = _add_member(admin, company_id, "dana")
+    reader2 = _add_member(admin, company_id, "sam")
+    boss = _add_member(admin, company_id, "shane", role="admin")
+
+    part_id = (
+        admin.table("parts")
+        .insert({"company_id": company_id, "part_name": f"BRACKET-{os.urandom(2).hex()}"})
+        .execute()
+        .data[0]["id"]
+    )
+    wc_id = (
+        admin.table("work_centers")
+        .insert({"company_id": company_id, "name": f"MILL-{os.urandom(2).hex()}"})
+        .execute()
+        .data[0]["id"]
+    )
+    routing_id = (
+        admin.table("routings")
+        .insert({"company_id": company_id, "part_id": part_id, "name": "Main"})
+        .execute()
+        .data[0]["id"]
+    )
+    routing_op_id = (
+        admin.table("routing_operations")
+        .insert({"routing_id": routing_id, "work_center_id": wc_id, "sequence": 10})
+        .execute()
+        .data[0]["id"]
+    )
+
+    jobs = []
+    for n in ("J-0041", "J-0052"):
+        jobs.append(
+            admin.table("jobs")
+            .insert({"company_id": company_id, "job_number": f"{n}-{os.urandom(2).hex()}"})
+            .execute()
+            .data[0]["id"]
+        )
+
+    ctx = {
+        "company_id": company_id,
+        "author": author,
+        "reader": reader,
+        "reader2": reader2,
+        "boss": boss,
+        "part_id": part_id,
+        "routing_operation_id": routing_op_id,
+        "job_a": jobs[0],
+        "job_b": jobs[1],
+        "admin": admin,
+    }
+    yield ctx
+
+    for table in ("jobs", "routings", "parts", "work_centers"):
+        try:
+            admin.table(table).delete().eq("company_id", company_id).execute()
+        except Exception:
+            pass
+    admin.table("companies").delete().eq("id", company_id).execute()
+    for m in (author, reader, reader2, boss):
+        try:
+            admin.auth.admin.delete_user(m["user_id"])
+        except Exception:
+            pass
+
+
+def _make_note(shop, body: str = "back the feed off on the last pass") -> str:
+    """A DURABLE part-subject note authored by `author`, captured on job A."""
+    return (
+        shop["admin"]
+        .table("notes")
+        .insert(
+            {
+                "company_id": shop["company_id"],
+                "subject_kind": "part",
+                "part_id": shop["part_id"],
+                "routing_operation_id": shop["routing_operation_id"],
+                "captured_job_id": shop["job_a"],
+                "author_id": shop["author"]["access_id"],
+                "body": body,
+            }
+        )
+        .execute()
+        .data[0]["id"]
+    )
+
+
+def _counts(shop, note_id: str) -> tuple[int, int]:
+    row = (
+        shop["admin"]
+        .table("notes")
+        .select("viewer_count, usage_count")
+        .eq("id", note_id)
+        .single()
+        .execute()
+        .data
+    )
+    return row["viewer_count"], row["usage_count"]
+
+
+def _rows(shop, note_id: str) -> list[dict]:
+    return (
+        shop["admin"].table("note_views").select("*").eq("note_id", note_id).execute().data
+    )
+
+
+# ── dedupe: rows are (person, job), counters split people from jobs ──────────
+
+
+def test_same_person_same_job_twice_is_one_row(shop):
+    note_id = _make_note(shop)
+    for _ in range(2):
+        shop["reader"]["client"].rpc(
+            "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+        ).execute()
+
+    assert len(_rows(shop, note_id)) == 1
+    assert _counts(shop, note_id) == (1, 1)
+
+
+def test_same_person_two_jobs_is_repeat_use_not_repeat_opens(shop):
+    """The distinction the two counters exist for: one PERSON, two JOBS."""
+    note_id = _make_note(shop)
+    for job in (shop["job_a"], shop["job_b"]):
+        shop["reader"]["client"].rpc(
+            "log_note_views", {"p_note_ids": [note_id], "p_job_id": job}
+        ).execute()
+
+    assert len(_rows(shop, note_id)) == 2
+    viewers, usage = _counts(shop, note_id)
+    assert viewers == 1, "one person read it, however many jobs they used it on"
+    assert usage == 2, "used on two jobs — the signal that it is load-bearing"
+
+
+def test_job_less_reads_dedupe_to_one_row(shop):
+    """NULLS NOT DISTINCT. Without it, every Playbook read inserts a new row."""
+    note_id = _make_note(shop)
+    for _ in range(3):
+        shop["reader"]["client"].rpc(
+            "log_note_views", {"p_note_ids": [note_id], "p_job_id": None}
+        ).execute()
+
+    assert len(_rows(shop, note_id)) == 1
+    viewers, usage = _counts(shop, note_id)
+    assert viewers == 1
+    assert usage == 0, "a read with no job context is not usage on a job"
+
+
+def test_two_people_two_viewers(shop):
+    note_id = _make_note(shop)
+    for m in ("reader", "reader2"):
+        shop[m]["client"].rpc(
+            "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+        ).execute()
+
+    assert _counts(shop, note_id) == (2, 1)
+
+
+# ── exclusions, enforced in the DB rather than the client ────────────────────
+
+
+def test_author_reading_own_note_logs_nothing(shop):
+    note_id = _make_note(shop)
+    shop["author"]["client"].rpc(
+        "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+    ).execute()
+
+    assert _rows(shop, note_id) == []
+    assert _counts(shop, note_id) == (0, 0)
+
+
+def test_excluded_account_logs_nothing(shop):
+    """The founder logs in constantly and must not inflate anyone's numbers."""
+    note_id = _make_note(shop)
+    shop["admin"].table("user_company_access").update(
+        {"excluded_from_metrics": True}
+    ).eq("id", shop["reader"]["access_id"]).execute()
+
+    shop["reader"]["client"].rpc(
+        "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+    ).execute()
+
+    assert _rows(shop, note_id) == []
+
+
+def test_browser_cannot_flip_the_exclusion_flag(shop):
+    """Otherwise: exclude everyone but one person, watch the counters, and you
+    have that person's entire reading history. RLS cannot scope to a column;
+    the column-level GRANT is what closes this."""
+    with pytest.raises(Exception) as exc:
+        shop["boss"]["client"].table("user_company_access").update(
+            {"excluded_from_metrics": True}
+        ).eq("id", shop["reader"]["access_id"]).execute()
+    assert "42501" in str(exc.value).lower() or "permission" in str(exc.value).lower()
+
+
+def test_admin_can_still_change_a_member_role(shop):
+    """Regression guard on the column-scoped grant above: the one browser write
+    this table actually has must keep working."""
+    shop["boss"]["client"].table("user_company_access").update({"role": "user"}).eq(
+        "id", shop["reader2"]["access_id"]
+    ).execute()
+    row = (
+        shop["admin"]
+        .table("user_company_access")
+        .select("role")
+        .eq("id", shop["reader2"]["access_id"])
+        .single()
+        .execute()
+        .data
+    )
+    assert row["role"] == "user"
+
+
+# ── visibility: counts for everyone, names for the author only ───────────────
+
+
+def test_note_views_is_unreadable_by_any_browser_role(shop):
+    note_id = _make_note(shop)
+    shop["reader"]["client"].rpc(
+        "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+    ).execute()
+
+    for who in ("author", "reader", "boss"):
+        try:
+            res = shop[who]["client"].table("note_views").select("*").execute()
+            assert res.data == [], f"{who} could read note_views rows"
+        except Exception as exc:  # a permission error is the expected outcome
+            assert "42501" in str(exc).lower() or "permission" in str(exc).lower()
+
+
+def test_author_sees_named_viewers_with_job_numbers(shop):
+    note_id = _make_note(shop)
+    shop["reader"]["client"].rpc(
+        "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+    ).execute()
+
+    rows = shop["author"]["client"].rpc("note_viewers", {"p_note_id": note_id}).execute().data
+    assert [r["viewer_name"] for r in rows] == ["Dana"]
+    assert rows[0]["job_number"]
+
+
+def test_author_sees_one_row_per_person_however_many_jobs(shop):
+    """With job in the dedupe key this is a query obligation rather than a
+    physical impossibility, so it gets its own test."""
+    note_id = _make_note(shop)
+    for job in (shop["job_a"], shop["job_b"]):
+        shop["reader"]["client"].rpc(
+            "log_note_views", {"p_note_ids": [note_id], "p_job_id": job}
+        ).execute()
+
+    rows = shop["author"]["client"].rpc("note_viewers", {"p_note_id": note_id}).execute().data
+    assert len(rows) == 1, "the author must never see that one person came back"
+
+
+def test_non_author_gets_no_names(shop):
+    note_id = _make_note(shop)
+    shop["reader"]["client"].rpc(
+        "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+    ).execute()
+
+    assert shop["reader2"]["client"].rpc("note_viewers", {"p_note_id": note_id}).execute().data == []
+
+
+def test_admin_gets_no_names_even_on_a_note_they_authored(shop):
+    """Closes the bait-note bypass: an admin authors a must-read note, then
+    harvests a named read list entirely legitimately."""
+    note_id = (
+        shop["admin"]
+        .table("notes")
+        .insert(
+            {
+                "company_id": shop["company_id"],
+                "subject_kind": "part",
+                "part_id": shop["part_id"],
+                "author_id": shop["boss"]["access_id"],
+                "body": "everyone read the new spec",
+            }
+        )
+        .execute()
+        .data[0]["id"]
+    )
+    shop["reader"]["client"].rpc(
+        "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+    ).execute()
+
+    assert shop["boss"]["client"].rpc("note_viewers", {"p_note_id": note_id}).execute().data == []
+    # ...but the aggregate count is still visible, as designed.
+    assert _counts(shop, note_id)[0] == 1
+
+
+def test_counters_never_fall_when_a_member_is_deleted(shop):
+    """The strongest attack this design faces: snapshot the counters, delete one
+    member so their rows cascade, snapshot again, and every note whose count
+    dropped was read by that person. Monotonic counters close it."""
+    note_id = _make_note(shop)
+    for m in ("reader", "reader2"):
+        shop[m]["client"].rpc(
+            "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+        ).execute()
+    before = _counts(shop, note_id)
+
+    shop["admin"].table("user_company_access").delete().eq(
+        "id", shop["reader"]["access_id"]
+    ).execute()
+
+    assert _counts(shop, note_id) == before
+
+
+# ── the login-banner digest ──────────────────────────────────────────────────
+
+
+def test_digest_counts_people_not_rows(shop):
+    """Three rows can be one person on three jobs. "3 people used your notes"
+    for a single reader is the exact overstatement this must not make."""
+    note_id = _make_note(shop)
+    for job in (shop["job_a"], shop["job_b"]):
+        shop["reader"]["client"].rpc(
+            "log_note_views", {"p_note_ids": [note_id], "p_job_id": job}
+        ).execute()
+
+    assert len(_rows(shop, note_id)) == 2
+    n = shop["author"]["client"].rpc(
+        "my_note_view_digest", {"p_tz": "America/Detroit"}
+    ).execute().data
+    assert n == 1
+
+
+def test_digest_is_scoped_to_the_callers_own_notes(shop):
+    note_id = _make_note(shop)
+    shop["reader"]["client"].rpc(
+        "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+    ).execute()
+
+    n = shop["reader2"]["client"].rpc(
+        "my_note_view_digest", {"p_tz": "America/Detroit"}
+    ).execute().data
+    assert n == 0
+
+
+# ── the durable subject, and the constraints protecting it ───────────────────
+
+
+def test_durable_note_is_readable_without_touching_the_capturing_job(shop):
+    """The whole point: a note written on job A is found by part + step alone."""
+    note_id = _make_note(shop)
+
+    found = (
+        shop["reader"]["client"]
+        .table("notes")
+        .select("id")
+        .eq("part_id", shop["part_id"])
+        .eq("routing_operation_id", shop["routing_operation_id"])
+        .execute()
+        .data
+    )
+    assert [r["id"] for r in found] == [note_id]
+
+
+def test_subject_check_rejects_a_mixed_subject(shop):
+    with pytest.raises(Exception):
+        shop["admin"].table("notes").insert(
+            {
+                "company_id": shop["company_id"],
+                "subject_kind": "part",
+                "part_id": shop["part_id"],
+                "job_id": shop["job_a"],  # a part-subject note has no job
+                "body": "mixed",
+            }
+        ).execute()
+
+
+def test_subject_check_rejects_an_unknown_kind(shop):
+    with pytest.raises(Exception):
+        shop["admin"].table("notes").insert(
+            {
+                "company_id": shop["company_id"],
+                "subject_kind": "sandwich",
+                "part_id": shop["part_id"],
+                "body": "nope",
+            }
+        ).execute()
+
+
+def test_subject_must_belong_to_the_same_company(shop, supabase_admin):
+    """A Postgres CHECK cannot span tables, so this is the trigger's job. The
+    hole predates this work: a member of two companies could file a note under
+    company A referencing company B's job."""
+    other_company = (
+        supabase_admin.table("companies")
+        .insert({"name": f"nv-other-{os.urandom(3).hex()}"})
+        .execute()
+        .data[0]["id"]
+    )
+    other_part = (
+        supabase_admin.table("parts")
+        .insert({"company_id": other_company, "part_name": "FOREIGN"})
+        .execute()
+        .data[0]["id"]
+    )
+    try:
+        with pytest.raises(Exception) as exc:
+            supabase_admin.table("notes").insert(
+                {
+                    "company_id": shop["company_id"],
+                    "subject_kind": "part",
+                    "part_id": other_part,
+                    "body": "cross-tenant",
+                }
+            ).execute()
+        assert "not in company" in str(exc.value)
+    finally:
+        supabase_admin.table("parts").delete().eq("company_id", other_company).execute()
+        supabase_admin.table("companies").delete().eq("id", other_company).execute()
+
+
+def test_note_survives_its_routing_step_being_deleted(shop):
+    """Deleting a routing step must degrade the note to part-level, never destroy
+    accumulated knowledge. This is why part_id is stored alongside the step."""
+    note_id = _make_note(shop)
+    shop["admin"].table("routing_operations").delete().eq(
+        "id", shop["routing_operation_id"]
+    ).execute()
+
+    row = shop["admin"].table("notes").select("*").eq("id", note_id).single().execute().data
+    assert row["routing_operation_id"] is None
+    assert row["part_id"] == shop["part_id"]
+    assert row["subject_kind"] == "part"
+
+
+# ── drift and coverage invariants ────────────────────────────────────────────
+
+
+def test_counters_never_drift_below_reality(supabase_admin):
+    """One-sided by design: stored > live is expected (departed members), stored
+    < live means the trigger failed."""
+    rows = supabase_admin.rpc("note_count_anomalies", {}).execute().data
+    assert rows == [], f"counter drift: {rows}"
+
+
+def test_new_tables_are_gated_or_explicitly_exempt(supabase_admin):
+    """Mirrors test_no_tenant_table_left_ungated — note_views and operator_events
+    are SECURITY DEFINER-only writers, so they are exempt rather than gated."""
+    rows = supabase_admin.rpc("tenant_tables_missing_write_gate", {}).execute().data
+    assert rows == [], f"un-gated tenant tables: {rows}"

--- a/api/tests/integration/test_note_views_rls.py
+++ b/api/tests/integration/test_note_views_rls.py
@@ -524,3 +524,16 @@ def test_new_tables_are_gated_or_explicitly_exempt(supabase_admin):
     are SECURITY DEFINER-only writers, so they are exempt rather than gated."""
     rows = supabase_admin.rpc("tenant_tables_missing_write_gate", {}).execute().data
     assert rows == [], f"un-gated tenant tables: {rows}"
+
+
+def test_read_log_is_not_granted_to_the_ai_sql_role(shop):
+    """Regression guard for a grant that arrives by DEFAULT, not by anyone writing it.
+
+    baseline.sql sets `ALTER DEFAULT PRIVILEGES ... GRANT SELECT ON TABLES TO
+    jigged_ai_readonly`, so every new public table is granted to the AI SQL role on
+    creation. Both tables here therefore need an explicit REVOKE, and this test
+    exists because reading the migration will not reveal the grant — only the
+    database will. "Which operators read the setup notes?" must not be answerable.
+    """
+    leaks = shop["admin"].rpc("no_client_access_grant_leaks", {}).execute().data
+    assert leaks == [], f"no-client-access tables are granted to: {leaks}"

--- a/api/tests/integration/test_note_views_rls.py
+++ b/api/tests/integration/test_note_views_rls.py
@@ -84,9 +84,18 @@ def shop(supabase_admin):
     reader2 = _add_member(admin, company_id, "sam")
     boss = _add_member(admin, company_id, "shane", role="admin")
 
+    # primary_unit is NOT NULL via parts_requires_unit; production/fulfillment
+    # status are NOT NULL on jobs. Both are easy to miss because the access layer
+    # always supplies them.
     part_id = (
         admin.table("parts")
-        .insert({"company_id": company_id, "part_name": f"BRACKET-{os.urandom(2).hex()}"})
+        .insert(
+            {
+                "company_id": company_id,
+                "part_name": f"BRACKET-{os.urandom(2).hex()}",
+                "primary_unit": "ea",
+            }
+        )
         .execute()
         .data[0]["id"]
     )
@@ -113,7 +122,14 @@ def shop(supabase_admin):
     for n in ("J-0041", "J-0052"):
         jobs.append(
             admin.table("jobs")
-            .insert({"company_id": company_id, "job_number": f"{n}-{os.urandom(2).hex()}"})
+            .insert(
+                {
+                    "company_id": company_id,
+                    "job_number": f"{n}-{os.urandom(2).hex()}",
+                    "production_status": "not_started",
+                    "fulfillment_status": "unshipped",
+                }
+            )
             .execute()
             .data[0]["id"]
         )
@@ -498,7 +514,13 @@ def test_subject_must_belong_to_the_same_company(shop, supabase_admin):
     )
     other_part = (
         supabase_admin.table("parts")
-        .insert({"company_id": other_company, "part_name": "FOREIGN"})
+        .insert(
+            {
+                "company_id": other_company,
+                "part_name": "FOREIGN",
+                "primary_unit": "ea",
+            }
+        )
         .execute()
         .data[0]["id"]
     )

--- a/api/tools/schema_context.py
+++ b/api/tools/schema_context.py
@@ -439,4 +439,15 @@ SENSITIVE_TABLES = frozenset({
     "quickbooks_connections",
     "quickbooks_customer_map",
     "quickbooks_invoice_links",
+    # Read-tracking and capture-funnel instrumentation. "Which operators read the
+    # setup notes?" is a natural question for a shop owner to type, and answering
+    # it is exactly what the product forbids: if an owner can audit who reads
+    # notes, reading becomes an admission of ignorance and the read side dies.
+    # These are already triple-blocked (absent from ALLOWED_TABLES, no grant to
+    # jigged_ai_readonly, no ai_readonly_select policy); this is the whole-word
+    # backstop. Never grant these to jigged_ai_readonly and never add them to
+    # ALLOWED_TABLES. notes.viewer_count / usage_count riding along if `notes` is
+    # ever allowlisted is fine — those are aggregate counts, not identities.
+    "note_views",
+    "operator_events",
 })

--- a/docs/modules/ai-insights.md
+++ b/docs/modules/ai-insights.md
@@ -164,7 +164,9 @@ The `sql_validator.py` module enforces these rules before any query reaches the 
 
 Enforced by the `SENSITIVE_TABLES` denylist in `api/tools/schema_context.py` — rejected if referenced anywhere in a query:
 
-`user_company_access`, `user_preferences`, `system_admins`, `auth_audit_log`, `ai_chat_queries`, `ai_config`, `saved_insights`, `demo_data_templates`, `quickbooks_connections`, `quickbooks_customer_map`, `quickbooks_invoice_links`
+`user_company_access`, `user_preferences`, `system_admins`, `auth_audit_log`, `ai_chat_queries`, `ai_config`, `saved_insights`, `demo_data_templates`, `quickbooks_connections`, `quickbooks_customer_map`, `quickbooks_invoice_links`, `note_views`, `operator_events`
+
+**`note_views` and `operator_events` are excluded for a product reason, not just a privacy-hygiene one.** "Which operators read the setup notes?" is a natural question for a shop owner to type, and answering it is precisely what the notes feature forbids: if an owner can audit who reads notes, reading becomes an admission of ignorance and the read side dies. They are already blocked three ways — absent from `ALLOWED_TABLES`, no `GRANT` to `jigged_ai_readonly`, and no `ai_readonly_select` policy — and the denylist is the whole-word backstop. **Never** add them to `ALLOWED_TABLES` or grant them to `jigged_ai_readonly`. (`notes.viewer_count` / `usage_count` riding along if `notes` is ever allowlisted is fine: those are aggregate counts, never identities.)
 
 ### Adding a New Table to AI Scope
 

--- a/supabase/migrations/20260728040701_notes_subjects_and_view_logging.sql
+++ b/supabase/migrations/20260728040701_notes_subjects_and_view_logging.sql
@@ -1,0 +1,903 @@
+-- Attribution and the read-back loop, Iteration A.
+--
+-- THE PROBLEM THIS SOLVES. Every note in Jigged is job-scoped: job_notes.job_id is
+-- NOT NULL, so a note an operator writes at the machine dies with the job. Nothing in
+-- the schema says "this is how you run this part at this step" — that knowledge is
+-- reconstructed at READ time by getPartPreviousNotes(), a heuristic that walks up to 10
+-- prior completed jobs and matches steps by routing_operation_id with an
+-- operation_name fallback (~22 round trips). So a motivated operator has nowhere to put
+-- knowledge that outlives the job.
+--
+-- This migration creates the durable, job-independent subject that makes a note worth
+-- reading twice, and the view-logging that measures whether it gets read.
+--
+--   job_notes      -> notes         (+ subject columns, provenance, counters)
+--   job_note_media -> note_media
+--   part_notes     -> part_comments (RENAME ONLY — different domain, see below)
+--   + note_views, note_reactions, operator_events
+--
+-- WHY part_comments IS NOT FOLDED IN. part_notes is the manual half of an office
+-- activity feed that also carries system-generated pricing entries; its audience is
+-- office staff, not the shop floor, and it needs none of the view logging, reactions,
+-- confirmations, corrections or media that notes need. It is renamed purely to free the
+-- `notes` name. Folding it in would attach view counts to pricing entries and force
+-- every knowledge surface to remember to filter change-log rows — the same
+-- silent-filter bug class as a forgotten `deleted_at IS NULL`.
+--
+-- PRIVACY IS THE POINT, not a side concern. note_views has NO client-reachable read
+-- path at all: no SELECT grant, plus a RESTRICTIVE deny-all so a future well-meaning
+-- permissive policy still evaluates false. Authors get names via one SECURITY DEFINER
+-- function; everyone else gets counts via a column. Rationale for each choice is
+-- inline. If a shop owner can audit who reads notes, reading becomes an admission of
+-- ignorance and the read side dies.
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 1. RENAMES
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- RENAME rather than create-and-copy so ids survive and job_note_media's FK keeps
+-- resolving. Indexes, constraints, policies and grants all follow the table.
+
+ALTER TABLE public.job_notes      RENAME TO notes;
+ALTER TABLE public.job_note_media RENAME TO note_media;
+ALTER TABLE public.part_notes     RENAME TO part_comments;
+
+ALTER INDEX idx_job_notes_job_created   RENAME TO idx_notes_job_created;
+ALTER INDEX idx_job_note_media_note     RENAME TO idx_note_media_note;
+ALTER INDEX idx_part_notes_part_created RENAME TO idx_part_comments_part_created;
+
+ALTER TABLE public.notes RENAME CONSTRAINT job_notes_pkey TO notes_pkey;
+ALTER TABLE public.notes RENAME CONSTRAINT job_notes_company_id_fkey TO notes_company_fk;
+ALTER TABLE public.notes RENAME CONSTRAINT job_notes_job_id_fkey TO notes_job_fk;
+ALTER TABLE public.notes RENAME CONSTRAINT job_notes_author_id_fkey TO notes_author_fk;
+ALTER TABLE public.notes RENAME CONSTRAINT job_notes_job_part_id_fkey TO notes_job_part_fk;
+ALTER TABLE public.notes
+  RENAME CONSTRAINT job_notes_job_operation_id_fkey TO notes_job_operation_fk;
+ALTER TABLE public.notes
+  RENAME CONSTRAINT job_notes_body_blank_or_null TO notes_body_blank_or_null;
+ALTER TABLE public.notes
+  RENAME CONSTRAINT job_notes_note_type_check TO notes_note_type_check;
+
+ALTER TABLE public.note_media RENAME CONSTRAINT job_note_media_pkey TO note_media_pkey;
+ALTER TABLE public.note_media
+  RENAME CONSTRAINT job_note_media_note_id_fkey TO note_media_note_fk;
+ALTER TABLE public.note_media
+  RENAME CONSTRAINT job_note_media_company_id_fkey TO note_media_company_fk;
+ALTER TABLE public.note_media
+  RENAME CONSTRAINT job_note_media_kind_check TO note_media_kind_check;
+
+ALTER TABLE public.part_comments RENAME CONSTRAINT part_notes_pkey TO part_comments_pkey;
+ALTER TABLE public.part_comments
+  RENAME CONSTRAINT part_notes_company_id_fkey TO part_comments_company_fk;
+ALTER TABLE public.part_comments
+  RENAME CONSTRAINT part_notes_part_id_fkey TO part_comments_part_fk;
+ALTER TABLE public.part_comments
+  RENAME CONSTRAINT part_notes_author_id_fkey TO part_comments_author_fk;
+ALTER TABLE public.part_comments
+  RENAME CONSTRAINT part_notes_body_not_blank TO part_comments_body_not_blank;
+ALTER TABLE public.part_comments
+  RENAME CONSTRAINT part_notes_note_type_check TO part_comments_note_type_check;
+
+COMMENT ON TABLE public.notes IS
+  'Shop-floor knowledge. Subject is one of job / part / work_center (subject_kind), each with an optional finer grain. A part-subject note with a routing_operation_id is DURABLE and job-independent: the next person running that part reads it directly, with no traversal of prior jobs. Distinct from part_comments, which is the office activity feed.';
+COMMENT ON TABLE public.part_comments IS
+  'Office activity feed on a part: manual comments plus system-generated pricing entries. Renamed from part_notes. NOT shop-floor knowledge — deliberately carries no view logging, reactions or media. See public.notes.';
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 2. NOTES: SUBJECT COLUMNS, PROVENANCE, COUNTERS
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+ALTER TABLE public.notes
+  ADD COLUMN subject_kind text,                     -- NOT NULL after the backfill below
+  -- The durable, job-independent subject.
+  ADD COLUMN part_id              uuid,
+  ADD COLUMN routing_operation_id uuid,
+  ADD COLUMN work_center_id       uuid,
+  -- PROVENANCE, NOT SUBJECT: where a part-subject note was captured, so it still shows
+  -- in that job's feed. Deliberately excluded from notes_subject_valid below.
+  ADD COLUMN captured_job_id           uuid,
+  ADD COLUMN captured_job_operation_id uuid,
+  -- Iteration B ships the UI; the column ships now so B needs no migration.
+  ADD COLUMN corrects_note_id     uuid,
+  -- Two maintained counts, two meanings. Both on the row so list rendering is one
+  -- round trip, and both MONOTONIC (see the trigger in section 6).
+  ADD COLUMN viewer_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN usage_count  integer NOT NULL DEFAULT 0;
+
+ALTER TABLE public.notes
+  ADD CONSTRAINT notes_part_fk FOREIGN KEY (part_id)
+      REFERENCES public.parts(id) ON DELETE CASCADE,
+  -- SET NULL, not CASCADE: deleting a routing step must degrade the note to part-level,
+  -- never destroy accumulated knowledge. This is why part_id is stored even though
+  -- routings.part_id is UNIQUE and would imply it.
+  ADD CONSTRAINT notes_routing_operation_fk FOREIGN KEY (routing_operation_id)
+      REFERENCES public.routing_operations(id) ON DELETE SET NULL,
+  -- Work centers are soft-deleted (deleted_at), so CASCADE never fires; SET NULL would
+  -- violate the subject CHECK. RESTRICT on a row that is never hard-deleted is honest.
+  ADD CONSTRAINT notes_work_center_fk FOREIGN KEY (work_center_id)
+      REFERENCES public.work_centers(id) ON DELETE RESTRICT,
+  -- Provenance goes NULL if the job is deleted: the knowledge survives its origin.
+  ADD CONSTRAINT notes_captured_job_fk FOREIGN KEY (captured_job_id)
+      REFERENCES public.jobs(id) ON DELETE SET NULL,
+  ADD CONSTRAINT notes_captured_job_operation_fk FOREIGN KEY (captured_job_operation_id)
+      REFERENCES public.job_operations(id) ON DELETE SET NULL,
+  ADD CONSTRAINT notes_corrects_fk FOREIGN KEY (corrects_note_id)
+      REFERENCES public.notes(id) ON DELETE SET NULL,
+  ADD CONSTRAINT notes_viewer_count_nonneg CHECK (viewer_count >= 0),
+  ADD CONSTRAINT notes_usage_count_nonneg  CHECK (usage_count  >= 0),
+  ADD CONSTRAINT notes_no_self_correction
+      CHECK (corrects_note_id IS NULL OR corrects_note_id <> id);
+
+-- Part- and work-center-subject notes have no job. Multi-tenancy is UNAFFECTED: every
+-- policy resolves on notes.company_id (which stays NOT NULL), never through job_id.
+ALTER TABLE public.notes ALTER COLUMN job_id DROP NOT NULL;
+
+-- Every pre-existing row is genuinely job-scoped. There is no honest way to retro-anchor
+-- one to a routing step — a wrong guess pins a note to the wrong step permanently — so
+-- they stay 'job'. The finer columns already carry their grain.
+UPDATE public.notes SET subject_kind = 'job';
+ALTER TABLE public.notes ALTER COLUMN subject_kind SET NOT NULL;
+
+ALTER TABLE public.notes DROP CONSTRAINT job_notes_operation_requires_part;
+ALTER TABLE public.notes ADD CONSTRAINT notes_subject_valid CHECK (
+  CASE subject_kind
+    WHEN 'job' THEN
+      job_id IS NOT NULL
+      -- Preserves the old job_notes_operation_requires_part rule: job_operations is
+      -- keyed by job_part_id, so an operation without a part is ambiguous.
+      AND (job_operation_id IS NULL OR job_part_id IS NOT NULL)
+      AND part_id IS NULL AND routing_operation_id IS NULL AND work_center_id IS NULL
+    WHEN 'part' THEN
+      -- routing_operation_id is the OPTIONAL step refinement, which is what lets a
+      -- note survive its routing step being deleted (FK is SET NULL above).
+      part_id IS NOT NULL
+      AND work_center_id IS NULL
+      AND job_id IS NULL AND job_part_id IS NULL AND job_operation_id IS NULL
+    WHEN 'work_center' THEN
+      work_center_id IS NOT NULL
+      AND part_id IS NULL AND routing_operation_id IS NULL
+      AND job_id IS NULL AND job_part_id IS NULL AND job_operation_id IS NULL
+    ELSE false          -- an unknown kind is rejected, not silently allowed
+  END
+);
+
+COMMENT ON COLUMN public.notes.subject_kind IS
+  'job | part | work_center. Names the ROOT subject; the finer columns refine within it (job -> job_part -> job_operation, part -> routing_operation). Enforced by notes_subject_valid.';
+COMMENT ON COLUMN public.notes.routing_operation_id IS
+  'The routing TEMPLATE step (the same step across every run), not a job''s instance of it. This is what makes a part-subject note durable and job-independent.';
+COMMENT ON COLUMN public.notes.captured_job_id IS
+  'Provenance only: the job this note was written on, so it still appears in that job''s feed. Never a subject, never drives the Playbook.';
+COMMENT ON COLUMN public.notes.viewer_count IS
+  'Distinct PEOPLE who have read this note, excluding the author and accounts excluded from metrics. Maintained ONLY by note_views_bump_counts(). MONOTONIC: never decremented, so deleting a member cannot be used to difference out what they read.';
+COMMENT ON COLUMN public.notes.usage_count IS
+  'Distinct JOBS this note was consulted on (job-less reads do not count). The primary quality signal — a note used on 11 jobs is load-bearing, one read by 11 people once is curiosity. Same maintenance and monotonicity as viewer_count.';
+
+-- ── Cross-table consistency (a Postgres CHECK cannot span tables) ──────────────
+-- Closes two holes: a subject row belonging to a different company than the note
+-- (pre-existing on job_notes — a member of companies A and B could insert a note with
+-- company_id = A and one of B's jobs), and part_id drifting from the routing step's own
+-- part. Legacy rows are not re-validated; this governs new writes only.
+CREATE OR REPLACE FUNCTION public.notes_validate_subject()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_part uuid;
+BEGIN
+  IF NEW.job_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1 FROM public.jobs j
+      WHERE j.id = NEW.job_id AND j.company_id = NEW.company_id)
+  THEN
+    RAISE EXCEPTION 'job % is not in company %', NEW.job_id, NEW.company_id;
+  END IF;
+
+  IF NEW.part_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1 FROM public.parts p
+      WHERE p.id = NEW.part_id AND p.company_id = NEW.company_id)
+  THEN
+    RAISE EXCEPTION 'part % is not in company %', NEW.part_id, NEW.company_id;
+  END IF;
+
+  IF NEW.work_center_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1 FROM public.work_centers w
+      WHERE w.id = NEW.work_center_id AND w.company_id = NEW.company_id)
+  THEN
+    RAISE EXCEPTION 'work center % is not in company %',
+                    NEW.work_center_id, NEW.company_id;
+  END IF;
+
+  -- routing_operations has NO company_id; tenancy resolves through routings. The same
+  -- query yields the part, so tenancy and part-consistency are checked together.
+  IF NEW.routing_operation_id IS NOT NULL THEN
+    SELECT r.part_id INTO v_part
+    FROM public.routing_operations ro
+    JOIN public.routings r ON r.id = ro.routing_id
+    WHERE ro.id = NEW.routing_operation_id AND r.company_id = NEW.company_id;
+
+    IF v_part IS NULL THEN
+      RAISE EXCEPTION 'routing operation % is not in company %',
+                      NEW.routing_operation_id, NEW.company_id;
+    END IF;
+    IF v_part IS DISTINCT FROM NEW.part_id THEN
+      RAISE EXCEPTION 'routing operation % belongs to part %, not %',
+                      NEW.routing_operation_id, v_part, NEW.part_id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER notes_validate_subject_trg
+  BEFORE INSERT OR UPDATE OF company_id, job_id, part_id, routing_operation_id,
+                             work_center_id
+  ON public.notes
+  FOR EACH ROW EXECUTE FUNCTION public.notes_validate_subject();
+
+-- ── Read-path indexes ─────────────────────────────────────────────────────────
+-- THE read-back index: "notes for this part at this step", no job traversal at all.
+CREATE INDEX idx_notes_part_step
+  ON public.notes (part_id, routing_operation_id, created_at DESC)
+  WHERE part_id IS NOT NULL;
+CREATE INDEX idx_notes_work_center
+  ON public.notes (work_center_id, created_at DESC)
+  WHERE work_center_id IS NOT NULL;
+-- The job feed unions job-subject rows with part-subject rows captured on that job.
+CREATE INDEX idx_notes_captured_job
+  ON public.notes (captured_job_id, created_at DESC)
+  WHERE captured_job_id IS NOT NULL;
+CREATE INDEX idx_notes_author
+  ON public.notes (author_id)
+  WHERE author_id IS NOT NULL;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 3. POLICIES + GRANTS ON THE RENAMED TABLES
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Policies survived the rename but still carry job_notes / part_notes names. Recreate
+-- with current names and unchanged semantics.
+
+DROP POLICY IF EXISTS "Users can view job_notes"                ON public.notes;
+DROP POLICY IF EXISTS "Users can insert own job_notes"          ON public.notes;
+DROP POLICY IF EXISTS "Authors and admins can delete job_notes" ON public.notes;
+
+CREATE POLICY notes_select ON public.notes
+    FOR SELECT TO authenticated
+    USING (company_id IN (SELECT public.get_user_company_ids()));
+
+CREATE POLICY notes_insert ON public.notes
+    FOR INSERT TO authenticated
+    WITH CHECK (
+      company_id IN (SELECT public.get_user_company_ids())
+      -- Author is always the acting member. There is no impersonation path: an admin
+      -- cannot enter a note on someone else's behalf, by design.
+      AND author_id = public.get_operator_access_id(company_id)
+    );
+
+CREATE POLICY notes_delete ON public.notes
+    FOR DELETE TO authenticated
+    USING (author_id = public.get_operator_access_id(company_id)
+           OR public.is_company_admin(company_id));
+
+-- No UPDATE policy, matching today's behaviour (notes are append-only). REVOKE anyway:
+-- grants and RLS are independent layers, and an UPDATE grant with no policy is one
+-- future permissive policy away from letting an operator write viewer_count = 999, or
+-- an admin set a known value and watch it move — a one-bit read oracle per note.
+-- If body editing is ever added it needs BOTH a permissive policy AND a column-scoped
+-- grant that excludes viewer_count, usage_count, company_id, author_id and every
+-- subject column.
+REVOKE UPDATE ON public.notes FROM anon, authenticated;
+
+DROP POLICY IF EXISTS "Users can view job_note_media"   ON public.note_media;
+DROP POLICY IF EXISTS "Users can insert job_note_media" ON public.note_media;
+DROP POLICY IF EXISTS "Authors and admins can delete job_note_media" ON public.note_media;
+
+CREATE POLICY note_media_select ON public.note_media
+    FOR SELECT TO authenticated
+    USING (company_id IN (SELECT public.get_user_company_ids()));
+
+CREATE POLICY note_media_insert ON public.note_media
+    FOR INSERT TO authenticated
+    WITH CHECK (
+      company_id IN (SELECT public.get_user_company_ids())
+      AND public.get_operator_access_id(company_id) IS NOT NULL
+    );
+
+CREATE POLICY note_media_delete ON public.note_media
+    FOR DELETE TO authenticated
+    USING (public.is_company_admin(company_id)
+           OR EXISTS (SELECT 1 FROM public.notes n
+                      WHERE n.id = note_media.note_id
+                        AND n.author_id = public.get_operator_access_id(n.company_id)));
+
+DROP POLICY IF EXISTS "Users can view part_notes"       ON public.part_comments;
+DROP POLICY IF EXISTS "Users can insert own part_notes" ON public.part_comments;
+DROP POLICY IF EXISTS "Authors and admins can delete part_notes" ON public.part_comments;
+
+CREATE POLICY part_comments_select ON public.part_comments
+    FOR SELECT TO authenticated
+    USING (company_id IN (SELECT public.get_user_company_ids()));
+
+CREATE POLICY part_comments_insert ON public.part_comments
+    FOR INSERT TO authenticated
+    WITH CHECK (
+      company_id IN (SELECT public.get_user_company_ids())
+      AND author_id = public.get_operator_access_id(company_id)
+    );
+
+CREATE POLICY part_comments_delete ON public.part_comments
+    FOR DELETE TO authenticated
+    USING (author_id = public.get_operator_access_id(company_id)
+           OR public.is_company_admin(company_id));
+
+-- The billing gate's policies are named billing_gate_* and also survived the rename;
+-- re-apply so they are unambiguously attached to the current table names.
+SELECT public.apply_billing_write_gate('public.notes');
+SELECT public.apply_billing_write_gate('public.note_media');
+SELECT public.apply_billing_write_gate('public.part_comments');
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 4. EXCLUDE-FROM-METRICS FLAG
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Two mechanisms, one evaluation point. Neither alone is sufficient: system_admins
+-- cannot express "the shop owner's own account", and a per-membership column alone
+-- means the founder must remember to flag every new company — and a forgotten flag
+-- inflates a customer's numbers, a silent failure in the forbidden direction.
+
+ALTER TABLE public.user_company_access
+  ADD COLUMN excluded_from_metrics boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.user_company_access.excluded_from_metrics IS
+  'When true, this membership never produces a note_views row, so it cannot inflate note read counts. Service-role only: NOT writable by any browser role (see the column-scoped grants below), because an admin who could flip it on everyone-but-one would learn what that one person reads by watching counts move.';
+
+CREATE OR REPLACE FUNCTION public.viewer_excluded_from_metrics(p_access_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.user_company_access uca
+    WHERE uca.id = p_access_id
+      AND (uca.excluded_from_metrics OR public.is_system_admin(uca.user_id))
+  );
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.viewer_excluded_from_metrics(uuid) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.viewer_excluded_from_metrics(uuid) TO service_role;
+-- Not granted to authenticated: it is only ever called from inside log_note_views(),
+-- which runs as the table owner. Granting it would hand the browser a per-member probe.
+
+-- RLS cannot scope a policy to a column; GRANT can. Without this, the existing
+-- "Admins can update company access" policy lets an admin set excluded_from_metrics on
+-- every member except one and read that person's entire history off the counters.
+-- The only browser write to this table is `.update({ role })` from the team member page
+-- (app/dashboard/[companyId]/team/members/[id]/page.tsx), plus name/email/pin_hash via
+-- the own-row policy. Backend inserts use the service role; accept_invitation() is
+-- SECURITY DEFINER. All unaffected by column-scoped grants.
+REVOKE UPDATE ON public.user_company_access FROM anon, authenticated;
+GRANT  UPDATE (name, role, email, pin_hash) ON public.user_company_access TO authenticated;
+
+-- INSERT too, or an admin DELETEs a membership (they have that policy) and re-INSERTs
+-- it with excluded_from_metrics = true.
+REVOKE INSERT ON public.user_company_access FROM anon, authenticated;
+GRANT  INSERT (user_id, company_id, role, name, email, pin_hash)
+  ON public.user_company_access TO authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 5. NOTE_VIEWS
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+CREATE TABLE public.note_views (
+    id         uuid NOT NULL DEFAULT gen_random_uuid(),
+    company_id uuid NOT NULL,
+    note_id    uuid NOT NULL,
+    -- user_company_access.id (the per-membership shop identity), matching notes.author_id.
+    viewer_id  uuid NOT NULL,
+    -- The read CONTEXT, and part of the key. NULL when read outside a job.
+    job_id     uuid,
+    created_at timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT note_views_pkey PRIMARY KEY (id),
+
+    -- THE dedupe. One row per (note, person, job-context), forever. Re-reading the same
+    -- note while working the same job is still ONE row, so this records repeat USE
+    -- (consulted again on a new job) and never repeat OPENS.
+    --
+    -- NULLS NOT DISTINCT is load-bearing, not decoration: job_id is nullable, and the
+    -- SQL default (NULLS DISTINCT) treats every NULL as unequal — so repeated job-less
+    -- reads by one person would insert unbounded rows and inflate every count.
+    CONSTRAINT note_views_note_viewer_job_key
+        UNIQUE NULLS NOT DISTINCT (note_id, viewer_id, job_id),
+
+    CONSTRAINT note_views_company_fk FOREIGN KEY (company_id)
+        REFERENCES public.companies(id) ON DELETE CASCADE,
+    CONSTRAINT note_views_note_fk FOREIGN KEY (note_id)
+        REFERENCES public.notes(id) ON DELETE CASCADE,
+    -- CASCADE: a departing member's read history is erased, which is privacy-positive.
+    -- Safe ONLY because the counters are monotonic (section 6).
+    CONSTRAINT note_views_viewer_fk FOREIGN KEY (viewer_id)
+        REFERENCES public.user_company_access(id) ON DELETE CASCADE,
+    -- SET NULL: deleting a job must not delete the fact that someone read the note.
+    CONSTRAINT note_views_job_fk FOREIGN KEY (job_id)
+        REFERENCES public.jobs(id) ON DELETE SET NULL
+);
+
+COMMENT ON TABLE public.note_views IS
+  'Who has read which note. NO client read path by design: no SELECT grant to anon/authenticated, plus a RESTRICTIVE deny-all. Authors get names via note_viewers(); everyone else gets counts via notes.viewer_count / usage_count. Never expose a per-job read breakdown, and never add this table to the supabase_realtime publication or to the AI SQL allowlist — either would reconstruct a per-operator reading report.';
+
+CREATE INDEX idx_note_views_company ON public.note_views (company_id);
+-- DELIBERATELY ABSENT: indexes on (viewer_id) and (job_id). The only queries those
+-- serve are "everything this person read" and "who read notes on job X" — the two
+-- queries this product forbids. Without them, any future accidental implementation is
+-- a seq scan: slow enough to be noticed in review or in prod metrics.
+
+ALTER TABLE public.note_views ENABLE ROW LEVEL SECURITY;
+
+-- The only policy. With no permissive policy the table already denies everything; the
+-- value of writing this down is that RESTRICTIVE policies AND together, so a future
+-- migration that adds a well-meaning permissive SELECT policy still evaluates false.
+-- The guarantee survives someone else's good intentions.
+CREATE POLICY note_views_no_client_access ON public.note_views
+    AS RESTRICTIVE FOR ALL TO anon, authenticated
+    USING (false) WITH CHECK (false);
+
+-- Grants are the load-bearing control here, more than RLS is. In particular there is no
+-- SELECT grant, which is what blocks `HEAD ...?note_id=eq.X&viewer_id=eq.Y` with
+-- `Prefer: count=exact` — a per-pair oracle that returns a count with an empty body and
+-- that RLS is powerless against, because the count is over exactly the rows a policy
+-- admitted. If SELECT is ever granted with ANY row-returning policy, that hole is open.
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.note_views TO service_role;
+-- No-ops under the current default privileges; kept as documentation-as-code, matching
+-- the quickbooks_connections precedent for backend-only tables.
+REVOKE ALL ON public.note_views FROM anon, authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 6. COUNTERS
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- AFTER INSERT, not BEFORE: with ON CONFLICT DO NOTHING a conflicting row is never
+-- inserted, so AFTER INSERT does not fire for a duplicate. A BEFORE trigger WOULD fire
+-- and then have its row discarded.
+--
+-- A blind +1 is not available: with job_id in the dedupe key an insert no longer
+-- implies a new person. A conditional increment races between two concurrent reads by
+-- the same person on different jobs. So: recount, and GREATEST to stay monotonic.
+
+CREATE OR REPLACE FUNCTION public.note_views_bump_counts()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+BEGIN
+  -- Take the row lock as its OWN command, before counting. This is the whole trick.
+  -- In READ COMMITTED a sub-SELECT inside an UPDATE's SET clause is evaluated against
+  -- the statement's snapshot; when that UPDATE blocks on a concurrent writer and then
+  -- unblocks, the target row is re-fetched but the subquery is NOT re-evaluated against
+  -- the newly-committed data. Two people reading the same note concurrently would then
+  -- both compute 1 and GREATEST(1,1) would leave it at 1 — an undercount that
+  -- note_count_anomalies() would correctly flag, turning a legitimate race into a red
+  -- build. Locking first means the UPDATE below is a NEW command whose snapshot is
+  -- taken after the other transaction committed.
+  PERFORM 1 FROM public.notes WHERE id = NEW.note_id FOR UPDATE;
+
+  UPDATE public.notes SET
+    viewer_count = GREATEST(viewer_count, (
+      SELECT count(DISTINCT nv.viewer_id)
+      FROM public.note_views nv WHERE nv.note_id = NEW.note_id)),
+    usage_count  = GREATEST(usage_count, (
+      SELECT count(DISTINCT nv.job_id)
+      FROM public.note_views nv
+      WHERE nv.note_id = NEW.note_id AND nv.job_id IS NOT NULL))
+  WHERE id = NEW.note_id;
+
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER note_views_bump_counts_trg
+  AFTER INSERT ON public.note_views
+  FOR EACH ROW EXECUTE FUNCTION public.note_views_bump_counts();
+
+-- NO DECREMENT TRIGGER, and that is a security decision rather than laziness. An admin
+-- can delete a membership (they have that policy); if the counters fell when the rows
+-- cascaded, snapshotting every count, deleting one member, and snapshotting again would
+-- name every note that person had read. GREATEST keeps that closed now that the value
+-- is recomputed rather than incremented: a post-cascade recount can only be lower, and
+-- lower loses.
+
+-- One-sided drift check. Because the counters are monotonic, stored > live is EXPECTED
+-- (departed members, purged jobs); stored < live means the trigger failed.
+CREATE OR REPLACE FUNCTION public.note_count_anomalies()
+RETURNS TABLE(note_id uuid, stored_viewers integer, live_viewers bigint,
+                            stored_usage integer,   live_usage bigint)
+LANGUAGE sql
+STABLE
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT n.id, n.viewer_count, COALESCE(v.viewers, 0),
+                n.usage_count,  COALESCE(v.usage, 0)
+  FROM public.notes n
+  LEFT JOIN (
+    SELECT nv.note_id,
+           count(DISTINCT nv.viewer_id) AS viewers,
+           count(DISTINCT nv.job_id) FILTER (WHERE nv.job_id IS NOT NULL) AS usage
+    FROM public.note_views nv
+    GROUP BY nv.note_id
+  ) v ON v.note_id = n.id
+  WHERE n.viewer_count < COALESCE(v.viewers, 0)
+     OR n.usage_count  < COALESCE(v.usage, 0)
+  ORDER BY 1;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.note_count_anomalies() FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.note_count_anomalies() TO service_role;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 7. THE THREE CLIENT-FACING FUNCTIONS
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- PERMANENT RULE for this family: no function that touches note_views may ever accept
+-- a viewer/member parameter. That is what keeps RPC probing closed.
+
+-- ── 7a. Write path ────────────────────────────────────────────────────────────
+-- Array-first so a screenful of notes is one round trip; callers must never loop it.
+-- SECURITY DEFINER genuinely bypasses RLS and the RESTRICTIVE billing policies: inside
+-- the body current_user is the function owner, which is also the table owner, and no
+-- table in this schema has FORCE ROW LEVEL SECURITY. (Do not reason about this via the
+-- TO clause — in Supabase, postgres is a member of authenticated, so a TO authenticated
+-- policy WOULD apply if RLS were being enforced at all. The guarantee is owner
+-- exemption.) That is also why note_views is on the billing-gate exempt list: a gate
+-- here would be unreachable code.
+CREATE OR REPLACE FUNCTION public.log_note_views(
+  p_note_ids uuid[],
+  p_job_id   uuid DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_note      record;
+  v_viewer_id uuid;
+  v_job_ok    boolean;
+  v_companies uuid[];
+BEGIN
+  IF p_note_ids IS NULL OR array_length(p_note_ids, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- auth.uid() reads the request JWT GUC, which is set per-request independently of
+  -- current_user, so it is still the real caller inside a SECURITY DEFINER body.
+  SELECT array_agg(cid) INTO v_companies
+  FROM (SELECT public.get_user_company_ids() AS cid) s;
+  IF v_companies IS NULL THEN
+    RETURN;                              -- not a member of anything
+  END IF;
+
+  FOR v_note IN
+    -- Tenant validation by construction: a note outside the caller's companies simply
+    -- does not resolve, so there is no "wrong company" branch to get wrong. DISTINCT
+    -- absorbs a caller that passes the same id twice.
+    SELECT DISTINCT n.id, n.company_id, n.author_id
+    FROM public.notes n
+    WHERE n.id = ANY(p_note_ids) AND n.company_id = ANY(v_companies)
+  LOOP
+    -- Resolved per-note because a multi-company user has a different access id per shop.
+    v_viewer_id := public.get_operator_access_id(v_note.company_id);
+    CONTINUE WHEN v_viewer_id IS NULL;
+
+    -- Never the author viewing their own note. DB-enforced, and the client cannot opt
+    -- out because the client has no INSERT grant at all.
+    CONTINUE WHEN v_note.author_id IS NOT NULL AND v_viewer_id = v_note.author_id;
+
+    -- Never an account excluded from metrics. Also DB-enforced.
+    CONTINUE WHEN public.viewer_excluded_from_metrics(v_viewer_id);
+
+    -- A job from another company, or a garbage uuid, degrades to NULL rather than
+    -- raising: a bad job id must never cost us the read fact.
+    SELECT EXISTS (
+      SELECT 1 FROM public.jobs j
+      WHERE j.id = p_job_id AND j.company_id = v_note.company_id
+    ) INTO v_job_ok;
+
+    INSERT INTO public.note_views (company_id, note_id, viewer_id, job_id)
+    VALUES (v_note.company_id, v_note.id, v_viewer_id,
+            CASE WHEN v_job_ok THEN p_job_id ELSE NULL END)
+    -- The permanent dedupe. A repeat read is a no-op: no row, no trigger, no counter
+    -- movement, no error. Idempotent, so the client needs no bookkeeping of its own.
+    --
+    -- Named constraint rather than a column list: with NULLS NOT DISTINCT, arbiter
+    -- inference from (note_id, viewer_id, job_id) is subtle enough that naming the
+    -- constraint removes the question entirely, and it fails loudly if the constraint
+    -- is ever renamed instead of silently matching a different index.
+    ON CONFLICT ON CONSTRAINT note_views_note_viewer_job_key DO NOTHING;
+  END LOOP;
+END;
+$$;
+
+COMMENT ON FUNCTION public.log_note_views(uuid[], uuid) IS
+  'Log that the caller read these notes. Returns void deliberately: a duplicate must be indistinguishable from a first view, so there is no state oracle keyed on (note, caller) and no body for a failed write to surface to the operator. Fire-and-forget from the client; report errors to Sentry, never to the user. Deliberately has no EXCEPTION handler — every expected condition already returns silently, and a genuine fault should raise so it is observed.';
+
+REVOKE EXECUTE ON FUNCTION public.log_note_views(uuid[], uuid) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.log_note_views(uuid[], uuid) TO authenticated;
+
+-- ── 7b. The author's named list ───────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.note_viewers(p_note_id uuid)
+RETURNS TABLE (viewer_name text, job_number text)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  -- ONE ROW PER PERSON, collapsed by GROUP BY. With job_id in the dedupe key, someone
+  -- who consulted this note on three jobs has three rows; the author must see them
+  -- once. min(job_number) picks the representative job LEXICOGRAPHICALLY, not by time —
+  -- an earliest-by-created_at pick would smuggle back exactly the timing signal the
+  -- no-timestamps rule exists to deny. Deliberately NOT count(DISTINCT job_id) per
+  -- person: "Kurtis keeps coming back to this" is repeat use attached to a name, which
+  -- is the reader-watching we refuse. Repeat use is published in aggregate only, as
+  -- notes.usage_count.
+  SELECT uca.name, min(j.job_number)
+  FROM public.notes n
+  JOIN public.note_views v            ON v.note_id = n.id
+  JOIN public.user_company_access uca ON uca.id = v.viewer_id
+  LEFT JOIN public.jobs j             ON j.id = v.job_id
+  WHERE n.id = p_note_id
+    -- The caller must BE the author. author_id is nullable (ON DELETE SET NULL) and
+    -- get_operator_access_id() is NULL for a non-member, so the IS NOT NULL guard
+    -- prevents a NULL = NULL accident from ever mattering.
+    AND n.author_id IS NOT NULL
+    AND n.author_id = public.get_operator_access_id(n.company_id)
+    -- The boss never gets names, not even on notes he wrote himself. Without this an
+    -- admin authors a must-read note and harvests a named read list entirely
+    -- legitimately — the largest hole that looks like a feature.
+    AND NOT public.is_company_admin(n.company_id)
+  GROUP BY uca.id, uca.name
+  -- Ordered by NAME, never by time. No timestamp is returned at all.
+  ORDER BY uca.name NULLS LAST;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.note_viewers(uuid) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.note_viewers(uuid) TO authenticated;
+
+-- ── 7c. The login-banner digest ───────────────────────────────────────────────
+-- Nothing else can produce this: both counters are all-time and monotonic, note_views
+-- has no client read path, and note_viewers() deliberately returns no timestamps.
+CREATE OR REPLACE FUNCTION public.my_note_view_digest(p_tz text)
+RETURNS integer
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  -- count DISTINCT viewer_id, not count(*). With job_id in the dedupe key three rows
+  -- can be one person on three jobs, and count(*) would render "3 people used your
+  -- notes" for a single reader — the exact overstatement this design exists to prevent.
+  SELECT count(DISTINCT v.viewer_id)::integer
+  FROM public.notes n
+  JOIN public.note_views v ON v.note_id = n.id
+  WHERE n.author_id IS NOT NULL
+    AND n.author_id = public.get_operator_access_id(n.company_id)
+    AND v.created_at >= (date_trunc('week', now() AT TIME ZONE p_tz) AT TIME ZONE p_tz);
+$$;
+
+COMMENT ON FUNCTION public.my_note_view_digest(text) IS
+  'Distinct people who read the caller''s own notes since the start of the current week in the given IANA timezone. Takes a TIMEZONE, not an arbitrary window: a caller-supplied (from, to) would be a bisection oracle recovering WHEN a read happened, which is the timing signal note_viewers() refuses to give. Powers the operator login banner; renders nothing when zero.';
+
+REVOKE EXECUTE ON FUNCTION public.my_note_view_digest(text) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.my_note_view_digest(text) TO authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 8. NOTE_REACTIONS  (schema now, UI in Iteration B)
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Shaped as the deliberate OPPOSITE of note_views. A read log is an involuntary record
+-- of ignorance; a reaction is a voluntary claim of endorsement. Publishing the latter
+-- is the product.
+
+CREATE TABLE public.note_reactions (
+    id         uuid NOT NULL DEFAULT gen_random_uuid(),
+    company_id uuid NOT NULL,
+    note_id    uuid NOT NULL,
+    -- Named reactor_id, not user_id: this is a user_company_access(id), and schema-wide
+    -- user_id means auth.users(id). A column named user_id holding an access id is a
+    -- bug waiting for its first JOIN.
+    reactor_id uuid NOT NULL,
+    kind       text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT note_reactions_pkey PRIMARY KEY (id),
+    -- Two values, and there is no negative option — not deferred, structurally absent.
+    CONSTRAINT note_reactions_kind_check CHECK (kind IN ('helpful', 'confirmed')),
+    CONSTRAINT note_reactions_note_reactor_kind_key UNIQUE (note_id, reactor_id, kind),
+    CONSTRAINT note_reactions_company_fk FOREIGN KEY (company_id)
+        REFERENCES public.companies(id) ON DELETE CASCADE,
+    CONSTRAINT note_reactions_note_fk FOREIGN KEY (note_id)
+        REFERENCES public.notes(id) ON DELETE CASCADE,
+    CONSTRAINT note_reactions_reactor_fk FOREIGN KEY (reactor_id)
+        REFERENCES public.user_company_access(id) ON DELETE CASCADE
+);
+
+COMMENT ON TABLE public.note_reactions IS
+  'helpful = thumbs up (there is no thumbs down, ever). confirmed = "I ran this part and this note is still accurate", rendered as "confirmed by <name>, <month year>" with a coarse date. NEVER add a constraint or trigger requiring a note_views row before a reaction is allowed: it looks like tidy integrity and would turn this endpoint into a clean oracle for "has member X viewed note N".';
+
+CREATE INDEX idx_note_reactions_note ON public.note_reactions (note_id);
+
+ALTER TABLE public.note_reactions ENABLE ROW LEVEL SECURITY;
+
+-- Attributable and public inside the shop — the deliberate opposite of note_views.
+CREATE POLICY note_reactions_select ON public.note_reactions
+    FOR SELECT TO authenticated
+    USING (company_id IN (SELECT public.get_user_company_ids()));
+
+CREATE POLICY note_reactions_insert ON public.note_reactions
+    FOR INSERT TO authenticated
+    WITH CHECK (
+      company_id IN (SELECT public.get_user_company_ids())
+      -- Own identity only: no forging "Kurtis confirmed this".
+      AND reactor_id = public.get_operator_access_id(company_id)
+      -- Not your own note: self-confirmation is noise.
+      AND NOT EXISTS (
+        SELECT 1 FROM public.notes n
+        WHERE n.id = note_id
+          AND n.author_id = public.get_operator_access_id(company_id))
+    );
+
+-- Un-react is yours alone. Admins deliberately CANNOT delete other people's reactions:
+-- a boss who can curate the public record of what the shop found helpful is a worse
+-- problem than a stale reaction.
+CREATE POLICY note_reactions_delete ON public.note_reactions
+    FOR DELETE TO authenticated
+    USING (reactor_id = public.get_operator_access_id(company_id));
+
+-- No UPDATE policy and no UPDATE grant: a reaction is created or removed, never edited
+-- (an editable kind would let 'helpful' silently become 'confirmed').
+GRANT SELECT, INSERT, DELETE         ON public.note_reactions TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.note_reactions TO service_role;
+
+-- A real browser write on a tenant table, so it gets the real gate.
+SELECT public.apply_billing_write_gate('public.note_reactions');
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 9. OPERATOR_EVENTS  (funnel instrumentation)
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Distinguishes never-opened-the-app from opened-but-took-no-action from
+-- started-capture-and-abandoned. Without it no adoption result is readable — and with
+-- an empty starting corpus it is the ONLY instrument for the first weeks, because
+-- note_views, the banner and reactions are all structurally silent until someone writes
+-- something.
+
+CREATE TABLE public.operator_events (
+    id          uuid NOT NULL DEFAULT gen_random_uuid(),
+    company_id  uuid NOT NULL,
+    actor_id    uuid,
+    kind        text NOT NULL,
+    -- Loose context: { jobId, jobPartId, jobOperationId, workCenterId, ... }.
+    -- NEVER note bodies, and NEVER the ids of notes the actor READ — that is
+    -- note_views' job, and it is deliberately unreadable.
+    context     jsonb NOT NULL DEFAULT '{}'::jsonb,
+    occurred_at timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT operator_events_pkey PRIMARY KEY (id),
+    CONSTRAINT operator_events_company_fk FOREIGN KEY (company_id)
+        REFERENCES public.companies(id) ON DELETE CASCADE,
+    CONSTRAINT operator_events_actor_fk FOREIGN KEY (actor_id)
+        REFERENCES public.user_company_access(id) ON DELETE SET NULL,
+    -- CHECK-constrained rather than free text so a typo is a failed insert, not a
+    -- silently uncounted funnel step.
+    CONSTRAINT operator_events_kind_check CHECK (kind IN (
+      'app_opened',
+      'station_selected',
+      'op_card_opened',
+      'prior_notes_opened',      -- THAT they opened prior notes, never WHICH ones
+      'composer_focused',
+      'composer_abandoned',
+      'note_saved',
+      'note_saved_with_photo',
+      'photo_attached',
+      'completion_recorded'
+    ))
+);
+
+COMMENT ON TABLE public.operator_events IS
+  'Capture-funnel instrumentation. Service-role read only — NOT readable by the shop''s own admin, because a per-operator event log would reconstruct the reading behaviour that note_views'' RLS exists to prevent. Founder access is via the SQL editor. Written only through log_operator_event().';
+
+CREATE INDEX idx_operator_events_company_time
+  ON public.operator_events (company_id, occurred_at DESC);
+
+ALTER TABLE public.operator_events ENABLE ROW LEVEL SECURITY;
+
+-- Same shape as note_views, and for the same reason.
+CREATE POLICY operator_events_no_client_access ON public.operator_events
+    AS RESTRICTIVE FOR ALL TO anon, authenticated
+    USING (false) WITH CHECK (false);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.operator_events TO service_role;
+REVOKE ALL ON public.operator_events FROM anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.log_operator_event(
+  p_company_id uuid,
+  p_kind       text,
+  p_context    jsonb DEFAULT '{}'::jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_actor_id uuid;
+BEGIN
+  v_actor_id := public.get_operator_access_id(p_company_id);
+  -- Not a member of this company: log nothing rather than raising. Instrumentation must
+  -- never be able to break the interaction it is measuring.
+  IF v_actor_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO public.operator_events (company_id, actor_id, kind, context)
+  VALUES (p_company_id, v_actor_id, p_kind, COALESCE(p_context, '{}'::jsonb));
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.log_operator_event(uuid, text, jsonb) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.log_operator_event(uuid, text, jsonb) TO authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 10. BILLING-GATE EXEMPT LIST
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- note_views and operator_events both carry company_id, so the CI guard
+-- (test_no_tenant_table_left_ungated) will flag them unless they are gated or exempt.
+-- They are exempt, for two independent reasons each:
+--
+--   1. Mechanical. Their only writer is a SECURITY DEFINER function owned by the table
+--      owner, so RLS is skipped entirely — permissive and RESTRICTIVE alike. A gate
+--      would install policies that are never evaluated, and shipping decorative
+--      policies is worse than an honest exempt entry: the next reader mistakes them for
+--      protection.
+--   2. Product. Reading is a read, and instrumentation must not stop. Gating would
+--      silently zero counts during a billing lapse and resume afterwards, making every
+--      count a lie about a period nobody remembers. The rule is bias to UNDERCOUNT,
+--      not bias to lie.
+--
+-- Note the alternative that would have been WRONG: omitting company_id so the guard
+-- cannot see the table. That evades the mechanism; this list is the reviewable record
+-- of a deliberate decision, which is the entire point of the function.
+CREATE OR REPLACE FUNCTION public.tenant_tables_missing_write_gate()
+RETURNS TABLE(table_name text)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT c.relname::text
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  JOIN pg_attribute a
+    ON a.attrelid = c.oid AND a.attname = 'company_id' AND NOT a.attisdropped
+  WHERE n.nspname = 'public'
+    AND c.relkind = 'r'
+    AND c.relname NOT IN (
+      -- identity / bootstrap (gating would block signup / team / preferences)
+      'companies', 'user_company_access', 'user_preferences', 'system_admins',
+      'invitations', 'demo_data_templates', 'waitlist', 'saved_insights', 'feedback',
+      'company_billing',
+      -- service-role-only / SELECT-only (writes never come from the browser)
+      'auth_audit_log', 'job_fulfillment_audit', 'part_location_stock',
+      'company_order_counters', 'quickbooks_connections', 'quickbooks_customer_map',
+      'quickbooks_invoice_links', 'quickbooks_invoice_line_items',
+      -- SECURITY DEFINER-only writers; see the block comment above
+      'note_views', 'operator_events'
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_policies p
+      WHERE p.schemaname = 'public'
+        AND p.tablename = c.relname
+        AND p.policyname = 'billing_gate_insert'
+    )
+  ORDER BY 1;
+$$;
+
+COMMENT ON FUNCTION public.tenant_tables_missing_write_gate() IS
+  'Lists public tables with a company_id column that are neither billing-gated nor exempt. A CI test asserts this returns no rows, so a new tenant table left un-gated fails the build instead of silently bypassing billing.';
+
+GRANT EXECUTE ON FUNCTION public.tenant_tables_missing_write_gate() TO service_role;

--- a/supabase/migrations/20260728040701_notes_subjects_and_view_logging.sql
+++ b/supabase/migrations/20260728040701_notes_subjects_and_view_logging.sql
@@ -659,15 +659,26 @@ AS $$
   JOIN public.user_company_access uca ON uca.id = v.viewer_id
   LEFT JOIN public.jobs j             ON j.id = v.job_id
   WHERE n.id = p_note_id
-    -- The caller must BE the author. author_id is nullable (ON DELETE SET NULL) and
-    -- get_operator_access_id() is NULL for a non-member, so the IS NOT NULL guard
-    -- prevents a NULL = NULL accident from ever mattering.
+    -- The caller must BE the author, and that is the ONLY test. author_id is
+    -- nullable (ON DELETE SET NULL) and get_operator_access_id() is NULL for a
+    -- non-member, so the IS NOT NULL guard prevents a NULL = NULL accident from
+    -- ever mattering.
+    --
+    -- DELIBERATELY NOT role-dependent. An earlier draft excluded company admins,
+    -- to block an admin authoring a must-read note and harvesting a named read
+    -- list. That is dropped, because in a fifteen-person shop roles are fluid:
+    -- an operator promoted to lead would silently stop seeing who used their own
+    -- notes, losing the feedback loop that got them writing. Behaviour that
+    -- changes when someone's role changes is worse than the speed bump it buys —
+    -- and the bump was already defeatable, since anyone who can create accounts
+    -- can author from a non-admin one.
+    --
+    -- The guarantee is now one sentence with no exceptions: you see who used YOUR
+    -- notes; nobody sees who used anyone else's. The protection that actually
+    -- matters — no shop-wide report of who read which notes — is unaffected, and
+    -- lives in note_views having no client read path at all.
     AND n.author_id IS NOT NULL
     AND n.author_id = public.get_operator_access_id(n.company_id)
-    -- The boss never gets names, not even on notes he wrote himself. Without this an
-    -- admin authors a must-read note and harvests a named read list entirely
-    -- legitimately — the largest hole that looks like a feature.
-    AND NOT public.is_company_admin(n.company_id)
   GROUP BY uca.id, uca.name
   -- Ordered by NAME, never by time. No timestamp is returned at all.
   ORDER BY uca.name NULLS LAST;

--- a/supabase/migrations/20260728040701_notes_subjects_and_view_logging.sql
+++ b/supabase/migrations/20260728040701_notes_subjects_and_view_logging.sql
@@ -439,8 +439,16 @@ ALTER TABLE public.note_views ENABLE ROW LEVEL SECURITY;
 -- value of writing this down is that RESTRICTIVE policies AND together, so a future
 -- migration that adds a well-meaning permissive SELECT policy still evaluates false.
 -- The guarantee survives someone else's good intentions.
+--
+-- jigged_ai_readonly is named EXPLICITLY, and that is not belt-and-braces. The AI SQL
+-- path (api/tools/sql_executor.py) runs LLM-generated SQL as that role, and
+-- docs/modules/ai-insights.md instructs anyone widening AI scope to add an
+-- `ai_readonly_select ... USING (true)` policy to the table. On a table whose
+-- RESTRICTIVE policy named only anon/authenticated, that instruction would silently
+-- open the read log to "which operators read the setup notes?". Listing the role here
+-- makes the deny survive that too.
 CREATE POLICY note_views_no_client_access ON public.note_views
-    AS RESTRICTIVE FOR ALL TO anon, authenticated
+    AS RESTRICTIVE FOR ALL TO anon, authenticated, jigged_ai_readonly
     USING (false) WITH CHECK (false);
 
 -- Grants are the load-bearing control here, more than RLS is. In particular there is no
@@ -449,9 +457,15 @@ CREATE POLICY note_views_no_client_access ON public.note_views
 -- that RLS is powerless against, because the count is over exactly the rows a policy
 -- admitted. If SELECT is ever granted with ANY row-returning policy, that hole is open.
 GRANT SELECT, INSERT, UPDATE, DELETE ON public.note_views TO service_role;
--- No-ops under the current default privileges; kept as documentation-as-code, matching
--- the quickbooks_connections precedent for backend-only tables.
 REVOKE ALL ON public.note_views FROM anon, authenticated;
+
+-- NOT a no-op, unlike the line above. baseline.sql:6431 sets
+--   ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+--     GRANT SELECT ON TABLES TO jigged_ai_readonly;
+-- so every new public table is granted to the AI role on creation. Without this
+-- REVOKE the read log ships readable-by-grant, held shut only by RLS and a Python
+-- denylist. Any new table in this family needs the same line.
+REVOKE ALL ON public.note_views FROM jigged_ai_readonly;
 
 -- ═══════════════════════════════════════════════════════════════════════════════
 -- 6. COUNTERS
@@ -808,13 +822,17 @@ CREATE INDEX idx_operator_events_company_time
 
 ALTER TABLE public.operator_events ENABLE ROW LEVEL SECURITY;
 
--- Same shape as note_views, and for the same reason.
+-- Same shape as note_views, and for the same reasons — including naming
+-- jigged_ai_readonly so a future ai_readonly_select policy cannot open a
+-- per-operator behaviour log.
 CREATE POLICY operator_events_no_client_access ON public.operator_events
-    AS RESTRICTIVE FOR ALL TO anon, authenticated
+    AS RESTRICTIVE FOR ALL TO anon, authenticated, jigged_ai_readonly
     USING (false) WITH CHECK (false);
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON public.operator_events TO service_role;
 REVOKE ALL ON public.operator_events FROM anon, authenticated;
+-- Undoes the baseline's default GRANT to the AI role — see the note on note_views.
+REVOKE ALL ON public.operator_events FROM jigged_ai_readonly;
 
 CREATE OR REPLACE FUNCTION public.log_operator_event(
   p_company_id uuid,
@@ -901,3 +919,37 @@ COMMENT ON FUNCTION public.tenant_tables_missing_write_gate() IS
   'Lists public tables with a company_id column that are neither billing-gated nor exempt. A CI test asserts this returns no rows, so a new tenant table left un-gated fails the build instead of silently bypassing billing.';
 
 GRANT EXECUTE ON FUNCTION public.tenant_tables_missing_write_gate() TO service_role;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 11. NO-CLIENT-ACCESS COMPLETENESS CHECK
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- The tables in section 5 and 9 must be unreachable by every non-service role. The
+-- non-obvious hazard is that one of those grants arrives BY DEFAULT: baseline.sql
+-- runs
+--     ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+--       GRANT SELECT ON TABLES TO jigged_ai_readonly;
+-- so a new table is granted to the AI SQL role at CREATE time, without anyone
+-- writing a GRANT. Reading the migration will not reveal it — only the database
+-- will — so this is a runtime check rather than a code-review convention.
+--
+-- Same idiom as tenant_tables_missing_write_gate(): a CI test asserts no rows, so a
+-- future table in this family that forgets its REVOKE fails the build instead of
+-- silently exposing a per-operator reading report.
+CREATE OR REPLACE FUNCTION public.no_client_access_grant_leaks()
+RETURNS TABLE(table_name text, grantee text, privilege_type text)
+LANGUAGE sql
+STABLE
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT g.table_name::text, g.grantee::text, g.privilege_type::text
+  FROM information_schema.role_table_grants g
+  WHERE g.table_schema = 'public'
+    AND g.table_name IN ('note_views', 'operator_events')
+    AND g.grantee IN ('anon', 'authenticated', 'jigged_ai_readonly', 'PUBLIC')
+  ORDER BY 1, 2, 3;
+$$;
+
+COMMENT ON FUNCTION public.no_client_access_grant_leaks() IS
+  'Lists any grant on the no-client-access tables (note_views, operator_events) to a browser or AI role. Must always be empty: those tables are readable only by service_role, and written only through SECURITY DEFINER functions. Catches the default-privilege GRANT to jigged_ai_readonly that lands automatically on every new public table.';
+
+GRANT EXECUTE ON FUNCTION public.no_client_access_grant_leaks() TO service_role;

--- a/supabase/migrations/20260728041800_part_playbook_notes_rpc.sql
+++ b/supabase/migrations/20260728041800_part_playbook_notes_rpc.sql
@@ -1,0 +1,168 @@
+-- part_playbook_notes(): the read-back query, in one round trip.
+--
+-- REPLACES getPartPreviousNotes() (utils/operatorAccess.ts), which issued
+-- 1 (job_parts) + 1 (step identity) + 2N (getJobNotes + matchingStepOperationIds per
+-- prior run) round trips — up to 22 for the default maxRuns of 10 — then sorted and
+-- capped in JS. On shop wifi nobody waited for that, which is a large part of why the
+-- seeded knowledge in the last usability session went unread.
+--
+-- After the subject migration, most of this is no longer needed at all: a note whose
+-- subject is (part_id, routing_operation_id) is DURABLE and job-independent, so the
+-- next person running the part reads it from a single index hit on idx_notes_part_step
+-- with no traversal of prior jobs. The prior-run walk survives only as branch 2, for
+-- notes written BEFORE that migration, and it shrinks in relevance every month. When
+-- the pre-migration corpus stops mattering, delete branch 2 and this becomes a plain
+-- PostgREST select.
+--
+-- SECURITY INVOKER is deliberate. Running as `authenticated` means notes / jobs /
+-- job_parts RLS still applies, so tenant isolation is free — there is no hand-written
+-- `company_id IN (SELECT get_user_company_ids())` to forget and no way for this to
+-- become a cross-tenant oracle. It reads no privileged table: viewer_count and
+-- usage_count are columns on notes, and note_views is never touched. log_note_views()
+-- and note_viewers() must be DEFINER precisely because they DO touch note_views;
+-- keeping DEFINER to only those two is what holds the audit surface to two functions.
+
+CREATE OR REPLACE FUNCTION public.part_playbook_notes(
+  p_part_id              uuid,
+  -- The step, when scoping to one. NULL returns everything known about the part.
+  p_routing_operation_id uuid    DEFAULT NULL,
+  -- Legacy step-name fallback, for prior-run job notes whose job_operation has no
+  -- routing_operation_id (an ad-hoc step added to a job). Mirrors the fallback that
+  -- matchingStepOperationIds() used.
+  p_operation_name       text    DEFAULT NULL,
+  -- The current job: its own notes are already in the job feed, so they are not
+  -- "previous" notes.
+  p_exclude_job_id       uuid    DEFAULT NULL,
+  -- Bounds branch 2 only. Branch 1 needs no cap — it is one indexed lookup.
+  p_max_runs             integer DEFAULT 10
+)
+RETURNS TABLE (
+  id                   uuid,
+  body                 text,
+  created_at           timestamptz,
+  note_type            text,
+  subject_kind         text,
+  routing_operation_id uuid,
+  corrects_note_id     uuid,
+  viewer_count         integer,
+  usage_count          integer,
+  author_name          text,
+  job_number           text,
+  operation_label      text,
+  media                jsonb,
+  reactions            jsonb
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  WITH durable AS (
+    -- BRANCH 1 — the durable subject. One index hit on idx_notes_part_step. No prior
+    -- runs, no step-name heuristic, no cap. This is every note written after the
+    -- subject migration, and it is what makes the read-back loop possible at all.
+    SELECT
+      n.id, n.body, n.created_at, n.note_type, n.subject_kind, n.routing_operation_id,
+      n.corrects_note_id, n.viewer_count, n.usage_count, n.author_id,
+      cj.job_number AS src_job_number,
+      CASE
+        WHEN ro.id IS NULL THEN NULL
+        ELSE 'Op ' || ro.sequence::text ||
+             COALESCE(' · ' || wc.name, '')
+      END AS src_operation_label
+    FROM public.notes n
+    LEFT JOIN public.jobs cj              ON cj.id = n.captured_job_id
+    LEFT JOIN public.routing_operations ro ON ro.id = n.routing_operation_id
+    LEFT JOIN public.work_centers wc       ON wc.id = ro.work_center_id
+    WHERE n.subject_kind = 'part'
+      AND n.part_id = p_part_id
+      AND (p_routing_operation_id IS NULL
+           OR n.routing_operation_id = p_routing_operation_id)
+      -- Captured on the job the operator is standing in front of: already visible in
+      -- that job's feed, so showing it again as "previous" is noise.
+      AND (p_exclude_job_id IS NULL
+           OR n.captured_job_id IS DISTINCT FROM p_exclude_job_id)
+  ),
+  runs AS (
+    -- BRANCH 2 scaffolding — the most recent completed runs of this part.
+    SELECT jp.job_id, j.job_number
+    FROM public.job_parts jp
+    JOIN public.jobs j ON j.id = jp.job_id
+    WHERE jp.part_id = p_part_id
+      AND jp.production_status = 'completed'
+      AND (p_exclude_job_id IS NULL OR jp.job_id <> p_exclude_job_id)
+    ORDER BY jp.completed_at DESC NULLS LAST
+    LIMIT p_max_runs
+  ),
+  legacy AS (
+    -- BRANCH 2 — pre-migration notes, which are all subject_kind = 'job'. Step match
+    -- by routing_operation_id, falling back to operation_name when the job's step has
+    -- no routing link. Delete this branch once the old corpus stops mattering.
+    SELECT
+      n.id, n.body, n.created_at, n.note_type, n.subject_kind, n.routing_operation_id,
+      n.corrects_note_id, n.viewer_count, n.usage_count, n.author_id,
+      r.job_number AS src_job_number,
+      CASE
+        WHEN jo.id IS NULL THEN NULL
+        WHEN jo.sequence IS NULL THEN jo.operation_name
+        ELSE 'Op ' || jo.sequence::text || ' · ' || jo.operation_name
+      END AS src_operation_label
+    FROM runs r
+    JOIN public.notes n ON n.job_id = r.job_id AND n.subject_kind = 'job'
+    LEFT JOIN public.job_operations jo ON jo.id = n.job_operation_id
+    WHERE p_routing_operation_id IS NULL
+       OR jo.routing_operation_id = p_routing_operation_id
+       OR (jo.routing_operation_id IS NULL
+           AND p_operation_name IS NOT NULL
+           AND jo.operation_name = p_operation_name)
+  ),
+  combined AS (
+    SELECT * FROM durable
+    UNION ALL
+    SELECT * FROM legacy
+  )
+  SELECT
+    c.id, c.body, c.created_at, c.note_type, c.subject_kind, c.routing_operation_id,
+    c.corrects_note_id, c.viewer_count, c.usage_count,
+    a.name AS author_name,
+    c.src_job_number,
+    c.src_operation_label,
+    COALESCE(m.media, '[]'::jsonb),
+    COALESCE(rx.reactions, '[]'::jsonb)
+  FROM combined c
+  LEFT JOIN public.user_company_access a ON a.id = c.author_id
+  LEFT JOIN LATERAL (
+    SELECT jsonb_agg(jsonb_build_object(
+             'id', md.id,
+             'storage_path', md.storage_path,
+             'thumbnail_path', md.thumbnail_path,
+             'kind', md.kind,
+             'mime_type', md.mime_type,
+             'width', md.width,
+             'height', md.height
+           ) ORDER BY md.created_at) AS media
+    FROM public.note_media md
+    WHERE md.note_id = c.id
+  ) m ON true
+  LEFT JOIN LATERAL (
+    -- Reactions embed here because they are PUBLIC within the shop — the deliberate
+    -- opposite of note_views, which has no read path at any level. Names and counts
+    -- both derive from this one array client-side, so the number and the names can
+    -- never disagree; that is why there is no denormalized reaction counter.
+    SELECT jsonb_agg(jsonb_build_object(
+             'kind', x.kind,
+             'name', u.name,
+             'created_at', x.created_at
+           )) AS reactions
+    FROM public.note_reactions x
+    JOIN public.user_company_access u ON u.id = x.reactor_id
+    WHERE x.note_id = c.id
+  ) rx ON true
+  ORDER BY c.created_at DESC;
+$$;
+
+COMMENT ON FUNCTION public.part_playbook_notes(uuid, uuid, text, uuid, integer) IS
+  'Everything known about running this part (optionally scoped to one routing step), newest first, in one round trip. Unions durable part-subject notes (a single index hit) with legacy job-scoped notes from recent completed runs. SECURITY INVOKER so notes/jobs/job_parts RLS still enforces tenancy. Replaces getPartPreviousNotes and its ~22 round trips.';
+
+REVOKE EXECUTE ON FUNCTION public.part_playbook_notes(uuid, uuid, text, uuid, integer) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.part_playbook_notes(uuid, uuid, text, uuid, integer) TO authenticated;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -599,25 +599,44 @@ begin
   end if;
 end $$;
 
+-- Job-level note: genuinely about this run, so subject_kind stays 'job'.
 create function pg_temp.add_note(p_job uuid, p_body text, p_type text, p_days int)
 returns void language plpgsql as $$
 begin
-  insert into public.job_notes (company_id, job_id, author_id, body, note_type, created_at)
-  values ('22222222-2222-2222-2222-222222222222', p_job, '23000000-0000-0000-0000-000000000001', p_body, p_type, now() - (p_days||' days')::interval);
+  insert into public.notes (company_id, subject_kind, job_id, author_id, body, note_type, created_at)
+  values ('22222222-2222-2222-2222-222222222222', 'job', p_job, '23000000-0000-0000-0000-000000000001', p_body, p_type, now() - (p_days||' days')::interval);
 end $$;
 
--- Step-tagged operator note: ties a note to a specific operation (by sequence)
--- on the job's part, so the operator "Previous notes" view surfaces it for later
--- runs of the same part and can filter to "this step". Author is an operator's
--- user_company_access id (operators write these on the floor).
+-- Step note captured on the floor. Mirrors what addJobNote() does in the app: if
+-- the job's step has a routing link, the note's SUBJECT is the durable
+-- (part, routing step) and the job is recorded only as provenance — so the next
+-- run of this part surfaces it with no prior-job traversal. Falls back to a
+-- job-subject note for an ad-hoc step with no routing link.
+--
+-- Keeping the seed on the same branch as the app matters: E2E specs assert
+-- against this shape, and a seed that only ever wrote job-subject notes would
+-- leave the durable read-back path untested.
 create function pg_temp.add_op_note(p_job uuid, p_seq int, p_author uuid, p_body text, p_days int)
 returns void language plpgsql as $$
-declare v_jp uuid; v_op uuid;
+declare v_jp uuid; v_op uuid; v_part uuid; v_ro uuid;
 begin
-  select id into v_jp from public.job_parts where job_id = p_job order by sequence limit 1;
-  select id into v_op from public.job_operations where job_part_id = v_jp and sequence = p_seq limit 1;
-  insert into public.job_notes (company_id, job_id, author_id, job_part_id, job_operation_id, body, note_type, created_at)
-  values ('22222222-2222-2222-2222-222222222222', p_job, p_author, v_jp, v_op, p_body, 'user', now() - (p_days||' days')::interval);
+  select id, part_id into v_jp, v_part
+    from public.job_parts where job_id = p_job order by sequence limit 1;
+  select id, routing_operation_id into v_op, v_ro
+    from public.job_operations where job_part_id = v_jp and sequence = p_seq limit 1;
+
+  if v_ro is not null and v_part is not null then
+    insert into public.notes (company_id, subject_kind, part_id, routing_operation_id,
+                              captured_job_id, captured_job_operation_id,
+                              author_id, body, note_type, created_at)
+    values ('22222222-2222-2222-2222-222222222222', 'part', v_part, v_ro,
+            p_job, v_op, p_author, p_body, 'user', now() - (p_days||' days')::interval);
+  else
+    insert into public.notes (company_id, subject_kind, job_id, job_part_id, job_operation_id,
+                              author_id, body, note_type, created_at)
+    values ('22222222-2222-2222-2222-222222222222', 'job', p_job, v_jp, v_op,
+            p_author, p_body, 'user', now() - (p_days||' days')::interval);
+  end if;
 end $$;
 
 create function pg_temp.add_invoice(p_job uuid, p_quote uuid, p_doc text, p_days int)

--- a/types/database.ts
+++ b/types/database.ts
@@ -937,354 +937,6 @@ export type Database = {
           },
         ]
       }
-      note_media: {
-        Row: {
-          company_id: string
-          created_at: string
-          duration_seconds: number | null
-          height: number | null
-          id: string
-          kind: string
-          mime_type: string | null
-          note_id: string
-          size_bytes: number | null
-          storage_path: string
-          thumbnail_path: string | null
-          width: number | null
-        }
-        Insert: {
-          company_id: string
-          created_at?: string
-          duration_seconds?: number | null
-          height?: number | null
-          id?: string
-          kind?: string
-          mime_type?: string | null
-          note_id: string
-          size_bytes?: number | null
-          storage_path: string
-          thumbnail_path?: string | null
-          width?: number | null
-        }
-        Update: {
-          company_id?: string
-          created_at?: string
-          duration_seconds?: number | null
-          height?: number | null
-          id?: string
-          kind?: string
-          mime_type?: string | null
-          note_id?: string
-          size_bytes?: number | null
-          storage_path?: string
-          thumbnail_path?: string | null
-          width?: number | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "note_media_company_fk"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "note_media_note_fk"
-            columns: ["note_id"]
-            isOneToOne: false
-            referencedRelation: "notes"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      notes: {
-        Row: {
-          author_id: string | null
-          body: string | null
-          captured_job_id: string | null
-          captured_job_operation_id: string | null
-          company_id: string
-          corrects_note_id: string | null
-          created_at: string
-          id: string
-          job_id: string | null
-          job_operation_id: string | null
-          job_part_id: string | null
-          note_type: string
-          part_id: string | null
-          routing_operation_id: string | null
-          subject_kind: string
-          usage_count: number
-          viewer_count: number
-          work_center_id: string | null
-        }
-        Insert: {
-          author_id?: string | null
-          body?: string | null
-          captured_job_id?: string | null
-          captured_job_operation_id?: string | null
-          company_id: string
-          corrects_note_id?: string | null
-          created_at?: string
-          id?: string
-          job_id?: string | null
-          job_operation_id?: string | null
-          job_part_id?: string | null
-          note_type?: string
-          part_id?: string | null
-          routing_operation_id?: string | null
-          subject_kind: string
-          usage_count?: number
-          viewer_count?: number
-          work_center_id?: string | null
-        }
-        Update: {
-          author_id?: string | null
-          body?: string | null
-          captured_job_id?: string | null
-          captured_job_operation_id?: string | null
-          company_id?: string
-          corrects_note_id?: string | null
-          created_at?: string
-          id?: string
-          job_id?: string | null
-          job_operation_id?: string | null
-          job_part_id?: string | null
-          note_type?: string
-          part_id?: string | null
-          routing_operation_id?: string | null
-          subject_kind?: string
-          usage_count?: number
-          viewer_count?: number
-          work_center_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "notes_author_fk"
-            columns: ["author_id"]
-            isOneToOne: false
-            referencedRelation: "user_company_access"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "notes_captured_job_fk"
-            columns: ["captured_job_id"]
-            isOneToOne: false
-            referencedRelation: "jobs"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "notes_captured_job_operation_fk"
-            columns: ["captured_job_operation_id"]
-            isOneToOne: false
-            referencedRelation: "job_operations"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "notes_company_fk"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "notes_corrects_fk"
-            columns: ["corrects_note_id"]
-            isOneToOne: false
-            referencedRelation: "notes"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "notes_job_fk"
-            columns: ["job_id"]
-            isOneToOne: false
-            referencedRelation: "jobs"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "notes_job_operation_fk"
-            columns: ["job_operation_id"]
-            isOneToOne: false
-            referencedRelation: "job_operations"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "notes_job_part_fk"
-            columns: ["job_part_id"]
-            isOneToOne: false
-            referencedRelation: "job_parts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "notes_part_fk"
-            columns: ["part_id"]
-            isOneToOne: false
-            referencedRelation: "parts"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "notes_routing_operation_fk"
-            columns: ["routing_operation_id"]
-            isOneToOne: false
-            referencedRelation: "routing_operations"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "notes_work_center_fk"
-            columns: ["work_center_id"]
-            isOneToOne: false
-            referencedRelation: "work_centers"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      note_reactions: {
-        Row: {
-          company_id: string
-          created_at: string
-          id: string
-          kind: string
-          note_id: string
-          reactor_id: string
-        }
-        Insert: {
-          company_id: string
-          created_at?: string
-          id?: string
-          kind: string
-          note_id: string
-          reactor_id: string
-        }
-        Update: {
-          company_id?: string
-          created_at?: string
-          id?: string
-          kind?: string
-          note_id?: string
-          reactor_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "note_reactions_company_fk"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "note_reactions_note_fk"
-            columns: ["note_id"]
-            isOneToOne: false
-            referencedRelation: "notes"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "note_reactions_reactor_fk"
-            columns: ["reactor_id"]
-            isOneToOne: false
-            referencedRelation: "user_company_access"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      note_views: {
-        Row: {
-          company_id: string
-          created_at: string
-          id: string
-          job_id: string | null
-          note_id: string
-          viewer_id: string
-        }
-        Insert: {
-          company_id: string
-          created_at?: string
-          id?: string
-          job_id?: string | null
-          note_id: string
-          viewer_id: string
-        }
-        Update: {
-          company_id?: string
-          created_at?: string
-          id?: string
-          job_id?: string | null
-          note_id?: string
-          viewer_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "note_views_company_fk"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "note_views_job_fk"
-            columns: ["job_id"]
-            isOneToOne: false
-            referencedRelation: "jobs"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "note_views_note_fk"
-            columns: ["note_id"]
-            isOneToOne: false
-            referencedRelation: "notes"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "note_views_viewer_fk"
-            columns: ["viewer_id"]
-            isOneToOne: false
-            referencedRelation: "user_company_access"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      operator_events: {
-        Row: {
-          actor_id: string | null
-          company_id: string
-          context: Json
-          id: string
-          kind: string
-          occurred_at: string
-        }
-        Insert: {
-          actor_id?: string | null
-          company_id: string
-          context?: Json
-          id?: string
-          kind: string
-          occurred_at?: string
-        }
-        Update: {
-          actor_id?: string | null
-          company_id?: string
-          context?: Json
-          id?: string
-          kind?: string
-          occurred_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "operator_events_actor_fk"
-            columns: ["actor_id"]
-            isOneToOne: false
-            referencedRelation: "user_company_access"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "operator_events_company_fk"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       job_operation_completions: {
         Row: {
           company_id: string
@@ -1663,6 +1315,354 @@ export type Database = {
           },
         ]
       }
+      note_media: {
+        Row: {
+          company_id: string
+          created_at: string
+          duration_seconds: number | null
+          height: number | null
+          id: string
+          kind: string
+          mime_type: string | null
+          note_id: string
+          size_bytes: number | null
+          storage_path: string
+          thumbnail_path: string | null
+          width: number | null
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          duration_seconds?: number | null
+          height?: number | null
+          id?: string
+          kind?: string
+          mime_type?: string | null
+          note_id: string
+          size_bytes?: number | null
+          storage_path: string
+          thumbnail_path?: string | null
+          width?: number | null
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          duration_seconds?: number | null
+          height?: number | null
+          id?: string
+          kind?: string
+          mime_type?: string | null
+          note_id?: string
+          size_bytes?: number | null
+          storage_path?: string
+          thumbnail_path?: string | null
+          width?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "note_media_company_fk"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_media_note_fk"
+            columns: ["note_id"]
+            isOneToOne: false
+            referencedRelation: "notes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      note_reactions: {
+        Row: {
+          company_id: string
+          created_at: string
+          id: string
+          kind: string
+          note_id: string
+          reactor_id: string
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          id?: string
+          kind: string
+          note_id: string
+          reactor_id: string
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          id?: string
+          kind?: string
+          note_id?: string
+          reactor_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "note_reactions_company_fk"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_reactions_note_fk"
+            columns: ["note_id"]
+            isOneToOne: false
+            referencedRelation: "notes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_reactions_reactor_fk"
+            columns: ["reactor_id"]
+            isOneToOne: false
+            referencedRelation: "user_company_access"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      note_views: {
+        Row: {
+          company_id: string
+          created_at: string
+          id: string
+          job_id: string | null
+          note_id: string
+          viewer_id: string
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          id?: string
+          job_id?: string | null
+          note_id: string
+          viewer_id: string
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          id?: string
+          job_id?: string | null
+          note_id?: string
+          viewer_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "note_views_company_fk"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_views_job_fk"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_views_note_fk"
+            columns: ["note_id"]
+            isOneToOne: false
+            referencedRelation: "notes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_views_viewer_fk"
+            columns: ["viewer_id"]
+            isOneToOne: false
+            referencedRelation: "user_company_access"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      notes: {
+        Row: {
+          author_id: string | null
+          body: string | null
+          captured_job_id: string | null
+          captured_job_operation_id: string | null
+          company_id: string
+          corrects_note_id: string | null
+          created_at: string
+          id: string
+          job_id: string | null
+          job_operation_id: string | null
+          job_part_id: string | null
+          note_type: string
+          part_id: string | null
+          routing_operation_id: string | null
+          subject_kind: string
+          usage_count: number
+          viewer_count: number
+          work_center_id: string | null
+        }
+        Insert: {
+          author_id?: string | null
+          body?: string | null
+          captured_job_id?: string | null
+          captured_job_operation_id?: string | null
+          company_id: string
+          corrects_note_id?: string | null
+          created_at?: string
+          id?: string
+          job_id?: string | null
+          job_operation_id?: string | null
+          job_part_id?: string | null
+          note_type?: string
+          part_id?: string | null
+          routing_operation_id?: string | null
+          subject_kind: string
+          usage_count?: number
+          viewer_count?: number
+          work_center_id?: string | null
+        }
+        Update: {
+          author_id?: string | null
+          body?: string | null
+          captured_job_id?: string | null
+          captured_job_operation_id?: string | null
+          company_id?: string
+          corrects_note_id?: string | null
+          created_at?: string
+          id?: string
+          job_id?: string | null
+          job_operation_id?: string | null
+          job_part_id?: string | null
+          note_type?: string
+          part_id?: string | null
+          routing_operation_id?: string | null
+          subject_kind?: string
+          usage_count?: number
+          viewer_count?: number
+          work_center_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "notes_author_fk"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "user_company_access"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_captured_job_fk"
+            columns: ["captured_job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_captured_job_operation_fk"
+            columns: ["captured_job_operation_id"]
+            isOneToOne: false
+            referencedRelation: "job_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_company_fk"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_corrects_fk"
+            columns: ["corrects_note_id"]
+            isOneToOne: false
+            referencedRelation: "notes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_job_fk"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_job_operation_fk"
+            columns: ["job_operation_id"]
+            isOneToOne: false
+            referencedRelation: "job_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_job_part_fk"
+            columns: ["job_part_id"]
+            isOneToOne: false
+            referencedRelation: "job_parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_part_fk"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_routing_operation_fk"
+            columns: ["routing_operation_id"]
+            isOneToOne: false
+            referencedRelation: "routing_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_work_center_fk"
+            columns: ["work_center_id"]
+            isOneToOne: false
+            referencedRelation: "work_centers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      operator_events: {
+        Row: {
+          actor_id: string | null
+          company_id: string
+          context: Json
+          id: string
+          kind: string
+          occurred_at: string
+        }
+        Insert: {
+          actor_id?: string | null
+          company_id: string
+          context?: Json
+          id?: string
+          kind: string
+          occurred_at?: string
+        }
+        Update: {
+          actor_id?: string | null
+          company_id?: string
+          context?: Json
+          id?: string
+          kind?: string
+          occurred_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "operator_events_actor_fk"
+            columns: ["actor_id"]
+            isOneToOne: false
+            referencedRelation: "user_company_access"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "operator_events_company_fk"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       part_attachments: {
         Row: {
           company_id: string
@@ -1724,55 +1724,6 @@ export type Database = {
           },
         ]
       }
-      part_location_stock: {
-        Row: {
-          company_id: string
-          created_at: string
-          id: string
-          location_id: string
-          part_id: string
-          quantity: number
-        }
-        Insert: {
-          company_id: string
-          created_at?: string
-          id?: string
-          location_id: string
-          part_id: string
-          quantity?: number
-        }
-        Update: {
-          company_id?: string
-          created_at?: string
-          id?: string
-          location_id?: string
-          part_id?: string
-          quantity?: number
-        }
-        Relationships: [
-          {
-            foreignKeyName: "part_location_stock_company_fkey"
-            columns: ["company_id"]
-            isOneToOne: false
-            referencedRelation: "companies"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "part_location_stock_location_fkey"
-            columns: ["location_id"]
-            isOneToOne: false
-            referencedRelation: "inventory_locations"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "part_location_stock_part_fkey"
-            columns: ["part_id"]
-            isOneToOne: false
-            referencedRelation: "parts"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       part_comments: {
         Row: {
           author_id: string | null
@@ -1818,6 +1769,55 @@ export type Database = {
           },
           {
             foreignKeyName: "part_comments_part_fk"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      part_location_stock: {
+        Row: {
+          company_id: string
+          created_at: string
+          id: string
+          location_id: string
+          part_id: string
+          quantity: number
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          id?: string
+          location_id: string
+          part_id: string
+          quantity?: number
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          id?: string
+          location_id?: string
+          part_id?: string
+          quantity?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "part_location_stock_company_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "part_location_stock_location_fkey"
+            columns: ["location_id"]
+            isOneToOne: false
+            referencedRelation: "inventory_locations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "part_location_stock_part_fkey"
             columns: ["part_id"]
             isOneToOne: false
             referencedRelation: "parts"
@@ -3305,61 +3305,6 @@ export type Database = {
         Returns: undefined
       }
       archive_parts: { Args: { p_ids: string[] }; Returns: undefined }
-      log_note_views: {
-        Args: { p_job_id?: string; p_note_ids: string[] }
-        Returns: undefined
-      }
-      log_operator_event: {
-        Args: { p_company_id: string; p_context?: Json; p_kind: string }
-        Returns: undefined
-      }
-      my_note_view_digest: { Args: { p_tz: string }; Returns: number }
-      note_count_anomalies: {
-        Args: Record<PropertyKey, never>
-        Returns: {
-          live_usage: number
-          live_viewers: number
-          note_id: string
-          stored_usage: number
-          stored_viewers: number
-        }[]
-      }
-      note_viewers: {
-        Args: { p_note_id: string }
-        Returns: {
-          job_number: string
-          viewer_name: string
-        }[]
-      }
-      part_playbook_notes: {
-        Args: {
-          p_exclude_job_id?: string
-          p_max_runs?: number
-          p_operation_name?: string
-          p_part_id: string
-          p_routing_operation_id?: string
-        }
-        Returns: {
-          author_name: string
-          body: string
-          corrects_note_id: string
-          created_at: string
-          id: string
-          job_number: string
-          media: Json
-          note_type: string
-          operation_label: string
-          reactions: Json
-          routing_operation_id: string
-          subject_kind: string
-          usage_count: number
-          viewer_count: number
-        }[]
-      }
-      viewer_excluded_from_metrics: {
-        Args: { p_access_id: string }
-        Returns: boolean
-      }
       company_can_write: {
         Args: { check_company_id: string }
         Returns: boolean
@@ -3524,7 +3469,66 @@ export type Database = {
         Args: { p_job_part_id: string }
         Returns: string
       }
+      log_note_views: {
+        Args: { p_job_id?: string; p_note_ids: string[] }
+        Returns: undefined
+      }
+      log_operator_event: {
+        Args: { p_company_id: string; p_context?: Json; p_kind: string }
+        Returns: undefined
+      }
+      my_note_view_digest: { Args: { p_tz: string }; Returns: number }
       next_order_number: { Args: { company_uuid: string }; Returns: number }
+      no_client_access_grant_leaks: {
+        Args: never
+        Returns: {
+          grantee: string
+          privilege_type: string
+          table_name: string
+        }[]
+      }
+      note_count_anomalies: {
+        Args: never
+        Returns: {
+          live_usage: number
+          live_viewers: number
+          note_id: string
+          stored_usage: number
+          stored_viewers: number
+        }[]
+      }
+      note_viewers: {
+        Args: { p_note_id: string }
+        Returns: {
+          job_number: string
+          viewer_name: string
+        }[]
+      }
+      part_playbook_notes: {
+        Args: {
+          p_exclude_job_id?: string
+          p_max_runs?: number
+          p_operation_name?: string
+          p_part_id: string
+          p_routing_operation_id?: string
+        }
+        Returns: {
+          author_name: string
+          body: string
+          corrects_note_id: string
+          created_at: string
+          id: string
+          job_number: string
+          media: Json
+          note_type: string
+          operation_label: string
+          reactions: Json
+          routing_operation_id: string
+          subject_kind: string
+          usage_count: number
+          viewer_count: number
+        }[]
+      }
       parts_deletion_impact: {
         Args: { p_ids: string[] }
         Returns: {
@@ -3575,6 +3579,10 @@ export type Database = {
           p_unit: string
         }
         Returns: Json
+      }
+      viewer_excluded_from_metrics: {
+        Args: { p_access_id: string }
+        Returns: boolean
       }
     }
     Enums: {
@@ -3704,9 +3712,6 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
   public: {
     Enums: {},
   },

--- a/types/database.ts
+++ b/types/database.ts
@@ -937,7 +937,7 @@ export type Database = {
           },
         ]
       }
-      job_note_media: {
+      note_media: {
         Row: {
           company_id: string
           created_at: string
@@ -982,89 +982,305 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "job_note_media_company_id_fkey"
+            foreignKeyName: "note_media_company_fk"
             columns: ["company_id"]
             isOneToOne: false
             referencedRelation: "companies"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "job_note_media_note_id_fkey"
+            foreignKeyName: "note_media_note_fk"
             columns: ["note_id"]
             isOneToOne: false
-            referencedRelation: "job_notes"
+            referencedRelation: "notes"
             referencedColumns: ["id"]
           },
         ]
       }
-      job_notes: {
+      notes: {
         Row: {
           author_id: string | null
           body: string | null
+          captured_job_id: string | null
+          captured_job_operation_id: string | null
           company_id: string
+          corrects_note_id: string | null
           created_at: string
           id: string
-          job_id: string
+          job_id: string | null
           job_operation_id: string | null
           job_part_id: string | null
           note_type: string
+          part_id: string | null
+          routing_operation_id: string | null
+          subject_kind: string
+          usage_count: number
+          viewer_count: number
+          work_center_id: string | null
         }
         Insert: {
           author_id?: string | null
           body?: string | null
+          captured_job_id?: string | null
+          captured_job_operation_id?: string | null
           company_id: string
+          corrects_note_id?: string | null
           created_at?: string
           id?: string
-          job_id: string
+          job_id?: string | null
           job_operation_id?: string | null
           job_part_id?: string | null
           note_type?: string
+          part_id?: string | null
+          routing_operation_id?: string | null
+          subject_kind: string
+          usage_count?: number
+          viewer_count?: number
+          work_center_id?: string | null
         }
         Update: {
           author_id?: string | null
           body?: string | null
+          captured_job_id?: string | null
+          captured_job_operation_id?: string | null
           company_id?: string
+          corrects_note_id?: string | null
           created_at?: string
           id?: string
-          job_id?: string
+          job_id?: string | null
           job_operation_id?: string | null
           job_part_id?: string | null
           note_type?: string
+          part_id?: string | null
+          routing_operation_id?: string | null
+          subject_kind?: string
+          usage_count?: number
+          viewer_count?: number
+          work_center_id?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: "job_notes_author_id_fkey"
+            foreignKeyName: "notes_author_fk"
             columns: ["author_id"]
             isOneToOne: false
             referencedRelation: "user_company_access"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "job_notes_company_id_fkey"
+            foreignKeyName: "notes_captured_job_fk"
+            columns: ["captured_job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_captured_job_operation_fk"
+            columns: ["captured_job_operation_id"]
+            isOneToOne: false
+            referencedRelation: "job_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_company_fk"
             columns: ["company_id"]
             isOneToOne: false
             referencedRelation: "companies"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "job_notes_job_id_fkey"
+            foreignKeyName: "notes_corrects_fk"
+            columns: ["corrects_note_id"]
+            isOneToOne: false
+            referencedRelation: "notes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_job_fk"
             columns: ["job_id"]
             isOneToOne: false
             referencedRelation: "jobs"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "job_notes_job_operation_id_fkey"
+            foreignKeyName: "notes_job_operation_fk"
             columns: ["job_operation_id"]
             isOneToOne: false
             referencedRelation: "job_operations"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "job_notes_job_part_id_fkey"
+            foreignKeyName: "notes_job_part_fk"
             columns: ["job_part_id"]
             isOneToOne: false
             referencedRelation: "job_parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_part_fk"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_routing_operation_fk"
+            columns: ["routing_operation_id"]
+            isOneToOne: false
+            referencedRelation: "routing_operations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_work_center_fk"
+            columns: ["work_center_id"]
+            isOneToOne: false
+            referencedRelation: "work_centers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      note_reactions: {
+        Row: {
+          company_id: string
+          created_at: string
+          id: string
+          kind: string
+          note_id: string
+          reactor_id: string
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          id?: string
+          kind: string
+          note_id: string
+          reactor_id: string
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          id?: string
+          kind?: string
+          note_id?: string
+          reactor_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "note_reactions_company_fk"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_reactions_note_fk"
+            columns: ["note_id"]
+            isOneToOne: false
+            referencedRelation: "notes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_reactions_reactor_fk"
+            columns: ["reactor_id"]
+            isOneToOne: false
+            referencedRelation: "user_company_access"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      note_views: {
+        Row: {
+          company_id: string
+          created_at: string
+          id: string
+          job_id: string | null
+          note_id: string
+          viewer_id: string
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          id?: string
+          job_id?: string | null
+          note_id: string
+          viewer_id: string
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          id?: string
+          job_id?: string | null
+          note_id?: string
+          viewer_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "note_views_company_fk"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_views_job_fk"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_views_note_fk"
+            columns: ["note_id"]
+            isOneToOne: false
+            referencedRelation: "notes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_views_viewer_fk"
+            columns: ["viewer_id"]
+            isOneToOne: false
+            referencedRelation: "user_company_access"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      operator_events: {
+        Row: {
+          actor_id: string | null
+          company_id: string
+          context: Json
+          id: string
+          kind: string
+          occurred_at: string
+        }
+        Insert: {
+          actor_id?: string | null
+          company_id: string
+          context?: Json
+          id?: string
+          kind: string
+          occurred_at?: string
+        }
+        Update: {
+          actor_id?: string | null
+          company_id?: string
+          context?: Json
+          id?: string
+          kind?: string
+          occurred_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "operator_events_actor_fk"
+            columns: ["actor_id"]
+            isOneToOne: false
+            referencedRelation: "user_company_access"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "operator_events_company_fk"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
             referencedColumns: ["id"]
           },
         ]
@@ -1557,7 +1773,7 @@ export type Database = {
           },
         ]
       }
-      part_notes: {
+      part_comments: {
         Row: {
           author_id: string | null
           body: string
@@ -1587,21 +1803,21 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "part_notes_author_id_fkey"
+            foreignKeyName: "part_comments_author_fk"
             columns: ["author_id"]
             isOneToOne: false
             referencedRelation: "user_company_access"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "part_notes_company_id_fkey"
+            foreignKeyName: "part_comments_company_fk"
             columns: ["company_id"]
             isOneToOne: false
             referencedRelation: "companies"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "part_notes_part_id_fkey"
+            foreignKeyName: "part_comments_part_fk"
             columns: ["part_id"]
             isOneToOne: false
             referencedRelation: "parts"
@@ -2768,6 +2984,7 @@ export type Database = {
           company_id: string
           created_at: string | null
           email: string | null
+          excluded_from_metrics: boolean
           id: string
           name: string | null
           pin_hash: string | null
@@ -2778,6 +2995,7 @@ export type Database = {
           company_id: string
           created_at?: string | null
           email?: string | null
+          excluded_from_metrics?: boolean
           id?: string
           name?: string | null
           pin_hash?: string | null
@@ -2788,6 +3006,7 @@ export type Database = {
           company_id?: string
           created_at?: string | null
           email?: string | null
+          excluded_from_metrics?: boolean
           id?: string
           name?: string | null
           pin_hash?: string | null
@@ -3086,6 +3305,61 @@ export type Database = {
         Returns: undefined
       }
       archive_parts: { Args: { p_ids: string[] }; Returns: undefined }
+      log_note_views: {
+        Args: { p_job_id?: string; p_note_ids: string[] }
+        Returns: undefined
+      }
+      log_operator_event: {
+        Args: { p_company_id: string; p_context?: Json; p_kind: string }
+        Returns: undefined
+      }
+      my_note_view_digest: { Args: { p_tz: string }; Returns: number }
+      note_count_anomalies: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          live_usage: number
+          live_viewers: number
+          note_id: string
+          stored_usage: number
+          stored_viewers: number
+        }[]
+      }
+      note_viewers: {
+        Args: { p_note_id: string }
+        Returns: {
+          job_number: string
+          viewer_name: string
+        }[]
+      }
+      part_playbook_notes: {
+        Args: {
+          p_exclude_job_id?: string
+          p_max_runs?: number
+          p_operation_name?: string
+          p_part_id: string
+          p_routing_operation_id?: string
+        }
+        Returns: {
+          author_name: string
+          body: string
+          corrects_note_id: string
+          created_at: string
+          id: string
+          job_number: string
+          media: Json
+          note_type: string
+          operation_label: string
+          reactions: Json
+          routing_operation_id: string
+          subject_kind: string
+          usage_count: number
+          viewer_count: number
+        }[]
+      }
+      viewer_excluded_from_metrics: {
+        Args: { p_access_id: string }
+        Returns: boolean
+      }
       company_can_write: {
         Args: { check_company_id: string }
         Returns: boolean

--- a/types/database.ts
+++ b/types/database.ts
@@ -3712,6 +3712,9 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {},
   },

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -263,6 +263,24 @@ export interface JobNote {
   created_at: string;
   /** Author display name (from user_company_access.name); null if unknown. */
   author_name: string | null;
+  /**
+   * What the note is ABOUT, which is not the same as where it was captured.
+   * 'part' is the durable subject — anchored to (part, routing step), so it
+   * outlives the job and is what the next person running the part reads.
+   * 'job' is either a legacy note or one genuinely about this run only.
+   */
+  subject_kind: 'job' | 'part' | 'work_center';
+  /**
+   * Distinct PEOPLE who have read this note, excluding the author and accounts
+   * excluded from metrics. Saturates near shop size — that is what it means.
+   */
+  viewer_count: number;
+  /**
+   * Distinct JOBS this note was consulted on. Uncapped, and the number that
+   * distinguishes a load-bearing note from one read once out of curiosity.
+   * Renders as "used on 11 jobs by 4 people".
+   */
+  usage_count: number;
   /** Attached photos/videos, in insertion order. */
   media: JobNoteMedia[];
 }

--- a/utils/dashboardAccess.ts
+++ b/utils/dashboardAccess.ts
@@ -457,7 +457,7 @@ export async function getPinnedMetricValues(
 // ============== Activity feed ==============
 //
 // A cross-module "what happened" stream, built UNION-on-read over the
-// authoritative tables (jobs, quotes, shipments, job_notes, job_operations) —
+// authoritative tables (jobs, quotes, shipments, notes, job_operations) —
 // NOT a materialized/fan-out activity table. Per-tenant volume is tiny and the
 // status/timestamps already live on those rows, so a second source of truth
 // would only invite drift (mirrors the getPartActivity aggregate-on-read).
@@ -626,8 +626,12 @@ async function fetchShipmentActivity(
 type NoteActivityRow = {
   id: string;
   created_at: string;
-  job_id: string;
+  // Both nullable now: a job-subject note has job_id, a durable part-subject note has
+  // captured_job_id, and a work-center-subject note has neither.
+  job_id: string | null;
+  captured_job_id: string | null;
   job: { job_number: string } | { job_number: string }[] | null;
+  captured_job: { job_number: string } | { job_number: string }[] | null;
   author: { name: string | null } | { name: string | null }[] | null;
   media: { id: string }[] | null;
 };
@@ -638,9 +642,20 @@ async function fetchNoteActivity(
   perSource: number,
 ): Promise<ActivityItem[]> {
   const supabase = getSupabase();
+  // A note now resolves to a job one of two ways: job_id (a job-subject note) or
+  // captured_job_id (a DURABLE part-subject note, whose subject is the part but which
+  // was written while running a job). Both are embedded and coalesced below —
+  // PostgREST cannot COALESCE in a select, and keying only on job_id would silently
+  // drop every new operator capture from the activity feed.
+  // Two FKs point at `jobs`, so each embed must name its constraint to disambiguate.
   let q = supabase
-    .from('job_notes')
-    .select('id, created_at, job_id, job:jobs(job_number), author:user_company_access(name), media:job_note_media(id)')
+    .from('notes')
+    .select(
+      'id, created_at, job_id, captured_job_id, ' +
+        'job:jobs!notes_job_fk(job_number), ' +
+        'captured_job:jobs!notes_captured_job_fk(job_number), ' +
+        'author:user_company_access(name), media:note_media(id)',
+    )
     .eq('company_id', companyId)
     .order('created_at', { ascending: false })
     .limit(perSource);
@@ -651,16 +666,23 @@ async function fetchNoteActivity(
   for (const r of (data ?? []) as unknown as NoteActivityRow[]) {
     if (!r.created_at) continue;
     const hasMedia = (r.media ?? []).length > 0;
+    const jobId = r.job_id ?? r.captured_job_id;
+    const jobNumber =
+      firstRel(r.job)?.job_number ?? firstRel(r.captured_job)?.job_number ?? '';
     items.push({
       id: `note-${r.id}`,
       // A note carrying photos surfaces as a 'photo' event so the /activity
       // filter can separate the two; text-only notes are 'note'.
       type: hasMedia ? 'photo' : 'note',
       action: hasMedia ? 'photo_added' : 'noted',
-      entityNumber: firstRel(r.job)?.job_number ?? '',
+      entityNumber: jobNumber,
       timestamp: r.created_at,
       authorName: firstRel(r.author)?.name ?? undefined,
-      href: `/dashboard/${companyId}/jobs/${r.job_id}`,
+      // A work-center-subject note has no job at all; link to the feed itself
+      // rather than emitting /jobs/undefined.
+      href: jobId
+        ? `/dashboard/${companyId}/jobs/${jobId}`
+        : `/dashboard/${companyId}/activity`,
     });
   }
   return items;
@@ -772,7 +794,7 @@ async function collectActivity(
   if (want('job')) tasks.push(fetchJobActivity(companyId, before, perSource));
   if (want('quote')) tasks.push(fetchQuoteActivity(companyId, before, perSource));
   if (want('shipment')) tasks.push(fetchShipmentActivity(companyId, before, perSource));
-  // 'note' and 'photo' both come from job_notes (one query yields both kinds).
+  // 'note' and 'photo' both come from notes (one query yields both kinds).
   if (want('note') || want('photo')) tasks.push(fetchNoteActivity(companyId, before, perSource));
   if (want('operation')) tasks.push(fetchOperationActivity(companyId, before, perSource));
 

--- a/utils/jobNoteMediaAccess.ts
+++ b/utils/jobNoteMediaAccess.ts
@@ -8,11 +8,16 @@ import {
 import type { JobNoteMedia } from '@/types/operator';
 
 /**
- * Access layer for job-note media — photos (and, later, short videos) attached
- * to a job_notes entry. File bytes live in the private `attachments` storage
- * bucket under {companyId}/jobs/{jobId}/... (see utils/storageHelpers.ts, whose
- * bucket RLS already gates by the company folder); this module manages the
- * job_note_media metadata rows and ties the two together.
+ * Access layer for note media — photos (and, later, short videos) attached to a
+ * `notes` entry. File bytes live in the private `attachments` storage bucket
+ * under {companyId}/jobs/{jobId}/... (see utils/storageHelpers.ts, whose bucket
+ * RLS already gates by the company folder); this module manages the `note_media`
+ * metadata rows and ties the two together.
+ *
+ * The storage path still keys on the capturing job even for durable
+ * part-subject notes: it is only a folder layout, and the company segment (which
+ * is what the bucket RLS gates on) is unchanged. Repathing existing objects would
+ * be a data migration with no functional benefit.
  *
  * Mirrors partAttachmentsAccess.ts. Heavy media work (compression, EXIF fix,
  * dimension reading) happens in the browser BEFORE these calls — they only see
@@ -67,7 +72,7 @@ export async function addJobNoteMedia(
   await uploadFileToStorage(storagePath, file);
 
   const { data, error } = await supabase
-    .from('job_note_media')
+    .from('note_media')
     .insert({
       company_id: companyId,
       note_id: noteId,
@@ -107,7 +112,7 @@ export async function deleteJobNoteMedia(media: {
   storage_path: string;
 }): Promise<void> {
   const supabase = getSupabase();
-  const { error } = await supabase.from('job_note_media').delete().eq('id', media.id);
+  const { error } = await supabase.from('note_media').delete().eq('id', media.id);
   if (error) {
     console.error('Error deleting job note media row:', error);
     throw error;
@@ -129,7 +134,7 @@ export async function deleteJobNote(noteId: string): Promise<void> {
   // Read media storage paths before the cascade removes the rows.
   let paths: string[] = [];
   const { data: mediaRows, error: listError } = await supabase
-    .from('job_note_media')
+    .from('note_media')
     .select('storage_path')
     .eq('note_id', noteId);
   if (listError) {
@@ -140,7 +145,7 @@ export async function deleteJobNote(noteId: string): Promise<void> {
       .filter(Boolean);
   }
 
-  const { error } = await supabase.from('job_notes').delete().eq('id', noteId);
+  const { error } = await supabase.from('notes').delete().eq('id', noteId);
   if (error) {
     console.error('Error deleting job note:', error);
     throw error;

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -1270,23 +1270,36 @@ export async function getJobPartsOverview(
 // Each note carries its optional step tag (job_operations) and its media so the
 // feed renders thumbnails without a second round-trip.
 const JOB_NOTE_SELECT =
-  'id, job_id, job_operation_id, body, note_type, created_at, ' +
+  'id, subject_kind, job_id, job_operation_id, captured_job_id, ' +
+  'captured_job_operation_id, part_id, routing_operation_id, ' +
+  'viewer_count, usage_count, body, note_type, created_at, ' +
   'author:user_company_access(name), ' +
-  'operation:job_operations(operation_name, sequence), ' +
-  'media:job_note_media(id, note_id, storage_path, thumbnail_path, kind, mime_type, width, height)';
+  'operation:job_operations!notes_job_operation_fk(operation_name, sequence), ' +
+  'captured_operation:job_operations!notes_captured_job_operation_fk(operation_name, sequence), ' +
+  'media:note_media(id, note_id, storage_path, thumbnail_path, kind, mime_type, width, height)';
+
+type StepRel =
+  | { operation_name: string | null; sequence: number | null }
+  | { operation_name: string | null; sequence: number | null }[]
+  | null;
 
 type JobNoteRow = {
   id: string;
-  job_id: string;
+  subject_kind: string;
+  job_id: string | null;
   job_operation_id: string | null;
+  captured_job_id: string | null;
+  captured_job_operation_id: string | null;
+  part_id: string | null;
+  routing_operation_id: string | null;
+  viewer_count: number;
+  usage_count: number;
   body: string | null;
   note_type: string | null;
   created_at: string;
   author: { name: string | null } | { name: string | null }[] | null;
-  operation:
-    | { operation_name: string | null; sequence: number | null }
-    | { operation_name: string | null; sequence: number | null }[]
-    | null;
+  operation: StepRel;
+  captured_operation: StepRel;
   media: Array<{
     id: string;
     note_id: string;
@@ -1299,14 +1312,18 @@ type JobNoteRow = {
   }> | null;
 };
 
+function stepLabel(rel: StepRel): string | null {
+  const op = Array.isArray(rel) ? rel[0] : rel;
+  if (!op?.operation_name) return null;
+  return op.sequence != null ? `Op ${op.sequence} · ${op.operation_name}` : op.operation_name;
+}
+
 function mapJobNoteRow(n: JobNoteRow): JobNote {
   const author = Array.isArray(n.author) ? n.author[0] : n.author;
-  const op = Array.isArray(n.operation) ? n.operation[0] : n.operation;
-  const operationLabel = op?.operation_name
-    ? op.sequence != null
-      ? `Op ${op.sequence} · ${op.operation_name}`
-      : op.operation_name
-    : null;
+  // A durable part-subject note carries no job_operation_id — its step is the
+  // routing step. Its captured_job_operation_id is what names the step the operator
+  // was standing at, so the feed row still reads "Op 20 · Deburr" either way.
+  const operationLabel = stepLabel(n.operation) ?? stepLabel(n.captured_operation);
   const media: JobNoteMedia[] = (n.media ?? []).map((m) => ({
     id: m.id,
     note_id: m.note_id,
@@ -1319,23 +1336,36 @@ function mapJobNoteRow(n: JobNoteRow): JobNote {
   }));
   return {
     id: n.id,
-    job_id: n.job_id,
-    job_operation_id: n.job_operation_id,
+    // The job this note belongs to FROM THE FEED'S POINT OF VIEW: its own job for a
+    // job-subject note, the capturing job for a durable part-subject one.
+    job_id: n.job_id ?? n.captured_job_id ?? '',
+    job_operation_id: n.job_operation_id ?? n.captured_job_operation_id,
     operation_label: operationLabel,
     body: n.body,
     note_type: n.note_type === 'event' ? 'event' : 'user',
     created_at: n.created_at,
     author_name: author?.name ?? null,
+    subject_kind: n.subject_kind === 'part' || n.subject_kind === 'work_center'
+      ? n.subject_kind
+      : 'job',
+    viewer_count: n.viewer_count,
+    usage_count: n.usage_count,
     media,
   };
 }
 
 /**
- * The job feed (newest first): one append-only stream per job. Returns both
- * job-level notes and operation-scoped notes — operation notes roll up here
- * automatically because they still carry job_id. Each note includes its step
- * tag label (if any) and its attached media. Backs both the traveler (read-only)
- * and the operation page.
+ * The job feed (newest first): one append-only stream per job. Two kinds of row
+ * appear here, and the union is the point:
+ *
+ *   - job-subject notes (job_id) — legacy captures, and anything genuinely about
+ *     THIS run only;
+ *   - durable part-subject notes captured on this job (captured_job_id) — every
+ *     new operator capture. Their subject is (part, routing step), so the next
+ *     person running the part reads them without ever touching this job.
+ *
+ * Filtering on job_id alone would silently drop every new capture from the feed.
+ * Both columns are indexed, so the `or` is a bitmap OR, not a scan.
  */
 export async function getJobNotes(
   jobId: string,
@@ -1344,10 +1374,10 @@ export async function getJobNotes(
   const supabase = getSupabase();
 
   const { data, error } = await supabase
-    .from('job_notes')
+    .from('notes')
     .select(JOB_NOTE_SELECT)
-    .eq('job_id', jobId)
     .eq('company_id', companyId)
+    .or(`job_id.eq.${jobId},captured_job_id.eq.${jobId}`)
     .order('created_at', { ascending: false });
 
   if (error) throw new Error(error.message);
@@ -1356,19 +1386,55 @@ export async function getJobNotes(
 }
 
 /**
- * Append a note to the job feed. `authorId` is the author's user_company_access
- * id (from getCurrentMember); RLS requires it to match the caller's access row.
+ * Resolve the DURABLE anchor for a step the operator is standing at: the part and
+ * the routing (template) step, as opposed to this job's instance of it.
  *
- * `opts.jobOperationId` is the optional step tag. The operation page always
- * passes it (with `jobPartId`) so operator captures are step-scoped; the
- * read-only traveler never calls this. `body` may be null/blank for a media-only
- * note — callers must guarantee body-or-media (a fully empty note is useless);
- * the returned note's `media` is empty until media is attached via
- * addJobNoteMedia.
+ * Returns null when the job operation has no routing link — an ad-hoc step added
+ * to one job has nothing durable to anchor to. That is a real subject difference,
+ * not a silent fallback for a data-at-rest problem.
+ */
+async function resolveDurableAnchor(
+  jobOperationId: string,
+): Promise<{ partId: string; routingOperationId: string } | null> {
+  const supabase = getSupabase();
+  const { data } = await supabase
+    .from('job_operations')
+    .select('routing_operation_id, job_part:job_parts(part_id)')
+    .eq('id', jobOperationId)
+    .single();
+
+  if (!data?.routing_operation_id) return null;
+  const jobPart = Array.isArray(data.job_part) ? data.job_part[0] : data.job_part;
+  if (!jobPart?.part_id) return null;
+
+  return { partId: jobPart.part_id, routingOperationId: data.routing_operation_id };
+}
+
+/**
+ * Append a note. `authorId` is the author's user_company_access id (from
+ * getCurrentMember); RLS requires it to match the caller's access row — there is
+ * no path for anyone to author as someone else.
  *
- * `opts.noteType` defaults to 'user' (a human-authored note). Pass 'event' for
- * auto-logged feed entries (e.g. the order-quantity-change audit trail) so the
- * feed can style them differently from typed notes.
+ * SUBJECT CHOICE, which is the whole point of this workstream. The operator is
+ * never asked to classify anything:
+ *
+ *   - step has a routing link  -> subject_kind 'part', anchored to
+ *     (part_id, routing_operation_id), with the capturing job recorded as
+ *     PROVENANCE. The note outlives the job, so the next person running this part
+ *     reads it from one index hit — no prior-run traversal, no toggle.
+ *   - otherwise                -> subject_kind 'job', the old behaviour, because
+ *     there is no durable step to anchor to.
+ *
+ * Either way the note appears in this job's feed (getJobNotes unions both), so
+ * nothing is lost at the capture surface.
+ *
+ * `body` may be null/blank for a media-only note — callers must guarantee
+ * body-or-media (a fully empty note is useless); the returned note's `media` is
+ * empty until media is attached via addJobNoteMedia.
+ *
+ * `opts.noteType` defaults to 'user'. Pass 'event' for auto-logged feed entries
+ * (e.g. the order-quantity-change audit trail); those are always job-subject,
+ * since a machine-generated audit line is not durable part knowledge.
  */
 export async function addJobNote(
   jobId: string,
@@ -1384,18 +1450,41 @@ export async function addJobNote(
   const supabase = getSupabase();
 
   const trimmed = body?.trim() || null;
+  const noteType = opts?.noteType ?? 'user';
+
+  const anchor =
+    noteType === 'user' && opts?.jobOperationId
+      ? await resolveDurableAnchor(opts.jobOperationId)
+      : null;
+
+  const row = anchor
+    ? {
+        company_id: companyId,
+        author_id: authorId,
+        body: trimmed,
+        note_type: noteType,
+        subject_kind: 'part',
+        part_id: anchor.partId,
+        routing_operation_id: anchor.routingOperationId,
+        // Provenance, never subject: keeps the note in this job's feed and lets
+        // the card name the step, without tying the knowledge to the job.
+        captured_job_id: jobId,
+        captured_job_operation_id: opts?.jobOperationId ?? null,
+      }
+    : {
+        company_id: companyId,
+        author_id: authorId,
+        body: trimmed,
+        note_type: noteType,
+        subject_kind: 'job',
+        job_id: jobId,
+        job_part_id: opts?.jobPartId ?? null,
+        job_operation_id: opts?.jobOperationId ?? null,
+      };
 
   const { data, error } = await supabase
-    .from('job_notes')
-    .insert({
-      company_id: companyId,
-      job_id: jobId,
-      author_id: authorId,
-      body: trimmed,
-      note_type: opts?.noteType ?? 'user',
-      job_part_id: opts?.jobPartId ?? null,
-      job_operation_id: opts?.jobOperationId ?? null,
-    })
+    .from('notes')
+    .insert(row)
     .select(JOB_NOTE_SELECT)
     .single();
 
@@ -1411,7 +1500,7 @@ export async function addJobNote(
   return mapJobNoteRow(data as unknown as JobNoteRow);
 }
 
-/** Resolve a step's identity (routing op id + name) for cross-run matching. */
+/** Resolve a step's identity for the RPC's legacy step-name fallback. */
 async function getStepIdentity(
   jobOperationId: string,
 ): Promise<{ routing_operation_id: string | null; operation_name: string } | null> {
@@ -1424,43 +1513,40 @@ async function getStepIdentity(
   return (data as { routing_operation_id: string | null; operation_name: string } | null) ?? null;
 }
 
-/**
- * The job_operation ids within `jobId` that are the SAME step as `identity` —
- * matched by routing_operation_id, falling back to operation_name when either
- * side lacks a routing id. Used to scope prior-run notes to "this step".
- */
-async function matchingStepOperationIds(
-  jobId: string,
-  identity: { routing_operation_id: string | null; operation_name: string },
-): Promise<Set<string>> {
-  const supabase = getSupabase();
-  const { data } = await supabase
-    .from('job_operations')
-    .select('id, routing_operation_id, operation_name')
-    .eq('job_id', jobId);
-  type OpRow = { id: string; routing_operation_id: string | null; operation_name: string };
-  return new Set(
-    ((data ?? []) as OpRow[])
-      .filter((op) =>
-        identity.routing_operation_id && op.routing_operation_id
-          ? op.routing_operation_id === identity.routing_operation_id
-          : op.operation_name === identity.operation_name,
-      )
-      .map((op) => op.id),
-  );
-}
+type PlaybookRow = {
+  id: string;
+  body: string | null;
+  created_at: string;
+  note_type: string | null;
+  subject_kind: string;
+  routing_operation_id: string | null;
+  corrects_note_id: string | null;
+  viewer_count: number;
+  usage_count: number;
+  author_name: string | null;
+  job_number: string | null;
+  operation_label: string | null;
+  media: JobNoteMedia[] | null;
+  reactions: unknown;
+};
 
 /**
- * Notes from PRIOR completed runs of a part, flattened newest-first — the
- * operator's "previous notes for this part" guidance (accumulated setup tips,
- * gotchas, photos), NOT a list of past jobs. Each note keeps its source
- * job_number for a light reference.
+ * Everything known about running this part, newest first — accumulated setup
+ * tips, gotchas and photos, NOT a list of past jobs. Part-centric and never
+ * operator-comparative: no time metrics, no per-person counters.
  *
- * Part-centric (keyed on part_id), never operator-comparative — no time metrics.
- * When `jobOperationId` is given, notes are filtered to the SAME step across runs
- * (matched by routing_operation_id, falling back to operation_name) for the
- * sheet's "this step" filter. Capped at the most recent `maxRuns` completed runs
- * (default 10) to bound the per-run note fetches. Empty array when none.
+ * ONE round trip, via the part_playbook_notes RPC. This used to issue up to 22
+ * (one for the prior runs, then getJobNotes + a step lookup per run, capped at
+ * 10) and sort in JS — slow enough on shop wifi that prior knowledge effectively
+ * wasn't there, which is a large part of why seeded notes went unread in the last
+ * usability session.
+ *
+ * Most of what the RPC does is now vestigial: a note written after the subject
+ * migration is anchored to (part, routing step) directly, so it comes back from a
+ * single index hit. The prior-run walk survives only for pre-migration notes.
+ *
+ * When `jobOperationId` is given, scopes to that step: by routing step for
+ * durable notes, falling back to operation_name for legacy ones.
  */
 export async function getPartPreviousNotes(
   partId: string,
@@ -1469,45 +1555,41 @@ export async function getPartPreviousNotes(
 ): Promise<PartPreviousNote[]> {
   const supabase = getSupabase();
 
-  // Completed prior runs of this part (job_parts carries part-level completion
-  // + company_id). Low volume per part, so sort/cap in JS.
-  const { data, error } = await supabase
-    .from('job_parts')
-    .select('job_id, completed_at, jobs!inner(id, job_number)')
-    .eq('part_id', partId)
-    .eq('company_id', companyId)
-    .eq('production_status', 'completed');
+  const identity = opts?.jobOperationId
+    ? await getStepIdentity(opts.jobOperationId)
+    : null;
+
+  const { data, error } = await supabase.rpc('part_playbook_notes', {
+    p_part_id: partId,
+    p_routing_operation_id: identity?.routing_operation_id ?? undefined,
+    p_operation_name: identity?.operation_name ?? undefined,
+    p_exclude_job_id: opts?.excludeJobId ?? undefined,
+    p_max_runs: opts?.maxRuns ?? 10,
+  });
+
+  // companyId is intentionally unused as a filter: the RPC is SECURITY INVOKER, so
+  // RLS on notes/jobs/job_parts already scopes it to the caller's companies. A
+  // second client-side filter would be a redundant source of truth.
+  void companyId;
 
   if (error || !data) return [];
 
-  type PriorRow = {
-    job_id: string;
-    completed_at: string | null;
-    jobs: { id: string; job_number: string } | { id: string; job_number: string }[] | null;
-  };
-  const rows = (data as unknown as PriorRow[])
-    .filter((r) => r.job_id !== opts?.excludeJobId)
-    // Newest completed first (nulls last), then cap the number of runs scanned.
-    .sort((a, b) => (b.completed_at ?? '').localeCompare(a.completed_at ?? ''))
-    .slice(0, opts?.maxRuns ?? 10);
-  if (rows.length === 0) return [];
-
-  // Resolve the current step's identity once for the optional "this step" filter.
-  const stepIdentity = opts?.jobOperationId ? await getStepIdentity(opts.jobOperationId) : null;
-
-  const perRun = await Promise.all(
-    rows.map(async (row): Promise<PartPreviousNote[]> => {
-      const priorJob = Array.isArray(row.jobs) ? row.jobs[0] : row.jobs;
-      if (!priorJob) return [];
-      let notes = await getJobNotes(row.job_id, companyId);
-      if (stepIdentity) {
-        const matchIds = await matchingStepOperationIds(row.job_id, stepIdentity);
-        notes = notes.filter((n) => n.job_operation_id && matchIds.has(n.job_operation_id));
-      }
-      return notes.map((n) => ({ ...n, job_number: priorJob.job_number }));
-    }),
-  );
-
-  // Flatten across runs, newest note first.
-  return perRun.flat().sort((a, b) => b.created_at.localeCompare(a.created_at));
+  return (data as unknown as PlaybookRow[]).map((r) => ({
+    id: r.id,
+    job_id: '',
+    job_operation_id: null,
+    operation_label: r.operation_label,
+    body: r.body,
+    note_type: r.note_type === 'event' ? 'event' : 'user',
+    created_at: r.created_at,
+    author_name: r.author_name,
+    subject_kind:
+      r.subject_kind === 'part' || r.subject_kind === 'work_center'
+        ? r.subject_kind
+        : 'job',
+    viewer_count: r.viewer_count,
+    usage_count: r.usage_count,
+    media: r.media ?? [],
+    job_number: r.job_number ?? '',
+  }));
 }

--- a/utils/partsAccess.ts
+++ b/utils/partsAccess.ts
@@ -1724,7 +1724,7 @@ export async function getPartNotes(partId: string, companyId: string): Promise<P
   const supabase = getSupabase();
 
   const { data, error } = await supabase
-    .from('part_notes')
+    .from('part_comments')
     .select('id, part_id, body, created_at, author_id, note_type, author:user_company_access(name)')
     .eq('part_id', partId)
     .eq('company_id', companyId)
@@ -1778,7 +1778,7 @@ export async function addPartNote(
   if (!trimmed) throw new Error('Note cannot be empty.');
 
   const { data, error } = await supabase
-    .from('part_notes')
+    .from('part_comments')
     .insert({
       company_id: companyId,
       part_id: partId,
@@ -1836,7 +1836,7 @@ export async function addPartPricingNote(
  */
 export async function deletePartNote(noteId: string): Promise<void> {
   const supabase = getSupabase();
-  const { error } = await supabase.from('part_notes').delete().eq('id', noteId);
+  const { error } = await supabase.from('part_comments').delete().eq('id', noteId);
   if (error) {
     console.error('Error deleting part note:', error);
     throw error;


### PR DESCRIPTION
## Why

Jigged's thesis is that shop-floor knowledge is a durable asset. It isn't accumulating — a week-long diary trial at our one live shop produced one note.

The audit turned up a structural reason for that, independent of motivation: **every note in Jigged is job-scoped.** `job_notes.job_id` was `NOT NULL`, so a note an operator writes at the machine dies with the job, and the next person running that part depends on a read-time heuristic that walks up to 10 prior jobs (~22 round trips). There was nowhere to put knowledge that outlives the job.

So this isn't "add view logging to existing notes." It's **create the durable subject that makes a note worth reading twice, then measure whether it gets read.**

Iteration A, phases 1–2 (schema + access layer). The operator-facing surfaces — attribution on the card, the dwell client, login banner, funnel instrumentation, photo fix, guardrail removals — are phases 3–8 and are **not** in this PR. Nothing an operator sees changes yet; the schema can record reads that nothing yet logs.

## What changed

**Schema**

| before | after |
|---|---|
| `job_notes` | `notes` (+ subject taxonomy, provenance, two counters) |
| `job_note_media` | `note_media` |
| `part_notes` | `part_comments` — rename only |
| — | `note_views`, `note_reactions`, `operator_events` |

`part_comments` is deliberately **not** folded in: it's the manual half of an office activity feed that also carries system-generated pricing entries. Its audience is office staff, and it needs none of the view logging, reactions or media that notes need. Folding it in would have attached view counts to pricing entries and forced every knowledge surface to remember to filter change-log rows — the same silent-filter bug class as a forgotten `deleted_at IS NULL`. It's renamed purely to free the `notes` name.

**The durable subject.** A note's subject is now `job` / `part` / `work_center`, each with an optional finer grain, enforced by `notes_subject_valid`. The durable case is `part` + `routing_operation_id` — the routing *template* step, so the note is job-independent and the next run reads it from one index hit. The capturing job is recorded as **provenance** (`captured_job_id`), which keeps the note in that job's feed without tying the knowledge to it.

`addJobNote` picks the subject from the step; the operator is never asked to classify anything. An ad-hoc step with no routing link stays job-scoped — a real subject difference, not a fallback papering over bad data.

**`work_center` is in the taxonomy already**, so machine notes need no further migration when they land.

**Two counters, because one number would conflate them.** `viewer_count` (distinct people — saturates near shop size) and `usage_count` (distinct jobs — uncapped, and the number that distinguishes a load-bearing note from one read once out of curiosity). Dedupe is `UNIQUE NULLS NOT DISTINCT (note, viewer, job)`: repeat **use** counts, repeat **opens** never do.

## Privacy is the design, not a side concern

If a shop owner can audit who reads notes, reading becomes an admission of ignorance and the read side dies. The rule is one sentence with **no role branch**:

> you see who used your notes; nobody sees who used anyone else's.

- **`note_views` has no client read path at all** — no `SELECT` grant, plus a RESTRICTIVE deny-all. This is what blocks `Prefer: count=exact` probing, which RLS is powerless against (the count is over exactly the rows a policy admitted).
- Authors get names via `note_viewers()`; everyone else gets counts via columns. **Identical for every role** — see the decision note below.
- **Counters are monotonic.** Without that, an admin could snapshot counts, delete a member so their rows cascade, and name every note that person had read.
- Column-scoped `GRANT`s on `notes` and `user_company_access` close two more differencing attacks that RLS cannot express (RLS can't scope to a column; `GRANT` can).

**Also fixes a pre-existing hole:** a member of two companies could file a note under company A referencing company B's job. `notes_validate_subject` now checks every subject FK's company — a `CHECK` cannot span tables.

### Decision changed during review: attribution is role-neutral

An earlier revision excluded company admins from `note_viewers()`, to block an admin authoring a must-read note and harvesting a named read list. **That was removed** (c333743).

Roles are interchangeable and move up and down in a fifteen-person shop. A role-dependent rule means an operator promoted to lead would silently stop seeing who used notes they had already written — losing exactly the feedback loop that got them writing. Behaviour that changes when someone's role changes is worse than the speed bump, and the bump was defeatable anyway: anyone who can create accounts can author from a non-admin one.

What remains is bounded and unchanged — an author learns who used **their own** notes, one note at a time. There is still no shop-wide report of who read which notes. Two tests pin it: an admin author sees names like anyone else, and **promoting an author changes nothing** about what they can see.

## The bug the container validation caught

`jigged_ai_readonly` — the role that executes LLM-generated SQL — had `SELECT` on `note_views` and `operator_events`, and **nothing in the migration granted it.** `baseline.sql:6431` sets `ALTER DEFAULT PRIVILEGES … GRANT SELECT ON TABLES TO jigged_ai_readonly`, so every new public table gets it at CREATE time. Reading the migration will never reveal it; only the database will.

Not live exposure — RLS still denied. But the RESTRICTIVE deny-all named only `anon, authenticated`, and `docs/modules/ai-insights.md` instructs anyone widening AI scope to add an `ai_readonly_select … USING (true)` policy. Following that documented procedure would have opened *"which operators read the setup notes?"*

Fixed at both layers, plus `no_client_access_grant_leaks()` — same idiom as `tenant_tables_missing_write_gate()`, so the next table in this family that forgets its REVOKE fails the build. A review convention can't catch a grant nobody writes.

## Read path

`part_playbook_notes()` replaces `getPartPreviousNotes`' ~22 round trips with one. `SECURITY INVOKER`, so `notes`/`jobs`/`job_parts` RLS still enforces tenancy — no hand-written `company_id IN (…)` to forget. The prior-run walk survives only for pre-migration notes and is marked for deletion once that corpus stops mattering.

## Verification

**All checks green.** The parts worth calling out:

- **25 integration tests in `test_note_views_rls.py` ran and passed — zero skipped.** Verified explicitly rather than trusting the green tick, because this repo has a documented incident where a runtime-skipped spec masked a broken `jobs.status` SELECT in production. These are the assertions that need real JWT clients: a non-author cannot read `note_views` at all; a non-author gets no names; an operator cannot flip `excluded_from_metrics`; an admin **can** still change a member's role (the grant surgery didn't break the one real browser write); counters don't move when a member is deleted.
- **Backend 394 passed**, i.e. the new file plus an unaffected existing suite.
- **Supabase Preview passed** — the migration applies cleanly to a real branch DB.
- **Playwright E2E passed**, which exercises the modified `seed.sql` (it now writes the durable `part` subject rather than job-scoped notes).
- Frontend 1200 tests, `tsc` clean.

Additionally, all 68 migrations were replayed from scratch into a throwaway Postgres 17 with 23 behavioural checks — dedupe, `NULLS NOT DISTINCT` collapse, author/excluded exclusion, monotonic counters under member deletion, subject CHECK, cross-company trigger, routing-step-delete degradation. That harness runs as the table owner, so it could only prove constructs behave, never that a policy *denies* — which is why the integration tests above are the ones that matter for the privacy claims.

## Visual verification — what a human still needs to look at

**No UI code changed in this PR.** But the *data shape* flowing into three existing surfaces did, and `seed.sql` now writes durable `part`-subject notes instead of job-scoped ones — so previews and local runs exercise the new shape. **No E2E spec covers the operator surfaces or notes**, so the green Playwright run says nothing about these.

I verified the query layer directly: spun up Postgres + PostgREST against a full migration replay and issued the exact queries the app sends, including the embed hints (`jobs!notes_job_fk(...)`), which are strings TypeScript cannot check. All three return correct shapes:

| Path | Result |
|---|---|
| Job feed (`getJobNotes`) | Returns **both** a legacy job-subject note and a durable part-subject one for the same job. The durable note has `operation: null` but `captured_operation: {sequence: 20, operation_name: "Mill"}`, so the step-chip fallback resolves |
| Dashboard activity (`fetchNoteActivity`) | Both notes resolve `job_number` and a valid link id via the coalesce — no blanks, no `/jobs/undefined` |
| Playbook (`part_playbook_notes`) | Returns the durable note with label and job number; correctly excludes an in-progress job from "previous" runs |

So the remaining risk is low and cosmetic rather than structural. One pass on the Vercel preview (it's behind Vercel SSO, so it needs your login) would confirm:

1. **Operator op card → Job Feed** — seeded step notes still appear, each with an author name and an "Op N · …" chip. If the chip is missing on some notes, the `captured_operation` fallback isn't firing.
2. **"Previous notes" sheet** on the op card — still lists notes from prior completed runs. This is an entirely new code path (one RPC, replacing a 22-round-trip JS fan-out), so it's the most worth eyeballing.
3. **Dashboard → Activity** — note/photo entries show a job number and link somewhere real.

**One known cosmetic inconsistency, flagged so it isn't mistaken for a bug:** the same step renders as `Op 20 · Mill` in the job feed (from `job_operations.operation_name`) but `Op 20 · MILL` in the Playbook (from `work_centers.name`). `routing_operations` has no `operation_name` column — only a work centre — so the durable path has no other source for the label. Cosmetic only; worth deciding whether to normalise in phase 3, when the note card is reworked anyway.

## Review notes

- `types/database.ts` is **generated**, not hand-edited (bf40f89, 6b701a4). Produced with the CI-pinned generator against a full migration replay. The structural diff against `main` was verified to contain only the intended changes.
- `note_views` and `operator_events` are on the billing-gate **exempt** list, not gated. Their only writer is a `SECURITY DEFINER` function owned by the table owner, so RLS is skipped entirely — a gate would install policies that are never evaluated. And reading is a read: gating would silently zero counts during a lapse, making every count a lie about a period nobody remembers.
- `notes` has **no `UPDATE` grant at all** (stronger than the column-scoped grant originally planned) because notes have no UPDATE policy today. Body editing would need both a policy and a column-scoped grant excluding the counters.
- **One role asymmetry left untouched, flagged for a separate decision:** admins can delete anyone's note (`notes_delete` allows `is_company_admin`), inherited unchanged from `job_notes`. That's moderation rather than attribution, so it didn't fall under the role-neutrality change above. Reactions are already uniform — nobody can remove anyone else's, admins included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

