### PR TITLE
feat(notes): surface prior-knowledge count, instrument the reader flow

### DIFF
--- a/__tests__/components/operator/JobFeed.test.tsx
+++ b/__tests__/components/operator/JobFeed.test.tsx
@@ -6,6 +6,7 @@ import JobFeed from '@/components/operator/JobFeed';
 import { getJobNotes, addJobNote, getCurrentMember } from '@/utils/operatorAccess';
 import { addJobNoteMedia, getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
 import { compressPhoto } from '@/utils/imageCompression';
+import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import type { JobNote } from '@/types/operator';
 
 vi.mock('@/utils/operatorAccess', () => ({
@@ -18,6 +19,7 @@ vi.mock('@/utils/jobNoteMediaAccess', () => ({
   getJobNoteMediaUrl: vi.fn(),
 }));
 vi.mock('@/utils/imageCompression', () => ({ compressPhoto: vi.fn() }));
+vi.mock('@/utils/operatorEventsAccess', () => ({ logOperatorEvent: vi.fn() }));
 
 const mock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
 
@@ -222,5 +224,113 @@ describe('JobFeed — dictation hint', () => {
     await user.click(screen.getByRole('button', { name: 'Dismiss tip' }));
     expect(screen.queryByText(HINT_TEXT)).not.toBeInTheDocument();
     expect(JSON.parse(window.localStorage.getItem(HINT_KEY)!).dismissed).toBe(true);
+  });
+});
+
+// The capture funnel. With an empty notes corpus these events are the only
+// readable signal for the first weeks of the pilot, so what matters is that the
+// steps stay DISTINGUISHABLE: "opened the composer" must not be conflated with
+// "saved", and a failed post must never be counted as a save. Otherwise the
+// result reads as "adoption was poor" with no way to tell friction from fit.
+describe('JobFeed — capture funnel events', () => {
+  it('records composer_focused once, however many times they refocus', async () => {
+    const user = userEvent.setup();
+    renderFeed();
+    await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
+    const field = screen.getByPlaceholderText('Add a note or photo for this step…');
+
+    await user.click(field);
+    await user.tab();
+    await user.click(field);
+
+    const focused = mock(logOperatorEvent).mock.calls.filter(
+      (c: unknown[]) => c[1] === 'composer_focused',
+    );
+    expect(focused).toHaveLength(1);
+  });
+
+  it('records note_saved only after the write resolves', async () => {
+    const user = userEvent.setup();
+    mock(addJobNote).mockResolvedValue(makeNote({ id: 'new', body: 'watch the bore' }));
+    renderFeed();
+    await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
+
+    await user.type(
+      screen.getByPlaceholderText('Add a note or photo for this step…'),
+      'watch the bore',
+    );
+    await user.click(screen.getByRole('button', { name: 'Post' }));
+
+    await waitFor(() =>
+      expect(mock(logOperatorEvent).mock.calls.some((c: unknown[]) => c[1] === 'note_saved')).toBe(
+        true,
+      ),
+    );
+  });
+
+  it('does NOT record a save when the post fails', async () => {
+    // The distinction the funnel exists for: they tried and it broke is capture
+    // friction, not a successful capture.
+    const user = userEvent.setup();
+    mock(addJobNote).mockRejectedValue(new Error('offline'));
+    renderFeed();
+    await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
+
+    await user.type(
+      screen.getByPlaceholderText('Add a note or photo for this step…'),
+      'never lands',
+    );
+    await user.click(screen.getByRole('button', { name: 'Post' }));
+
+    await screen.findByRole('alert');
+    expect(
+      mock(logOperatorEvent).mock.calls.some(
+        (c: unknown[]) => c[1] === 'note_saved' || c[1] === 'note_saved_with_photo',
+      ),
+    ).toBe(false);
+  });
+
+  it('records composer_abandoned when they open it and leave without saving', async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderFeed();
+    await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
+
+    await user.type(
+      screen.getByPlaceholderText('Add a note or photo for this step…'),
+      'half a thought',
+    );
+    unmount();
+
+    const abandoned = mock(logOperatorEvent).mock.calls.filter(
+      (c: unknown[]) => c[1] === 'composer_abandoned',
+    );
+    expect(abandoned).toHaveLength(1);
+    expect(abandoned[0][2]).toMatchObject({ bodyLength: 'half a thought'.length });
+  });
+
+  it('does NOT record abandonment when they never opened the composer', async () => {
+    const { unmount } = renderFeed();
+    await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
+    unmount();
+
+    expect(
+      mock(logOperatorEvent).mock.calls.some((c: unknown[]) => c[1] === 'composer_abandoned'),
+    ).toBe(false);
+  });
+
+  it('does NOT record abandonment after a successful save', async () => {
+    const user = userEvent.setup();
+    mock(addJobNote).mockResolvedValue(makeNote({ id: 'new', body: 'saved' }));
+    const { unmount } = renderFeed();
+    await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
+
+    await user.type(screen.getByPlaceholderText('Add a note or photo for this step…'), 'saved');
+    await user.click(screen.getByRole('button', { name: 'Post' }));
+    await waitFor(() => expect(addJobNote).toHaveBeenCalled());
+    unmount();
+
+    expect(
+      mock(logOperatorEvent).mock.calls.some((c: unknown[]) => c[1] === 'composer_abandoned'),
+    ).toBe(false);
   });
 });

--- a/__tests__/components/operator/PartNotesSheet.test.tsx
+++ b/__tests__/components/operator/PartNotesSheet.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@/__tests__/test-utils';
+import userEvent from '@testing-library/user-event';
+
+import PartNotesSheet from '@/components/operator/PartNotesSheet';
+import { getPartPreviousNotes } from '@/utils/operatorAccess';
+import { logOperatorEvent } from '@/utils/operatorEventsAccess';
+import type { PartPreviousNote } from '@/types/operator';
+
+vi.mock('@/utils/operatorAccess', () => ({ getPartPreviousNotes: vi.fn() }));
+vi.mock('@/utils/operatorEventsAccess', () => ({ logOperatorEvent: vi.fn() }));
+vi.mock('@/components/operator/NoteMediaGallery', () => ({ default: () => null }));
+
+const mock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
+function note(over: Partial<PartPreviousNote> = {}): PartPreviousNote {
+  return {
+    id: 'n1',
+    job_id: '',
+    job_operation_id: null,
+    operation_label: 'Op 10 · CNC Mill',
+    body: 'indicate the fixture to 0.001 before the first bore',
+    note_type: 'user',
+    created_at: '2026-04-19T00:00:00Z',
+    author_name: 'Diego Alvarez',
+    subject_kind: 'part',
+    viewer_count: 0,
+    usage_count: 0,
+    media: [],
+    job_number: 'J-0004',
+    ...over,
+  };
+}
+
+const onClose = vi.fn();
+
+function renderSheet(props: Partial<React.ComponentProps<typeof PartNotesSheet>> = {}) {
+  return render(
+    <PartNotesSheet
+      open
+      onClose={onClose}
+      partId="p1"
+      companyId="c1"
+      excludeJobId="job-current"
+      jobOperationId="op1"
+      partName="PROD-MANIFOLD-300"
+      {...props}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mock(getPartPreviousNotes).mockResolvedValue([note()]);
+});
+
+describe('PartNotesSheet — scope', () => {
+  it('opens at All part, the broader view', async () => {
+    // The toggle NARROWS; it does not gate. Worth pinning, because the plan once
+    // proposed deleting it on the belief that it hid knowledge behind a
+    // non-default — which the default being the broader view contradicts.
+    renderSheet();
+    await screen.findByText(/indicate the fixture/);
+
+    expect(screen.getByRole('button', { name: 'All part' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('re-queries scoped to the step when narrowed', async () => {
+    const user = userEvent.setup();
+    renderSheet();
+    await screen.findByText(/indicate the fixture/);
+
+    await user.click(screen.getByRole('button', { name: 'This step' }));
+
+    await waitFor(() =>
+      expect(getPartPreviousNotes).toHaveBeenLastCalledWith(
+        'p1',
+        'c1',
+        expect.objectContaining({ jobOperationId: 'op1' }),
+      ),
+    );
+  });
+});
+
+// Whether All-part-first is the right default is deliberately an open question,
+// to be settled by what operators actually do rather than by argument. These
+// tests pin the instrument that will answer it.
+describe('PartNotesSheet — scope instrumentation', () => {
+  it('records the scope they left on, and that they narrowed', async () => {
+    const user = userEvent.setup();
+    renderSheet();
+    await screen.findByText(/indicate the fixture/);
+
+    await user.click(screen.getByRole('button', { name: 'This step' }));
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(logOperatorEvent).toHaveBeenCalledWith(
+      'c1',
+      'prior_notes_opened',
+      expect.objectContaining({ finalScope: 'step', toggled: true }),
+    );
+  });
+
+  it('records an untouched toggle as such, which is the signal it is dead weight', async () => {
+    const user = userEvent.setup();
+    renderSheet();
+    await screen.findByText(/indicate the fixture/);
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(logOperatorEvent).toHaveBeenCalledWith(
+      'c1',
+      'prior_notes_opened',
+      expect.objectContaining({ finalScope: 'part', toggled: false, noteCount: 1 }),
+    );
+  });
+
+  it('distinguishes opening from the operation vs the traveler', async () => {
+    // Read-back matters most at the machine; the traveler is browsing. Conflating
+    // them would make the discoverability numbers unreadable.
+    const user = userEvent.setup();
+    renderSheet({ jobOperationId: undefined });
+    await screen.findByText(/indicate the fixture/);
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(logOperatorEvent).toHaveBeenCalledWith(
+      'c1',
+      'prior_notes_opened',
+      expect.objectContaining({ openedFrom: 'traveler' }),
+    );
+  });
+
+  it('never records which notes were shown, only how many', async () => {
+    // operator_events is service-role readable. A row naming the notes someone
+    // read would reconstruct exactly what note_views' RLS exists to prevent.
+    const user = userEvent.setup();
+    renderSheet();
+    await screen.findByText(/indicate the fixture/);
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+
+    const ctx = JSON.stringify(mock(logOperatorEvent).mock.calls[0][2]);
+    expect(ctx).not.toContain('n1');
+    expect(ctx).not.toContain('indicate the fixture');
+    expect(ctx).toContain('noteCount');
+  });
+});

--- a/__tests__/components/operator/PartReferenceRow.test.tsx
+++ b/__tests__/components/operator/PartReferenceRow.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@/__tests__/test-utils';
+
+import PartReferenceRow from '@/components/operator/PartReferenceRow';
+import { countPartAttachments } from '@/utils/partAttachmentsAccess';
+import { countPartPreviousNotes } from '@/utils/operatorAccess';
+
+vi.mock('@/utils/partAttachmentsAccess', () => ({ countPartAttachments: vi.fn() }));
+vi.mock('@/utils/operatorAccess', () => ({ countPartPreviousNotes: vi.fn() }));
+// The sheets only render when opened; stub them so this test doesn't drag in the
+// whole notes/files stack (and a real Supabase client) just to check a label.
+vi.mock('@/components/operator/PartFilesSheet', () => ({ default: () => null }));
+vi.mock('@/components/operator/PartNotesSheet', () => ({ default: () => null }));
+
+const mock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
+function renderRow() {
+  return render(
+    <PartReferenceRow
+      companyId="c1"
+      partId="p1"
+      partName="PROD-MANIFOLD-300"
+      excludeJobId="job-current"
+      jobOperationId="op1"
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mock(countPartAttachments).mockResolvedValue(0);
+  mock(countPartPreviousNotes).mockResolvedValue(0);
+});
+
+// The read-back gap this fixes: the affordance used to be a bare "Previous notes"
+// label, so an operator had no way to tell whether anything was behind it — while
+// Files sat right next to it showing a count. Knowledge nobody knows exists is not
+// reachable, whatever the tap count says.
+describe('PartReferenceRow — previous-notes count', () => {
+  it('shows the count when prior notes exist', async () => {
+    mock(countPartPreviousNotes).mockResolvedValue(3);
+    renderRow();
+
+    expect(await screen.findByRole('button', { name: 'Previous notes · 3' })).toBeInTheDocument();
+  });
+
+  it('stays a bare label when there is nothing to read', async () => {
+    // Not "· 0" — a zero badge is noise that trains operators to ignore the number.
+    mock(countPartPreviousNotes).mockResolvedValue(0);
+    renderRow();
+
+    await waitFor(() => expect(countPartPreviousNotes).toHaveBeenCalled());
+    expect(screen.getByRole('button', { name: 'Previous notes' })).toBeInTheDocument();
+  });
+
+  it('excludes the current job, so a note is never "previous" to itself', async () => {
+    renderRow();
+
+    await waitFor(() =>
+      expect(countPartPreviousNotes).toHaveBeenCalledWith(
+        'p1',
+        expect.objectContaining({ excludeJobId: 'job-current' }),
+      ),
+    );
+  });
+
+  it('still renders the affordance when the count fails', async () => {
+    // Decoration on a hot path: an operator must never lose access to prior
+    // knowledge because a badge query failed.
+    mock(countPartPreviousNotes).mockRejectedValue(new Error('offline'));
+    renderRow();
+
+    expect(await screen.findByRole('button', { name: 'Previous notes' })).toBeInTheDocument();
+  });
+});

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -37,6 +37,7 @@ import {
 } from '@/components/operations/operationMath';
 import { useStationContext } from '@/components/operator/OperatorStationContext';
 import { useSetOperatorChrome, useOperatorNav } from '@/components/operator/OperatorChromeContext';
+import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import StationSelector from '@/components/operator/StationSelector';
 import JobFeed from '@/components/operator/JobFeed';
 import PartReferenceRow from '@/components/operator/PartReferenceRow';
@@ -95,6 +96,18 @@ export default function OperatorOperationActionPage() {
     }
     loadOperator();
   }, [companyId]);
+
+  // Top of the funnel for the reader flow: they reached a step. Compared against
+  // prior_notes_opened this is what shows whether prior knowledge is being found
+  // — notes written but never opened is a discoverability problem, not a
+  // motivation one, and only these two numbers together can tell them apart.
+  //
+  // Keyed on the operation so re-renders don't re-count, and fired regardless of
+  // whether a station is selected — landing here and bouncing off the station
+  // picker is itself a funnel step worth seeing.
+  useEffect(() => {
+    logOperatorEvent(companyId, 'op_card_opened', { jobOperationId });
+  }, [companyId, jobOperationId]);
 
   const {
     data: job,

--- a/components/operator/JobFeed.tsx
+++ b/components/operator/JobFeed.tsx
@@ -21,6 +21,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import { getJobNotes, addJobNote, getCurrentMember } from '@/utils/operatorAccess';
 import { addJobNoteMedia, getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
 import { compressPhoto } from '@/utils/imageCompression';
+import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import type { JobNote, JobNoteMedia } from '@/types/operator';
 
 const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
@@ -148,6 +149,13 @@ export default function JobFeed({
   // Date.now()+filename produced for rapid same-name camera captures.
   const pendingIdRef = useRef(0);
 
+  // Funnel state. Refs, not state: these are read once at unmount, and putting
+  // them in state would re-render the composer on every keystroke to record
+  // something the operator never sees.
+  const focusedRef = useRef(false);
+  const capturedRef = useRef(false);
+  const draftRef = useRef({ bodyLength: 0, photoCount: 0 });
+
   const showComposer = !readOnly && !!operationContext;
 
   const {
@@ -256,6 +264,30 @@ export default function JobFeed({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Keep the unmount snapshot current. In an effect, not during render: mutating
+  // a ref while rendering is unsafe under concurrent rendering (and StrictMode's
+  // double invoke), which the react-hooks lint rule correctly rejects.
+  useEffect(() => {
+    draftRef.current = { bodyLength: noteDraft.trim().length, photoCount: pending.length };
+  }, [noteDraft, pending]);
+
+  // Abandonment: they opened the composer and left without saving. This is the
+  // funnel step that separates "capture friction" from "container fit" — a high
+  // focus rate with a low save rate means they tried and gave up, which is a very
+  // different problem from never reaching for it at all.
+  //
+  // Fires on unmount, which is the only place that reliably catches leaving. The
+  // draft size rides along as context: focused-and-typed-nothing and
+  // typed-a-paragraph-then-bailed are both abandonment, but not the same story.
+  useEffect(() => {
+    return () => {
+      if (!showComposer) return;
+      if (!focusedRef.current || capturedRef.current) return;
+      logOperatorEvent(companyId, 'composer_abandoned', draftRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handlePickPhotos = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const input = e.target;
     const files = Array.from(input.files ?? []);
@@ -355,6 +387,13 @@ export default function JobFeed({
       pending.forEach((p) => URL.revokeObjectURL(p.previewUrl));
       setPending([]);
       setNoteDraft('');
+      // After the write resolves, so a failed post is never counted as a save —
+      // the funnel's whole job is separating "tried" from "succeeded".
+      capturedRef.current = true;
+      logOperatorEvent(companyId, media.length > 0 ? 'note_saved_with_photo' : 'note_saved', {
+        photoCount: media.length,
+        bodyLength: body.length,
+      });
     } catch (err) {
       setComposerError(err instanceof Error ? err.message : 'Could not post. Please try again.');
       // The note may have been created with partial media — refresh to show truth.
@@ -434,6 +473,13 @@ export default function JobFeed({
               placeholder="Add a note or photo for this step…"
               value={noteDraft}
               onChange={(e) => setNoteDraft(e.target.value)}
+              onFocus={() => {
+                // Once per composer mount: this is the "started capture" step, and
+                // counting every refocus would inflate it past the save rate.
+                if (focusedRef.current) return;
+                focusedRef.current = true;
+                logOperatorEvent(companyId, 'composer_focused');
+              }}
               inputRef={noteFieldRef}
               fullWidth
               size="small"

--- a/components/operator/PartNotesSheet.tsx
+++ b/components/operator/PartNotesSheet.tsx
@@ -16,6 +16,7 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import CloseIcon from '@mui/icons-material/Close';
 import { getPartPreviousNotes } from '@/utils/operatorAccess';
+import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import NoteMediaGallery from '@/components/operator/NoteMediaGallery';
 import type { PartPreviousNote } from '@/types/operator';
 
@@ -89,7 +90,23 @@ export default function PartNotesSheet({
 }: PartNotesSheetProps) {
   // Default to the whole part's notes (the operator asked for "notes for the
   // part"); when opened from a step, offer a filter to just that step.
+  //
+  // Whether this default is RIGHT is an open question, and deliberately an
+  // empirical one rather than an argued one. An earlier revision of the plan
+  // proposed deleting the toggle in favour of a step-first list, on the inference
+  // that it was the "non-default toggle" that hid seeded knowledge in a prior
+  // usability session. That inference was unsupported — the default is the
+  // BROADER view, so the toggle narrows rather than hides — and it contradicted
+  // the operator request recorded above. The industry evidence splits too:
+  // work-instruction guidance favours per-step scoping, but tribal knowledge is
+  // precisely the cross-cutting material that isn't in a step's SOP.
+  //
+  // So: keep the toggle, and instrument it (see handleClose). If operators
+  // habitually narrow to their step, that argues for a step-first default. If the
+  // toggle is never touched, it is dead weight and can go. Either way the next
+  // decision is made on data from the shop rather than on a plausible story.
   const [scope, setScope] = useState<Scope>('part');
+  const [toggled, setToggled] = useState(false);
 
   const { data, loading, error } = useLoad(
     () =>
@@ -101,8 +118,27 @@ export default function PartNotesSheet({
   );
   const notes = data ?? [];
 
+  // One event per visit, emitted on close so it can carry the whole interaction:
+  // which scope they landed on, whether they narrowed, and how much was there to
+  // read. Logging on OPEN instead would miss the toggle entirely, and a separate
+  // "scope changed" kind would need a migration to widen the kind CHECK.
+  //
+  // Records counts and the scope only — never which notes were shown. Naming the
+  // notes someone read is exactly what note_views' RLS exists to prevent, and an
+  // operator_events row is service-role readable, so it must not become a back
+  // door into the same information.
+  const handleClose = () => {
+    logOperatorEvent(companyId, 'prior_notes_opened', {
+      openedFrom: jobOperationId ? 'operation' : 'traveler',
+      finalScope: scope,
+      toggled,
+      noteCount: notes.length,
+    });
+    onClose();
+  };
+
   return (
-    <Dialog open={open} onClose={onClose} fullScreen>
+    <Dialog open={open} onClose={handleClose} fullScreen>
       <AppBar position="relative" elevation={0} sx={{ bgcolor: 'rgba(17, 20, 57, 0.98)' }}>
         <Toolbar>
           <Box sx={{ flex: 1, minWidth: 0 }}>
@@ -115,7 +151,7 @@ export default function PartNotesSheet({
               </Typography>
             )}
           </Box>
-          <IconButton edge="end" aria-label="Close" onClick={onClose}>
+          <IconButton edge="end" aria-label="Close" onClick={handleClose}>
             <CloseIcon />
           </IconButton>
         </Toolbar>
@@ -128,7 +164,9 @@ export default function PartNotesSheet({
             exclusive
             value={scope}
             onChange={(_e, v) => {
-              if (v) setScope(v as Scope);
+              if (!v) return;
+              setScope(v as Scope);
+              setToggled(true);
             }}
             aria-label="Notes scope"
             sx={{ mb: 2 }}

--- a/components/operator/PartReferenceRow.tsx
+++ b/components/operator/PartReferenceRow.tsx
@@ -7,6 +7,7 @@ import Button from '@mui/material/Button';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
 import HistoryIcon from '@mui/icons-material/History';
 import { countPartAttachments } from '@/utils/partAttachmentsAccess';
+import { countPartPreviousNotes } from '@/utils/operatorAccess';
 import PartFilesSheet from '@/components/operator/PartFilesSheet';
 import PartNotesSheet from '@/components/operator/PartNotesSheet';
 
@@ -41,10 +42,24 @@ export default function PartReferenceRow({
   const [filesOpen, setFilesOpen] = useState(false);
   const [notesOpen, setNotesOpen] = useState(false);
 
-  // Eager count so the Files button can signal that a drawing exists. Notes stay
-  // lazy (optional reference, heavier query) — the sheet fetches them on open.
+  // Eager count so the Files button can signal that a drawing exists.
   const { data: fileCount } = useLoad(() => countPartAttachments(partId), [partId]);
   const hasFiles = (fileCount ?? 0) > 0;
+
+  // Notes now carry a count too. They used to be lazy on the grounds that they
+  // were an optional reference and a heavier query — but that left the affordance
+  // as a bare label, so an operator had NO WAY to tell whether anything was behind
+  // it. Files sat right beside it showing "Files · 3"; notes showed nothing
+  // whether the part had ten notes or none. Prior knowledge that nobody knows
+  // exists is not reachable, whatever the tap count says.
+  //
+  // The cost is one server-side count (head request, no rows transferred), which
+  // is what makes the eager fetch affordable now.
+  const { data: noteCount } = useLoad(
+    () => countPartPreviousNotes(partId, { excludeJobId }),
+    [partId, excludeJobId],
+  );
+  const hasNotes = (noteCount ?? 0) > 0;
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 3 }}>
@@ -63,9 +78,9 @@ export default function PartReferenceRow({
         variant="outlined"
         startIcon={<HistoryIcon />}
         onClick={() => setNotesOpen(true)}
-        sx={{ minHeight: 48 }}
+        sx={{ minHeight: 48, fontWeight: hasNotes ? 700 : 400 }}
       >
-        Previous notes
+        {hasNotes ? `Previous notes · ${noteCount}` : 'Previous notes'}
       </Button>
 
       {filesOpen && (

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -96,6 +96,10 @@ function makeAdminClient(env: SetupEnv): SupabaseClient {
  * reset makes re-runs deterministic without a full DB reset. (On CI the DB
  * is always fresh, so this is a no-op there.)
  */
+/** Body of the seeded durable note; the read-back spec asserts on this string. */
+export const DURABLE_NOTE_BODY =
+  'E2E durable note: indicate the fixture to 0.001 before the first bore.';
+
 async function ensureAuthUser(supabase: SupabaseClient): Promise<User> {
   const { data: existingList, error: listErr } = await supabase.auth.admin.listUsers({
     perPage: 100,
@@ -442,6 +446,84 @@ interface JobStageSpec {
  * triggers with no shipment/operation rows. Find key is (company, job_number)
  * so re-runs are idempotent.
  */
+/**
+ * A DURABLE part-subject note on a prior run, so the read-back loop has something
+ * to read.
+ *
+ * Anchored to (part_id, routing_operation_id) — the routing TEMPLATE step — which
+ * is what makes it job-independent: the operator on a later job for this part sees
+ * it without any traversal of the job it was written on. `captured_job_id` records
+ * where it came from (provenance, never subject), so the sheet can show its source
+ * job number.
+ *
+ * Seeded rather than runtime-skipped, per CLAUDE.md: a skip would hide exactly the
+ * regression this spec exists to catch — the jobs.status incident shipped that way.
+ */
+async function ensureDurableNote(
+  supabase: SupabaseClient,
+  companyId: string,
+  partId: string,
+  capturedJobNumber: string,
+): Promise<void> {
+  const { data: existing, error: lookupErr } = await supabase
+    .from('notes')
+    .select('id')
+    .eq('company_id', companyId)
+    .eq('part_id', partId)
+    .eq('body', DURABLE_NOTE_BODY)
+    .maybeSingle();
+  if (lookupErr) throw new Error(`note lookup failed: ${lookupErr.message}`);
+  if (existing) return;
+
+  // The routing step for this part. routing_operations has no company_id — it
+  // resolves through routings — and notes_validate_subject enforces that the step
+  // actually belongs to part_id, so this must be looked up rather than guessed.
+  const { data: routing, error: rErr } = await supabase
+    .from('routings')
+    .select('id')
+    .eq('company_id', companyId)
+    .eq('part_id', partId)
+    .maybeSingle();
+  if (rErr || !routing) throw new Error(`routing lookup failed: ${rErr?.message ?? 'missing'}`);
+
+  const { data: routingOp, error: roErr } = await supabase
+    .from('routing_operations')
+    .select('id')
+    .eq('routing_id', routing.id)
+    .order('sequence')
+    .limit(1)
+    .maybeSingle();
+  if (roErr || !routingOp) {
+    throw new Error(`routing_operation lookup failed: ${roErr?.message ?? 'missing'}`);
+  }
+
+  const { data: access, error: aErr } = await supabase
+    .from('user_company_access')
+    .select('id')
+    .eq('company_id', companyId)
+    .limit(1)
+    .maybeSingle();
+  if (aErr || !access) throw new Error(`access lookup failed: ${aErr?.message ?? 'missing'}`);
+
+  const { data: capturedJob } = await supabase
+    .from('jobs')
+    .select('id')
+    .eq('company_id', companyId)
+    .eq('job_number', capturedJobNumber)
+    .maybeSingle();
+
+  const { error } = await supabase.from('notes').insert({
+    company_id: companyId,
+    subject_kind: 'part',
+    part_id: partId,
+    routing_operation_id: routingOp.id,
+    captured_job_id: capturedJob?.id ?? null,
+    author_id: access.id,
+    body: DURABLE_NOTE_BODY,
+  });
+  if (error) throw new Error(`durable note insert failed: ${error.message}`);
+}
+
 async function ensureJobAtStage(
   supabase: SupabaseClient,
   companyId: string,
@@ -581,6 +663,9 @@ export default async function globalSetup(): Promise<void> {
     productionStatus: 'cancelled',
     fulfillmentStatus: 'unshipped',
   });
+
+  // After the jobs, so the note's provenance job resolves.
+  await ensureDurableNote(supabase, companyId, mfgPartId, 'E2E-JS-DONE');
 
   console.log(`[e2e/global-setup] Done. user=${TEST_EMAIL} company=${companyId}`);
 }

--- a/e2e/operator-notes-loop.spec.ts
+++ b/e2e/operator-notes-loop.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+import { navigateTo, waitForGridLoaded } from './helpers/navigation';
 import { DURABLE_NOTE_BODY } from './global-setup';
 
 /**
@@ -14,36 +15,53 @@ import { DURABLE_NOTE_BODY } from './global-setup';
  *
  * WHAT IT ASSERTS. That a note whose subject is the PART, written on one job, is
  * discoverable and readable from a different job for the same part — the product
- * thesis in one flow. Specifically:
+ * thesis in one flow:
  *
  *   1. the affordance advertises that knowledge exists (the count), because
  *      prior knowledge nobody knows about is not reachable whatever the tap
  *      count says;
- *   2. the note itself comes back, with its author and its step.
+ *   2. the note itself comes back, with its author.
  *
- * The note is seeded by global-setup rather than runtime-skipped. A skip here
- * would hide precisely the regression this exists to catch — see the jobs.status
+ * The note is seeded by global-setup rather than runtime-skipped. A skip would
+ * hide precisely the regression this exists to catch — see the jobs.status
  * incident, where a runtime-skipped spec masked a broken SELECT in production.
  */
 
+const JOB_SEARCH = /Job #, PO, customer/i;
+
+/**
+ * Land on a job's operator traveler.
+ *
+ * Goes through the UI rather than a constructed URL so the spec also covers the
+ * ids resolving. Note `/dashboard` is NOT a route — only `/dashboard/[companyId]`
+ * exists — so entry is via `/`, which redirects to the user's company. The
+ * operator hub then redirects a single-part job straight to its traveler.
+ */
+async function openTravelerFor(page: Page, jobNumber: string): Promise<void> {
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/dashboard\//, { timeout: 30_000 });
+  const companyId = page.url().match(/\/dashboard\/([0-9a-f-]{36})/)?.[1];
+  expect(companyId, 'company id should be in the dashboard URL').toBeTruthy();
+
+  await navigateTo(page, 'Jobs');
+  await waitForGridLoaded(page);
+  await page.getByPlaceholder(JOB_SEARCH).fill(jobNumber);
+  await waitForGridLoaded(page);
+
+  // getByText, matching the pattern the passing jobs-list specs use — the grid
+  // does not expose job numbers as named gridcells reliably.
+  await page.getByText(jobNumber).first().click();
+  await expect(page).toHaveURL(/\/jobs\/[0-9a-f-]{36}/, { timeout: 30_000 });
+  const jobId = page.url().match(/\/jobs\/([0-9a-f-]{36})/)?.[1];
+  expect(jobId, 'job id should be in the job URL').toBeTruthy();
+
+  await page.goto(`/operator/${companyId}/jobs/${jobId}`);
+  await expect(page).toHaveURL(/\/parts\/[0-9a-f-]{36}/, { timeout: 30_000 });
+}
+
 test.describe('operator read-back loop', () => {
   test('a durable part note is advertised and readable from a later job', async ({ page }) => {
-    // Reach the traveler through the UI rather than a constructed URL, so the
-    // spec also covers the ids actually resolving.
-    await page.goto('/dashboard');
-    await page.waitForURL(/\/dashboard\/[0-9a-f-]{36}/, { timeout: 60_000 });
-    const companyId = page.url().match(/\/dashboard\/([0-9a-f-]{36})/)?.[1];
-    expect(companyId, 'company id should be in the dashboard URL').toBeTruthy();
-
-    await page.goto(`/dashboard/${companyId}/jobs`);
-    await page.getByRole('gridcell', { name: 'E2E-JS-NOTSTARTED' }).first().click();
-    await page.waitForURL(/\/jobs\/[0-9a-f-]{36}/, { timeout: 60_000 });
-    const jobId = page.url().match(/\/jobs\/([0-9a-f-]{36})/)?.[1];
-    expect(jobId, 'job id should be in the job URL').toBeTruthy();
-
-    // The operator hub redirects a single-part job straight to its traveler.
-    await page.goto(`/operator/${companyId}/jobs/${jobId}`);
-    await page.waitForURL(/\/parts\/[0-9a-f-]{36}/, { timeout: 60_000 });
+    await openTravelerFor(page, 'E2E-JS-NOTSTARTED');
 
     // 1. The affordance advertises that there is something to read. This is the
     //    discoverability half — it used to be a bare "Previous notes" label while
@@ -61,17 +79,14 @@ test.describe('operator read-back loop', () => {
     // Thin but load-bearing: getJobNotes unions job_id with captured_job_id and
     // embeds two FKs to `jobs`, all as PostgREST strings. A wrong hint throws at
     // runtime and the feed silently shows its error state instead of notes.
-    await page.goto('/dashboard');
-    await page.waitForURL(/\/dashboard\/[0-9a-f-]{36}/, { timeout: 60_000 });
-    const companyId = page.url().match(/\/dashboard\/([0-9a-f-]{36})/)?.[1];
-
-    await page.goto(`/dashboard/${companyId}/jobs`);
-    await page.getByRole('gridcell', { name: 'E2E-JS-DONE' }).first().click();
-    await page.waitForURL(/\/jobs\/[0-9a-f-]{36}/, { timeout: 60_000 });
-    const jobId = page.url().match(/\/jobs\/([0-9a-f-]{36})/)?.[1];
-
-    await page.goto(`/operator/${companyId}/jobs/${jobId}`);
-    await page.waitForURL(/\/parts\/[0-9a-f-]{36}/, { timeout: 60_000 });
+    //
+    // Uses an OPEN job deliberately. E2E-JS-DONE would be the better subject —
+    // it is where the seeded note was captured, so its feed exercises the
+    // captured_job_id half of the union — but the jobs list hides closed jobs by
+    // default, so reaching it would mean driving the status filter and coupling
+    // this spec to that control. The provenance path is covered instead by test
+    // 1, whose note is captured on a DIFFERENT job from the one being read.
+    await openTravelerFor(page, 'E2E-JS-NOTSTARTED');
 
     await expect(page.getByText('Job Feed')).toBeVisible({ timeout: 30_000 });
     await expect(page.getByText('Could not load the feed.')).toHaveCount(0);

--- a/e2e/operator-notes-loop.spec.ts
+++ b/e2e/operator-notes-loop.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from '@playwright/test';
+import { DURABLE_NOTE_BODY } from './global-setup';
+
+/**
+ * The read-back loop, end to end.
+ *
+ * WHY THIS SPEC EXISTS. No E2E spec touched the operator surfaces before this
+ * one, which is why the notes-subject migration had to be verified by hand in a
+ * browser: the whole suite went green while the operator job feed, the previous-
+ * notes sheet and the dashboard activity feed were all untested. Every one of
+ * those reads through PostgREST embed hints (`jobs!notes_job_fk(...)`) and RPC
+ * signatures that TypeScript cannot check — they compile perfectly and render
+ * nothing.
+ *
+ * WHAT IT ASSERTS. That a note whose subject is the PART, written on one job, is
+ * discoverable and readable from a different job for the same part — the product
+ * thesis in one flow. Specifically:
+ *
+ *   1. the affordance advertises that knowledge exists (the count), because
+ *      prior knowledge nobody knows about is not reachable whatever the tap
+ *      count says;
+ *   2. the note itself comes back, with its author and its step.
+ *
+ * The note is seeded by global-setup rather than runtime-skipped. A skip here
+ * would hide precisely the regression this exists to catch — see the jobs.status
+ * incident, where a runtime-skipped spec masked a broken SELECT in production.
+ */
+
+test.describe('operator read-back loop', () => {
+  test('a durable part note is advertised and readable from a later job', async ({ page }) => {
+    // Reach the traveler through the UI rather than a constructed URL, so the
+    // spec also covers the ids actually resolving.
+    await page.goto('/dashboard');
+    await page.waitForURL(/\/dashboard\/[0-9a-f-]{36}/, { timeout: 60_000 });
+    const companyId = page.url().match(/\/dashboard\/([0-9a-f-]{36})/)?.[1];
+    expect(companyId, 'company id should be in the dashboard URL').toBeTruthy();
+
+    await page.goto(`/dashboard/${companyId}/jobs`);
+    await page.getByRole('gridcell', { name: 'E2E-JS-NOTSTARTED' }).first().click();
+    await page.waitForURL(/\/jobs\/[0-9a-f-]{36}/, { timeout: 60_000 });
+    const jobId = page.url().match(/\/jobs\/([0-9a-f-]{36})/)?.[1];
+    expect(jobId, 'job id should be in the job URL').toBeTruthy();
+
+    // The operator hub redirects a single-part job straight to its traveler.
+    await page.goto(`/operator/${companyId}/jobs/${jobId}`);
+    await page.waitForURL(/\/parts\/[0-9a-f-]{36}/, { timeout: 60_000 });
+
+    // 1. The affordance advertises that there is something to read. This is the
+    //    discoverability half — it used to be a bare "Previous notes" label while
+    //    Files beside it showed a count.
+    const priorNotes = page.getByRole('button', { name: /^Previous notes · \d+$/ });
+    await expect(priorNotes).toBeVisible({ timeout: 30_000 });
+
+    // 2. The knowledge itself, written against a DIFFERENT job for this part.
+    await priorNotes.click();
+    await expect(page.getByText(DURABLE_NOTE_BODY)).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText('E2E Test User').first()).toBeVisible();
+  });
+
+  test('the traveler feed renders without erroring on the notes query', async ({ page }) => {
+    // Thin but load-bearing: getJobNotes unions job_id with captured_job_id and
+    // embeds two FKs to `jobs`, all as PostgREST strings. A wrong hint throws at
+    // runtime and the feed silently shows its error state instead of notes.
+    await page.goto('/dashboard');
+    await page.waitForURL(/\/dashboard\/[0-9a-f-]{36}/, { timeout: 60_000 });
+    const companyId = page.url().match(/\/dashboard\/([0-9a-f-]{36})/)?.[1];
+
+    await page.goto(`/dashboard/${companyId}/jobs`);
+    await page.getByRole('gridcell', { name: 'E2E-JS-DONE' }).first().click();
+    await page.waitForURL(/\/jobs\/[0-9a-f-]{36}/, { timeout: 60_000 });
+    const jobId = page.url().match(/\/jobs\/([0-9a-f-]{36})/)?.[1];
+
+    await page.goto(`/operator/${companyId}/jobs/${jobId}`);
+    await page.waitForURL(/\/parts\/[0-9a-f-]{36}/, { timeout: 60_000 });
+
+    await expect(page.getByText('Job Feed')).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText('Could not load the feed.')).toHaveCount(0);
+  });
+});

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -1548,6 +1548,42 @@ type PlaybookRow = {
  * When `jobOperationId` is given, scopes to that step: by routing step for
  * durable notes, falling back to operation_name for legacy ones.
  */
+/**
+ * How many previous notes exist for this part — for the count on the operator's
+ * "Previous notes" affordance.
+ *
+ * Deliberately the SAME RPC the sheet reads, counted server-side via
+ * `head: true, count: 'exact'`, so no rows cross the wire. Counting a different
+ * source (say, part-subject notes only) would be cheaper but would drift from
+ * what the sheet actually shows — and a badge that disagrees with the list is
+ * worse than no badge, because it teaches operators the number is noise.
+ *
+ * Unscoped by step on purpose: the affordance opens at "All part" scope, so the
+ * count must describe what they will land on.
+ *
+ * Returns 0 rather than throwing. This is decoration on a hot path — an operator
+ * must never lose the op card because a count failed.
+ */
+export async function countPartPreviousNotes(
+  partId: string,
+  opts?: { excludeJobId?: string; maxRuns?: number },
+): Promise<number> {
+  const supabase = getSupabase();
+
+  const { count, error } = await supabase.rpc(
+    'part_playbook_notes',
+    {
+      p_part_id: partId,
+      p_exclude_job_id: opts?.excludeJobId ?? undefined,
+      p_max_runs: opts?.maxRuns ?? 10,
+    },
+    { head: true, count: 'exact' },
+  );
+
+  if (error) return 0;
+  return count ?? 0;
+}
+
 export async function getPartPreviousNotes(
   partId: string,
   companyId: string,

--- a/utils/operatorEventsAccess.ts
+++ b/utils/operatorEventsAccess.ts
@@ -1,0 +1,83 @@
+import * as Sentry from '@sentry/nextjs';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+
+/**
+ * Capture-funnel instrumentation.
+ *
+ * WHY THIS EXISTS. The notes corpus starts empty — there is no seeded knowledge,
+ * so view counts, the login banner and reactions are all structurally silent
+ * until somebody writes something. For the first weeks of the pilot these events
+ * are the ONLY readable signal, and they are what distinguishes the failure modes
+ * from each other:
+ *
+ *   app_opened ~ 0                              -> deployment, not the product
+ *   op_card_opened high, composer_focused ~ 0   -> container fit; they aren't reaching for it
+ *   composer_focused high, note_saved low       -> capture friction; they tried and gave up
+ *   notes written, prior_notes_opened low       -> discoverability in the READER flow
+ *
+ * Without them, "adoption was poor" is unreadable.
+ *
+ * WHAT IT MUST NEVER DO. Instrumentation cannot be allowed to break, block or
+ * slow the interaction it is measuring. Every call here is fire-and-forget: never
+ * awaited into a user-visible path, never surfaced to the operator, errors go to
+ * Sentry only. The underlying RPC is SECURITY DEFINER and returns void, and it
+ * returns silently for a non-member rather than raising.
+ *
+ * WHAT IT MUST NEVER RECORD. `context` carries ids and coarse counts only —
+ * never note bodies, and never the ids of notes the actor READ. Read tracking is
+ * note_views' job, and that table is deliberately unreadable by any browser or AI
+ * role precisely so no per-operator reading report can be reconstructed. An
+ * operator_events row that named which notes someone opened would reintroduce
+ * exactly what note_views' RLS exists to prevent.
+ */
+
+/** Mirrors the operator_events_kind_check constraint. Adding one needs a migration. */
+export type OperatorEventKind =
+  | 'app_opened'
+  | 'station_selected'
+  | 'op_card_opened'
+  | 'prior_notes_opened'
+  | 'composer_focused'
+  | 'composer_abandoned'
+  | 'note_saved'
+  | 'note_saved_with_photo'
+  | 'photo_attached'
+  | 'completion_recorded';
+
+export type OperatorEventContext = Record<string, string | number | boolean | null>;
+
+/**
+ * Record one funnel event. Returns nothing and never rejects — callers must not
+ * await it, and there is deliberately no success signal to branch on.
+ */
+export function logOperatorEvent(
+  companyId: string,
+  kind: OperatorEventKind,
+  context: OperatorEventContext = {},
+): void {
+  if (!companyId) return;
+
+  try {
+    void getSupabase()
+      .rpc('log_operator_event', {
+        p_company_id: companyId,
+        p_kind: kind,
+        p_context: context,
+      })
+      .then(({ error }) => {
+        if (error) {
+          Sentry.captureException(error, {
+            level: 'warning',
+            tags: { area: 'operator_events', kind },
+          });
+        }
+      });
+  } catch (err) {
+    // Belt and braces: a throw before the promise exists (no client, no session)
+    // must still not reach the operator.
+    Sentry.captureException(err, {
+      level: 'warning',
+      tags: { area: 'operator_events', kind },
+    });
+  }
+}


### PR DESCRIPTION
PR 1 of 3 on the attribution loop. Read surfaces plus the funnel events for them. **Nothing here changes what a note is** — only whether anyone finds it, and whether we can tell what happened.

## The count on "Previous notes"

The affordance was a bare label while Files sat right beside it showing `Files · 3`. An operator had no way to tell whether a part had ten notes or none.

**That is the read-back gap** — not the tap count. Prior knowledge nobody knows exists isn't reachable however few taps it is.

`countPartPreviousNotes` calls the **same RPC the sheet reads**, counted server-side (`head + count=exact`, no rows on the wire). Counting a cheaper source would drift from what the sheet shows, and a badge that disagrees with the list is worse than no badge — it teaches operators the number is noise. Bare at zero rather than `· 0`, and returns 0 rather than throwing: decoration on a hot path must never cost someone the op card.

## Funnel instrumentation

With an empty corpus these are the **only** readable signal for the first weeks, and their job is keeping the failure modes apart:

| Signal | Diagnosis |
|---|---|
| `op_card_opened` high, `composer_focused` ≈ 0 | container fit — they aren't reaching for it |
| `composer_focused` high, `note_saved` low | capture friction — they tried and gave up |
| notes written, `prior_notes_opened` low | reader discoverability |

All fire-and-forget: never awaited into a user path, never surfaced, Sentry only. `note_saved` fires **after the write resolves**, so a failed post is never counted as a save — that distinction is the entire point, and it has a test.

Records ids and coarse counts only. **Never note bodies, never which notes were read.** `operator_events` is service-role readable, so a row naming what someone opened would reconstruct exactly what `note_views`' RLS exists to prevent. A test asserts the context contains neither the note id nor its body.

## The `This step / All part` toggle is kept — and instrumented instead

An earlier revision of the plan proposed deleting it for a step-first list, on the inference that it was the "non-default toggle" hiding seeded knowledge in a usability session.

**That inference was unsupported.** The default is the *broader* view, so the toggle narrows rather than hides — you flip it to see less. It also contradicted the operator request recorded in the code (`the operator asked for "notes for the part"`). The research splits too: work-instruction guidance favours per-step scoping, but tribal knowledge is precisely the cross-cutting material absent from a step's SOP.

So `prior_notes_opened` now carries `{ openedFrom, finalScope, toggled, noteCount }` on close. If operators habitually narrow, that argues for a step-first default. If the toggle is never touched, it's dead weight and goes. **Decided on the shop's data rather than on a plausible story.**

## Phase 8 dropped, not deferred

Removing quoted setup/cycle times is off the table. They're the engineer's routing estimate — an *input to the job*, not a measurement of the operator — and the guardrail's trigger is pace **versus** a quote, which needs an actual. Actual time is structurally unrepresentable (`operator_sessions` and `job_operations.actual_*` are gone).

Removing them from the screen alone would also have been theatre: [jobTravelerPdf.ts:328-329](utils/jobTravelerPdf.ts#L328-L329) prints the same figures, so the operator reads them off the paper — and the digital traveler ends up *less* useful than the paper it's meant to replace. Revisit only if actual time is ever captured and reflected back.

## E2E — the first spec to touch the operator surfaces

`e2e/operator-notes-loop.spec.ts`. There was no such spec before, which is **why the notes migration had to be verified by hand in a browser**: the suite went green while the job feed, the notes sheet and the dashboard activity feed were all untested. Every one reads through PostgREST embed hints (`jobs!notes_job_fk(...)`) and RPC signatures that TypeScript cannot check — they compile perfectly and render nothing.

It asserts the thesis in one flow: a note whose subject is the **part**, written on one job, is advertised (the count) and readable from a **different** job for the same part. The durable note is seeded in `global-setup` rather than runtime-skipped — a skip would hide the exact regression the spec exists to catch, as in the `jobs.status` incident.

## Scope note

Dropped the author/date item from the plan's PR 1. Verified already satisfied — bold `subtitle2` author and the date on the same card header row — so changing it would have been churn.

## Verification

`tsc` clean, **lint clean**, 1216 frontend tests pass (16 new). Lint caught a real bug in my first pass: I mutated a ref during render, which is unsafe under concurrent rendering; fixed by moving it into an effect rather than suppressing the rule.

E2E runs in CI — the shared local stack is a machine-wide singleton and can't be reset from a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
