### PR TITLE
feat(notes): close the loop — view logging and the login banner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -618,9 +618,32 @@ preview branch runs `supabase/seed.sql`, so it has the full Vanguard Precision
 Works data graph. Get `$PREVIEW_URL` from the PR's Vercel comment or
 `gh pr view <n> --json comments`.
 
+**Use a fresh `--session` per preview domain.** The bypass cookie is set for one
+host; carrying a session over from a previous PR's preview makes the new domain
+bounce to Vercel's SSO login even though the headers are correct. `agent-browser
+open … --session <pr-number>` avoids it.
+
+**If the app shows "Something Went Wrong" on every route, it is almost certainly
+not your code.** Check `agent-browser console` for:
+
+```
+@supabase/ssr: Your project's URL and API key are required to create a Supabase client!
+```
+
+That means the deployment has no `NEXT_PUBLIC_SUPABASE_*`. Those are inlined at
+**build** time, so the first Vercel build of a new preview branch can outrun
+Supabase Branching provisioning and bake in empty values. Observed on two
+consecutive PRs. **A rebuild fixes it with no code change** — push any commit, or
+redeploy from the Vercel dashboard.
+
+It presents as a total outage rather than a broken page because
+[`lib/supabase.ts`](lib/supabase.ts) creates the client eagerly at module scope
+(`export const supabase = typeof window !== 'undefined' ? getSupabase() : null`),
+so the throw happens during module evaluation and nothing renders anywhere.
+
 Notes: `agent-browser get text` needs a selector (`get text body`); prefer
 `snapshot -i -c` or `eval` since a not-yet-hydrated App Router page returns raw
-RSC payload. Docs:
+RSC payload. `agent-browser console` / `errors` are the fastest triage. Docs:
 <https://vercel.com/docs/deployment-protection/automated-agent-access>
 - **Merge → local:** merging to `main` auto-applies the migration to **prod**
   (branching pipeline), but your **local** stack only picks it up when you

--- a/__tests__/components/operator/JobFeed.test.tsx
+++ b/__tests__/components/operator/JobFeed.test.tsx
@@ -19,6 +19,9 @@ vi.mock('@/utils/jobNoteMediaAccess', () => ({
   getJobNoteMediaUrl: vi.fn(),
 }));
 vi.mock('@/utils/imageCompression', () => ({ compressPhoto: vi.fn() }));
+// Dwell tracking imports the Supabase client at module scope; it has its own
+// suite in __tests__/hooks/useNoteDwell.test.tsx.
+vi.mock('@/hooks/useNoteDwell', () => ({ useNoteDwell: () => ({ observe: () => () => {} }) }));
 vi.mock('@/utils/operatorEventsAccess', () => ({ logOperatorEvent: vi.fn() }));
 
 const mock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;

--- a/__tests__/components/operator/NoteUsageBanner.test.tsx
+++ b/__tests__/components/operator/NoteUsageBanner.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@/__tests__/test-utils';
+import userEvent from '@testing-library/user-event';
+
+import NoteUsageBanner from '@/components/operator/NoteUsageBanner';
+
+const rpc = vi.fn();
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => ({ rpc }),
+  getTypedSupabase: () => ({ rpc }),
+}));
+
+class MemoryStorage {
+  private store = new Map<string, string>();
+  get length() {
+    return this.store.size;
+  }
+  clear() {
+    this.store.clear();
+  }
+  getItem(k: string) {
+    return this.store.has(k) ? this.store.get(k)! : null;
+  }
+  key(i: number) {
+    return Array.from(this.store.keys())[i] ?? null;
+  }
+  removeItem(k: string) {
+    this.store.delete(k);
+  }
+  setItem(k: string, v: string) {
+    this.store.set(k, String(v));
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', new MemoryStorage());
+  rpc.mockReset();
+  rpc.mockResolvedValue({ data: 0, error: null });
+});
+
+describe('NoteUsageBanner', () => {
+  it('renders nothing at zero', async () => {
+    // "0 people used your notes this week" is a weekly reminder that nobody
+    // cares. Silence is better.
+    rpc.mockResolvedValue({ data: 0, error: null });
+    const { container } = render(<NoteUsageBanner companyId="c1" />);
+
+    await waitFor(() => expect(rpc).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('counts PEOPLE, and says so', async () => {
+    // Three must mean three colleagues, not one person opening a note three
+    // times. The author can just ask, so an inflated number discredits the loop.
+    rpc.mockResolvedValue({ data: 3, error: null });
+    render(<NoteUsageBanner companyId="c1" />);
+
+    expect(await screen.findByText('3 people used your notes this week.')).toBeInTheDocument();
+  });
+
+  it('reads naturally at one', async () => {
+    rpc.mockResolvedValue({ data: 1, error: null });
+    render(<NoteUsageBanner companyId="c1" />);
+
+    expect(
+      await screen.findByText('Someone used one of your notes this week.'),
+    ).toBeInTheDocument();
+  });
+
+  it('asks Postgres for the week boundary in the viewer’s own timezone', async () => {
+    // A UTC cutoff would flip mid-shift for a US shop, so Monday's banner would
+    // be reporting part of Sunday night.
+    rpc.mockResolvedValue({ data: 2, error: null });
+    render(<NoteUsageBanner companyId="c1" />);
+
+    await waitFor(() =>
+      expect(rpc).toHaveBeenCalledWith(
+        'my_note_view_digest',
+        expect.objectContaining({ p_tz: expect.any(String) }),
+      ),
+    );
+  });
+
+  it('stays silent when the digest fails', async () => {
+    // An operator starting work must not be shown a backend error.
+    rpc.mockResolvedValue({ data: null, error: { message: 'denied' } });
+    const { container } = render(<NoteUsageBanner companyId="c1" />);
+
+    await waitFor(() => expect(rpc).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('dismisses for this week only, so the loop survives one tap', async () => {
+    // A permanent dismissal would end the feedback loop the first time it is
+    // inconvenient. The key carries the ISO week.
+    const user = userEvent.setup();
+    rpc.mockResolvedValue({ data: 4, error: null });
+    render(<NoteUsageBanner companyId="c1" />);
+    await screen.findByText('4 people used your notes this week.');
+
+    await user.click(screen.getByRole('button', { name: /close/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByText('4 people used your notes this week.')).not.toBeInTheDocument(),
+    );
+    const stored = localStorage.getItem('jigged:note-usage-banner-dismissed');
+    expect(stored).toMatch(/^\d{4}-W\d{2}$/);
+  });
+
+  it('comes back next week after being dismissed', async () => {
+    localStorage.setItem('jigged:note-usage-banner-dismissed', '1999-W01');
+    rpc.mockResolvedValue({ data: 2, error: null });
+    render(<NoteUsageBanner companyId="c1" />);
+
+    expect(await screen.findByText('2 people used your notes this week.')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/operator/OperatorStationContext.test.tsx
+++ b/__tests__/components/operator/OperatorStationContext.test.tsx
@@ -4,6 +4,7 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 // Mutable holder for the mocked ?station= param (hoisted above vi.mock).
 const nav = vi.hoisted(() => ({ station: null as string | null }));
 
+vi.mock('@/utils/operatorEventsAccess', () => ({ logOperatorEvent: vi.fn() }));
 vi.mock('next/navigation', () => ({
   useParams: () => ({ companyId: 'c1' }),
   useSearchParams: () => new URLSearchParams(nav.station ? `station=${nav.station}` : ''),

--- a/__tests__/components/operator/PartNotesSheet.test.tsx
+++ b/__tests__/components/operator/PartNotesSheet.test.tsx
@@ -10,6 +10,9 @@ import type { PartPreviousNote } from '@/types/operator';
 vi.mock('@/utils/operatorAccess', () => ({ getPartPreviousNotes: vi.fn() }));
 vi.mock('@/utils/operatorEventsAccess', () => ({ logOperatorEvent: vi.fn() }));
 vi.mock('@/components/operator/NoteMediaGallery', () => ({ default: () => null }));
+// Dwell tracking imports the Supabase client at module scope; it has its own
+// suite in __tests__/hooks/useNoteDwell.test.tsx.
+vi.mock('@/hooks/useNoteDwell', () => ({ useNoteDwell: () => ({ observe: () => () => {} }) }));
 
 const mock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
 

--- a/__tests__/hooks/useNoteDwell.test.tsx
+++ b/__tests__/hooks/useNoteDwell.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@/__tests__/test-utils';
+import { useNoteDwell } from '@/hooks/useNoteDwell';
+
+const rpc = vi.fn().mockResolvedValue({ error: null });
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => ({ rpc }),
+  getTypedSupabase: () => ({ rpc }),
+}));
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }));
+
+/**
+ * These guard one promise: the count shown to an author must never exceed
+ * reality. In a fifteen-person shop the author can just ask whether someone read
+ * it, so an inflated number does not read as a bug — it discredits the loop.
+ */
+
+type Cb = (entries: Array<{ target: Element; isIntersecting: boolean }>) => void;
+let observerCb: Cb | undefined;
+const observed = new Set<Element>();
+
+class FakeIO {
+  constructor(cb: Cb) {
+    observerCb = cb;
+  }
+  observe(el: Element) {
+    observed.add(el);
+  }
+  unobserve(el: Element) {
+    observed.delete(el);
+  }
+  disconnect() {
+    observed.clear();
+  }
+}
+
+function Harness({ ids, enabled = true }: { ids: string[]; enabled?: boolean }) {
+  const { observe } = useNoteDwell('co1', 'job1', enabled);
+  return (
+    <>
+      {ids.map((id) => (
+        <p key={id} data-note={id} ref={observe(id)}>
+          body of {id}
+        </p>
+      ))}
+    </>
+  );
+}
+
+function intersect(container: HTMLElement, id: string, isIntersecting: boolean) {
+  const target = container.querySelector(`[data-note="${id}"]`) as Element;
+  act(() => observerCb?.([{ target, isIntersecting }]));
+}
+
+/** Dwell (2s) then the batch window (1s). */
+function elapse(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  rpc.mockClear();
+  observed.clear();
+  observerCb = undefined;
+  vi.stubGlobal('IntersectionObserver', FakeIO);
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => 'visible',
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('useNoteDwell', () => {
+  it('does not log a note that was scrolled past', () => {
+    // The brief's own case: rendered but not dwelled on produces no view.
+    const { container } = render(<Harness ids={['n1']} />);
+    intersect(container, 'n1', true);
+    elapse(1500);
+    intersect(container, 'n1', false);
+    elapse(5000);
+
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('logs a note that stayed visible past the dwell threshold', () => {
+    const { container } = render(<Harness ids={['n1']} />);
+    intersect(container, 'n1', true);
+    elapse(2000 + 1000);
+
+    expect(rpc).toHaveBeenCalledWith(
+      'log_note_views',
+      expect.objectContaining({ p_note_ids: ['n1'], p_job_id: 'job1' }),
+    );
+  });
+
+  it('does NOT log while the tab is backgrounded', () => {
+    // An IntersectionObserver reports "intersecting" for a phone in a pocket.
+    // Without this gate the count climbs while nobody is looking — the exact
+    // overstatement that is forbidden.
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    const { container } = render(<Harness ids={['n1']} />);
+    intersect(container, 'n1', true);
+    elapse(5000);
+
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('cancels in-flight dwell when the tab is backgrounded mid-read', () => {
+    const { container } = render(<Harness ids={['n1']} />);
+    intersect(container, 'n1', true);
+    elapse(1000);
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    elapse(5000);
+
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('batches a screenful into one round trip', () => {
+    // Otherwise a read N+1 is traded for a write N+1.
+    const { container } = render(<Harness ids={['n1', 'n2', 'n3']} />);
+    intersect(container, 'n1', true);
+    intersect(container, 'n2', true);
+    intersect(container, 'n3', true);
+    elapse(2000 + 1000);
+
+    expect(rpc).toHaveBeenCalledTimes(1);
+    expect(rpc.mock.calls[0][1].p_note_ids.sort()).toEqual(['n1', 'n2', 'n3']);
+  });
+
+  it('does not re-log the same note when it scrolls back into view', () => {
+    const { container } = render(<Harness ids={['n1']} />);
+    intersect(container, 'n1', true);
+    elapse(2000 + 1000);
+    expect(rpc).toHaveBeenCalledTimes(1);
+
+    intersect(container, 'n1', false);
+    intersect(container, 'n1', true);
+    elapse(2000 + 1000);
+
+    expect(rpc).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs nothing at all when disabled', () => {
+    // e.g. a closed sheet — its notes are mounted but not being read.
+    const { container } = render(<Harness ids={['n1']} enabled={false} />);
+    // No observer is created at all, so nothing can start a dwell timer.
+    expect(observerCb).toBeUndefined();
+    intersect(container, 'n1', true);
+    elapse(5000);
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('never surfaces a failed write', async () => {
+    // Invisible bookkeeping: it must not toast, block a tap, or break a feed.
+    rpc.mockResolvedValueOnce({ error: { message: 'denied' } });
+    const { container } = render(<Harness ids={['n1']} />);
+    intersect(container, 'n1', true);
+    elapse(2000 + 1000);
+
+    // The assertion is simply that nothing threw and the tree still renders.
+    expect(container.querySelector('[data-note="n1"]')).toBeInTheDocument();
+  });
+});

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -169,6 +169,8 @@ export default function OperatorOperationActionPage() {
         quantityGood: qty,
       });
       setQtyDirty(false);
+      // After the write resolves — a failed completion is not a completion.
+      logOperatorEvent(companyId, 'completion_recorded', { jobOperationId, quantityGood: qty });
       await reloadAll();
       // Completion is now persisted. Offer capture last, so a client death at
       // the prompt cannot un-complete the step.

--- a/app/operator/[companyId]/jobs/page.tsx
+++ b/app/operator/[companyId]/jobs/page.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/utils/operatorAccess';
 import { useStationContext } from '@/components/operator/OperatorStationContext';
 import StationSelector from '@/components/operator/StationSelector';
+import NoteUsageBanner from '@/components/operator/NoteUsageBanner';
 import { useOperatorNav } from '@/components/operator/OperatorChromeContext';
 import JobHotBadge from '@/components/jobs/JobHotBadge';
 import type { OperatorJob, OperatorPlantJob } from '@/types/operator';
@@ -244,6 +245,13 @@ function OperatorJobsPageContent() {
 
   return (
     <Box>
+      {/* The return half of the loop, placed exactly where the brief asks: after
+          station selection, above the job list. This is the first thing an
+          operator sees when they start work, and the only moment in the day when
+          "somebody used what you wrote" can land before the job takes over.
+          Renders nothing when the count is zero. */}
+      {!showStationSelector && <NoteUsageBanner companyId={companyId} />}
+
       {/* Toolbar: scope segmented control (primary) + a "Show completed"
           checkbox (secondary — an explicit on/off so it's clear whether you're
           viewing completed vs. active work, which a single color-toggle chip

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -26,6 +26,7 @@ import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 import { OperatorStationProvider, useStationContext } from '@/components/operator/OperatorStationContext';
 import { OperatorChromeProvider, useOperatorChrome, useOperatorNav } from '@/components/operator/OperatorChromeContext';
 import JiggedIcon from '@/components/branding/JiggedIcon';
+import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import type { AuthChangeEvent } from '@supabase/supabase-js';
 
 /**
@@ -88,6 +89,12 @@ export default function OperatorLayout({
       }
 
       setUserRole(operatorAccess.role || 'operator');
+
+      // Top of the funnel. Everything else is measured against this: if
+      // app_opened is near zero, no downstream number is interpretable and the
+      // problem is deployment, not the product. Fired after membership is
+      // confirmed so a bounced sign-in is not counted as a session.
+      logOperatorEvent(companyId, 'app_opened');
 
       setIsLoading(false);
     };

--- a/components/operator/JobFeed.tsx
+++ b/components/operator/JobFeed.tsx
@@ -21,6 +21,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import { getJobNotes, addJobNote, getCurrentMember } from '@/utils/operatorAccess';
 import { addJobNoteMedia, getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
 import { compressPhoto } from '@/utils/imageCompression';
+import { useNoteDwell } from '@/hooks/useNoteDwell';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import type { JobNote, JobNoteMedia } from '@/types/operator';
 
@@ -157,6 +158,10 @@ export default function JobFeed({
   const draftRef = useRef({ bodyLength: 0, photoCount: 0 });
 
   const showComposer = !readOnly && !!operationContext;
+
+  // Read tracking. The feed is where an operator encounters other people's notes
+  // in the course of a job, so it is the surface the whole loop is measuring.
+  const { observe } = useNoteDwell(companyId, jobId);
 
   const {
     data: loadedNotesData,
@@ -640,8 +645,14 @@ export default function JobFeed({
                   </Typography>
                 </Box>
 
+                {/* The observed element is the BODY, deliberately. Observing the
+                    card would count a header scrolling past as a read. */}
                 {note.body && (
-                  <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                  <Typography
+                    ref={observe(note.id)}
+                    variant="body2"
+                    sx={{ whiteSpace: 'pre-wrap' }}
+                  >
                     {note.body}
                   </Typography>
                 )}

--- a/components/operator/NoteUsageBanner.tsx
+++ b/components/operator/NoteUsageBanner.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState } from 'react';
+import { useLoad } from '@/hooks/useLoad';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+
+/**
+ * "3 people used your notes this week."
+ *
+ * The return half of the loop. An operator writes something down and, today,
+ * nothing comes back — no way to know whether it was read, no reason to believe
+ * writing it did anything. This is the smallest honest signal that it did.
+ *
+ * WHAT IT SAYS, AND WHAT IT MUST NOT
+ *   PEOPLE, not reads. The digest counts distinct viewers, so three means three
+ *   colleagues — not one person opening a note three times. In a shop this size
+ *   the author can simply ask, so an inflated number is not a rounding error, it
+ *   discredits the whole mechanism.
+ *
+ *   Nothing at zero. A "0 people used your notes" banner is a weekly reminder
+ *   that nobody cares, which is worse than silence. It renders null.
+ *
+ *   No names here. Who read what is the author's alone and lives behind
+ *   note_viewers(); a banner is glanceable and public to anyone over a shoulder.
+ *
+ * WEEK BOUNDARY
+ *   The browser's own timezone, passed to the digest so Postgres computes the
+ *   boundary. "This week" has to mean the shop's week — a UTC cutoff would flip
+ *   mid-shift for a US shop and make Monday morning's banner cover Sunday night.
+ *
+ * DISMISSAL IS PER WEEK
+ *   Permanent dismissal would kill the loop after one tap. The key carries the
+ *   ISO week, so dismissing this week's banner leaves next week's intact.
+ */
+
+const DISMISS_KEY = 'jigged:note-usage-banner-dismissed';
+
+/** ISO-8601 week key (YYYY-Www) in the viewer's own timezone. */
+function isoWeekKey(d: Date): string {
+  const t = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  // Thursday of this week determines the ISO year.
+  t.setUTCDate(t.getUTCDate() + 4 - (t.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(t.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((t.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${t.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+}
+
+function readDismissed(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(DISMISS_KEY);
+  } catch {
+    return null; // private mode / quota — the banner is best-effort
+  }
+}
+
+function writeDismissed(weekKey: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(DISMISS_KEY, weekKey);
+  } catch {
+    /* ignore */
+  }
+}
+
+interface NoteUsageBannerProps {
+  companyId: string;
+  /** Tapping through goes to the author's own notes; omitted until My Work ships. */
+  onOpenDetail?: () => void;
+}
+
+export default function NoteUsageBanner({ companyId, onOpenDetail }: NoteUsageBannerProps) {
+  const weekKey = isoWeekKey(new Date());
+  const [dismissed, setDismissed] = useState(() => readDismissed() === weekKey);
+
+  const { data: count } = useLoad(async () => {
+    const tz =
+      typeof Intl !== 'undefined'
+        ? Intl.DateTimeFormat().resolvedOptions().timeZone
+        : 'UTC';
+    const { data, error } = await getSupabase().rpc('my_note_view_digest', {
+      p_tz: tz || 'UTC',
+    });
+    // Silent on failure: a broken digest must not put an error in front of an
+    // operator who was only trying to start work.
+    if (error) return 0;
+    return (data as number | null) ?? 0;
+  }, [companyId]);
+
+  const n = count ?? 0;
+  if (dismissed || n <= 0) return null;
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Alert
+        severity="success"
+        onClose={() => {
+          writeDismissed(weekKey);
+          setDismissed(true);
+        }}
+        {...(onOpenDetail
+          ? { onClick: onOpenDetail, sx: { cursor: 'pointer', minHeight: 48 } }
+          : { sx: { minHeight: 48 } })}
+      >
+        {n === 1
+          ? 'Someone used one of your notes this week.'
+          : `${n} people used your notes this week.`}
+      </Alert>
+    </Box>
+  );
+}

--- a/components/operator/OperatorStationContext.tsx
+++ b/components/operator/OperatorStationContext.tsx
@@ -11,6 +11,8 @@ import type { Station } from '@/types/operator';
 // backgrounded-tab eviction / browser restart — the shop-floor reality that had
 // operators landing on a job with the station picker stacked underneath it every
 // morning. A QR deep-link (?station=) always overrides the stored value.
+import { logOperatorEvent } from '@/utils/operatorEventsAccess';
+
 const STORAGE_KEY = 'jigged_operator_station';
 
 // localStorage access can throw (Safari private mode throws on setItem; access
@@ -143,10 +145,16 @@ export function OperatorStationProvider({ children }: { children: ReactNode }) {
     resolveName();
   }, [stationId, stations]);
 
-  const setStation = useCallback((id: string) => {
-    setStationId(id);
-    writeStoredStation(id);
-  }, []);
+  // One call site covers every route in: the station picker, the header
+  // dropdown, and a station-placard QR — they all land here.
+  const setStation = useCallback(
+    (id: string) => {
+      setStationId(id);
+      writeStoredStation(id);
+      logOperatorEvent(companyId, 'station_selected', { workCenterId: id });
+    },
+    [companyId],
+  );
 
   return (
     <StationContext.Provider

--- a/components/operator/PartNotesSheet.tsx
+++ b/components/operator/PartNotesSheet.tsx
@@ -17,6 +17,7 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import CloseIcon from '@mui/icons-material/Close';
 import { getPartPreviousNotes } from '@/utils/operatorAccess';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
+import { useNoteDwell } from '@/hooks/useNoteDwell';
 import NoteMediaGallery from '@/components/operator/NoteMediaGallery';
 import type { PartPreviousNote } from '@/types/operator';
 
@@ -45,7 +46,13 @@ function formatTimestamp(value: string): string {
   });
 }
 
-function NoteRow({ note }: { note: PartPreviousNote }) {
+function NoteRow({
+  note,
+  observe,
+}: {
+  note: PartPreviousNote;
+  observe: (id: string) => (el: HTMLElement | null) => void;
+}) {
   return (
     <Box>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.25, flexWrap: 'wrap' }}>
@@ -61,7 +68,7 @@ function NoteRow({ note }: { note: PartPreviousNote }) {
         </Typography>
       </Box>
       {note.body && (
-        <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+        <Typography ref={observe(note.id)} variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
           {note.body}
         </Typography>
       )}
@@ -107,6 +114,11 @@ export default function PartNotesSheet({
   // decision is made on data from the shop rather than on a plausible story.
   const [scope, setScope] = useState<Scope>('part');
   const [toggled, setToggled] = useState(false);
+
+  // THE surface the read-back loop exists to measure: knowledge from a previous
+  // run, being read on a new one. excludeJobId is the job the operator is
+  // standing in, so it is the right read context for the per-job dedupe.
+  const { observe } = useNoteDwell(companyId, excludeJobId, open);
 
   const { data, loading, error } = useLoad(
     () =>
@@ -198,7 +210,7 @@ export default function PartNotesSheet({
             {notes.map((note, idx) => (
               <Box key={note.id}>
                 {idx > 0 && <Divider sx={{ my: 1.5 }} />}
-                <NoteRow note={note} />
+                <NoteRow note={note} observe={observe} />
               </Box>
             ))}
           </Box>

--- a/hooks/useNoteDwell.ts
+++ b/hooks/useNoteDwell.ts
@@ -1,0 +1,199 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import * as Sentry from '@sentry/nextjs';
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+
+/**
+ * Logs that a note was actually READ.
+ *
+ * The number this feeds is shown to the note's author ("4 people used this"), so
+ * the governing rule is that it must never overstate. An author who sees a count
+ * they can tell is wrong — in a fifteen-person shop they can simply ask — stops
+ * believing the whole loop. Every decision below biases toward undercounting.
+ *
+ * WHAT COUNTS AS A READ
+ *   - The note BODY has to be on screen. Observe the body element, never a card
+ *     header and never a count badge: scrolling past a list must not mark
+ *     everything in it as read.
+ *   - It has to stay there for DWELL_MS. A note that flicks past during a scroll
+ *     produces nothing.
+ *   - The tab has to be FOCUSED. An IntersectionObserver happily reports
+ *     "intersecting" for a phone in someone's pocket with the tab backgrounded;
+ *     without this gate the count would climb while nobody is looking, which is
+ *     precisely the overstatement that is forbidden.
+ *
+ * WHAT IT DOES NOT DO
+ *   Nothing here decides WHO gets logged. "Never the author" and "never an
+ *   account excluded from metrics" live inside log_note_views(), which is
+ *   SECURITY DEFINER — the browser has no INSERT grant on note_views at all, so
+ *   a client bug cannot forge or bypass those rules. Dedupe is likewise a UNIQUE
+ *   constraint, not a promise made here.
+ *
+ * FAILURE IS SILENT TO THE OPERATOR
+ *   Fire-and-forget, Sentry only. A view-write is invisible bookkeeping; it must
+ *   never produce a toast, block a tap, or make a feed look broken.
+ */
+
+/** Time a note body must be continuously visible AND focused before it counts. */
+const DWELL_MS = 2000;
+
+/** Batch window, so a screenful of notes is one round trip rather than one each. */
+const FLUSH_MS = 1000;
+
+export interface NoteDwellTracker {
+  /**
+   * Ref callback for the element wrapping a note's BODY. Pass the note id; pass
+   * the element or null on unmount.
+   */
+  observe: (noteId: string) => (el: HTMLElement | null) => void;
+}
+
+export function useNoteDwell(
+  companyId: string,
+  jobId: string | null,
+  enabled = true,
+): NoteDwellTracker {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+  const elements = useRef(new Map<Element, string>());
+  // Per mount. The DB dedupes permanently anyway; this just avoids pointless
+  // round trips when React re-renders or a note scrolls in and out repeatedly.
+  const logged = useRef(new Set<string>());
+  const queue = useRef(new Set<string>());
+  const flushTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // jobId is a plain dependency rather than a ref kept in sync during render:
+  // mutating a ref while rendering is unsafe under concurrent rendering, and the
+  // lint rule rejects it. Changing jobs tears down and rebuilds the observer,
+  // which is correct — a different job is a different read context.
+  const flush = useCallback(() => {
+    flushTimer.current = null;
+    const ids = Array.from(queue.current);
+    queue.current.clear();
+    if (ids.length === 0) return;
+
+    // Never awaited into a user-visible path, and no success branch to render.
+    void getSupabase()
+      .rpc('log_note_views', {
+        p_note_ids: ids,
+        p_job_id: jobId ?? undefined,
+      })
+      .then(({ error }) => {
+        if (error) {
+          Sentry.captureException(error, {
+            level: 'warning',
+            tags: { area: 'note_views' },
+          });
+        }
+      });
+  }, [jobId]);
+
+  const enqueue = useCallback(
+    (noteId: string) => {
+      if (logged.current.has(noteId)) return;
+      logged.current.add(noteId);
+      queue.current.add(noteId);
+      if (flushTimer.current === null) {
+        flushTimer.current = setTimeout(flush, FLUSH_MS);
+      }
+    },
+    [flush],
+  );
+
+  const clearTimer = useCallback((noteId: string) => {
+    const t = timers.current.get(noteId);
+    if (t) {
+      clearTimeout(t);
+      timers.current.delete(noteId);
+    }
+  }, []);
+
+  const startTimer = useCallback(
+    (noteId: string) => {
+      if (logged.current.has(noteId) || timers.current.has(noteId)) return;
+      if (document.visibilityState !== 'visible') return;
+      timers.current.set(
+        noteId,
+        setTimeout(() => {
+          timers.current.delete(noteId);
+          enqueue(noteId);
+        }, DWELL_MS),
+      );
+    },
+    [enqueue],
+  );
+
+  useEffect(() => {
+    if (!enabled || typeof IntersectionObserver === 'undefined') return;
+
+    // Elements are attached by their ref callbacks during commit, which happens
+    // BEFORE this effect runs — so anything already registered has to be picked
+    // up here. Observing only from the ref callback silently tracked nothing on
+    // first render, which is the failure mode a "no views were logged" test
+    // cannot distinguish from correct undercounting.
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const noteId = elements.current.get(entry.target);
+          if (!noteId) continue;
+          if (entry.isIntersecting) startTimer(noteId);
+          // Scrolled away before the dwell elapsed — it was passed, not read.
+          else clearTimer(noteId);
+        }
+      },
+      // Most of the body visible, not a sliver at the edge of the viewport.
+      { threshold: 0.5 },
+    );
+    observerRef.current = observer;
+    elements.current.forEach((_noteId, el) => observer.observe(el));
+
+    // Captured for the cleanup closure. The Map identity never changes, so this
+    // is the same object either way — but reading `timers.current` inside
+    // cleanup trips react-hooks/exhaustive-deps, and the warning budget is a
+    // hard build gate.
+    const activeTimers = timers.current;
+
+    // Backgrounding the tab cancels everything in flight, and returning to it
+    // restarts from zero rather than crediting time spent away.
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') return;
+      timers.current.forEach((t) => clearTimeout(t));
+      timers.current.clear();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      observer.disconnect();
+      observerRef.current = null;
+      activeTimers.forEach((t) => clearTimeout(t));
+      activeTimers.clear();
+      // Send whatever already earned its dwell; dropping it would undercount
+      // reads that genuinely happened.
+      if (flushTimer.current !== null) {
+        clearTimeout(flushTimer.current);
+        flush();
+      }
+    };
+  }, [enabled, startTimer, clearTimer, flush]);
+
+  const observe = useCallback(
+    (noteId: string) => (el: HTMLElement | null) => {
+      if (el) {
+        // Register unconditionally; the effect observes whatever is registered
+        // when it runs, so ref-before-effect ordering is handled either way.
+        elements.current.set(el, noteId);
+        observerRef.current?.observe(el);
+        return;
+      }
+      clearTimer(noteId);
+      elements.current.forEach((id, key) => {
+        if (id === noteId) elements.current.delete(key);
+      });
+    },
+    [clearTimer],
+  );
+
+  return { observe };
+}

--- a/supabase/migrations/20260728212230_create_attachments_storage_bucket.sql
+++ b/supabase/migrations/20260728212230_create_attachments_storage_bucket.sql
@@ -1,0 +1,34 @@
+-- Create the `attachments` storage bucket.
+--
+-- It has existed in production for a long time — created out-of-band, via the
+-- dashboard — and was captured in supabase/schema.prod.sql. But schema.prod.sql
+-- is a SNAPSHOT of prod, not something that gets applied: only
+-- supabase/migrations/ is replayed. So the bucket existed in exactly one place.
+--
+-- Consequence, confirmed on a preview deployment: every file upload fails with
+-- "Bucket not found" on every Supabase preview branch and on any freshly reset
+-- local stack. Photo capture, job attachments and part attachments have only
+-- ever worked in production.
+--
+-- That is also why job_note_media.thumbnail_path was never populated and nobody
+-- noticed: the photo path could not be exercised anywhere it was safe to look.
+-- A defect you cannot reach in dev is a defect you find in front of a customer.
+--
+-- The storage.objects RLS policies were already migration-managed (see
+-- 20260725210136_stripe_write_enforcement.sql), so preview branches have been
+-- carrying policies that guard a bucket which does not exist.
+--
+-- Idempotent, and deliberately matching the prod row exactly:
+--   public = false            — signed URLs only; the bucket is company-scoped by
+--                               the storage.objects policies, not by being public
+--   file_size_limit = NULL    — inherits the project default (50 MB); the client
+--                               compresses to ~1.5 MB before upload anyway
+--   allowed_mime_types = NULL — job/part attachments carry drawings and STEP
+--                               files, not only images
+--
+-- ON CONFLICT DO NOTHING so replaying against prod (which already has it) is a
+-- no-op and never rewrites the live bucket's settings.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('attachments', 'attachments', false, NULL, NULL)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
PR 3 of 3, and the last of **Iteration A**. Reads get recorded, and the author finds out. Until now an operator wrote something down and nothing came back.

## `useNoteDwell`

Logs that a note was actually **read**, on the two surfaces where notes are encountered: the job feed and the previous-notes sheet.

The number this feeds is shown to the author, so the governing rule is that **it must never overstate**. In a fifteen-person shop the author can simply ask whether you read it — an inflated count doesn't read as a bug, it discredits the loop. Every choice biases toward undercounting:

- the note **body** must be on screen — never the card header, never a count badge — so scrolling a list doesn't mark it all read
- it must stay there **2s**
- the tab must be **focused**. An `IntersectionObserver` happily reports "intersecting" for a phone in someone's pocket; without that gate the count climbs while nobody is looking

Backgrounding mid-read cancels the timer rather than crediting time away. Batched, so a screenful is one round trip and a read N+1 isn't traded for a write N+1. Fire-and-forget with Sentry only — view-writes are invisible bookkeeping and must never toast, block a tap, or make a feed look broken.

**Nothing here decides who gets logged.** "Never the author" and "never an excluded account" live in `log_note_views()`, which is `SECURITY DEFINER` with no browser INSERT grant on `note_views`, so a client bug cannot forge or bypass them. Dedupe is a UNIQUE constraint, not a promise made in TypeScript.

**Its tests caught a real bug.** Refs attach during commit, *before* effects run, so observing only from the ref callback tracked nothing on first render. That would have produced zero views forever and read as *"operators don't read notes"* — the exact wrong conclusion, and invisible to any test that only asserts nothing was logged.

## `NoteUsageBanner`

> 3 people used your notes this week.

After station selection, above the job list — the first thing seen on starting work, and the only moment in the day when this can land before the job takes over.

- **People, not reads.** Three means three colleagues, not one person opening a note three times.
- **Nothing at zero.** A weekly "0 people used your notes" is a reminder that nobody cares; silence is better.
- **No names.** A banner is glanceable over a shoulder; who-read-what belongs to the author alone, behind `note_viewers()`.
- **Week boundary computed by Postgres from the browser's timezone.** A UTC cutoff would flip mid-shift for a US shop, so Monday morning's banner would be reporting part of Sunday night.
- **Dismissal is keyed to the ISO week**, so it can't be silenced permanently by one tap — that would end the loop the first time it's inconvenient.

## Session events

`app_opened` (after membership is confirmed, so a bounced sign-in isn't counted as a session), `station_selected` (one call site covers the picker, the header dropdown and a placard QR), `completion_recorded`. That completes the funnel from PR 1.

## Folded in from the closed photo PR

The `attachments` storage bucket migration. The bucket lived only in `schema.prod.sql` — a snapshot, never applied — so uploads have failed on **every preview branch and every fresh local stack** with `Bucket not found`, and photos have only ever worked in production. Unrelated to view logging, but a genuine gap and a no-op against prod.

Everything else from that PR was dropped: the redundant Add-photo button was built on inference rather than data, and the funnel now shipping is what should answer whether the composer is being reached at all.

## Verification

`tsc` clean, lint **at the 17-warning baseline** (no new warnings — verified against a clean tree), **1231 tests pass**.

Three existing suites needed new mocks because `lib/supabase` creates its client at module scope, so any new import chain forces every consuming test to mock it. Same root cause as the preview outages now documented in CLAUDE.md; worth its own fix eventually.

## After this merges

Iteration A is complete and the plan says **stop and measure** rather than continue:

- ≥3 notes from someone other than the founder and the one tester
- ≥1 note read by a second person on a job later than the one it was written on
- median op-card→saved-note within the capture budget

With an empty corpus the funnel events are the only readable signal for the first weeks, and they're what separates *container fit* (`op_card_opened` high, `composer_focused` ~0) from *capture friction* (`composer_focused` high, `note_saved` low) from *reader discoverability* (notes written, `prior_notes_opened` low). Iteration B — Playbook, My Work, reactions UI, merged completion — is deliberately gated on that data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
