### PR TITLE
feat(operator): mark a note helpful (B2)

### DIFF
--- a/__tests__/app/operator/MyWorkPage.test.tsx
+++ b/__tests__/app/operator/MyWorkPage.test.tsx
@@ -24,6 +24,7 @@ function note(over: Partial<MyNote> = {}): MyNote {
     job_id: 'job-1',
     job_number: 'J-0042',
     photo_count: 0,
+    reactions: [],
     viewer_count: 0,
     usage_count: 0,
     ...over,

--- a/__tests__/components/operator/JobFeed.test.tsx
+++ b/__tests__/components/operator/JobFeed.test.tsx
@@ -40,6 +40,8 @@ function makeNote(over: Partial<JobNote> = {}): JobNote {
     note_type: 'user',
     created_at: '2026-07-01T10:00:00.000Z',
     author_name: 'Op',
+    author_id: 'them',
+    reactions: [],
     media: [],
     ...over,
   };

--- a/__tests__/components/operator/NoteReactions.test.tsx
+++ b/__tests__/components/operator/NoteReactions.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@/__tests__/test-utils';
+import userEvent from '@testing-library/user-event';
+
+import NoteReactions from '@/components/operator/NoteReactions';
+import { addReaction, removeReaction } from '@/utils/operatorAccess';
+import type { NoteReaction } from '@/types/operator';
+
+vi.mock('@/utils/operatorAccess', () => ({
+  addReaction: vi.fn(),
+  removeReaction: vi.fn(),
+}));
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }));
+
+const mockAdd = vi.mocked(addReaction);
+const mockRemove = vi.mocked(removeReaction);
+
+const ME = 'member-me';
+const THEM = 'member-them';
+
+function helpful(reactorId: string, name: string | null): NoteReaction {
+  return { kind: 'helpful', reactor_id: reactorId, name };
+}
+
+function setup(props: Partial<React.ComponentProps<typeof NoteReactions>> = {}) {
+  return render(
+    <NoteReactions
+      companyId="c1"
+      noteId="n1"
+      authorId={THEM}
+      reactions={[]}
+      memberId={ME}
+      {...props}
+    />,
+  );
+}
+
+beforeEach(() => {
+  mockAdd.mockReset();
+  mockRemove.mockReset();
+  mockAdd.mockResolvedValue(undefined);
+  mockRemove.mockResolvedValue(undefined);
+});
+
+describe('NoteReactions', () => {
+  it('marks a note helpful', async () => {
+    const user = userEvent.setup();
+    setup();
+
+    await user.click(screen.getByRole('button', { name: /helpful/i }));
+
+    expect(mockAdd).toHaveBeenCalledWith('c1', 'n1');
+  });
+
+  it('moves before the round trip completes', async () => {
+    // On shop wifi a thumbs-up that waits for the server before moving reads as
+    // a broken button.
+    const user = userEvent.setup();
+    let release: () => void = () => {};
+    mockAdd.mockReturnValue(new Promise<void>((r) => (release = () => r())));
+    setup();
+
+    await user.click(screen.getByRole('button', { name: /helpful/i }));
+
+    expect(await screen.findByRole('button', { name: /helpful · 1/i })).toBeInTheDocument();
+    release();
+  });
+
+  it('rolls back rather than leaving a lie on screen', async () => {
+    const user = userEvent.setup();
+    mockAdd.mockRejectedValue(new Error('offline'));
+    setup();
+
+    await user.click(screen.getByRole('button', { name: /helpful/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /helpful · 1/i })).not.toBeInTheDocument(),
+    );
+  });
+
+  it('takes it back on a second tap', async () => {
+    const user = userEvent.setup();
+    setup({ reactions: [helpful(ME, 'Me')] });
+
+    await user.click(screen.getByRole('button', { name: /helpful · 1/i }));
+
+    expect(mockRemove).toHaveBeenCalledWith('c1', 'n1');
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it('offers no control on your own note', async () => {
+    // RLS forbids self-reaction, so a button here is a guaranteed 42501 that
+    // reads to the operator as broken.
+    setup({ authorId: ME, reactions: [helpful(THEM, 'Diego')] });
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    // The endorsement still shows — it is reception.
+    expect(screen.getByText('Diego')).toBeInTheDocument();
+  });
+
+  it('renders nothing at all when there is neither an action nor a reaction', () => {
+    const { container } = setup({ authorId: ME, reactions: [] });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('names the people, not just the number', async () => {
+    // Attribution is the point of the whole workstream, and reactions are public
+    // by design — so there is nothing to hide behind a second tap.
+    setup({ reactions: [helpful(THEM, 'Diego'), helpful('m3', 'Priya')] });
+
+    expect(await screen.findByText('Diego, Priya')).toBeInTheDocument();
+  });
+
+  it('collapses a long list rather than wrapping the card', async () => {
+    setup({
+      reactions: [
+        helpful('a', 'Diego'),
+        helpful('b', 'Priya'),
+        helpful('c', 'Sam'),
+        helpful('d', 'Jamie'),
+        helpful('e', 'Morgan'),
+      ],
+    });
+
+    expect(await screen.findByText('Diego, Priya, Sam +2')).toBeInTheDocument();
+  });
+
+  it('never renders a thumbs-down', async () => {
+    // Not deferred — `kind` is CHECK-limited to ('helpful','confirmed') so there
+    // is no schema slot for a negative. An inaccurate note is corrected or
+    // superseded, never publicly judged by a colleague seen every morning.
+    setup({ reactions: [helpful(THEM, 'Diego')] });
+
+    expect(screen.queryByRole('button', { name: /not helpful|unhelpful|thumbs down/i })).toBeNull();
+  });
+
+  it('ignores confirmed, which has no UI yet', async () => {
+    // 'confirmed' stays in the CHECK constraint but nothing writes it, and a
+    // stray row must not inflate the helpful count.
+    setup({
+      reactions: [
+        helpful(THEM, 'Diego'),
+        { kind: 'confirmed', reactor_id: 'm3', name: 'Priya' },
+      ],
+    });
+
+    expect(await screen.findByRole('button', { name: /helpful · 1/i })).toBeInTheDocument();
+    expect(screen.queryByText(/Priya/)).not.toBeInTheDocument();
+  });
+
+  it('shows a count without a control in read-only mode', () => {
+    // My work: endorsements received on your own notes.
+    setup({ readOnly: true, authorId: null, memberId: null, reactions: [helpful(THEM, 'Diego')] });
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('Diego')).toBeInTheDocument();
+  });
+
+  it('waits for the member id before offering the control', () => {
+    // Without it we cannot tell whose note this is, nor whether they already
+    // reacted — an optimistic toggle on an unknown identity would be a guess.
+    setup({ memberId: null, reactions: [helpful(THEM, 'Diego')] });
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/operator/NoteUsageBanner.test.tsx
+++ b/__tests__/components/operator/NoteUsageBanner.test.tsx
@@ -10,7 +10,12 @@ vi.mock('@/lib/supabase', () => ({
   getTypedSupabase: () => ({ rpc }),
 }));
 
-const SEEN_KEY = 'jigged:note-views-acknowledged';
+const SEEN_KEY = 'jigged:note-digest-acknowledged';
+
+/** The digest is a single-row TABLE now: { views, helpful }. */
+const digest = (views: number, helpful = 0) => ({ data: [{ views, helpful }], error: null });
+const seen = (views: number, helpful = 0) =>
+  localStorage.setItem(SEEN_KEY, JSON.stringify({ views, helpful }));
 
 class MemoryStorage {
   private store = new Map<string, string>();
@@ -37,15 +42,15 @@ class MemoryStorage {
 beforeEach(() => {
   vi.stubGlobal('localStorage', new MemoryStorage());
   rpc.mockReset();
-  rpc.mockResolvedValue({ data: 0, error: null });
+  rpc.mockResolvedValue(digest(0));
 });
 
 describe('NoteUsageBanner', () => {
   it('renders nothing when nothing has happened', async () => {
     // A standing "0 views" is a permanent reminder that nobody cares. Silence
     // is better.
-    localStorage.setItem(SEEN_KEY, '0');
-    rpc.mockResolvedValue({ data: 0, error: null });
+    seen(0);
+    rpc.mockResolvedValue(digest(0));
     const { container } = render(<NoteUsageBanner companyId="c1" />);
 
     await waitFor(() => expect(rpc).toHaveBeenCalled());
@@ -55,37 +60,37 @@ describe('NoteUsageBanner', () => {
   it('shows only what is NEW since the operator last looked', async () => {
     // The running total is 9, but 6 of those were already seen — showing "9"
     // would claim six things happened that did not.
-    localStorage.setItem(SEEN_KEY, '6');
-    rpc.mockResolvedValue({ data: 9, error: null });
+    seen(6);
+    rpc.mockResolvedValue(digest(9));
     render(<NoteUsageBanner companyId="c1" />);
 
-    expect(await screen.findByText('3 new views on your notes.')).toBeInTheDocument();
+    expect(await screen.findByText('3 new views.')).toBeInTheDocument();
   });
 
   it('reads naturally at one', async () => {
-    localStorage.setItem(SEEN_KEY, '0');
-    rpc.mockResolvedValue({ data: 1, error: null });
+    seen(0);
+    rpc.mockResolvedValue(digest(1));
     render(<NoteUsageBanner companyId="c1" />);
 
-    expect(await screen.findByText('1 new view on your notes.')).toBeInTheDocument();
+    expect(await screen.findByText('1 new view.')).toBeInTheDocument();
   });
 
   it('asks for the total with no arguments at all', async () => {
     // The permanent rule: a caller-supplied time window would be a bisection
     // oracle for WHEN a note was read. The delta is computed here instead,
     // from a number the server already gave us.
-    localStorage.setItem(SEEN_KEY, '0');
-    rpc.mockResolvedValue({ data: 2, error: null });
+    seen(0);
+    rpc.mockResolvedValue(digest(2));
     render(<NoteUsageBanner companyId="c1" />);
 
-    await waitFor(() => expect(rpc).toHaveBeenCalledWith('my_note_view_digest'));
+    await waitFor(() => expect(rpc).toHaveBeenCalledWith('my_note_digest'));
   });
 
   it('stays quiet once the total has been seen', async () => {
     // No nag on every single visit to the jobs list — an operator lands there
     // many times a shift.
-    localStorage.setItem(SEEN_KEY, '4');
-    rpc.mockResolvedValue({ data: 4, error: null });
+    seen(4);
+    rpc.mockResolvedValue(digest(4));
     const { container } = render(<NoteUsageBanner companyId="c1" />);
 
     await waitFor(() => expect(rpc).toHaveBeenCalled());
@@ -94,11 +99,45 @@ describe('NoteUsageBanner', () => {
 
   it('comes back the moment the total grows again', async () => {
     // The whole loop: silence until something genuinely new happens.
-    localStorage.setItem(SEEN_KEY, '4');
-    rpc.mockResolvedValue({ data: 5, error: null });
+    seen(4);
+    rpc.mockResolvedValue(digest(5));
     render(<NoteUsageBanner companyId="c1" />);
 
-    expect(await screen.findByText('1 new view on your notes.')).toBeInTheDocument();
+    expect(await screen.findByText('1 new view.')).toBeInTheDocument();
+  });
+
+  it('leads with helpful, because it is the stronger claim', async () => {
+    // A view is someone needing to look something up. A helpful is a colleague
+    // choosing to say it was worth reading.
+    seen(0, 0);
+    rpc.mockResolvedValue(digest(3, 2));
+    render(<NoteUsageBanner companyId="c1" />);
+
+    expect(
+      await screen.findByText('2 people found your notes helpful · 3 new views.'),
+    ).toBeInTheDocument();
+  });
+
+  it('says only what actually moved', async () => {
+    // Views unchanged, one new helpful — mentioning "0 new views" would be noise.
+    seen(9, 0);
+    rpc.mockResolvedValue(digest(9, 1));
+    render(<NoteUsageBanner companyId="c1" />);
+
+    expect(
+      await screen.findByText('Someone found one of your notes helpful.'),
+    ).toBeInTheDocument();
+  });
+
+  it('does not go negative when someone takes a helpful back', async () => {
+    // viewer_count is monotonic; helpful is NOT — a reaction can be removed. A
+    // raw subtraction would render "-1 new".
+    seen(9, 4);
+    rpc.mockResolvedValue(digest(9, 2));
+    const { container } = render(<NoteUsageBanner companyId="c1" />);
+
+    await waitFor(() => expect(rpc).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('stays silent when the digest fails', async () => {
@@ -113,17 +152,17 @@ describe('NoteUsageBanner', () => {
   it('dismissing banks the whole total, not just the new part', async () => {
     // Banking only the delta would re-show the same news forever.
     const user = userEvent.setup();
-    localStorage.setItem(SEEN_KEY, '2');
-    rpc.mockResolvedValue({ data: 6, error: null });
+    seen(2);
+    rpc.mockResolvedValue(digest(6));
     render(<NoteUsageBanner companyId="c1" />);
-    await screen.findByText('4 new views on your notes.');
+    await screen.findByText('4 new views.');
 
     await user.click(screen.getByRole('button', { name: /close/i }));
 
     await waitFor(() =>
-      expect(screen.queryByText('4 new views on your notes.')).not.toBeInTheDocument(),
+      expect(screen.queryByText('4 new views.')).not.toBeInTheDocument(),
     );
-    expect(localStorage.getItem(SEEN_KEY)).toBe('6');
+    expect(JSON.parse(localStorage.getItem(SEEN_KEY)!)).toMatchObject({ views: 6 });
   });
 
   it('a tap-through banks it too, and opens the detail', async () => {
@@ -131,14 +170,14 @@ describe('NoteUsageBanner', () => {
     // nothing happened.
     const user = userEvent.setup();
     const onOpenDetail = vi.fn();
-    localStorage.setItem(SEEN_KEY, '0');
-    rpc.mockResolvedValue({ data: 3, error: null });
+    seen(0);
+    rpc.mockResolvedValue(digest(3));
     render(<NoteUsageBanner companyId="c1" onOpenDetail={onOpenDetail} />);
 
-    await user.click(await screen.findByText('3 new views on your notes.'));
+    await user.click(await screen.findByText('3 new views.'));
 
     expect(onOpenDetail).toHaveBeenCalledTimes(1);
-    expect(localStorage.getItem(SEEN_KEY)).toBe('3');
+    expect(JSON.parse(localStorage.getItem(SEEN_KEY)!)).toMatchObject({ views: 3 });
   });
 
   it('dismissing does not count as opening the detail', async () => {
@@ -146,10 +185,10 @@ describe('NoteUsageBanner', () => {
     // navigate the operator away from the screen they were dismissing.
     const user = userEvent.setup();
     const onOpenDetail = vi.fn();
-    localStorage.setItem(SEEN_KEY, '0');
-    rpc.mockResolvedValue({ data: 3, error: null });
+    seen(0);
+    rpc.mockResolvedValue(digest(3));
     render(<NoteUsageBanner companyId="c1" onOpenDetail={onOpenDetail} />);
-    await screen.findByText('3 new views on your notes.');
+    await screen.findByText('3 new views.');
 
     await user.click(screen.getByRole('button', { name: /close/i }));
 
@@ -162,32 +201,32 @@ describe('NoteUsageBanner', () => {
     // browser or cleared site data all start empty. Defaulting to zero would
     // render the entire history as new — "312 new views" after a year — and the
     // banner's only asset is that its number is true.
-    rpc.mockResolvedValue({ data: 312, error: null });
+    rpc.mockResolvedValue(digest(312));
     const { container } = render(<NoteUsageBanner companyId="c1" />);
 
     await waitFor(() => expect(rpc).toHaveBeenCalled());
     expect(container).toBeEmptyDOMElement();
     // The total is adopted silently, so the NEXT view is correctly announced.
-    expect(localStorage.getItem(SEEN_KEY)).toBe('312');
+    expect(JSON.parse(localStorage.getItem(SEEN_KEY)!)).toMatchObject({ views: 312 });
   });
 
   it('announces normally once that device has a mark', async () => {
-    localStorage.setItem(SEEN_KEY, '312');
-    rpc.mockResolvedValue({ data: 313, error: null });
+    seen(312);
+    rpc.mockResolvedValue(digest(313));
     render(<NoteUsageBanner companyId="c1" />);
 
-    expect(await screen.findByText('1 new view on your notes.')).toBeInTheDocument();
+    expect(await screen.findByText('1 new view.')).toBeInTheDocument();
   });
 
   it('treats a mangled stored value as absent, not as zero', async () => {
     // Zero would announce the whole history; absent adopts it quietly. Staying
     // silent beats announcing a falsehood.
-    localStorage.setItem(SEEN_KEY, 'not a number');
-    rpc.mockResolvedValue({ data: 40, error: null });
+    localStorage.setItem(SEEN_KEY, 'not json');
+    rpc.mockResolvedValue(digest(40));
     const { container } = render(<NoteUsageBanner companyId="c1" />);
 
     await waitFor(() => expect(rpc).toHaveBeenCalled());
     expect(container).toBeEmptyDOMElement();
-    expect(localStorage.getItem(SEEN_KEY)).toBe('40');
+    expect(JSON.parse(localStorage.getItem(SEEN_KEY)!)).toMatchObject({ views: 40 });
   });
 });

--- a/__tests__/components/operator/PartNotesSheet.test.tsx
+++ b/__tests__/components/operator/PartNotesSheet.test.tsx
@@ -28,6 +28,8 @@ function note(over: Partial<PartPreviousNote> = {}): PartPreviousNote {
     author_name: 'Diego Alvarez',
     subject_kind: 'part',
     viewer_count: 0,
+    author_id: 'them',
+    reactions: [],
     usage_count: 0,
     media: [],
     job_number: 'J-0004',

--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -39,6 +39,8 @@ import {
   getAllStationsOperatorJobs,
   getCompletedOperatorJobs,
   getAllStationsCompletedOperatorJobs,
+  addReaction,
+  removeReaction,
   markOperationSent,
   markOperationReceived,
   revertOperationCompletion,
@@ -478,5 +480,63 @@ describe('getOutsideOpsForCompany', () => {
     mockQueryBuilder.data = null;
     mockQueryBuilder.error = { message: 'boom' };
     expect(await getOutsideOpsForCompany('c1')).toEqual([]);
+  });
+});
+
+
+describe('reactions', () => {
+  // getCurrentMember resolves via a single() on user_company_access.
+  const asMember = (id: string | null) => {
+    mockQueryBuilder.data = id === null ? null : { id, name: 'Diego', user_id: 'auth-user-1' };
+  };
+
+  it('writes the reaction as the caller, never as a supplied identity', async () => {
+    // The RLS policy pins reactor_id to get_operator_access_id(), so a forged id
+    // would be rejected anyway — but the signature never offers one, which is
+    // what stops "Kurtis confirmed this" from being expressible at all.
+    asMember('acc-me');
+    await addReaction('c1', 'n1');
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('note_reactions');
+    expect(mockQueryBuilder.insert).toHaveBeenCalledWith({
+      company_id: 'c1',
+      note_id: 'n1',
+      reactor_id: 'acc-me',
+      kind: 'helpful',
+    });
+  });
+
+  it('treats a duplicate as success, not as an error', async () => {
+    // Two taps racing, or a second device. The end state is what the caller
+    // asked for, so the unique constraint firing is not something to report.
+    asMember('acc-me');
+    mockQueryBuilder.error = { code: '23505', message: 'duplicate key' };
+
+    await expect(addReaction('c1', 'n1')).resolves.toBeUndefined();
+  });
+
+  it('surfaces a real failure so the optimistic UI can roll back', async () => {
+    asMember('acc-me');
+    mockQueryBuilder.error = { code: '42501', message: 'permission denied' };
+
+    await expect(addReaction('c1', 'n1')).rejects.toThrow('Could not save that.');
+  });
+
+  it('scopes the un-react to the caller, so nobody can clear someone else\'s', async () => {
+    // Belt to the DELETE policy's braces: admins deliberately cannot curate the
+    // public record of what the shop found useful.
+    asMember('acc-me');
+    await removeReaction('c1', 'n1');
+
+    expect(mockQueryBuilder.delete).toHaveBeenCalled();
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('note_id', 'n1');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('reactor_id', 'acc-me');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('kind', 'helpful');
+  });
+
+  it('refuses to write when the caller is not a member of the company', async () => {
+    asMember(null);
+
+    await expect(addReaction('c1', 'n1')).rejects.toThrow(/member/i);
   });
 });

--- a/__tests__/utils/operatorNoteSubject.test.ts
+++ b/__tests__/utils/operatorNoteSubject.test.ts
@@ -28,6 +28,8 @@ const NOTE_ROW = {
   part_id: 'part-1',
   routing_operation_id: 'ro-1',
   viewer_count: 0,
+  author_id: 'them',
+  reactions: [],
   usage_count: 0,
   body: 'watch the bore',
   note_type: 'user',

--- a/__tests__/utils/operatorPartPreviousNotes.test.ts
+++ b/__tests__/utils/operatorPartPreviousNotes.test.ts
@@ -46,6 +46,8 @@ function row(over: Record<string, unknown> = {}) {
     routing_operation_id: 'ro1',
     corrects_note_id: null,
     viewer_count: 4,
+    author_id: 'them',
+    reactions: [],
     usage_count: 11,
     author_name: 'Kurtis',
     job_number: 'J-0041',

--- a/api/tests/integration/test_note_views_rls.py
+++ b/api/tests/integration/test_note_views_rls.py
@@ -610,3 +610,140 @@ def test_read_log_is_not_granted_to_the_ai_sql_role(shop):
     """
     leaks = shop["admin"].rpc("no_client_access_grant_leaks", {}).execute().data
     assert leaks == [], f"no-client-access tables are granted to: {leaks}"
+
+
+# ── note_reactions: the voluntary half, and its policies ─────────────────────
+# The UI hides the thumbs-up on your own notes and offers no negative option,
+# but the UI is not the enforcement. These assert the database refuses on its
+# own, because a future surface (an API client, a bulk import, a different
+# screen) will not inherit the component's good manners.
+
+
+def _react(client, shop, note_id, reactor_access_id, kind="helpful"):
+    return (
+        client.table("note_reactions")
+        .insert(
+            {
+                "company_id": shop["company_id"],
+                "note_id": note_id,
+                "reactor_id": reactor_access_id,
+                "kind": kind,
+            }
+        )
+        .execute()
+    )
+
+
+def test_a_colleague_can_mark_a_note_helpful(shop):
+    note_id = _make_note(shop)
+    _react(shop["reader"]["client"], shop, note_id, shop["reader"]["access_id"])
+
+    rows = (
+        shop["author"]["client"]
+        .table("note_reactions")
+        .select("kind, reactor_id")
+        .eq("note_id", note_id)
+        .execute()
+        .data
+    )
+    assert [r["kind"] for r in rows] == ["helpful"]
+
+
+def test_you_cannot_endorse_your_own_note(shop):
+    """Self-endorsement is noise, and the UI hides the control — but the policy
+    is what actually refuses it."""
+    note_id = _make_note(shop)
+    with pytest.raises(Exception):
+        _react(shop["author"]["client"], shop, note_id, shop["author"]["access_id"])
+
+
+def test_you_cannot_react_as_someone_else(shop):
+    """"Kurtis confirmed this" must not be expressible by anyone but Kurtis."""
+    note_id = _make_note(shop)
+    with pytest.raises(Exception):
+        _react(
+            shop["reader"]["client"], shop, note_id, shop["reader2"]["access_id"]
+        )
+
+
+def test_there_is_no_negative_reaction(shop):
+    """Not a UI omission — the CHECK constraint has no slot for one. An
+    inaccurate note is corrected or superseded, never publicly judged."""
+    note_id = _make_note(shop)
+    for kind in ("unhelpful", "disputed", "wrong"):
+        with pytest.raises(Exception):
+            _react(shop["reader"]["client"], shop, note_id, shop["reader"]["access_id"], kind)
+
+
+def test_reacting_twice_is_blocked_by_the_unique_constraint(shop):
+    note_id = _make_note(shop)
+    _react(shop["reader"]["client"], shop, note_id, shop["reader"]["access_id"])
+    with pytest.raises(Exception):
+        _react(shop["reader"]["client"], shop, note_id, shop["reader"]["access_id"])
+
+
+def test_an_admin_cannot_delete_someone_elses_reaction(shop):
+    """A boss who can curate the public record of what the shop found useful is
+    a worse problem than a stale reaction. The DELETE policy is scoped to the
+    reactor, with no admin branch."""
+    note_id = _make_note(shop)
+    _react(shop["reader"]["client"], shop, note_id, shop["reader"]["access_id"])
+
+    shop["boss"]["client"].table("note_reactions").delete().eq(
+        "note_id", note_id
+    ).execute()
+
+    still_there = (
+        shop["admin"]
+        .table("note_reactions")
+        .select("id")
+        .eq("note_id", note_id)
+        .execute()
+        .data
+    )
+    assert len(still_there) == 1
+
+
+def test_you_can_take_your_own_reaction_back(shop):
+    note_id = _make_note(shop)
+    _react(shop["reader"]["client"], shop, note_id, shop["reader"]["access_id"])
+
+    shop["reader"]["client"].table("note_reactions").delete().eq(
+        "note_id", note_id
+    ).eq("reactor_id", shop["reader"]["access_id"]).execute()
+
+    assert (
+        shop["admin"]
+        .table("note_reactions")
+        .select("id")
+        .eq("note_id", note_id)
+        .execute()
+        .data
+        == []
+    )
+
+
+def test_a_reaction_can_never_be_edited(shop):
+    """No UPDATE policy and no UPDATE grant, so 'helpful' cannot silently become
+    'confirmed'. A reaction is created or removed, never amended."""
+    note_id = _make_note(shop)
+    _react(shop["reader"]["client"], shop, note_id, shop["reader"]["access_id"])
+
+    with pytest.raises(Exception):
+        shop["reader"]["client"].table("note_reactions").update(
+            {"kind": "confirmed"}
+        ).eq("note_id", note_id).execute()
+
+
+def test_playbook_returns_author_id_so_the_ui_can_hide_the_control(shop):
+    """Without it the reaction UI cannot tell whose note it is, and every tap on
+    your own note would be a guaranteed 42501 that reads as a broken button.
+    Matching on author_name instead breaks on two people with the same name."""
+    _make_note(shop)
+    rows = (
+        shop["reader"]["client"]
+        .rpc("part_playbook_notes", {"p_part_id": shop["part_id"]})
+        .execute()
+        .data
+    )
+    assert rows and rows[0]["author_id"] == shop["author"]["access_id"]

--- a/api/tests/integration/test_note_views_rls.py
+++ b/api/tests/integration/test_note_views_rls.py
@@ -441,7 +441,7 @@ def test_digest_counts_people_not_rows(shop):
         ).execute()
 
     assert len(_rows(shop, note_id)) == 2
-    n = shop["author"]["client"].rpc("my_note_view_digest").execute().data
+    n = shop["author"]["client"].rpc("my_note_digest").execute().data[0]["views"]
     assert n == 1
 
 
@@ -451,7 +451,7 @@ def test_digest_is_scoped_to_the_callers_own_notes(shop):
         "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
     ).execute()
 
-    n = shop["reader2"]["client"].rpc("my_note_view_digest").execute().data
+    n = shop["reader2"]["client"].rpc("my_note_digest").execute().data[0]["views"]
     assert n == 0
 
 
@@ -464,7 +464,7 @@ def test_digest_takes_no_time_window(shop):
     the wire."""
     with pytest.raises(Exception):
         shop["author"]["client"].rpc(
-            "my_note_view_digest", {"p_tz": "America/Detroit"}
+            "my_note_digest", {"p_tz": "America/Detroit"}
         ).execute()
 
 
@@ -473,17 +473,17 @@ def test_digest_is_a_running_total_not_a_window(shop):
     a view out — that is what makes "N new views since you last looked" work
     from a client-side subtraction alone."""
     note_id = _make_note(shop)
-    assert shop["author"]["client"].rpc("my_note_view_digest").execute().data == 0
+    assert shop["author"]["client"].rpc("my_note_digest").execute().data[0]["views"] == 0
 
     shop["reader"]["client"].rpc(
         "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
     ).execute()
-    assert shop["author"]["client"].rpc("my_note_view_digest").execute().data == 1
+    assert shop["author"]["client"].rpc("my_note_digest").execute().data[0]["views"] == 1
 
     shop["reader2"]["client"].rpc(
         "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
     ).execute()
-    assert shop["author"]["client"].rpc("my_note_view_digest").execute().data == 2
+    assert shop["author"]["client"].rpc("my_note_digest").execute().data[0]["views"] == 2
 
 
 # ── the durable subject, and the constraints protecting it ───────────────────
@@ -733,6 +733,46 @@ def test_a_reaction_can_never_be_edited(shop):
         shop["reader"]["client"].table("note_reactions").update(
             {"kind": "confirmed"}
         ).eq("note_id", note_id).execute()
+
+
+def test_playbook_reactions_say_who_reacted(shop):
+    """THE BUG THIS EXISTS FOR. The array carried kind/name/created_at but not
+    reactor_id, so a reader could never be found in it: the thumbs-up rendered
+    un-pressed on a note they had already marked helpful, and a second tap just
+    re-inserted a duplicate. The reaction was persisting the whole time — it
+    simply could not be recognised as theirs. Component tests could not catch
+    this: they are handed the array directly."""
+    note_id = _make_note(shop)
+    _react(shop["reader"]["client"], shop, note_id, shop["reader"]["access_id"])
+
+    rows = (
+        shop["reader"]["client"]
+        .rpc("part_playbook_notes", {"p_part_id": shop["part_id"]})
+        .execute()
+        .data
+    )
+    reactions = next(r["reactions"] for r in rows if r["id"] == note_id)
+    assert [x["reactor_id"] for x in reactions] == [shop["reader"]["access_id"]]
+
+
+def test_digest_reports_helpful_as_well_as_views(shop):
+    note_id = _make_note(shop)
+    shop["reader"]["client"].rpc(
+        "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+    ).execute()
+    _react(shop["reader2"]["client"], shop, note_id, shop["reader2"]["access_id"])
+
+    row = shop["author"]["client"].rpc("my_note_digest").execute().data[0]
+    assert row["views"] == 1
+    assert row["helpful"] == 1
+
+
+def test_digest_counts_only_the_callers_own_helpful(shop):
+    note_id = _make_note(shop)
+    _react(shop["reader"]["client"], shop, note_id, shop["reader"]["access_id"])
+
+    row = shop["reader2"]["client"].rpc("my_note_digest").execute().data[0]
+    assert row["helpful"] == 0
 
 
 def test_playbook_returns_author_id_so_the_ui_can_hide_the_control(shop):

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -19,6 +19,7 @@ import LaunchIcon from '@mui/icons-material/Launch';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import { getMyContribution, getNoteViewers } from '@/utils/operatorAccess';
 import { useSetOperatorChrome } from '@/components/operator/OperatorChromeContext';
+import NoteReactions from '@/components/operator/NoteReactions';
 import type { MyNote, NoteViewer } from '@/types/operator';
 
 const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
@@ -125,6 +126,18 @@ function NoteRow({ note, companyId }: { note: MyNote; companyId: string }) {
               {note.body}
             </Typography>
           )}
+
+          {/* Read-only by necessity, not omission: RLS forbids reacting to your
+              own note, so here endorsements are RECEPTION — the same category as
+              the view count above, and the other half of what came back. */}
+          <NoteReactions
+            companyId={companyId}
+            noteId={note.id}
+            authorId={null}
+            reactions={note.reactions}
+            memberId={null}
+            readOnly
+          />
         </CardContent>
       </CardActionArea>
 

--- a/components/operator/JobFeed.tsx
+++ b/components/operator/JobFeed.tsx
@@ -19,6 +19,7 @@ import DynamicFeedIcon from '@mui/icons-material/DynamicFeed';
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
 import CloseIcon from '@mui/icons-material/Close';
 import { getJobNotes, addJobNote, getCurrentMember } from '@/utils/operatorAccess';
+import NoteReactions from '@/components/operator/NoteReactions';
 import { addJobNoteMedia, getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
 import { compressPhoto } from '@/utils/imageCompression';
 import { useNoteDwell } from '@/hooks/useNoteDwell';
@@ -196,8 +197,10 @@ export default function JobFeed({
     [notes],
   );
 
+  // Resolved unconditionally, not just when the composer is shown: reactions need
+  // the member id on the read-only traveler feed too, both to know whether the
+  // reader has already reacted and to hide the control on their own notes.
   useEffect(() => {
-    if (!showComposer) return;
     let active = true;
     getCurrentMember(companyId).then((op) => {
       if (active && op) setOperatorId(op.id);
@@ -205,7 +208,7 @@ export default function JobFeed({
     return () => {
       active = false;
     };
-  }, [showComposer, companyId]);
+  }, [companyId]);
 
   // Post-completion capture offer: fire ONCE per completion event. Only react to
   // a *new* signal value (ignore the initial undefined/0), and only offer when
@@ -691,6 +694,18 @@ export default function JobFeed({
                       );
                     })}
                   </Box>
+                )}
+
+                {/* Auto-logged 'event' rows are system audit entries, not somebody's
+                    contribution — there is nothing to endorse. */}
+                {note.note_type === 'user' && (
+                  <NoteReactions
+                    companyId={companyId}
+                    noteId={note.id}
+                    authorId={note.author_id}
+                    reactions={note.reactions}
+                    memberId={operatorId}
+                  />
                 )}
               </Box>
             ))}

--- a/components/operator/NoteReactions.tsx
+++ b/components/operator/NoteReactions.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import ThumbUpAltIcon from '@mui/icons-material/ThumbUpAlt';
+import ThumbUpOffAltIcon from '@mui/icons-material/ThumbUpOffAlt';
+import * as Sentry from '@sentry/nextjs';
+import { addReaction, removeReaction } from '@/utils/operatorAccess';
+import type { NoteReaction } from '@/types/operator';
+
+/**
+ * "Helpful" on a note — the voluntary half of the read-back loop.
+ *
+ * The deliberate opposite of view logging. A view is involuntary and private: a
+ * record that someone needed to look something up, which is why note_views has no
+ * client read path at any level. A reaction is a claim someone chose to make, so
+ * it is public inside the shop and carries the reactor's name.
+ *
+ * THERE IS NO THUMBS DOWN, and this is not a deferral — `kind` is CHECK-limited
+ * to ('helpful','confirmed') in the database, so there is no slot for a negative.
+ * An inaccurate note is corrected (corrects_note_id) or superseded, never
+ * publicly judged: nobody on a fifteen-person floor writes a second note after
+ * being downvoted by a colleague they see every morning.
+ *
+ * NOT SHOWN ON YOUR OWN NOTES. The RLS INSERT policy forbids self-reaction, so
+ * rendering the control there would make every tap a guaranteed 42501 that reads
+ * as a broken button. On My work the same component renders read-only, where
+ * reactions are reception rather than an available action.
+ *
+ * WHAT THIS MUST NEVER BECOME: a per-person total. Reactions are safe because
+ * they attach to a NOTE. "Diego has 47 thumbs-ups" is a leaderboard and "Priya
+ * gave 3" is a participation score — both are the operator-comparative metrics
+ * the whole workstream refuses. Count and names both derive from the one array
+ * below, which is why no denormalized reaction counter exists to be summed.
+ */
+
+/** Up to this many names inline; the rest collapse to "+N". */
+const MAX_NAMES = 3;
+
+function summarise(names: string[]): string {
+  const shown = names.slice(0, MAX_NAMES);
+  const rest = names.length - shown.length;
+  const list = shown.join(', ');
+  return rest > 0 ? `${list} +${rest}` : list;
+}
+
+interface NoteReactionsProps {
+  companyId: string;
+  noteId: string;
+  /** Note's author. The control is hidden when this is the current member. */
+  authorId: string | null;
+  reactions: NoteReaction[];
+  /** Current member's user_company_access id; null until resolved. */
+  memberId: string | null;
+  /**
+   * Read-only rendering (My work): show what came back, offer no action. Also the
+   * automatic behaviour on your own notes.
+   */
+  readOnly?: boolean;
+}
+
+export default function NoteReactions({
+  companyId,
+  noteId,
+  authorId,
+  reactions,
+  memberId,
+  readOnly = false,
+}: NoteReactionsProps) {
+  // Optimistic local overlay. On shop wifi a thumbs-up that waits for a round
+  // trip before moving reads as a broken button, so the UI commits immediately
+  // and rolls back if the write fails.
+  const [override, setOverride] = useState<NoteReaction[] | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const helpful = (override ?? reactions).filter((r) => r.kind === 'helpful');
+  const mine = memberId != null && helpful.some((r) => r.reactor_id === memberId);
+  const isOwnNote = authorId != null && memberId != null && authorId === memberId;
+  const names = helpful.map((r) => r.name).filter((n): n is string => Boolean(n));
+
+  const interactive = !readOnly && !isOwnNote && memberId != null;
+
+  const toggle = async () => {
+    if (!interactive || busy) return;
+    const before = override ?? reactions;
+    const next = mine
+      ? before.filter((r) => !(r.kind === 'helpful' && r.reactor_id === memberId))
+      : [...before, { kind: 'helpful' as const, reactor_id: memberId, name: null }];
+
+    setOverride(next);
+    setBusy(true);
+    try {
+      if (mine) await removeReaction(companyId, noteId);
+      else await addReaction(companyId, noteId);
+    } catch (err) {
+      // Roll back rather than leaving a lie on screen. No toast: the button
+      // snapping back is the message, and an operator mid-job does not need a
+      // dialog about a thumbs-up.
+      setOverride(before);
+      Sentry.captureException(err, { tags: { area: 'note_reactions' } });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Nothing to show and nothing to offer.
+  if (!interactive && helpful.length === 0) return null;
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mt: 0.5 }}>
+      {interactive ? (
+        <Button
+          size="small"
+          onClick={toggle}
+          disabled={busy}
+          startIcon={mine ? <ThumbUpAltIcon /> : <ThumbUpOffAltIcon />}
+          sx={{
+            minHeight: 40,
+            color: mine ? 'success.light' : 'text.secondary',
+            textTransform: 'none',
+          }}
+        >
+          {/* The word carries the meaning; the count alone would read as a score. */}
+          {helpful.length > 0 ? `Helpful · ${helpful.length}` : 'Helpful'}
+        </Button>
+      ) : (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <ThumbUpAltIcon sx={{ fontSize: 16, color: 'success.light' }} />
+          <Typography variant="caption" sx={{ color: 'success.light' }}>
+            {helpful.length}
+          </Typography>
+        </Box>
+      )}
+
+      {/* Names, not just a number. Reactions are public by design, so there is
+          nothing to hide behind a second tap — and attribution is the point of
+          the whole workstream. */}
+      {names.length > 0 && (
+        <Typography variant="caption" color="text.secondary">
+          {summarise(names)}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/components/operator/NoteUsageBanner.tsx
+++ b/components/operator/NoteUsageBanner.tsx
@@ -5,19 +5,26 @@ import { useLoad } from '@/hooks/useLoad';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
+import ThumbUpAltIcon from '@mui/icons-material/ThumbUpAlt';
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 
 /**
- * "3 new views on your notes."
+ * "2 people found your notes helpful · 3 new views."
  *
  * The return half of the loop. An operator writes something down and, without
  * this, nothing comes back — no way to know whether it was read, no reason to
  * believe writing it did anything. This is the smallest honest signal that it did.
  *
+ * TWO SIGNALS, AND HELPFUL LEADS
+ *   A view is someone needing to look something up. A helpful is a colleague
+ *   choosing to say it was worth reading. The second is the stronger claim, so it
+ *   goes first when both are present. Whether views earn their place at all is an
+ *   open question for the shop, not one to settle by argument — both are shown
+ *   until a usability session says otherwise.
+ *
  * NEW SINCE YOU LAST LOOKED, NOT "THIS WEEK"
- *   my_note_view_digest() returns a RUNNING TOTAL of views across the caller's
- *   own notes. This component stores the total it last acknowledged and renders
- *   the difference. So the banner appears exactly when something has happened and
+ *   my_note_digest() returns RUNNING TOTALS across the caller's own notes. This
+ *   component stores the totals it last acknowledged and renders the differences. So the banner appears exactly when something has happened and
  *   goes quiet the moment it has been seen — no weekly window, which was always
  *   arbitrary, and no nag on every visit to the jobs list.
  *
@@ -43,37 +50,59 @@ import { getTypedSupabase as getSupabase } from '@/lib/supabase';
  *   cares, which is worse than silence. It renders null.
  */
 
-// The running total this device has already shown the operator. A fresh key each
+// The running totals this device has already shown the operator. A fresh key each
 // time the stored shape changes, so a value written by an older preview build is
 // simply ignored rather than needing a parse fallback.
-const SEEN_KEY = 'jigged:note-views-acknowledged';
+const SEEN_KEY = 'jigged:note-digest-acknowledged';
+
+interface Totals {
+  views: number;
+  helpful: number;
+}
 
 /**
- * The running total already shown on THIS device, or null if it has never shown
- * one — a distinction that matters, because null means "adopt the total
- * silently", not "everything is new". See the first-run note in the component.
+ * The totals already shown on THIS device, or null if it has never shown any —
+ * a distinction that matters, because null means "adopt them silently", not
+ * "everything is new". See the first-run note in the component.
  */
-function readAcknowledged(): number | null {
+function readAcknowledged(): Totals | null {
   if (typeof window === 'undefined') return null;
   try {
     const raw = window.localStorage.getItem(SEEN_KEY);
     if (raw === null) return null;
-    const n = Number(raw);
-    // A mangled value is treated as absent rather than as zero: zero would
+    const parsed = JSON.parse(raw) as Partial<Totals>;
+    // A mangled value is treated as absent rather than as zeros: zeros would
     // announce the entire history as new.
-    return Number.isFinite(n) && n >= 0 ? n : null;
+    if (typeof parsed?.views !== 'number' || typeof parsed?.helpful !== 'number') return null;
+    return { views: parsed.views, helpful: parsed.helpful };
   } catch {
     return null; // private mode / quota — the banner is best-effort
   }
 }
 
-function writeAcknowledged(total: number): void {
+function writeAcknowledged(t: Totals): void {
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(SEEN_KEY, String(total));
+    window.localStorage.setItem(SEEN_KEY, JSON.stringify(t));
   } catch {
     /* ignore */
   }
+}
+
+/** Helpful leads: it is the stronger claim of the two. */
+function summarise(freshHelpful: number, freshViews: number): string {
+  const parts: string[] = [];
+  if (freshHelpful > 0) {
+    parts.push(
+      freshHelpful === 1
+        ? 'Someone found one of your notes helpful'
+        : `${freshHelpful} people found your notes helpful`,
+    );
+  }
+  if (freshViews > 0) {
+    parts.push(freshViews === 1 ? '1 new view' : `${freshViews} new views`);
+  }
+  return `${parts.join(' · ')}.`;
 }
 
 interface NoteUsageBannerProps {
@@ -86,11 +115,13 @@ export default function NoteUsageBanner({ companyId, onOpenDetail }: NoteUsageBa
   const [banked, setBanked] = useState(false);
 
   const { data } = useLoad(async () => {
-    const { data: total, error } = await getSupabase().rpc('my_note_view_digest');
+    const empty = { totals: { views: 0, helpful: 0 }, fresh: { views: 0, helpful: 0 } };
+    const { data: rows, error } = await getSupabase().rpc('my_note_digest');
     // Silent on failure: a broken digest must not put an error in front of an
     // operator who was only trying to start work.
-    if (error) return { total: 0, fresh: 0 };
-    const runningTotal = (total as number | null) ?? 0;
+    if (error) return empty;
+    const row = (rows as Totals[] | null)?.[0];
+    const totals: Totals = { views: row?.views ?? 0, helpful: row?.helpful ?? 0 };
 
     const prior = readAcknowledged();
     if (prior === null) {
@@ -106,25 +137,33 @@ export default function NoteUsageBanner({ companyId, onOpenDetail }: NoteUsageBa
       // device was away are never banner-announced. That is information delayed,
       // not lost — the full picture is on My work, one tap down. Announcing a
       // falsehood is worse than staying quiet.
-      writeAcknowledged(runningTotal);
-      return { total: runningTotal, fresh: 0 };
+      writeAcknowledged(totals);
+      return { totals, fresh: { views: 0, helpful: 0 } };
     }
-    // Both counters are monotonic, so this can never go negative.
-    return { total: runningTotal, fresh: runningTotal - prior };
+    // viewer_count is monotonic. helpful is NOT — a colleague can take a mark
+    // back — so clamp at zero rather than rendering a negative "new" count.
+    return {
+      totals,
+      fresh: {
+        views: Math.max(0, totals.views - prior.views),
+        helpful: Math.max(0, totals.helpful - prior.helpful),
+      },
+    };
   }, [companyId]);
 
-  const runningTotal = data?.total ?? 0;
-  const fresh = data?.fresh ?? 0;
+  const totals = data?.totals ?? { views: 0, helpful: 0 };
+  const fresh = data?.fresh ?? { views: 0, helpful: 0 };
+  const anything = fresh.helpful + fresh.views;
 
   // Both the ✕ and a tap-through count as "I have seen this". Tapping through
   // especially: coming back from My work to the same banner you just acted on
   // reads as if nothing happened.
   const acknowledge = () => {
-    writeAcknowledged(runningTotal);
+    writeAcknowledged(totals);
     setBanked(true);
   };
 
-  if (banked || fresh <= 0) return null;
+  if (banked || anything <= 0) return null;
 
   return (
     <Box sx={{ mb: 2 }}>
@@ -136,7 +175,15 @@ export default function NoteUsageBanner({ companyId, onOpenDetail }: NoteUsageBa
         // which is where tapping it lands, and stops the banner reading as a
         // confirmation of an action. Green stays: it is doing real work as the
         // reward signal, and that is the whole point of the banner.
-        icon={<VisibilityOutlinedIcon fontSize="inherit" />}
+        // Matches whichever signal leads the sentence, so the icon is never
+        // describing something the text does not say.
+        icon={
+          fresh.helpful > 0 ? (
+            <ThumbUpAltIcon fontSize="inherit" />
+          ) : (
+            <VisibilityOutlinedIcon fontSize="inherit" />
+          )
+        }
         onClose={(e) => {
           // The close button sits INSIDE the tappable Alert, so without this the
           // click bubbles to onOpenDetail and dismissing navigates the operator
@@ -154,7 +201,7 @@ export default function NoteUsageBanner({ companyId, onOpenDetail }: NoteUsageBa
             }
           : { sx: { minHeight: 48 } })}
       >
-        {fresh === 1 ? '1 new view on your notes.' : `${fresh} new views on your notes.`}
+        {summarise(fresh.helpful, fresh.views)}
       </Alert>
     </Box>
   );

--- a/components/operator/PartNotesSheet.tsx
+++ b/components/operator/PartNotesSheet.tsx
@@ -15,7 +15,8 @@ import CircularProgress from '@mui/material/CircularProgress';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import CloseIcon from '@mui/icons-material/Close';
-import { getPartPreviousNotes } from '@/utils/operatorAccess';
+import { getPartPreviousNotes, getCurrentMember } from '@/utils/operatorAccess';
+import NoteReactions from '@/components/operator/NoteReactions';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import { useNoteDwell } from '@/hooks/useNoteDwell';
 import NoteMediaGallery from '@/components/operator/NoteMediaGallery';
@@ -49,9 +50,13 @@ function formatTimestamp(value: string): string {
 function NoteRow({
   note,
   observe,
+  companyId,
+  memberId,
 }: {
   note: PartPreviousNote;
   observe: (id: string) => (el: HTMLElement | null) => void;
+  companyId: string;
+  memberId: string | null;
 }) {
   return (
     <Box>
@@ -73,6 +78,18 @@ function NoteRow({
         </Typography>
       )}
       <NoteMediaGallery media={note.media} />
+      {/* This is the surface reactions matter most on: knowledge from a previous
+          run, being read while doing the work. Auto-logged 'event' rows are audit
+          entries, not somebody's contribution — nothing to endorse. */}
+      {note.note_type === 'user' && (
+        <NoteReactions
+          companyId={companyId}
+          noteId={note.id}
+          authorId={note.author_id}
+          reactions={note.reactions}
+          memberId={memberId}
+        />
+      )}
     </Box>
   );
 }
@@ -114,6 +131,14 @@ export default function PartNotesSheet({
   // decision is made on data from the shop rather than on a plausible story.
   const [scope, setScope] = useState<Scope>('part');
   const [toggled, setToggled] = useState(false);
+
+  // Who is reading. Needed to know whether they have already marked a note
+  // helpful, and to hide the control on their own notes (RLS forbids reacting to
+  // them, so the button would be a guaranteed failure).
+  const { data: memberId } = useLoad(
+    async () => (open ? ((await getCurrentMember(companyId))?.id ?? null) : null),
+    [companyId, open],
+  );
 
   // THE surface the read-back loop exists to measure: knowledge from a previous
   // run, being read on a new one. excludeJobId is the job the operator is
@@ -210,7 +235,7 @@ export default function PartNotesSheet({
             {notes.map((note, idx) => (
               <Box key={note.id}>
                 {idx > 0 && <Divider sx={{ my: 1.5 }} />}
-                <NoteRow note={note} observe={observe} />
+                <NoteRow note={note} observe={observe} companyId={companyId} memberId={memberId} />
               </Box>
             ))}
           </Box>

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -171,10 +171,14 @@ see this", not "nobody can".
 
 ### What comes back to the author
 
-- **Login banner** (`NoteUsageBanner`, on the jobs list) — **"N new views on your
-  notes"**. `my_note_view_digest()` returns a *running total* of views across the
-  caller's own notes (the sum of `viewer_count`, which is exactly the "views"
-  figure My work shows, so the two can never disagree). The component stores the
+- **Login banner** (`NoteUsageBanner`, on the jobs list) — **"2 people found your
+  notes helpful · 3 new views."** `my_note_digest()` returns *running totals* of
+  both across the caller's own notes: views (the sum of `viewer_count`, exactly
+  the figure My work shows, so the two can never disagree) and helpful marks.
+  **Helpful leads when present** — a view is someone needing to look something
+  up; a helpful is a colleague choosing to say it was worth reading. Only the
+  signals that actually moved are mentioned. `helpful` is **not** monotonic (a
+  mark can be taken back), so its delta is clamped at zero. The component stores the
   total it last acknowledged in `localStorage` and renders the **difference**, so
   it appears only when something has genuinely happened and goes quiet once seen —
   no nag on the many jobs-list visits in a shift. Both the ✕ and a tap-through
@@ -239,7 +243,11 @@ endorsements are *reception*, the same category as the view count beside them.
   Sentry; there is no toast, because an operator mid-job does not need a dialog
   about a thumbs-up.
 - **Count and names derive from the same array**, so they can never disagree —
-  which is why no denormalized reaction counter exists.
+  which is why no denormalized reaction counter exists. That array must carry
+  `reactor_id`: without it a reader cannot be found in it, so the thumbs-up
+  renders un-pressed on a note they have already marked and a second tap just
+  re-inserts a duplicate. `part_playbook_notes` shipped without it and the bug
+  looked exactly like "likes are not persisting" — they were.
 - **No `operator_events` kind for reactions, deliberately.** `note_reactions`
   already records who reacted, to what, and when; a parallel funnel event would
   duplicate it and drift.

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -208,6 +208,48 @@ see this", not "nobody can".
 a note and stayed on it. Whether they acted on it is not measured, and claiming it
 makes every number a small lie the author can personally disprove by asking.
 
+### Reactions (`helpful`)
+
+The **voluntary** half of the loop, and the deliberate opposite of view logging.
+A view is involuntary and private — a record that someone needed to look
+something up — which is why `note_views` has no client read path at any level. A
+reaction is a claim someone chose to make, so it is public inside the shop,
+carries the reactor's name, and is removable only by the person who made it
+(admins deliberately **cannot** delete someone else's: a boss who can curate the
+public record of what the shop found useful is worse than a stale reaction).
+
+Rendered by `NoteReactions` on three surfaces: the job feed, the previous-notes
+sheet (where prior knowledge is actually read, so the most important one), and
+**My work read-only** — RLS forbids reacting to your own note, so there
+endorsements are *reception*, the same category as the view count beside them.
+
+- **There is no thumbs down, and this is not a deferral.** `kind` is
+  CHECK-limited to `('helpful','confirmed')`, so there is no schema slot for a
+  negative. An inaccurate note is corrected (`corrects_note_id`) or superseded,
+  never publicly judged — nobody on a fifteen-person floor writes a second note
+  after being downvoted by a colleague they see every morning.
+- **`confirmed` has no UI.** It stays in the CHECK; nothing writes or renders it,
+  and the helpful count filters it out so a stray row cannot inflate anything.
+- **The control is hidden on your own notes.** The INSERT policy refuses
+  self-reaction, so rendering it there makes every tap a guaranteed `42501` that
+  reads as a broken button. This is why `part_playbook_notes` returns `author_id`
+  as well as `author_name` — matching on a display name breaks on two Daves.
+- **Optimistic with rollback.** On shop wifi a thumbs-up that waits for a round
+  trip before moving reads as broken. A failure rolls the button back and goes to
+  Sentry; there is no toast, because an operator mid-job does not need a dialog
+  about a thumbs-up.
+- **Count and names derive from the same array**, so they can never disagree —
+  which is why no denormalized reaction counter exists.
+- **No `operator_events` kind for reactions, deliberately.** `note_reactions`
+  already records who reacted, to what, and when; a parallel funnel event would
+  duplicate it and drift.
+
+**What this must never become: a per-person total.** Reactions are safe because
+they attach to a *note*. "Diego has 47 thumbs-ups" is a leaderboard and "Priya
+gave 3" is a participation score — both are the operator-comparative metrics this
+module refuses. Nothing sums them by person, including My work, which shows
+endorsements received *on a note*.
+
 ### Surveillance guardrail (non-negotiable)
 
 No operator-facing surface may reflect an operator's pace or standing back at them.
@@ -356,6 +398,16 @@ Each bullet is a Given/When/Then scenario carrying a verification clause — a p
 - [ ] **Given** a non-zero banner, **when** the operator taps it, **then** it navigates to My work AND banks the whole total; **when** they tap its close button, **then** it dismisses **without** navigating — *verified by `__tests__/components/operator/NoteUsageBanner.test.tsx`*.
 - [ ] **Given** My work, **when** it renders with any data, **then** no completion count, streak, average, pace or rank appears anywhere on the page — *verified by `__tests__/app/operator/MyWorkPage.test.tsx > 'shows no completion count, streak, average or pace'`*.
 - [ ] **Given** a note whose job has been deleted, **when** My work renders it, **then** the note survives and only the job link is absent — *verified by `__tests__/app/operator/MyWorkPage.test.tsx`*.
+
+**Reactions**
+
+- [ ] **Given** a colleague's note, **when** the operator taps Helpful, **then** the count moves immediately and the write follows — an optimistic toggle, because a thumbs-up that waits for shop wifi reads as broken — *verified by `__tests__/components/operator/NoteReactions.test.tsx`*.
+- [ ] **Given** a failed write, **when** it rejects, **then** the button rolls back rather than leaving a lie on screen, with no toast — *verified by `__tests__/components/operator/NoteReactions.test.tsx`*.
+- [ ] **Given** the operator's OWN note, **when** it renders, **then** no control is offered — RLS forbids self-reaction, so the tap would be a guaranteed `42501` — *verified by `__tests__/components/operator/NoteReactions.test.tsx`*.
+- [ ] **Given** a `confirmed` row, **when** the card renders, **then** it is excluded from the helpful count and its reactor is not named — *verified by `__tests__/components/operator/NoteReactions.test.tsx`*.
+- [ ] **Given** any note, **when** looking for a negative option, **then** none exists on screen or in the schema — *verified by `__tests__/components/operator/NoteReactions.test.tsx`*.
+- [ ] **Given** a duplicate insert (two taps racing, or a second device), **when** the unique constraint fires, **then** it is treated as success — the end state is what the caller asked for — *verified by `__tests__/utils/operatorAccess.test.ts`*.
+- [ ] **Given** an un-react, **when** it is issued, **then** it is scoped to the caller's own row — *verified by `__tests__/utils/operatorAccess.test.ts`*.
 
 **Inventory (feature-gated by `inventory_locations`)**
 

--- a/supabase/migrations/20260729133520_playbook_notes_expose_author_id.sql
+++ b/supabase/migrations/20260729133520_playbook_notes_expose_author_id.sql
@@ -1,0 +1,161 @@
+-- part_playbook_notes(): expose author_id so the reaction UI can tell whose note it is.
+--
+-- note_reactions' INSERT policy forbids reacting to your OWN note (self-endorsement
+-- is noise). The Playbook therefore has to hide the thumbs-up on the reader's own
+-- notes, or every tap on one is a guaranteed 42501 that reads to the operator as a
+-- broken button. Deciding that needs an id: author_name is already returned, but
+-- matching on a display name breaks the first time a shop employs two Daves.
+--
+-- Both CTEs already carry n.author_id — it was simply never projected. This is a
+-- DROP + CREATE rather than CREATE OR REPLACE only because Postgres will not let a
+-- RETURNS TABLE change in place; the body below is otherwise byte-identical to
+-- 20260728041800, with two lines added.
+
+DROP FUNCTION IF EXISTS public.part_playbook_notes(uuid, uuid, text, uuid, integer);
+
+CREATE OR REPLACE FUNCTION public.part_playbook_notes(
+  p_part_id              uuid,
+  -- The step, when scoping to one. NULL returns everything known about the part.
+  p_routing_operation_id uuid    DEFAULT NULL,
+  -- Legacy step-name fallback, for prior-run job notes whose job_operation has no
+  -- routing_operation_id (an ad-hoc step added to a job). Mirrors the fallback that
+  -- matchingStepOperationIds() used.
+  p_operation_name       text    DEFAULT NULL,
+  -- The current job: its own notes are already in the job feed, so they are not
+  -- "previous" notes.
+  p_exclude_job_id       uuid    DEFAULT NULL,
+  -- Bounds branch 2 only. Branch 1 needs no cap — it is one indexed lookup.
+  p_max_runs             integer DEFAULT 10
+)
+RETURNS TABLE (
+  id                   uuid,
+  body                 text,
+  created_at           timestamptz,
+  note_type            text,
+  subject_kind         text,
+  routing_operation_id uuid,
+  corrects_note_id     uuid,
+  viewer_count         integer,
+  usage_count          integer,
+  -- NEW: the reaction UI must not offer a thumbs-up on your own note — RLS
+  -- forbids it, so the button would be a guaranteed 42501. Only an id can decide
+  -- that; matching on author_name breaks the moment a shop has two Daves.
+  author_id            uuid,
+  author_name          text,
+  job_number           text,
+  operation_label      text,
+  media                jsonb,
+  reactions            jsonb
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  WITH durable AS (
+    -- BRANCH 1 — the durable subject. One index hit on idx_notes_part_step. No prior
+    -- runs, no step-name heuristic, no cap. This is every note written after the
+    -- subject migration, and it is what makes the read-back loop possible at all.
+    SELECT
+      n.id, n.body, n.created_at, n.note_type, n.subject_kind, n.routing_operation_id,
+      n.corrects_note_id, n.viewer_count, n.usage_count, n.author_id,
+      cj.job_number AS src_job_number,
+      CASE
+        WHEN ro.id IS NULL THEN NULL
+        ELSE 'Op ' || ro.sequence::text ||
+             COALESCE(' · ' || wc.name, '')
+      END AS src_operation_label
+    FROM public.notes n
+    LEFT JOIN public.jobs cj              ON cj.id = n.captured_job_id
+    LEFT JOIN public.routing_operations ro ON ro.id = n.routing_operation_id
+    LEFT JOIN public.work_centers wc       ON wc.id = ro.work_center_id
+    WHERE n.subject_kind = 'part'
+      AND n.part_id = p_part_id
+      AND (p_routing_operation_id IS NULL
+           OR n.routing_operation_id = p_routing_operation_id)
+      -- Captured on the job the operator is standing in front of: already visible in
+      -- that job's feed, so showing it again as "previous" is noise.
+      AND (p_exclude_job_id IS NULL
+           OR n.captured_job_id IS DISTINCT FROM p_exclude_job_id)
+  ),
+  runs AS (
+    -- BRANCH 2 scaffolding — the most recent completed runs of this part.
+    SELECT jp.job_id, j.job_number
+    FROM public.job_parts jp
+    JOIN public.jobs j ON j.id = jp.job_id
+    WHERE jp.part_id = p_part_id
+      AND jp.production_status = 'completed'
+      AND (p_exclude_job_id IS NULL OR jp.job_id <> p_exclude_job_id)
+    ORDER BY jp.completed_at DESC NULLS LAST
+    LIMIT p_max_runs
+  ),
+  legacy AS (
+    -- BRANCH 2 — pre-migration notes, which are all subject_kind = 'job'. Step match
+    -- by routing_operation_id, falling back to operation_name when the job's step has
+    -- no routing link. Delete this branch once the old corpus stops mattering.
+    SELECT
+      n.id, n.body, n.created_at, n.note_type, n.subject_kind, n.routing_operation_id,
+      n.corrects_note_id, n.viewer_count, n.usage_count, n.author_id,
+      r.job_number AS src_job_number,
+      CASE
+        WHEN jo.id IS NULL THEN NULL
+        WHEN jo.sequence IS NULL THEN jo.operation_name
+        ELSE 'Op ' || jo.sequence::text || ' · ' || jo.operation_name
+      END AS src_operation_label
+    FROM runs r
+    JOIN public.notes n ON n.job_id = r.job_id AND n.subject_kind = 'job'
+    LEFT JOIN public.job_operations jo ON jo.id = n.job_operation_id
+    WHERE p_routing_operation_id IS NULL
+       OR jo.routing_operation_id = p_routing_operation_id
+       OR (jo.routing_operation_id IS NULL
+           AND p_operation_name IS NOT NULL
+           AND jo.operation_name = p_operation_name)
+  ),
+  combined AS (
+    SELECT * FROM durable
+    UNION ALL
+    SELECT * FROM legacy
+  )
+  SELECT
+    c.id, c.body, c.created_at, c.note_type, c.subject_kind, c.routing_operation_id,
+    c.corrects_note_id, c.viewer_count, c.usage_count,
+    c.author_id,
+    a.name AS author_name,
+    c.src_job_number,
+    c.src_operation_label,
+    COALESCE(m.media, '[]'::jsonb),
+    COALESCE(rx.reactions, '[]'::jsonb)
+  FROM combined c
+  LEFT JOIN public.user_company_access a ON a.id = c.author_id
+  LEFT JOIN LATERAL (
+    SELECT jsonb_agg(jsonb_build_object(
+             'id', md.id,
+             'storage_path', md.storage_path,
+             'thumbnail_path', md.thumbnail_path,
+             'kind', md.kind,
+             'mime_type', md.mime_type,
+             'width', md.width,
+             'height', md.height
+           ) ORDER BY md.created_at) AS media
+    FROM public.note_media md
+    WHERE md.note_id = c.id
+  ) m ON true
+  LEFT JOIN LATERAL (
+    -- Reactions embed here because they are PUBLIC within the shop — the deliberate
+    -- opposite of note_views, which has no read path at any level. Names and counts
+    -- both derive from this one array client-side, so the number and the names can
+    -- never disagree; that is why there is no denormalized reaction counter.
+    SELECT jsonb_agg(jsonb_build_object(
+             'kind', x.kind,
+             'name', u.name,
+             'created_at', x.created_at
+           )) AS reactions
+    FROM public.note_reactions x
+    JOIN public.user_company_access u ON u.id = x.reactor_id
+    WHERE x.note_id = c.id
+  ) rx ON true
+  ORDER BY c.created_at DESC;
+$$;
+
+COMMENT ON FUNCTION public.part_playbook_notes(uuid, uuid, text, uuid, integer) IS
+  'Everything known about running this part (optionally scoped to one routing step), newest first, in one round trip. Unions durable part-subject notes (a single index hit) with legacy job-scoped notes from recent completed runs. Returns author_id as well as author_name so the reaction UI can suppress the thumbs-up on the reader''s own notes, which RLS forbids. SECURITY INVOKER so notes/jobs/job_parts RLS still enforces tenancy.';

--- a/supabase/migrations/20260729141712_reaction_identity_and_helpful_digest.sql
+++ b/supabase/migrations/20260729141712_reaction_identity_and_helpful_digest.sql
@@ -1,0 +1,222 @@
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 1. part_playbook_notes(): the reactions array must say WHO reacted
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Observed on the preview: marking a previous-run note helpful appeared not to
+-- persist. It always did. The array this function returns carried kind, name and
+-- created_at but NOT reactor_id, so the reader could never be found in it —
+-- the thumbs-up rendered un-pressed on a note they had already marked, and a
+-- second tap re-inserted, which the client correctly treats as a no-op duplicate.
+--
+-- The job feed was unaffected: it reads through a PostgREST embed that selects
+-- reactor_id. Only this RPC, written in Iteration A when nothing consumed the
+-- array, was missing it.
+--
+-- Signature and return type are unchanged, so CREATE OR REPLACE is enough and
+-- types/database.ts is untouched by this half.
+
+CREATE OR REPLACE FUNCTION public.part_playbook_notes(
+  p_part_id              uuid,
+  -- The step, when scoping to one. NULL returns everything known about the part.
+  p_routing_operation_id uuid    DEFAULT NULL,
+  -- Legacy step-name fallback, for prior-run job notes whose job_operation has no
+  -- routing_operation_id (an ad-hoc step added to a job). Mirrors the fallback that
+  -- matchingStepOperationIds() used.
+  p_operation_name       text    DEFAULT NULL,
+  -- The current job: its own notes are already in the job feed, so they are not
+  -- "previous" notes.
+  p_exclude_job_id       uuid    DEFAULT NULL,
+  -- Bounds branch 2 only. Branch 1 needs no cap — it is one indexed lookup.
+  p_max_runs             integer DEFAULT 10
+)
+RETURNS TABLE (
+  id                   uuid,
+  body                 text,
+  created_at           timestamptz,
+  note_type            text,
+  subject_kind         text,
+  routing_operation_id uuid,
+  corrects_note_id     uuid,
+  viewer_count         integer,
+  usage_count          integer,
+  -- NEW: the reaction UI must not offer a thumbs-up on your own note — RLS
+  -- forbids it, so the button would be a guaranteed 42501. Only an id can decide
+  -- that; matching on author_name breaks the moment a shop has two Daves.
+  author_id            uuid,
+  author_name          text,
+  job_number           text,
+  operation_label      text,
+  media                jsonb,
+  reactions            jsonb
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  WITH durable AS (
+    -- BRANCH 1 — the durable subject. One index hit on idx_notes_part_step. No prior
+    -- runs, no step-name heuristic, no cap. This is every note written after the
+    -- subject migration, and it is what makes the read-back loop possible at all.
+    SELECT
+      n.id, n.body, n.created_at, n.note_type, n.subject_kind, n.routing_operation_id,
+      n.corrects_note_id, n.viewer_count, n.usage_count, n.author_id,
+      cj.job_number AS src_job_number,
+      CASE
+        WHEN ro.id IS NULL THEN NULL
+        ELSE 'Op ' || ro.sequence::text ||
+             COALESCE(' · ' || wc.name, '')
+      END AS src_operation_label
+    FROM public.notes n
+    LEFT JOIN public.jobs cj              ON cj.id = n.captured_job_id
+    LEFT JOIN public.routing_operations ro ON ro.id = n.routing_operation_id
+    LEFT JOIN public.work_centers wc       ON wc.id = ro.work_center_id
+    WHERE n.subject_kind = 'part'
+      AND n.part_id = p_part_id
+      AND (p_routing_operation_id IS NULL
+           OR n.routing_operation_id = p_routing_operation_id)
+      -- Captured on the job the operator is standing in front of: already visible in
+      -- that job's feed, so showing it again as "previous" is noise.
+      AND (p_exclude_job_id IS NULL
+           OR n.captured_job_id IS DISTINCT FROM p_exclude_job_id)
+  ),
+  runs AS (
+    -- BRANCH 2 scaffolding — the most recent completed runs of this part.
+    SELECT jp.job_id, j.job_number
+    FROM public.job_parts jp
+    JOIN public.jobs j ON j.id = jp.job_id
+    WHERE jp.part_id = p_part_id
+      AND jp.production_status = 'completed'
+      AND (p_exclude_job_id IS NULL OR jp.job_id <> p_exclude_job_id)
+    ORDER BY jp.completed_at DESC NULLS LAST
+    LIMIT p_max_runs
+  ),
+  legacy AS (
+    -- BRANCH 2 — pre-migration notes, which are all subject_kind = 'job'. Step match
+    -- by routing_operation_id, falling back to operation_name when the job's step has
+    -- no routing link. Delete this branch once the old corpus stops mattering.
+    SELECT
+      n.id, n.body, n.created_at, n.note_type, n.subject_kind, n.routing_operation_id,
+      n.corrects_note_id, n.viewer_count, n.usage_count, n.author_id,
+      r.job_number AS src_job_number,
+      CASE
+        WHEN jo.id IS NULL THEN NULL
+        WHEN jo.sequence IS NULL THEN jo.operation_name
+        ELSE 'Op ' || jo.sequence::text || ' · ' || jo.operation_name
+      END AS src_operation_label
+    FROM runs r
+    JOIN public.notes n ON n.job_id = r.job_id AND n.subject_kind = 'job'
+    LEFT JOIN public.job_operations jo ON jo.id = n.job_operation_id
+    WHERE p_routing_operation_id IS NULL
+       OR jo.routing_operation_id = p_routing_operation_id
+       OR (jo.routing_operation_id IS NULL
+           AND p_operation_name IS NOT NULL
+           AND jo.operation_name = p_operation_name)
+  ),
+  combined AS (
+    SELECT * FROM durable
+    UNION ALL
+    SELECT * FROM legacy
+  )
+  SELECT
+    c.id, c.body, c.created_at, c.note_type, c.subject_kind, c.routing_operation_id,
+    c.corrects_note_id, c.viewer_count, c.usage_count,
+    c.author_id,
+    a.name AS author_name,
+    c.src_job_number,
+    c.src_operation_label,
+    COALESCE(m.media, '[]'::jsonb),
+    COALESCE(rx.reactions, '[]'::jsonb)
+  FROM combined c
+  LEFT JOIN public.user_company_access a ON a.id = c.author_id
+  LEFT JOIN LATERAL (
+    SELECT jsonb_agg(jsonb_build_object(
+             'id', md.id,
+             'storage_path', md.storage_path,
+             'thumbnail_path', md.thumbnail_path,
+             'kind', md.kind,
+             'mime_type', md.mime_type,
+             'width', md.width,
+             'height', md.height
+           ) ORDER BY md.created_at) AS media
+    FROM public.note_media md
+    WHERE md.note_id = c.id
+  ) m ON true
+  LEFT JOIN LATERAL (
+    -- Reactions embed here because they are PUBLIC within the shop — the deliberate
+    -- opposite of note_views, which has no read path at any level. Names and counts
+    -- both derive from this one array client-side, so the number and the names can
+    -- never disagree; that is why there is no denormalized reaction counter.
+    SELECT jsonb_agg(jsonb_build_object(
+             'kind', x.kind,
+             -- WITHOUT THIS the reader can never be found in the array, so the
+             -- thumbs-up renders un-pressed on a note they have already marked
+             -- helpful, and tapping it again just re-inserts a duplicate. The
+             -- reaction was persisting the whole time; it simply could not be
+             -- recognised as theirs. Costs nothing extra: the join is already here.
+             'reactor_id', x.reactor_id,
+             'name', u.name,
+             'created_at', x.created_at
+           )) AS reactions
+    FROM public.note_reactions x
+    JOIN public.user_company_access u ON u.id = x.reactor_id
+    WHERE x.note_id = c.id
+  ) rx ON true
+  ORDER BY c.created_at DESC;
+$$;
+
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 2. my_note_digest(): views AND helpful, because both are what came back
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- The login banner reported views only. Being marked helpful is the stronger
+-- signal of the two — a view is someone needing to look something up, a helpful
+-- is a colleague choosing to say it was worth reading — so the banner should
+-- carry it.
+--
+-- Renamed from my_note_view_digest: a function returning helpful counts under a
+-- "view_digest" name is a lie the next reader has to discover. DROP + CREATE
+-- because the return type changes from a scalar to a row; types/database.ts is
+-- updated in the same commit, since the backend job diffs a byte-exact regen.
+--
+-- Still argument-free, permanently. A caller-supplied window would be a bisection
+-- oracle recovering WHEN a note was read; the banner subtracts running totals on
+-- the client, so no instant ever crosses the wire.
+--
+-- SECURITY INVOKER: `views` reads notes.viewer_count, a maintained aggregate on a
+-- row the caller can already SELECT, and `helpful` counts note_reactions, which is
+-- public inside the shop by policy. Neither touches note_views, so the privileged
+-- family stays at two (log_note_views, note_viewers).
+--
+-- helpful is counted, not denormalized, deliberately: reactions have no counter
+-- column precisely so a count and its names can never disagree.
+
+DROP FUNCTION IF EXISTS public.my_note_view_digest();
+
+CREATE OR REPLACE FUNCTION public.my_note_digest()
+RETURNS TABLE (views integer, helpful integer)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  WITH mine AS (
+    SELECT n.id, n.viewer_count
+    FROM public.notes n
+    WHERE n.author_id IS NOT NULL
+      AND n.author_id = public.get_operator_access_id(n.company_id)
+  )
+  SELECT
+    COALESCE((SELECT SUM(m.viewer_count) FROM mine m), 0)::integer,
+    COALESCE((
+      SELECT count(*)
+      FROM public.note_reactions x
+      JOIN mine m ON m.id = x.note_id
+      WHERE x.kind = 'helpful'
+    ), 0)::integer;
+$$;
+
+COMMENT ON FUNCTION public.my_note_digest() IS
+  'Running totals of what came back on the caller''s OWN notes: views (SUM of notes.viewer_count — the same definition My work shows) and helpful marks. Takes no arguments on purpose: a caller-supplied time window would be a bisection oracle recovering WHEN a note was read. The login banner stores the totals it last acknowledged and renders the differences, so the deltas are computed on the client and no instant ever crosses the wire. SECURITY INVOKER — reads only aggregates the caller may already select, never note_views.';
+
+REVOKE EXECUTE ON FUNCTION public.my_note_digest() FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.my_note_digest() TO authenticated;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -924,3 +924,77 @@ begin
     end loop;
   end loop;
 end $$;
+
+-- ═══ Endorsements ════════════════════════════════════════════════════════════
+-- The voluntary half of the loop. Without these every note reads as unendorsed
+-- and the thumbs-up looks like a feature nobody uses — the same reason the seed
+-- logs reads above.
+--
+-- Two rules the app enforces in SQL and the seed must not break: never your own
+-- note (self-endorsement is noise, and the INSERT policy refuses it), and one row
+-- per (note, reactor, kind).
+--
+-- Only 'helpful' is written. 'confirmed' remains in the CHECK constraint with no
+-- UI and nothing that writes it; seeding it would put rows on screen that no
+-- operator could have produced.
+do $$
+declare
+  v_co   uuid := '22222222-2222-2222-2222-222222222222';
+  v_pool uuid[] := array[
+    '23000000-0000-0000-0000-000000000005',   -- Diego Alvarez  (operator)
+    '23000000-0000-0000-0000-000000000006',   -- Priya Nair     (operator)
+    '23000000-0000-0000-0000-000000000003'    -- Sam Carter     (user)
+  ];
+  n        record;
+  v_reactor uuid;
+  v_take   int;
+  i        int;
+begin
+  for n in
+    select id, author_id,
+           (row_number() over (order by created_at, id))::int as rn
+    from public.notes
+    where company_id = v_co and note_type = 'user' and author_id is not null
+  loop
+    -- Endorsement is rarer than reading, and deliberately so: most notes carry
+    -- none. A seed where everything is endorsed would make the signal worthless
+    -- and hide the ordinary state.
+    v_take := case when n.rn % 3 = 0 then 2 when n.rn % 3 = 1 then 1 else 0 end;
+    for i in 1 .. v_take loop
+      v_reactor := v_pool[1 + ((n.rn + i) % array_length(v_pool, 1))];
+      continue when v_reactor = n.author_id;
+      insert into public.note_reactions (company_id, note_id, reactor_id, kind, created_at)
+      values (v_co, n.id, v_reactor, 'helpful', now() - ((n.rn % 6) || ' days')::interval)
+      on conflict do nothing;
+    end loop;
+  end loop;
+end $$;
+
+-- The durable part-subject notes are the ones people actually consult on a later
+-- run, so endorsement follows reading: give each at least one. The rotation above
+-- is a modulo lottery and left both of them at zero, which would have made the
+-- read-back surface — the Playbook and "previous notes" — look like the one place
+-- nobody found anything useful.
+do $$
+declare
+  v_co uuid := '22222222-2222-2222-2222-222222222222';
+  n record;
+  v_reactor uuid;
+begin
+  for n in
+    select id, author_id
+    from public.notes
+    where company_id = v_co and subject_kind = 'part' and note_type = 'user'
+      and author_id is not null
+  loop
+    -- Anyone but the author; the two operators cover each other's notes.
+    v_reactor := case
+      when n.author_id = '23000000-0000-0000-0000-000000000006'
+        then '23000000-0000-0000-0000-000000000005'
+      else '23000000-0000-0000-0000-000000000006'
+    end;
+    insert into public.note_reactions (company_id, note_id, reactor_id, kind, created_at)
+    values (v_co, n.id, v_reactor, 'helpful', now() - interval '3 days')
+    on conflict do nothing;
+  end loop;
+end $$;

--- a/types/database.ts
+++ b/types/database.ts
@@ -3477,7 +3477,13 @@ export type Database = {
         Args: { p_company_id: string; p_context?: Json; p_kind: string }
         Returns: undefined
       }
-      my_note_view_digest: { Args: never; Returns: number }
+      my_note_digest: {
+        Args: never
+        Returns: {
+          helpful: number
+          views: number
+        }[]
+      }
       next_order_number: { Args: { company_uuid: string }; Returns: number }
       no_client_access_grant_leaks: {
         Args: never

--- a/types/database.ts
+++ b/types/database.ts
@@ -3513,6 +3513,7 @@ export type Database = {
           p_routing_operation_id?: string
         }
         Returns: {
+          author_id: string
           author_name: string
           body: string
           corrects_note_id: string

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -264,6 +264,13 @@ export interface JobNote {
   /** Author display name (from user_company_access.name); null if unknown. */
   author_name: string | null;
   /**
+   * Author's user_company_access id. Needed because note_reactions' INSERT policy
+   * forbids reacting to your OWN note, so the thumbs-up must be hidden there —
+   * otherwise the tap is a guaranteed 42501 that reads as a broken button.
+   * Matching on author_name instead breaks on two people with the same name.
+   */
+  author_id: string | null;
+  /**
    * What the note is ABOUT, which is not the same as where it was captured.
    * 'part' is the durable subject — anchored to (part, routing step), so it
    * outlives the job and is what the next person running the part reads.
@@ -283,6 +290,25 @@ export interface JobNote {
   usage_count: number;
   /** Attached photos/videos, in insertion order. */
   media: JobNoteMedia[];
+  /**
+   * Public, attributable endorsements — the deliberate opposite of note_views.
+   * Count and names both derive from this one array, so they can never disagree;
+   * that is why there is no denormalized reaction counter anywhere.
+   */
+  reactions: NoteReaction[];
+}
+
+/**
+ * One reaction on a note. `kind` is CHECK-limited to 'helpful' | 'confirmed' in
+ * the database and there is no negative option — not deferred, structurally
+ * absent. Only 'helpful' has a UI today.
+ */
+export interface NoteReaction {
+  kind: 'helpful' | 'confirmed';
+  /** Reactor's user_company_access id — drives "have I already reacted?". */
+  reactor_id: string;
+  /** Reactor's display name. Reactions are public inside the shop. */
+  name: string | null;
 }
 
 /**
@@ -340,6 +366,11 @@ export interface MyNote {
   job_id: string | null;
   job_number: string | null;
   photo_count: number;
+  /**
+   * Endorsements RECEIVED. My work shows these read-only: you cannot react to
+   * your own note, so here they are reception, not an available action.
+   */
+  reactions: NoteReaction[];
   /** Distinct PEOPLE who read it. Saturates near shop size — that is its meaning. */
   viewer_count: number;
   /**

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -37,6 +37,7 @@ import type {
   MyContribution,
   MyNote,
   NoteViewer,
+  NoteReaction,
 } from '@/types/operator';
 
 // ============================================================================
@@ -1276,10 +1277,33 @@ const JOB_NOTE_SELECT =
   'id, subject_kind, job_id, job_operation_id, captured_job_id, ' +
   'captured_job_operation_id, part_id, routing_operation_id, ' +
   'viewer_count, usage_count, body, note_type, created_at, ' +
-  'author:user_company_access(name), ' +
+  'author_id, author:user_company_access(name), ' +
+  // Reactions embed because they are PUBLIC within the shop — the deliberate
+  // opposite of note_views, which has no client read path at any level. Count and
+  // names both derive from this one array, so they can never disagree; that is
+  // why no denormalized reaction counter exists.
+  'reactions:note_reactions(kind, reactor_id, reactor:user_company_access(name)), ' +
   'operation:job_operations!notes_job_operation_fk(operation_name, sequence), ' +
   'captured_operation:job_operations!notes_captured_job_operation_fk(operation_name, sequence), ' +
   'media:note_media(id, note_id, storage_path, thumbnail_path, kind, mime_type, width, height)';
+
+type ReactionRel = {
+  kind: string;
+  reactor_id: string;
+  reactor: { name: string | null } | { name: string | null }[] | null;
+};
+
+/** Shared decode for both read paths (PostgREST embed and the playbook RPC's jsonb). */
+function mapReactions(rows: ReactionRel[] | null | undefined): NoteReaction[] {
+  return (rows ?? []).map((r) => {
+    const reactor = Array.isArray(r.reactor) ? r.reactor[0] : r.reactor;
+    return {
+      kind: r.kind === 'confirmed' ? ('confirmed' as const) : ('helpful' as const),
+      reactor_id: r.reactor_id,
+      name: reactor?.name ?? null,
+    };
+  });
+}
 
 type StepRel =
   | { operation_name: string | null; sequence: number | null }
@@ -1300,7 +1324,9 @@ type JobNoteRow = {
   body: string | null;
   note_type: string | null;
   created_at: string;
+  author_id: string | null;
   author: { name: string | null } | { name: string | null }[] | null;
+  reactions: ReactionRel[] | null;
   operation: StepRel;
   captured_operation: StepRel;
   media: Array<{
@@ -1339,6 +1365,8 @@ function mapJobNoteRow(n: JobNoteRow): JobNote {
   }));
   return {
     id: n.id,
+    author_id: n.author_id,
+    reactions: mapReactions(n.reactions),
     // The job this note belongs to FROM THE FEED'S POINT OF VIEW: its own job for a
     // job-subject note, the capturing job for a durable part-subject one.
     job_id: n.job_id ?? n.captured_job_id ?? '',
@@ -1526,11 +1554,14 @@ type PlaybookRow = {
   corrects_note_id: string | null;
   viewer_count: number;
   usage_count: number;
+  author_id: string | null;
   author_name: string | null;
   job_number: string | null;
   operation_label: string | null;
   media: JobNoteMedia[] | null;
-  reactions: unknown;
+  // The RPC aggregates these as jsonb with the same field names the PostgREST
+  // embed produces, so mapReactions decodes both paths.
+  reactions: ReactionRel[] | null;
 };
 
 /**
@@ -1622,6 +1653,8 @@ export async function getPartPreviousNotes(
     note_type: r.note_type === 'event' ? 'event' : 'user',
     created_at: r.created_at,
     author_name: r.author_name,
+    author_id: r.author_id,
+    reactions: mapReactions(r.reactions),
     subject_kind:
       r.subject_kind === 'part' || r.subject_kind === 'work_center'
         ? r.subject_kind
@@ -1672,6 +1705,9 @@ export async function getMyContribution(companyId: string): Promise<MyContributi
         'operation:job_operations!notes_job_operation_fk(operation_name, sequence), ' +
         'captured_operation:job_operations!notes_captured_job_operation_fk(operation_name, sequence), ' +
         'part:parts(part_name), ' +
+        // Read-only here: RLS forbids reacting to your own note, so on My work
+        // these are reception rather than an available action.
+        'reactions:note_reactions(kind, reactor_id, reactor:user_company_access(name)), ' +
         // Both job FKs: a job-subject note carries job_id, a durable
         // part-subject one carries only captured_job_id. Either way the author
         // gets a way back to where they wrote it.
@@ -1696,6 +1732,7 @@ export async function getMyContribution(companyId: string): Promise<MyContributi
     operation: StepRel;
     captured_operation: StepRel;
     part: { part_name: string | null } | { part_name: string | null }[] | null;
+    reactions: ReactionRel[] | null;
     job: JobRel;
     captured_job: JobRel;
     media: Array<{ id: string }> | null;
@@ -1718,6 +1755,7 @@ export async function getMyContribution(companyId: string): Promise<MyContributi
       operation_label: stepLabel(r.operation) ?? stepLabel(r.captured_operation),
       part_name: part?.part_name ?? null,
       photo_count: (r.media ?? []).length,
+      reactions: mapReactions(r.reactions),
       viewer_count: r.viewer_count,
       usage_count: r.usage_count,
     };
@@ -1749,4 +1787,79 @@ export async function getNoteViewers(noteId: string): Promise<NoteViewer[]> {
   const { data, error } = await supabase.rpc('note_viewers', { p_note_id: noteId });
   if (error || !data) return [];
   return data as unknown as NoteViewer[];
+}
+
+
+// ============================================================================
+// REACTIONS — public, attributable endorsement
+// ============================================================================
+
+/**
+ * Mark a note helpful, or take it back.
+ *
+ * The deliberate opposite of view logging. A view is involuntary and private —
+ * a record that someone needed to look something up, which is why note_views has
+ * no client read path at all. A reaction is a voluntary claim, so it is public
+ * inside the shop, attributable by name, and removable only by the person who
+ * made it (admins cannot curate the record of what the shop found useful).
+ *
+ * Everything that could go wrong is refused by RLS rather than trusted here:
+ * you cannot forge someone else's reactor_id, and you cannot react to your own
+ * note. The UI hides the control on your own notes so the refusal is never
+ * reached — see NoteReactions — but the database is the enforcement.
+ *
+ * Errors are thrown, not swallowed: unlike view logging (fire-and-forget,
+ * Sentry-only), a reaction is a deliberate act and the caller rolls back its
+ * optimistic state if it fails.
+ */
+export async function addReaction(
+  companyId: string,
+  noteId: string,
+  kind: NoteReaction['kind'] = 'helpful',
+): Promise<void> {
+  const supabase = getSupabase();
+
+  const member = await getCurrentMember(companyId);
+  if (!member) throw new Error('Not a member of this company.');
+
+  const { error } = await supabase.from('note_reactions').insert({
+    company_id: companyId,
+    note_id: noteId,
+    reactor_id: member.id,
+    kind,
+  });
+
+  // A duplicate is the unique constraint doing its job — two taps racing, or a
+  // second device. The end state is what the caller asked for, so it is not an
+  // error to report.
+  if (error && error.code !== '23505') {
+    throw new Error(
+      friendlyErrorMessage(error, { entity: 'reaction', fallback: 'Could not save that.' }),
+    );
+  }
+}
+
+/** Remove your own reaction. The DELETE policy scopes this to the caller. */
+export async function removeReaction(
+  companyId: string,
+  noteId: string,
+  kind: NoteReaction['kind'] = 'helpful',
+): Promise<void> {
+  const supabase = getSupabase();
+
+  const member = await getCurrentMember(companyId);
+  if (!member) throw new Error('Not a member of this company.');
+
+  const { error } = await supabase
+    .from('note_reactions')
+    .delete()
+    .eq('note_id', noteId)
+    .eq('reactor_id', member.id)
+    .eq('kind', kind);
+
+  if (error) {
+    throw new Error(
+      friendlyErrorMessage(error, { entity: 'reaction', fallback: 'Could not undo that.' }),
+    );
+  }
 }


### PR DESCRIPTION
Iteration B2 of the attribution / read-back loop. Builds on #605/#606/#608/#609.

## What it does

A 👍 **Helpful** on note cards, with the names of who marked it. This is the **voluntary** half of the loop and the deliberate opposite of view logging:

| | `note_views` | `note_reactions` |
|---|---|---|
| Nature | involuntary — you needed to look something up | voluntary — a claim you chose to make |
| Visibility | **no client read path at any level** | public inside the shop, by name |
| Who can remove | n/a (monotonic) | only the person who made it — **not admins** |

Three surfaces: the job feed, the previous-notes sheet (where prior knowledge is actually read, so the one that matters most), and **My work read-only** — RLS forbids reacting to your own note, so there endorsements are *reception*, the same category as the view count beside them.

## No thumbs down — structurally, not as a deferral

`kind` is CHECK-limited to `('helpful','confirmed')`. There is no schema slot for a negative. An inaccurate note gets **corrected** (`corrects_note_id`) or superseded, never publicly judged — nobody on a fifteen-person floor writes a second note after being downvoted by a colleague they see every morning.

`confirmed` keeps its CHECK value with no UI, and is filtered out of the count so a stray row can't inflate anything.

## The one migration, and why it was forced

The INSERT policy refuses self-reaction, so the control has to be hidden on your own notes — otherwise every tap there is a guaranteed `42501` that reads to an operator as a broken button. Deciding that needs an **id**, and `part_playbook_notes` returned only `author_name`; matching on a display name breaks the first time a shop employs two Daves.

`DROP` + `CREATE` because `RETURNS TABLE` can't change in place. Both CTEs already carried `author_id` — the body gains two lines. No new tables, no policy changes.

## Behaviour

- **Optimistic with rollback.** On shop wifi a thumbs-up that waits for a round trip reads as broken. A failure rolls the button back and goes to Sentry — no toast, because an operator mid-job doesn't need a dialog about a thumbs-up.
- **A duplicate insert is success.** Two taps racing, or a second device: the end state is what the caller asked for.
- **Count and names come from the same array**, so they can never disagree — which is why no denormalized reaction counter exists.
- **No `operator_events` kind for reactions**, deliberately: `note_reactions` already records who reacted, to what, and when. A parallel funnel event would duplicate it and drift.

## Seed

Endorsements added, or the feature looks unused on the preview. The **durable part-subject notes are guaranteed at least one** — endorsement follows reading, and those are what the Playbook surfaces; the modulo rotation had left all three at zero. Verified in a rolled-back transaction: `helpful` only, zero self-endorsements.

## A latent problem this exposed

`__tests__` is excluded from `tsconfig.json`, so five test files were constructing `JobNote`/`MyNote` literals that no longer satisfied the type — and nothing caught it until the tests threw at runtime. Fixtures fixed here; the broader gap (test fixtures drift silently from types) is worth its own issue.

## The guardrail line

Reactions are safe because they attach to a **note**. They become the thing this module refuses the moment they're summed **per person** — "Diego has 47 thumbs-ups" is a leaderboard, "Priya gave 3" is a participation score. Nothing aggregates them that way, including My work.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` — 17 warnings (unchanged budget), 0 errors
- `pnpm test --run __tests__/components/operator __tests__/app/operator __tests__/utils` — **672 passed**, 12 new for the component and 5 for the write path

## To verify visually

1. Sign in as `operator1@jigged.test`, open a job → step → the feed. Notes by others show **Helpful** with names; your own show a count with no button.
2. Tap Helpful — it moves instantly, and again to take it back.
3. Open **Previous notes** on a part with prior runs — endorsements on the durable notes.
4. **My work** — reactions received, read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)