### PR TITLE
feat(operator): rank the Playbook by usefulness (B3)

### DIFF
--- a/__tests__/components/operator/PartReferenceRow.test.tsx
+++ b/__tests__/components/operator/PartReferenceRow.test.tsx
@@ -32,7 +32,7 @@ beforeEach(() => {
   mock(countPartPreviousNotes).mockResolvedValue(0);
 });
 
-// The read-back gap this fixes: the affordance used to be a bare "Previous notes"
+// The read-back gap this fixes: the affordance used to be a bare "Playbook"
 // label, so an operator had no way to tell whether anything was behind it — while
 // Files sat right next to it showing a count. Knowledge nobody knows exists is not
 // reachable, whatever the tap count says.
@@ -41,7 +41,7 @@ describe('PartReferenceRow — previous-notes count', () => {
     mock(countPartPreviousNotes).mockResolvedValue(3);
     renderRow();
 
-    expect(await screen.findByRole('button', { name: 'Previous notes · 3' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Playbook · 3' })).toBeInTheDocument();
   });
 
   it('stays a bare label when there is nothing to read', async () => {
@@ -50,7 +50,7 @@ describe('PartReferenceRow — previous-notes count', () => {
     renderRow();
 
     await waitFor(() => expect(countPartPreviousNotes).toHaveBeenCalled());
-    expect(screen.getByRole('button', { name: 'Previous notes' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Playbook' })).toBeInTheDocument();
   });
 
   it('excludes the current job, so a note is never "previous" to itself', async () => {
@@ -70,6 +70,6 @@ describe('PartReferenceRow — previous-notes count', () => {
     mock(countPartPreviousNotes).mockRejectedValue(new Error('offline'));
     renderRow();
 
-    expect(await screen.findByRole('button', { name: 'Previous notes' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Playbook' })).toBeInTheDocument();
   });
 });

--- a/api/tests/integration/test_note_views_rls.py
+++ b/api/tests/integration/test_note_views_rls.py
@@ -19,6 +19,7 @@ TEST_SUPABASE_PUBLISHABLE_KEY / TEST_SUPABASE_SECRET_KEY). Skipped without it.
 from __future__ import annotations
 
 import os
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from supabase import create_client
@@ -161,25 +162,30 @@ def shop(supabase_admin):
             pass
 
 
-def _make_note(shop, body: str = "back the feed off on the last pass") -> str:
-    """A DURABLE part-subject note authored by `author`, captured on job A."""
-    return (
-        shop["admin"]
-        .table("notes")
-        .insert(
-            {
-                "company_id": shop["company_id"],
-                "subject_kind": "part",
-                "part_id": shop["part_id"],
-                "routing_operation_id": shop["routing_operation_id"],
-                "captured_job_id": shop["job_a"],
-                "author_id": shop["author"]["access_id"],
-                "body": body,
-            }
-        )
-        .execute()
-        .data[0]["id"]
-    )
+def _make_note(
+    shop, body: str = "back the feed off on the last pass", days_ago: int | None = None
+) -> str:
+    """A DURABLE part-subject note authored by `author`, captured on job A.
+
+    `days_ago` matters for the ranking tests: the Playbook pins anything from the
+    last 14 days newest-first, so a note created NOW is ordered by recency and
+    tells you nothing about usefulness ranking. Age it past the window to exercise
+    that half.
+    """
+    row = {
+        "company_id": shop["company_id"],
+        "subject_kind": "part",
+        "part_id": shop["part_id"],
+        "routing_operation_id": shop["routing_operation_id"],
+        "captured_job_id": shop["job_a"],
+        "author_id": shop["author"]["access_id"],
+        "body": body,
+    }
+    if days_ago is not None:
+        row["created_at"] = (
+            datetime.now(timezone.utc) - timedelta(days=days_ago)
+        ).isoformat()
+    return shop["admin"].table("notes").insert(row).execute().data[0]["id"]
 
 
 def _counts(shop, note_id: str) -> tuple[int, int]:
@@ -733,6 +739,72 @@ def test_a_reaction_can_never_be_edited(shop):
         shop["reader"]["client"].table("note_reactions").update(
             {"kind": "confirmed"}
         ).eq("note_id", note_id).execute()
+
+
+def test_playbook_ranks_the_load_bearing_note_first(shop):
+    """Newest-first buried the note that had actually been consulted. usage_count
+    is behavioural — someone reached for it while doing the work — so it outranks
+    both recency and an opinion offered afterwards."""
+    # Both aged past the 14-day guard, and the VETERAN is the OLDER of the two —
+    # so if ordering were still recency-based this would fail.
+    veteran = _make_note(shop, "seat the bearings with the arbor fixture", days_ago=90)
+    curiosity = _make_note(shop, "read this once, never again", days_ago=30)
+
+    # The veteran is consulted on two jobs; the other on none.
+    for job in (shop["job_a"], shop["job_b"]):
+        shop["reader"]["client"].rpc(
+            "log_note_views", {"p_note_ids": [veteran], "p_job_id": job}
+        ).execute()
+
+    rows = (
+        shop["reader"]["client"]
+        .rpc("part_playbook_notes", {"p_part_id": shop["part_id"]})
+        .execute()
+        .data
+    )
+    ids = [r["id"] for r in rows]
+    assert ids.index(veteran) < ids.index(curiosity)
+
+
+def test_a_fresh_note_is_never_buried_by_a_veteran(shop):
+    """THE GUARD. Pure usefulness ranking sinks a correction written this morning
+    below an old note with a long history — and on a shop floor the fresh warning
+    is the one that must be seen. The original plan solved this with a 'confirmed'
+    reaction and visual decay; both were dropped, so this carries it alone."""
+    veteran = _make_note(shop, "the long-standing way we run this", days_ago=90)
+    for job in (shop["job_a"], shop["job_b"]):
+        shop["reader"]["client"].rpc(
+            "log_note_views", {"p_note_ids": [veteran], "p_job_id": job}
+        ).execute()
+
+    # Written today, never consulted: usage_count 0. Usefulness alone would sink it.
+    fresh = _make_note(shop, "FIXTURE CHANGED - the old arbor is scrapped")
+
+    rows = (
+        shop["reader"]["client"]
+        .rpc("part_playbook_notes", {"p_part_id": shop["part_id"]})
+        .execute()
+        .data
+    )
+    ids = [r["id"] for r in rows]
+    assert ids.index(fresh) < ids.index(veteran)
+
+
+def test_helpful_breaks_a_usage_tie(shop):
+    # Aged past the guard, and the ENDORSED one is older, so recency cannot be
+    # what puts it first.
+    b = _make_note(shop, "equally used, endorsed", days_ago=90)
+    a = _make_note(shop, "equally used, unendorsed", days_ago=30)
+    _react(shop["reader"]["client"], shop, b, shop["reader"]["access_id"])
+
+    rows = (
+        shop["reader"]["client"]
+        .rpc("part_playbook_notes", {"p_part_id": shop["part_id"]})
+        .execute()
+        .data
+    )
+    ids = [r["id"] for r in rows]
+    assert ids.index(b) < ids.index(a)
 
 
 def test_playbook_reactions_say_who_reacted(shop):

--- a/components/operator/PartNotesSheet.tsx
+++ b/components/operator/PartNotesSheet.tsx
@@ -95,9 +95,23 @@ function NoteRow({
 }
 
 /**
- * Full-screen "previous notes for this part" sheet. A flat, newest-first stream
- * of notes captured on PRIOR completed runs of the part — the accumulated shop
- * wisdom (setup tips, gotchas, photos) — rather than a list of past jobs. Each
+ * The part's Playbook: everything the shop has learned about running it, ranked
+ * so the useful thing is first — not a list of past jobs.
+ *
+ * ORDERING lives in part_playbook_notes, and is usefulness-first with a recency
+ * guard: anything from the last 14 days stays newest-first at the top, and
+ * everything older ranks by usage_count (distinct jobs it was consulted on) then
+ * helpful marks. Newest-first alone buried the load-bearing note on any part with
+ * several; pure usefulness would bury a correction written this morning, which on
+ * a shop floor is the dangerous direction.
+ *
+ * WHY THIS IS A SHEET AND NOT A PAGE. Operators already carry an annotated paper
+ * print, and paper wins on always-there and on spatial indexing — a margin note
+ * points AT a feature, which a text list cannot reproduce. What digital adds is
+ * that the knowledge survives the sheet being lost or superseded, exists in more
+ * than one place, and carries attribution and reception. All of that lands at the
+ * machine, one tap from the step. A browsable page would have asked an operator to
+ * go LOOKING for knowledge while off a job, which is exactly when they will not. Each
  * note shows its author, the step it was tagged to, a light source-job
  * reference, and its photos. When opened from an operation (jobOperationId set),
  * a "This step / All part" toggle narrows to the same step. Read-only, part-
@@ -180,7 +194,7 @@ export default function PartNotesSheet({
         <Toolbar>
           <Box sx={{ flex: 1, minWidth: 0 }}>
             <Typography variant="h6" noWrap>
-              Previous notes
+              Playbook
             </Typography>
             {partName && (
               <Typography variant="caption" color="text.secondary" noWrap component="div">

--- a/components/operator/PartReferenceRow.tsx
+++ b/components/operator/PartReferenceRow.tsx
@@ -26,7 +26,7 @@ interface PartReferenceRowProps {
  *
  * Files (drawings / STEP models) lead and show a count, because they're often
  * required to actually do the job — an operator shouldn't have to discover a
- * drawing exists by tapping a bare icon. Previous notes is a lighter, optional
+ * drawing exists by tapping a bare icon. The Playbook is a lighter, optional
  * reference. Both live in the content, deliberately apart from the header's
  * navigation and the account logout (which lives on the Profile tab), so a
  * frequent job-reference tap is never next to a destructive one — the mis-tap
@@ -80,7 +80,7 @@ export default function PartReferenceRow({
         onClick={() => setNotesOpen(true)}
         sx={{ minHeight: 48, fontWeight: hasNotes ? 700 : 400 }}
       >
-        {hasNotes ? `Previous notes · ${noteCount}` : 'Previous notes'}
+        {hasNotes ? `Playbook · ${noteCount}` : 'Playbook'}
       </Button>
 
       {filesOpen && (

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -212,6 +212,43 @@ see this", not "nobody can".
 a note and stayed on it. Whether they acted on it is not measured, and claiming it
 makes every number a small lie the author can personally disprove by asking.
 
+### The Playbook (previous notes)
+
+`PartNotesSheet`, opened from the op card's **Playbook · N**. Everything the shop
+has learned about running this part, ranked so the useful thing is first.
+
+**Ordering** lives in `part_playbook_notes`: usefulness-first with a recency
+guard.
+
+1. Anything from the **last 14 days**, newest-first
+2. Then `usage_count` — distinct jobs it was consulted on, the strongest signal
+   we have because it records someone reaching for the note *while doing the
+   work*, not an opinion offered afterwards
+3. Then helpful marks, then recency
+
+Newest-first alone buried the load-bearing note on any part with several. Pure
+usefulness would bury a correction written this morning below an old note with a
+long history, which on a shop floor is the dangerous direction — the original
+plan handled that with a `confirmed` reaction and visual decay of stale entries,
+and both were dropped, so the 14-day guard carries it alone. The window is a
+judgement, not a finding; revisit it with real data.
+
+**Why this is a sheet and not a page.** Operators already carry an annotated
+paper print, and paper wins on two things we cannot match: it is always at the
+machine, and its annotations are *spatially indexed* — a margin note points AT a
+feature, which a text list cannot reproduce. What digital adds is narrower and
+real: the knowledge survives the sheet being lost or superseded by a revision, it
+exists in more than one place (one annotated print sits at one machine), and it
+carries attribution and reception. All three land one tap from the step. A
+browsable `/parts/{partId}/playbook` route was planned and **deliberately not
+built**: it would have asked an operator to go *looking* for knowledge while off
+a job, which is exactly when they will not. If a part ever needs a destination of
+its own, that is the moment to add one — not before.
+
+**Corrections are not built either.** `corrects_note_id` exists in the schema
+with no writer anywhere, so a corrections section would be a display for
+something nothing can create.
+
 ### Reactions (`helpful`)
 
 The **voluntary** half of the loop, and the deliberate opposite of view logging.
@@ -406,6 +443,12 @@ Each bullet is a Given/When/Then scenario carrying a verification clause — a p
 - [ ] **Given** a non-zero banner, **when** the operator taps it, **then** it navigates to My work AND banks the whole total; **when** they tap its close button, **then** it dismisses **without** navigating — *verified by `__tests__/components/operator/NoteUsageBanner.test.tsx`*.
 - [ ] **Given** My work, **when** it renders with any data, **then** no completion count, streak, average, pace or rank appears anywhere on the page — *verified by `__tests__/app/operator/MyWorkPage.test.tsx > 'shows no completion count, streak, average or pace'`*.
 - [ ] **Given** a note whose job has been deleted, **when** My work renders it, **then** the note survives and only the job link is absent — *verified by `__tests__/app/operator/MyWorkPage.test.tsx`*.
+
+**Playbook ordering**
+
+- [ ] **Given** two notes both older than the recency window, **when** the Playbook loads, **then** the one consulted on more jobs comes first even if it is the older — *verified by `api/tests/integration/test_note_views_rls.py > test_playbook_ranks_the_load_bearing_note_first`*.
+- [ ] **Given** a note written today with zero usage and a veteran with several jobs, **when** the Playbook loads, **then** the fresh note is above it — a correction must never be buried — *verified by `api/tests/integration/test_note_views_rls.py > test_a_fresh_note_is_never_buried_by_a_veteran`*.
+- [ ] **Given** two equally-used notes, **when** one carries a helpful mark, **then** it ranks first — *verified by `api/tests/integration/test_note_views_rls.py > test_helpful_breaks_a_usage_tie`*.
 
 **Reactions**
 

--- a/e2e/operator-notes-loop.spec.ts
+++ b/e2e/operator-notes-loop.spec.ts
@@ -64,9 +64,9 @@ test.describe('operator read-back loop', () => {
     await openTravelerFor(page, 'E2E-JS-NOTSTARTED');
 
     // 1. The affordance advertises that there is something to read. This is the
-    //    discoverability half — it used to be a bare "Previous notes" label while
+    //    discoverability half — it used to be a bare "Playbook" label while
     //    Files beside it showed a count.
-    const priorNotes = page.getByRole('button', { name: /^Previous notes · \d+$/ });
+    const priorNotes = page.getByRole('button', { name: /^Playbook · \d+$/ });
     await expect(priorNotes).toBeVisible({ timeout: 30_000 });
 
     // 2. The knowledge itself, written against a DIFFERENT job for this part.

--- a/supabase/migrations/20260729161455_playbook_rank_by_usefulness.sql
+++ b/supabase/migrations/20260729161455_playbook_rank_by_usefulness.sql
@@ -1,0 +1,190 @@
+-- part_playbook_notes(): rank by usefulness, with a guard so nothing recent is buried.
+--
+-- Newest-first was safe but wrong on a part with several notes — the note actually
+-- consulted on eleven jobs could sit fourth, below three read once out of
+-- curiosity. That is the problem the Playbook work exists to solve, and it turns
+-- out to be an ORDER BY rather than a new screen: PartNotesSheet already puts this
+-- knowledge one tap from the machine, which is where it beats an annotated paper
+-- print. A browsable page would have asked the operator to go LOOKING for knowledge
+-- when off a job, which is exactly when they will not.
+--
+-- Body-only change: same signature, same RETURNS TABLE, so CREATE OR REPLACE is
+-- enough and types/database.ts is untouched. helpful_count is computed for ordering
+-- and deliberately not returned — the client counts the names array, which is what
+-- keeps a count and its names from ever disagreeing.
+
+CREATE OR REPLACE FUNCTION public.part_playbook_notes(
+  p_part_id              uuid,
+  -- The step, when scoping to one. NULL returns everything known about the part.
+  p_routing_operation_id uuid    DEFAULT NULL,
+  -- Legacy step-name fallback, for prior-run job notes whose job_operation has no
+  -- routing_operation_id (an ad-hoc step added to a job). Mirrors the fallback that
+  -- matchingStepOperationIds() used.
+  p_operation_name       text    DEFAULT NULL,
+  -- The current job: its own notes are already in the job feed, so they are not
+  -- "previous" notes.
+  p_exclude_job_id       uuid    DEFAULT NULL,
+  -- Bounds branch 2 only. Branch 1 needs no cap — it is one indexed lookup.
+  p_max_runs             integer DEFAULT 10
+)
+RETURNS TABLE (
+  id                   uuid,
+  body                 text,
+  created_at           timestamptz,
+  note_type            text,
+  subject_kind         text,
+  routing_operation_id uuid,
+  corrects_note_id     uuid,
+  viewer_count         integer,
+  usage_count          integer,
+  -- NEW: the reaction UI must not offer a thumbs-up on your own note — RLS
+  -- forbids it, so the button would be a guaranteed 42501. Only an id can decide
+  -- that; matching on author_name breaks the moment a shop has two Daves.
+  author_id            uuid,
+  author_name          text,
+  job_number           text,
+  operation_label      text,
+  media                jsonb,
+  reactions            jsonb
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  WITH durable AS (
+    -- BRANCH 1 — the durable subject. One index hit on idx_notes_part_step. No prior
+    -- runs, no step-name heuristic, no cap. This is every note written after the
+    -- subject migration, and it is what makes the read-back loop possible at all.
+    SELECT
+      n.id, n.body, n.created_at, n.note_type, n.subject_kind, n.routing_operation_id,
+      n.corrects_note_id, n.viewer_count, n.usage_count, n.author_id,
+      cj.job_number AS src_job_number,
+      CASE
+        WHEN ro.id IS NULL THEN NULL
+        ELSE 'Op ' || ro.sequence::text ||
+             COALESCE(' · ' || wc.name, '')
+      END AS src_operation_label
+    FROM public.notes n
+    LEFT JOIN public.jobs cj              ON cj.id = n.captured_job_id
+    LEFT JOIN public.routing_operations ro ON ro.id = n.routing_operation_id
+    LEFT JOIN public.work_centers wc       ON wc.id = ro.work_center_id
+    WHERE n.subject_kind = 'part'
+      AND n.part_id = p_part_id
+      AND (p_routing_operation_id IS NULL
+           OR n.routing_operation_id = p_routing_operation_id)
+      -- Captured on the job the operator is standing in front of: already visible in
+      -- that job's feed, so showing it again as "previous" is noise.
+      AND (p_exclude_job_id IS NULL
+           OR n.captured_job_id IS DISTINCT FROM p_exclude_job_id)
+  ),
+  runs AS (
+    -- BRANCH 2 scaffolding — the most recent completed runs of this part.
+    SELECT jp.job_id, j.job_number
+    FROM public.job_parts jp
+    JOIN public.jobs j ON j.id = jp.job_id
+    WHERE jp.part_id = p_part_id
+      AND jp.production_status = 'completed'
+      AND (p_exclude_job_id IS NULL OR jp.job_id <> p_exclude_job_id)
+    ORDER BY jp.completed_at DESC NULLS LAST
+    LIMIT p_max_runs
+  ),
+  legacy AS (
+    -- BRANCH 2 — pre-migration notes, which are all subject_kind = 'job'. Step match
+    -- by routing_operation_id, falling back to operation_name when the job's step has
+    -- no routing link. Delete this branch once the old corpus stops mattering.
+    SELECT
+      n.id, n.body, n.created_at, n.note_type, n.subject_kind, n.routing_operation_id,
+      n.corrects_note_id, n.viewer_count, n.usage_count, n.author_id,
+      r.job_number AS src_job_number,
+      CASE
+        WHEN jo.id IS NULL THEN NULL
+        WHEN jo.sequence IS NULL THEN jo.operation_name
+        ELSE 'Op ' || jo.sequence::text || ' · ' || jo.operation_name
+      END AS src_operation_label
+    FROM runs r
+    JOIN public.notes n ON n.job_id = r.job_id AND n.subject_kind = 'job'
+    LEFT JOIN public.job_operations jo ON jo.id = n.job_operation_id
+    WHERE p_routing_operation_id IS NULL
+       OR jo.routing_operation_id = p_routing_operation_id
+       OR (jo.routing_operation_id IS NULL
+           AND p_operation_name IS NOT NULL
+           AND jo.operation_name = p_operation_name)
+  ),
+  combined AS (
+    SELECT * FROM durable
+    UNION ALL
+    SELECT * FROM legacy
+  )
+  SELECT
+    c.id, c.body, c.created_at, c.note_type, c.subject_kind, c.routing_operation_id,
+    c.corrects_note_id, c.viewer_count, c.usage_count,
+    c.author_id,
+    a.name AS author_name,
+    c.src_job_number,
+    c.src_operation_label,
+    COALESCE(m.media, '[]'::jsonb),
+    COALESCE(rx.reactions, '[]'::jsonb)
+  FROM combined c
+  LEFT JOIN public.user_company_access a ON a.id = c.author_id
+  LEFT JOIN LATERAL (
+    SELECT jsonb_agg(jsonb_build_object(
+             'id', md.id,
+             'storage_path', md.storage_path,
+             'thumbnail_path', md.thumbnail_path,
+             'kind', md.kind,
+             'mime_type', md.mime_type,
+             'width', md.width,
+             'height', md.height
+           ) ORDER BY md.created_at) AS media
+    FROM public.note_media md
+    WHERE md.note_id = c.id
+  ) m ON true
+  LEFT JOIN LATERAL (
+    -- Reactions embed here because they are PUBLIC within the shop — the deliberate
+    -- opposite of note_views, which has no read path at any level. Names and counts
+    -- both derive from this one array client-side, so the number and the names can
+    -- never disagree; that is why there is no denormalized reaction counter.
+    SELECT jsonb_agg(jsonb_build_object(
+             'kind', x.kind,
+             -- WITHOUT THIS the reader can never be found in the array, so the
+             -- thumbs-up renders un-pressed on a note they have already marked
+             -- helpful, and tapping it again just re-inserts a duplicate. The
+             -- reaction was persisting the whole time; it simply could not be
+             -- recognised as theirs. Costs nothing extra: the join is already here.
+             'reactor_id', x.reactor_id,
+             'name', u.name,
+             'created_at', x.created_at
+           )) AS reactions,
+           count(*) FILTER (WHERE x.kind = 'helpful') AS helpful_count
+    FROM public.note_reactions x
+    JOIN public.user_company_access u ON u.id = x.reactor_id
+    WHERE x.note_id = c.id
+  ) rx ON true
+  -- RANKING: the load-bearing note first, EXCEPT that nothing recent gets buried.
+  --
+  -- Newest-first was safe but wrong on a part with several notes: the one that has
+  -- actually been consulted on eleven jobs could sit fourth, below three that were
+  -- read once out of curiosity. Ranking by usefulness fixes that.
+  --
+  -- The recency guard is not a nicety. Pure usefulness ranking sinks a note written
+  -- this morning about a changed fixture below an old note with a long history —
+  -- and on a shop floor the fresh correction is the one that must be seen. The
+  -- original plan solved this with a 'confirmed' reaction and visual decay of stale
+  -- entries; both were dropped, so the guard carries that weight alone.
+  --
+  -- 14 days is a judgement, not a finding: long enough to cover a part that runs
+  -- monthly, short enough that the pinned group stays small. Worth revisiting with
+  -- real data.
+  ORDER BY
+    (c.created_at >= now() - interval '14 days') DESC,
+    -- Within the recent group, newest first. NULL for older notes, which the first
+    -- key has already partitioned below, so they tie here and fall through.
+    CASE WHEN c.created_at >= now() - interval '14 days' THEN c.created_at END DESC,
+    -- Distinct JOBS it was consulted on: behavioural, and the strongest signal we
+    -- have. It beats helpful because it records someone reaching for the note while
+    -- doing the work, not an opinion offered afterwards.
+    c.usage_count DESC,
+    COALESCE(rx.helpful_count, 0) DESC,
+    c.created_at DESC;
+$$;


### PR DESCRIPTION
B3, and **deliberately smaller than planned** — see below.

## The problem

Newest-first buried the load-bearing note. On a part with several notes, the one actually consulted on eleven jobs could sit fourth, below three read once out of curiosity. That's what the Playbook work exists to fix, and it turns out to be an `ORDER BY`, not a new screen.

## Ranking

1. **Last 14 days**, newest-first — pinned above everything
2. `usage_count` — distinct jobs it was consulted on
3. helpful marks
4. recency

`usage_count` leads because it's **behavioural**: it records someone reaching for the note *while doing the work*, rather than an opinion offered afterwards.

**The recency guard is not a nicety.** Pure usefulness ranking sinks a correction written this morning below an old note with a long history, and on a shop floor the fresh warning is the one that must be seen. The original plan solved this with a `confirmed` reaction plus visual decay of stale entries; both were dropped, so the guard carries it alone. 14 days is a judgement, not a finding — worth revisiting with real data.

## What I did NOT build, and why

**The `/parts/{partId}/playbook` page.** Operators already carry an annotated paper print, and paper wins on two things we cannot match: it's always at the machine, and its annotations are **spatially indexed** — a margin note points *at* a feature, which a text list can't reproduce.

What digital adds is narrower and real: the knowledge survives the sheet being lost or superseded by a revision, it exists in more than one place (one annotated print sits at one machine), and it carries attribution and reception. **All three already land one tap from the step.** A browsable page would have asked an operator to go *looking* for knowledge while off a job — exactly when they won't.

**Corrections.** `corrects_note_id` exists in the schema with no writer anywhere. A corrections section would be a display for something nothing can create.

## Rename

"Previous notes · N" → **"Playbook · N"**. It's no longer a list of what happened; it's what to know.

## Verification

Body-only SQL change — same signature, same `RETURNS TABLE` — so no `types/database.ts` update.

Verified against a local stack in a rolled-back transaction:
- usage **4, 4, 1, 0** descending, with the helpful count breaking the 4–4 tie
- a same-day correction with **zero** usage sitting above two four-job veterans

The three new integration tests **age their fixtures past the 14-day window on purpose**. Written at "now" they'd all fall inside the guard and merely re-assert that newer sorts first — a tautology.

- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` — 17 warnings (unchanged), 0 errors
- 675 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)