### PR TITLE
test(operator): pin the completion path before B4 rewrites it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -667,6 +667,35 @@ RSC payload. `agent-browser console` / `errors` are the fastest triage. Docs:
   extend `e2e/global-setup.ts` rather than runtime-skipping. Skips
   hide real regressions — see the `jobs.status` prod incident
   (May 2026) where a runtime-skipped spec masked a broken SELECT.
+- **From a worktree, Playwright will happily test the WRONG BRANCH.**
+  `playwright.config.ts` no longer launches a dev server — it trusts
+  whatever is already serving `localhost:3000`. Run E2E from a worktree
+  while the primary checkout's `pnpm dev` is up and the whole suite
+  exercises the primary's code against your branch's expectations. It
+  fails, or worse passes, for reasons unrelated to your change. The tell
+  is a stale string: renamed UI still showing its old label.
+
+  Serve your own port and point Playwright at it — no need to stop
+  anyone else's server:
+
+  ```bash
+  eval "$(supabase status -o env)"
+  export NEXT_PUBLIC_SUPABASE_URL=$API_URL NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY
+  pnpm next dev -p 3311 &                       # from the worktree
+  export TEST_SUPABASE_URL=$API_URL TEST_SUPABASE_SECRET_KEY=$SERVICE_ROLE_KEY
+  export PLAYWRIGHT_TEST_BASE_URL=http://localhost:3311
+  pnpm exec playwright test e2e/<spec>.spec.ts --reporter=list
+  ```
+
+  Confirm which checkout owns port 3000 before trusting a local E2E run:
+  `lsof -p $(lsof -ti:3000) -a -d cwd`.
+- **`global-setup` is find-or-insert, so an incomplete row STAYS
+  incomplete.** A seeder that early-returns on "the job exists" will
+  never backfill something added to it later — the local stack keeps
+  whatever the first run created until `supabase db reset`. When
+  extending a seeder, ensure each child record separately rather than
+  behind the parent's existence check, and remember CI always starts
+  clean while your machine does not.
 
 ### Where the detailed docs live
 

--- a/__tests__/app/operator/OperationActionPage.test.tsx
+++ b/__tests__/app/operator/OperationActionPage.test.tsx
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@mui/material/styles';
+import jiggedTheme from '@/lib/theme';
+
+import OperatorOperationActionPage from '@/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page';
+import { getOperatorOperationDetail, revertOperationCompletion } from '@/utils/operatorAccess';
+import {
+  createOperationCompletion,
+  getOperationCompletionSummaries,
+} from '@/utils/operationCompletionsAccess';
+import { logOperatorEvent } from '@/utils/operatorEventsAccess';
+
+/**
+ * CHARACTERISATION TESTS — what the completion path does TODAY.
+ *
+ * Written before B4 rewrites this screen, and deliberately not written
+ * alongside it: tests authored next to a rewrite describe the new code, which
+ * is precisely what a rewrite must not be judged by.
+ *
+ * Completion is the one action an operator must never lose, and until now it had
+ * nine unit tests on the access layer, no component test, and no E2E — the page
+ * that owns handleRecord and handleRevert was unprotected. Anything here that
+ * goes red during B4 is a regression to explain, not an argument to have.
+ *
+ * Two invariants matter more than the rest and are called out where they are
+ * asserted: completion must be DURABLE BEFORE any capture prompt appears, and
+ * undoing a completion must never be recorded as making one.
+ */
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({
+    companyId: 'co1',
+    jobId: 'job1',
+    jobPartId: 'jp1',
+    jobOperationId: 'op1',
+  }),
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+  usePathname: () => '/operator/co1/jobs/job1/parts/jp1/operations/op1',
+}));
+
+vi.mock('@/utils/operatorAccess', () => ({
+  getOperatorOperationDetail: vi.fn(),
+  getCurrentMember: vi.fn(async () => ({ id: 'acc1', name: 'Diego', user_id: 'u1' })),
+  revertOperationCompletion: vi.fn(async () => undefined),
+  markOperationSent: vi.fn(),
+  markOperationReceived: vi.fn(),
+}));
+
+vi.mock('@/utils/operationCompletionsAccess', () => ({
+  createOperationCompletion: vi.fn(async () => undefined),
+  getOperationCompletionSummaries: vi.fn(),
+}));
+
+vi.mock('@/utils/operatorEventsAccess', () => ({ logOperatorEvent: vi.fn() }));
+
+// The page embeds the feed and the part reference row; both reach Supabase.
+vi.mock('@/components/operator/JobFeed', () => ({
+  default: ({ captureOfferSignal }: { captureOfferSignal?: number }) => (
+    <div data-testid="job-feed" data-offer-signal={captureOfferSignal ?? 0} />
+  ),
+}));
+vi.mock('@/components/operator/PartReferenceRow', () => ({ default: () => <div /> }));
+
+// A station is selected and MATCHES the step, so the guard is out of the way
+// unless a test overrides it.
+const station = { stationId: 'wc1', stationName: 'Assembly Bench', initializing: false };
+vi.mock('@/components/operator/OperatorStationContext', () => ({
+  useStationContext: () => station,
+}));
+vi.mock('@/components/operator/OperatorChromeContext', () => ({
+  useSetOperatorChrome: () => {},
+  useOperatorNav: () => ({ push: vi.fn(), goBack: vi.fn() }),
+}));
+vi.mock('@/components/operator/StationSelector', () => ({ default: () => <div /> }));
+
+const mockDetail = vi.mocked(getOperatorOperationDetail);
+const mockSummaries = vi.mocked(getOperationCompletionSummaries);
+const mockCreate = vi.mocked(createOperationCompletion);
+const mockRevert = vi.mocked(revertOperationCompletion);
+const mockEvent = vi.mocked(logOperatorEvent);
+
+function detail(over: Record<string, unknown> = {}) {
+  return {
+    id: 'jp1',
+    job_id: 'job1',
+    part_id: 'part1',
+    job_number: 'J-0010',
+    customer_name: 'Cascade Robotics',
+    part_name: 'PROD-PUMP-100',
+    part_description: null,
+    part_quantity: 10,
+    production_status: 'in_progress',
+    operation_id: 'op1',
+    operation_name: 'Assembly',
+    operation_status: 'pending',
+    operation_instructions: null,
+    operation_work_center_id: 'wc1',
+    operation_work_center_name: 'Assembly Bench',
+    operation_work_center_kind: 'internal' as const,
+    operation_vendor_name: null,
+    operation_sent_at: null,
+    estimated_minutes: null,
+    operations_total: 2,
+    operations_completed: 0,
+    ...over,
+  };
+}
+
+/** One row of the partial-completion summary for this op. */
+function summary(qtyGood: number, target = 10) {
+  return [
+    {
+      job_operation_id: 'op1',
+      target,
+      qty_good: qtyGood,
+      qty_remaining: Math.max(0, target - qtyGood),
+    },
+  ];
+}
+
+function renderPage() {
+  return render(
+    <ThemeProvider theme={jiggedTheme}>
+      <OperatorOperationActionPage />
+    </ThemeProvider>,
+  );
+}
+
+const recordButton = () => screen.getByRole('button', { name: /record completion/i });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDetail.mockResolvedValue(detail() as never);
+  mockSummaries.mockResolvedValue(summary(0) as never);
+  mockCreate.mockResolvedValue(undefined as never);
+  mockRevert.mockResolvedValue(undefined as never);
+});
+
+describe('operation action page — completion (characterisation)', () => {
+  it('defaults the quantity to what is REMAINING, not the order quantity', async () => {
+    // 10 ordered, 4 already good → the field offers 6. Defaulting to the order
+    // quantity would silently double-count on the second visit.
+    mockSummaries.mockResolvedValue(summary(4) as never);
+    renderPage();
+
+    const field = await screen.findByLabelText('Good pieces finished');
+    await waitFor(() => expect(field).toHaveValue(6));
+  });
+
+  it('records the quantity in the field', async () => {
+    renderPage();
+    await screen.findByLabelText('Good pieces finished');
+
+    await userEvent.click(recordButton());
+
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith({
+        companyId: 'co1',
+        jobOperationId: 'op1',
+        jobPartId: 'jp1',
+        quantityGood: 10,
+      }),
+    );
+  });
+
+  it('records a partial when the number is dialled down', async () => {
+    // The whole point of one field and one button: a partial is the same
+    // gesture with a smaller number, not a separate mode.
+    const user = userEvent.setup();
+    renderPage();
+    const field = await screen.findByLabelText('Good pieces finished');
+
+    await user.clear(field);
+    await user.type(field, '3');
+    await user.click(recordButton());
+
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ quantityGood: 3 })),
+    );
+  });
+
+  it('cannot record zero', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const field = await screen.findByLabelText('Good pieces finished');
+
+    await user.clear(field);
+
+    await waitFor(() => expect(recordButton()).toBeDisabled());
+  });
+
+  it('allows over-completion — warned, never blocked', async () => {
+    // Shops finish more than ordered. Blocking it would leave the operator
+    // unable to record what physically happened.
+    const user = userEvent.setup();
+    renderPage();
+    const field = await screen.findByLabelText('Good pieces finished');
+
+    await user.clear(field);
+    await user.type(field, '12');
+
+    expect(recordButton()).toBeEnabled();
+    await user.click(recordButton());
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ quantityGood: 12 })),
+    );
+  });
+
+  it('logs completion_recorded only AFTER the write resolves', async () => {
+    // The funnel's entire job is separating "tried" from "succeeded". A failed
+    // completion that still logged would make the number a lie.
+    let release: () => void = () => {};
+    mockCreate.mockReturnValue(new Promise<void>((r) => (release = () => r())) as never);
+    renderPage();
+    await screen.findByLabelText('Good pieces finished');
+
+    await userEvent.click(recordButton());
+    expect(mockEvent).not.toHaveBeenCalledWith('co1', 'completion_recorded', expect.anything());
+
+    release();
+    await waitFor(() =>
+      expect(mockEvent).toHaveBeenCalledWith(
+        'co1',
+        'completion_recorded',
+        expect.objectContaining({ jobOperationId: 'op1', quantityGood: 10 }),
+      ),
+    );
+  });
+
+  it('does not log a completion when the write fails', async () => {
+    mockCreate.mockRejectedValue(new Error('offline') as never);
+    renderPage();
+    await screen.findByLabelText('Good pieces finished');
+
+    await userEvent.click(recordButton());
+
+    expect(await screen.findByText('offline')).toBeInTheDocument();
+    expect(mockEvent).not.toHaveBeenCalledWith('co1', 'completion_recorded', expect.anything());
+  });
+
+  it('prompts for capture only AFTER completion is durable', async () => {
+    // THE INVARIANT B4 MUST PRESERVE IN WHATEVER SHAPE IT TAKES. The offer
+    // signal is bumped strictly after the write resolves, so a client death at
+    // the prompt cannot un-complete a finished step. B4 removes the prompt; the
+    // ordering it protects — completion first, capture second — must survive.
+    let release: () => void = () => {};
+    mockCreate.mockReturnValue(new Promise<void>((r) => (release = () => r())) as never);
+    renderPage();
+    await screen.findByLabelText('Good pieces finished');
+
+    await userEvent.click(recordButton());
+    expect(screen.getByTestId('job-feed')).toHaveAttribute('data-offer-signal', '0');
+
+    release();
+    await waitFor(() =>
+      expect(screen.getByTestId('job-feed')).toHaveAttribute('data-offer-signal', '1'),
+    );
+  });
+
+  it('offers Undo only once something has been recorded', async () => {
+    renderPage();
+    await screen.findByLabelText('Good pieces finished');
+    expect(screen.queryByRole('button', { name: /undo all/i })).not.toBeInTheDocument();
+
+    mockSummaries.mockResolvedValue(summary(4) as never);
+    await userEvent.click(recordButton());
+
+    expect(await screen.findByRole('button', { name: /undo all \(4\)/i })).toBeInTheDocument();
+  });
+
+  it('undoing is NOT recorded as a completion', async () => {
+    // Both handlers share the same tail (clear dirty, reload), and the funnel
+    // event once sat in the wrong one — an operator UNDOING a step counted as
+    // finishing it.
+    mockSummaries.mockResolvedValue(summary(4) as never);
+    renderPage();
+
+    await userEvent.click(await screen.findByRole('button', { name: /undo all/i }));
+
+    await waitFor(() => expect(mockRevert).toHaveBeenCalledWith('op1'));
+    expect(mockEvent).not.toHaveBeenCalledWith('co1', 'completion_recorded', expect.anything());
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed undo without pretending it worked', async () => {
+    mockSummaries.mockResolvedValue(summary(4) as never);
+    mockRevert.mockRejectedValue(new Error('could not undo') as never);
+    renderPage();
+
+    await userEvent.click(await screen.findByRole('button', { name: /undo all/i }));
+
+    expect(await screen.findByText('could not undo')).toBeInTheDocument();
+  });
+
+  it('warns on a station mismatch but still lets the step be recorded', async () => {
+    // Completion keys off the operation id, not the station, so a mismatch is a
+    // likely wrong-QR signal — not a reason to stop someone recording real work.
+    mockDetail.mockResolvedValue(
+      detail({ operation_work_center_id: 'wc9', operation_work_center_name: 'Bandsaw' }) as never,
+    );
+    renderPage();
+
+    expect(await screen.findByText(/but this step runs at/i)).toBeInTheDocument();
+    await userEvent.click(recordButton());
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+  });
+
+  it('reports reaching the step, for the reader funnel', async () => {
+    renderPage();
+
+    await waitFor(() =>
+      expect(mockEvent).toHaveBeenCalledWith(
+        'co1',
+        'op_card_opened',
+        expect.objectContaining({ jobOperationId: 'op1' }),
+      ),
+    );
+  });
+});

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -334,7 +334,7 @@ async function ensureRouting(
   companyId: string,
   partId: string,
   workCenterId: string,
-): Promise<void> {
+): Promise<string> {
   const { data: existing, error: lookupErr } = await supabase
     .from('routings')
     .select('id')
@@ -367,7 +367,7 @@ async function ensureRouting(
     .eq('sequence', 10)
     .maybeSingle();
   if (opLookupErr) throw new Error(`routing op lookup failed: ${opLookupErr.message}`);
-  if (existingOp) return;
+  if (existingOp) return routingId;
 
   const { error: opErr } = await supabase.from('routing_operations').insert({
     routing_id: routingId,
@@ -378,6 +378,7 @@ async function ensureRouting(
     labor_rate_override: 100,
   });
   if (opErr) throw new Error(`routing op insert failed: ${opErr.message}`);
+  return routingId;
 }
 
 async function ensurePricingTier(
@@ -435,6 +436,15 @@ interface JobStageSpec {
   jobNumber: string;
   productionStatus: 'not_started' | 'in_progress' | 'completed' | 'cancelled';
   fulfillmentStatus: 'unshipped' | 'partially_shipped' | 'fully_shipped';
+  /**
+   * Order quantity on the job_part. Defaults to 1.
+   *
+   * operator-completion.spec.ts needs > 1 on the job it drives: recording the
+   * whole remaining balance is a FULL completion, so with a quantity of 1 a
+   * PARTIAL is not expressible at all and that half of the flow cannot be
+   * covered.
+   */
+  quantity?: number;
 }
 
 /**
@@ -529,6 +539,7 @@ async function ensureJobAtStage(
   companyId: string,
   customerId: string,
   partId: string,
+  routingId: string,
   spec: JobStageSpec,
 ): Promise<void> {
   const { data: existing, error: lookupErr } = await supabase
@@ -538,7 +549,16 @@ async function ensureJobAtStage(
     .eq('job_number', spec.jobNumber)
     .maybeSingle();
   if (lookupErr) throw new Error(`job lookup failed (${spec.jobNumber}): ${lookupErr.message}`);
-  if (existing) return;
+
+  if (existing) {
+    // The job is already here, but a run seeded before this function created
+    // job_operations would have left it with no steps — and a job_part with no
+    // steps renders "This part has no operations", so there is nothing to open
+    // and nothing to complete. Ensure the step separately rather than returning:
+    // every other seeder in this file is find-or-insert, and this one was not.
+    await ensureJobOperation(supabase, existing.id, routingId, spec);
+    return;
+  }
 
   const { data: job, error: jobErr } = await supabase
     .from('jobs')
@@ -558,13 +578,74 @@ async function ensureJobAtStage(
     company_id: companyId,
     part_id: partId,
     sequence: 1,
-    quantity: 1,
+    quantity: spec.quantity ?? 1,
     unit_price: 10,
-    total_price: 10,
+    total_price: 10 * (spec.quantity ?? 1),
     production_status: spec.productionStatus,
     fulfillment_status: spec.fulfillmentStatus,
   });
   if (partErr) throw new Error(`job_part insert failed (${spec.jobNumber}): ${partErr.message}`);
+
+  await ensureJobOperation(supabase, job.id, routingId, spec);
+}
+
+/**
+ * The step an operator actually opens and completes.
+ *
+ * These jobs are inserted directly rather than converted from a quote, and it is
+ * conversion that normally snapshots routing_operations into job_operations — so
+ * without this a job_part has no steps, the traveler renders "This part has no
+ * operations", and there is nothing to complete.
+ *
+ * Carries routing_operation_id so a note captured on this step gets the DURABLE
+ * (part, routing step) subject rather than falling back to a job subject.
+ */
+async function ensureJobOperation(
+  supabase: SupabaseClient,
+  jobId: string,
+  routingId: string,
+  spec: JobStageSpec,
+): Promise<void> {
+  const { data: existingOp, error: opLookupErr } = await supabase
+    .from('job_operations')
+    .select('id')
+    .eq('job_id', jobId)
+    .maybeSingle();
+  if (opLookupErr) {
+    throw new Error(`job_operation lookup failed (${spec.jobNumber}): ${opLookupErr.message}`);
+  }
+  if (existingOp) return;
+
+  const { data: jobPart, error: jpErr } = await supabase
+    .from('job_parts')
+    .select('id')
+    .eq('job_id', jobId)
+    .single();
+  if (jpErr || !jobPart) {
+    throw new Error(`job_part lookup failed (${spec.jobNumber}): ${jpErr?.message}`);
+  }
+
+  const { data: routingOp } = await supabase
+    .from('routing_operations')
+    .select('id, work_center_id')
+    .eq('routing_id', routingId)
+    .eq('sequence', 10)
+    .maybeSingle();
+
+  const { error: opErr } = await supabase.from('job_operations').insert({
+    job_id: jobId,
+    job_part_id: jobPart.id,
+    // No company_id here: job_operations has none, tenancy resolves through the job.
+    sequence: 10,
+    operation_name: WC_INTERNAL_NAME,
+    work_center_id: routingOp?.work_center_id ?? null,
+    routing_operation_id: routingOp?.id ?? null,
+    estimated_setup_minutes: 15,
+    estimated_run_minutes_per_unit: 2.5,
+    // Mirrors the job: a completed job's step must not read as outstanding.
+    status: spec.productionStatus === 'completed' ? 'completed' : 'pending',
+  });
+  if (opErr) throw new Error(`job_operation insert failed (${spec.jobNumber}): ${opErr.message}`);
 }
 
 export default async function globalSetup(): Promise<void> {
@@ -630,7 +711,7 @@ export default async function globalSetup(): Promise<void> {
     cost_per_unit: null,
   });
 
-  await ensureRouting(supabase, companyId, mfgPartId, wcInternalId);
+  const mfgRoutingId = await ensureRouting(supabase, companyId, mfgPartId, wcInternalId);
   await ensureRouting(supabase, companyId, lengthPartId, wcInternalId);
   await ensureBomEdge(supabase, mfgPartId, subPartId);
   // Two pricing tiers so QuoteForm can resolve a tier on the seeded MFG part.
@@ -643,22 +724,26 @@ export default async function globalSetup(): Promise<void> {
   // Jobs at distinct lifecycle stages for jobs-list-status.spec.ts. Shared
   // "E2E-JS-" job-number prefix so the spec can isolate them by search from
   // whatever jobs other specs create in the same shared company.
-  await ensureJobAtStage(supabase, companyId, customerId, mfgPartId, {
+  await ensureJobAtStage(supabase, companyId, customerId, mfgPartId, mfgRoutingId, {
     jobNumber: 'E2E-JS-NOTSTARTED',
     productionStatus: 'not_started',
     fulfillmentStatus: 'unshipped',
+    // > 1 so operator-completion.spec.ts can record a PARTIAL. Safe to change:
+    // no spec asserts this quantity — the status specs assert statuses, and the
+    // notes spec asserts note bodies.
+    quantity: 5,
   });
-  await ensureJobAtStage(supabase, companyId, customerId, mfgPartId, {
+  await ensureJobAtStage(supabase, companyId, customerId, mfgPartId, mfgRoutingId, {
     jobNumber: 'E2E-JS-READY',
     productionStatus: 'completed',
     fulfillmentStatus: 'unshipped',
   });
-  await ensureJobAtStage(supabase, companyId, customerId, mfgPartId, {
+  await ensureJobAtStage(supabase, companyId, customerId, mfgPartId, mfgRoutingId, {
     jobNumber: 'E2E-JS-DONE',
     productionStatus: 'completed',
     fulfillmentStatus: 'fully_shipped',
   });
-  await ensureJobAtStage(supabase, companyId, customerId, mfgPartId, {
+  await ensureJobAtStage(supabase, companyId, customerId, mfgPartId, mfgRoutingId, {
     jobNumber: 'E2E-JS-CANCELLED',
     productionStatus: 'cancelled',
     fulfillmentStatus: 'unshipped',

--- a/e2e/operator-completion.spec.ts
+++ b/e2e/operator-completion.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect, type Page } from '@playwright/test';
+import { navigateTo, waitForGridLoaded } from './helpers/navigation';
+
+/**
+ * Recording a completion, end to end.
+ *
+ * WHY THIS SPEC EXISTS. Completion is the one action an operator must never
+ * lose, and until now it had unit tests on the access layer and nothing above
+ * it: no component test on the page that owns handleRecord/handleRevert, and no
+ * E2E at all. The whole suite went green with the station guard, the quantity
+ * default, the write and the undo unexercised in a browser.
+ *
+ * It is written BEFORE B4 merges capture into completion, deliberately. Tests
+ * authored alongside a rewrite describe the new code, which is exactly what a
+ * rewrite must not be judged by. Whatever B4 changes about the screen, this flow
+ * — pick a station, open a step, record a quantity, see it counted, undo it —
+ * has to keep working, and if the assertions here need editing then B4 changed
+ * operator-visible behaviour and that should be a decision rather than a
+ * surprise.
+ *
+ * It drives the real UI rather than constructed URLs so that the station guard,
+ * the id resolution and the partial-completion summary are all covered — the
+ * classes of failure that compile perfectly and render nothing.
+ */
+
+const JOB_SEARCH = /Job #, PO, customer/i;
+const WC_INTERNAL = 'E2E Internal WC';
+
+/** Reach a job's operator traveler, with a station selected. */
+async function openTravelerWithStation(page: Page, jobNumber: string): Promise<void> {
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/dashboard\//, { timeout: 30_000 });
+  const companyId = page.url().match(/\/dashboard\/([0-9a-f-]{36})/)?.[1];
+  expect(companyId, 'company id should be in the dashboard URL').toBeTruthy();
+
+  await navigateTo(page, 'Jobs');
+  await waitForGridLoaded(page);
+  await page.getByPlaceholder(JOB_SEARCH).fill(jobNumber);
+  await waitForGridLoaded(page);
+  await page.getByText(jobNumber).first().click();
+  await expect(page).toHaveURL(/\/jobs\/[0-9a-f-]{36}/, { timeout: 30_000 });
+  const jobId = page.url().match(/\/jobs\/([0-9a-f-]{36})/)?.[1];
+
+  // The station picker gates the completion action, so go through it rather than
+  // around it — a spec that skipped it would not cover the guard that decides
+  // whether an operator can record anything at all.
+  await page.goto(`/operator/${companyId}/jobs`);
+  const picker = page.getByRole('button', { name: WC_INTERNAL });
+  await expect(picker).toBeVisible({ timeout: 30_000 });
+  await picker.click();
+
+  await page.goto(`/operator/${companyId}/jobs/${jobId}`);
+  await expect(page).toHaveURL(/\/parts\/[0-9a-f-]{36}/, { timeout: 30_000 });
+}
+
+/** Open the seeded step from the traveler. */
+async function openStep(page: Page): Promise<void> {
+  await page.getByRole('button', { name: new RegExp(WC_INTERNAL) }).first().click();
+  await expect(page).toHaveURL(/\/operations\/[0-9a-f-]{36}/, { timeout: 30_000 });
+}
+
+const qtyField = (page: Page) => page.getByLabel('Good pieces finished');
+const recordButton = (page: Page) => page.getByRole('button', { name: /record completion/i });
+const undoButton = (page: Page) => page.getByRole('button', { name: /undo all/i });
+const completeBanner = (page: Page) =>
+  page.getByRole('button', { name: /this step is complete/i });
+
+// These tests all drive the SAME job's completions, so they are order-dependent
+// by nature — run in parallel they race on shared mutable state and fail at
+// random. CI already uses one worker; this only constrains local runs.
+test.describe.configure({ mode: 'serial' });
+
+test.describe('operator completion', () => {
+  test('records a partial, counts it, and undoes it', async ({ page }) => {
+    // E2E-JS-NOTSTARTED is the open job, so its step is actionable, and it is
+    // seeded with quantity 5 — with a quantity of 1 the whole balance IS the
+    // order and a partial cannot be expressed.
+    await openTravelerWithStation(page, 'E2E-JS-NOTSTARTED');
+    await openStep(page);
+
+    // The field states its own outcome: it arrives holding the remaining
+    // balance, so RECORD COMPLETION finishes the step by default.
+    const field = qtyField(page);
+    await expect(field).toBeVisible({ timeout: 30_000 });
+    const remaining = Number(await field.inputValue());
+    expect(remaining, 'the field should default to the remaining balance').toBeGreaterThan(1);
+
+    // Dial it down: a partial is the same gesture with a smaller number, not a
+    // separate mode.
+    await field.fill('2');
+    await recordButton(page).click();
+
+    // This line only renders once something is banked, so its presence IS the
+    // assertion that the write landed AND was read back through the summary.
+    await expect(page.getByText(/2 of 5 good so far/)).toBeVisible({ timeout: 30_000 });
+    // Still actionable, because a partial leaves the rest outstanding.
+    await expect(field).toBeVisible();
+    await expect(field).toHaveValue('3');
+
+    // Undo is offered only against recorded work, and voids all of it.
+    await undoButton(page).click();
+
+    await expect(page.getByText(/good so far/)).toHaveCount(0, { timeout: 30_000 });
+    await expect(undoButton(page)).toHaveCount(0);
+    // Back to offering the full balance, which is what makes a second attempt
+    // safe rather than a double-count.
+    await expect(qtyField(page)).toHaveValue(String(remaining));
+  });
+
+  test('completing the balance closes the step, and undo reopens it', async ({ page }) => {
+    // The default path: leave the number alone and tap once. The screen then
+    // swaps the action for a completed state, which is a different branch of the
+    // page and was the half this spec originally missed.
+    await openTravelerWithStation(page, 'E2E-JS-NOTSTARTED');
+    await openStep(page);
+    await expect(qtyField(page)).toBeVisible({ timeout: 30_000 });
+
+    await recordButton(page).click();
+
+    await expect(completeBanner(page)).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(/5 of 5 good/)).toBeVisible();
+    // No way to record again while complete — the field is gone, not merely
+    // disabled, so a second tap cannot double-count.
+    await expect(qtyField(page)).toHaveCount(0);
+
+    // A completed step stays reversible: the banner itself is the undo.
+    await completeBanner(page).click();
+
+    await expect(qtyField(page)).toBeVisible({ timeout: 30_000 });
+    await expect(qtyField(page)).toHaveValue('5');
+  });
+
+  test('will not record nothing', async ({ page }) => {
+    // The only floor is > 0. Without it an empty tap would append a zero-quantity
+    // completion event and the step would read as worked-on when it was not.
+    await openTravelerWithStation(page, 'E2E-JS-NOTSTARTED');
+    await openStep(page);
+
+    await expect(qtyField(page)).toBeVisible({ timeout: 30_000 });
+    await qtyField(page).fill('0');
+
+    await expect(recordButton(page)).toBeDisabled();
+  });
+});


### PR DESCRIPTION
**Phase 1 of B4, merged first on purpose.** No behaviour changes — only tests, one seed fix, and two documented traps.

## Why this is its own PR

B4 merges capture into completion and ships **on for everyone, with no feature flag**. Here's what protected that path before this PR:

| Layer | Coverage |
|---|---|
| `operationCompletionsAccess` | 9 unit tests ✅ |
| The operation page (590 lines — owns `handleRecord`/`handleRevert`) | **none** |
| E2E | **none** — no spec typed "RECORD COMPLETION" anywhere |

So the whole suite went green with the station guard, the quantity default, the write and the undo unexercised in a browser. These tests are written against what the code does **today**, before the rewrite rather than alongside it — tests authored next to a rewrite describe the new code, which is precisely what a rewrite must not be judged by.

Anything here that goes red during B4 is a regression to explain, not an argument to have.

## What's covered

**13 component tests**, including two invariants called out where they're asserted:
- **Completion must be durable before any capture prompt.** B4 deletes the prompt; the ordering it protects has to survive.
- **Undoing must never be recorded as completing.** The funnel event once sat in the wrong handler and an operator *undoing* a step counted as finishing it.

Plus: the field defaults to *remaining* not the order quantity (a double-count if wrong), partials, over-completion allowed-but-warned, zero refused, station mismatch warns without blocking, failures neither logged nor silently swallowed.

**3 E2E tests** — pick a station, open a step, record a partial, see it counted, undo; complete the balance and watch the action swap for a completed state that reopens; refuse to record nothing. Serialized, since they mutate one job's completions and the local runner is fully parallel.

## Three tests verified by mutation, not trust

13 passing first run is suspicious, so I broke the source deliberately:

| Mutation | Caught by |
|---|---|
| `completion_recorded` moved into `handleRevert` | *undoing is NOT recorded as a completion* |
| Capture prompt bumped **before** the write resolves | *prompts for capture only AFTER completion is durable* |
| Field defaults to order qty instead of remaining | *defaults the quantity to what is REMAINING* |

Each failed exactly one test, and the right one.

## Two seed gaps this uncovered

1. **The E2E jobs had no `job_operations` at all.** They're inserted directly rather than converted from a quote, and conversion is what snapshots `routing_operations` — so the traveler read *"This part has no operations"* and there was no step to open.
2. **`ensureJobAtStage` early-returned on an existing job**, so the fix above would never have reached jobs an earlier run created. The step is now ensured separately, like every other seeder in the file.

`E2E-JS-NOTSTARTED` gets `quantity: 5` so a **partial** is expressible — at quantity 1 the whole balance *is* the order. No spec asserts that quantity; verified by re-running `jobs-list-status` and `operator-notes-loop`, both green.

## Two traps now in CLAUDE.md

- **Playwright will test the wrong branch from a worktree.** The config no longer launches a dev server — it trusts whatever owns `localhost:3000`. My first run silently exercised the **primary checkout**; the tell was a button B3 renamed still showing its old label. Documented with the fix (serve your own port, point `PLAYWRIGHT_TEST_BASE_URL` at it) so nobody else loses the time.
- **Find-or-insert seeding leaves incomplete rows incomplete** on a local stack until `db reset`, while CI always starts clean.

## Verification

All run against a dev server built from **this** worktree on port 3311, with the primary's server left alone:

- `pnpm exec playwright test e2e/operator-completion.spec.ts` — **3 passed**
- `jobs-list-status` + `operator-notes-loop` — **4 passed** (seed change is safe)
- 96 component tests pass; tsc clean; lint 17 warnings (unchanged), 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)