### PR TITLE
feat(operator): finishing a step and writing it down are one act (B4 + B5)

### DIFF
--- a/__tests__/app/operator/OperationActionPage.test.tsx
+++ b/__tests__/app/operator/OperationActionPage.test.tsx
@@ -215,13 +215,64 @@ describe('operation action page — completion (characterisation)', () => {
   });
 
   it('cannot record zero', async () => {
+    // The floor is unchanged: no zero-quantity completion. What changed is the
+    // button's label when the quantity is empty — with nothing to record and
+    // nothing typed there is no action to offer, so it is disabled either way.
     const user = userEvent.setup();
     renderPage();
     const field = await screen.findByLabelText('Good pieces finished');
 
     await user.clear(field);
 
-    await waitFor(() => expect(recordButton()).toBeDisabled());
+    await waitFor(() => expect(screen.getByRole('button', { name: /save note/i })).toBeDisabled());
+    expect(screen.queryByRole('button', { name: /record completion/i })).not.toBeInTheDocument();
+  });
+
+  it('saves a note alone when nothing was finished', async () => {
+    // THE HOLE B4 OPENED. Capture rides on RECORD COMPLETION, which needs
+    // qty > 0 — so an operator who finished ZERO pieces ("machine down",
+    // "waiting on material") had to either say nothing, losing exactly the
+    // knowledge this workstream exists to capture, or type a false quantity to
+    // get the note saved. Falsifying production data to satisfy a UI constraint
+    // is much worse than an extra code path.
+    const user = userEvent.setup();
+    renderPage();
+    const field = await screen.findByLabelText('Good pieces finished');
+
+    await user.clear(field);
+    await user.type(screen.getByPlaceholderText(/worth noting/i), 'machine down, nothing run');
+
+    const save = screen.getByRole('button', { name: /save note/i });
+    await waitFor(() => expect(save).toBeEnabled());
+    await user.click(save);
+
+    await waitFor(() =>
+      expect(mockAddNote).toHaveBeenCalledWith(
+        'job1',
+        'co1',
+        'acc1',
+        'machine down, nothing run',
+        { jobPartId: 'jp1', jobOperationId: 'op1' },
+      ),
+    );
+    // And crucially: NO completion was invented to carry it.
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('collapses the job details by default, and opens them in place', async () => {
+    // Reference detail does not belong between an operator and the button they
+    // came to press — but it should not cost a page navigation either.
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByLabelText('Good pieces finished');
+
+    expect(screen.queryByText('Cascade Robotics')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /show job details/i }));
+
+    expect(await screen.findByText('Cascade Robotics')).toBeInTheDocument();
+    // Still on the same screen — expanded, not navigated.
+    expect(screen.getByLabelText('Good pieces finished')).toBeInTheDocument();
   });
 
   it('allows over-completion — warned, never blocked', async () => {

--- a/__tests__/app/operator/OperationActionPage.test.tsx
+++ b/__tests__/app/operator/OperationActionPage.test.tsx
@@ -92,7 +92,11 @@ vi.mock('@/components/operator/JobFeed', () => ({
     />
   ),
 }));
-vi.mock('@/components/operator/PartReferenceRow', () => ({ default: () => <div /> }));
+// Must render `trailing`: the quantity field now shares this row, so a mock that
+// drops the slot silently removes the control every completion test drives.
+vi.mock('@/components/operator/PartReferenceRow', () => ({
+  default: ({ trailing }: { trailing?: React.ReactNode }) => <div>{trailing}</div>,
+}));
 
 // A station is selected and MATCHES the step, so the guard is out of the way
 // unless a test overrides it.
@@ -178,13 +182,13 @@ describe('operation action page — completion (characterisation)', () => {
     mockSummaries.mockResolvedValue(summary(4) as never);
     renderPage();
 
-    const field = await screen.findByLabelText('Good pieces finished');
+    const field = await screen.findByLabelText('Parts finished');
     await waitFor(() => expect(field).toHaveValue(6));
   });
 
   it('records the quantity in the field', async () => {
     renderPage();
-    await screen.findByLabelText('Good pieces finished');
+    await screen.findByLabelText('Parts finished');
 
     await userEvent.click(recordButton());
 
@@ -203,7 +207,7 @@ describe('operation action page — completion (characterisation)', () => {
     // gesture with a smaller number, not a separate mode.
     const user = userEvent.setup();
     renderPage();
-    const field = await screen.findByLabelText('Good pieces finished');
+    const field = await screen.findByLabelText('Parts finished');
 
     await user.clear(field);
     await user.type(field, '3');
@@ -220,7 +224,7 @@ describe('operation action page — completion (characterisation)', () => {
     // nothing typed there is no action to offer, so it is disabled either way.
     const user = userEvent.setup();
     renderPage();
-    const field = await screen.findByLabelText('Good pieces finished');
+    const field = await screen.findByLabelText('Parts finished');
 
     await user.clear(field);
 
@@ -237,7 +241,7 @@ describe('operation action page — completion (characterisation)', () => {
     // is much worse than an extra code path.
     const user = userEvent.setup();
     renderPage();
-    const field = await screen.findByLabelText('Good pieces finished');
+    const field = await screen.findByLabelText('Parts finished');
 
     await user.clear(field);
     await user.type(screen.getByPlaceholderText(/worth noting/i), 'machine down, nothing run');
@@ -264,7 +268,7 @@ describe('operation action page — completion (characterisation)', () => {
     // came to press — but it should not cost a page navigation either.
     const user = userEvent.setup();
     renderPage();
-    await screen.findByLabelText('Good pieces finished');
+    await screen.findByLabelText('Parts finished');
 
     expect(screen.queryByText('Cascade Robotics')).not.toBeInTheDocument();
 
@@ -272,7 +276,7 @@ describe('operation action page — completion (characterisation)', () => {
 
     expect(await screen.findByText('Cascade Robotics')).toBeInTheDocument();
     // Still on the same screen — expanded, not navigated.
-    expect(screen.getByLabelText('Good pieces finished')).toBeInTheDocument();
+    expect(screen.getByLabelText('Parts finished')).toBeInTheDocument();
   });
 
   it('allows over-completion — warned, never blocked', async () => {
@@ -280,7 +284,7 @@ describe('operation action page — completion (characterisation)', () => {
     // unable to record what physically happened.
     const user = userEvent.setup();
     renderPage();
-    const field = await screen.findByLabelText('Good pieces finished');
+    const field = await screen.findByLabelText('Parts finished');
 
     await user.clear(field);
     await user.type(field, '12');
@@ -298,7 +302,7 @@ describe('operation action page — completion (characterisation)', () => {
     let release: () => void = () => {};
     mockCreate.mockReturnValue(new Promise<void>((r) => (release = () => r())) as never);
     renderPage();
-    await screen.findByLabelText('Good pieces finished');
+    await screen.findByLabelText('Parts finished');
 
     await userEvent.click(recordButton());
     expect(mockEvent).not.toHaveBeenCalledWith('co1', 'completion_recorded', expect.anything());
@@ -316,7 +320,7 @@ describe('operation action page — completion (characterisation)', () => {
   it('does not log a completion when the write fails', async () => {
     mockCreate.mockRejectedValue(new Error('offline') as never);
     renderPage();
-    await screen.findByLabelText('Good pieces finished');
+    await screen.findByLabelText('Parts finished');
 
     await userEvent.click(recordButton());
 
@@ -334,7 +338,7 @@ describe('operation action page — completion (characterisation)', () => {
     let release: () => void = () => {};
     mockCreate.mockReturnValue(new Promise<void>((r) => (release = () => r())) as never);
     renderPage();
-    await screen.findByLabelText('Good pieces finished');
+    await screen.findByLabelText('Parts finished');
 
     await user.type(screen.getByPlaceholderText(/worth noting/i), 'fixture walks');
     await user.click(recordButton());
@@ -349,7 +353,7 @@ describe('operation action page — completion (characterisation)', () => {
     // Capture is optional, always. Requiring it would make finishing a step
     // conditional on having something to say.
     renderPage();
-    await screen.findByLabelText('Good pieces finished');
+    await screen.findByLabelText('Parts finished');
 
     await userEvent.click(recordButton());
 
@@ -363,7 +367,7 @@ describe('operation action page — completion (characterisation)', () => {
     // read as finished, and a back tap discarded it silently.
     const user = userEvent.setup();
     renderPage();
-    await screen.findByLabelText('Good pieces finished');
+    await screen.findByLabelText('Parts finished');
 
     await user.type(screen.getByPlaceholderText(/worth noting/i), 'back the feed off');
     await user.click(recordButton());
@@ -385,7 +389,7 @@ describe('operation action page — completion (characterisation)', () => {
     const user = userEvent.setup();
     mockAddNote.mockRejectedValue(new Error('note write failed'));
     renderPage();
-    await screen.findByLabelText('Good pieces finished');
+    await screen.findByLabelText('Parts finished');
 
     await user.type(screen.getByPlaceholderText(/worth noting/i), 'something');
     await user.click(recordButton());
@@ -403,7 +407,7 @@ describe('operation action page — completion (characterisation)', () => {
   it('owns capture itself, so the feed does not offer a second composer', async () => {
     // Two composers on one screen would be a bug; this asserts which one is live.
     renderPage();
-    await screen.findByLabelText('Good pieces finished');
+    await screen.findByLabelText('Parts finished');
 
     expect(screen.getByTestId('job-feed')).toHaveAttribute('data-standalone-capture', 'false');
   });
@@ -436,7 +440,7 @@ describe('operation action page — completion (characterisation)', () => {
 
   it('offers Undo only once something has been recorded', async () => {
     renderPage();
-    await screen.findByLabelText('Good pieces finished');
+    await screen.findByLabelText('Parts finished');
     expect(screen.queryByRole('button', { name: /undo all/i })).not.toBeInTheDocument();
 
     mockSummaries.mockResolvedValue(summary(4) as never);

--- a/__tests__/app/operator/OperationActionPage.test.tsx
+++ b/__tests__/app/operator/OperationActionPage.test.tsx
@@ -11,6 +11,7 @@ import {
   getOperationCompletionSummaries,
 } from '@/utils/operationCompletionsAccess';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
+import { addJobNote } from '@/utils/operatorAccess';
 
 /**
  * CHARACTERISATION TESTS — what the completion path does TODAY.
@@ -25,8 +26,15 @@ import { logOperatorEvent } from '@/utils/operatorEventsAccess';
  * goes red during B4 is a regression to explain, not an argument to have.
  *
  * Two invariants matter more than the rest and are called out where they are
- * asserted: completion must be DURABLE BEFORE any capture prompt appears, and
- * undoing a completion must never be recorded as making one.
+ * asserted: completion must be DURABLE BEFORE the note is attempted, and undoing
+ * a completion must never be recorded as making one.
+ *
+ * UPDATED BY B4, deliberately and in one place. The offer-signal assertion below
+ * became an ordering assertion: B4 deleted the post-completion prompt, but the
+ * property that prompt existed to protect — completion lands first, capture
+ * second, so a slow photo upload can never un-complete finished work — is now
+ * enforced by the submit sequence instead. Everything else here passed unchanged
+ * through the rewrite.
  */
 
 vi.mock('next/navigation', () => ({
@@ -46,6 +54,19 @@ vi.mock('@/utils/operatorAccess', () => ({
   revertOperationCompletion: vi.fn(async () => undefined),
   markOperationSent: vi.fn(),
   markOperationReceived: vi.fn(),
+  // B4: the page now writes the note itself, through useNoteCapture.
+  addJobNote: vi.fn(async () => ({ id: 'note1', media: [] })),
+}));
+
+// useNoteCapture reaches these, and jobNoteMediaAccess imports lib/supabase,
+// which creates its client at MODULE scope — so without a mock the whole test
+// file throws on import rather than on use.
+vi.mock('@/utils/jobNoteMediaAccess', () => ({
+  addJobNoteMedia: vi.fn(async () => ({ id: 'media1' })),
+  getJobNoteMediaUrl: vi.fn(async () => 'blob:x'),
+}));
+vi.mock('@/utils/imageCompression', () => ({
+  compressPhoto: vi.fn(async (f: File) => ({ file: f, dims: { width: 10, height: 10 } })),
 }));
 
 vi.mock('@/utils/operationCompletionsAccess', () => ({
@@ -57,8 +78,18 @@ vi.mock('@/utils/operatorEventsAccess', () => ({ logOperatorEvent: vi.fn() }));
 
 // The page embeds the feed and the part reference row; both reach Supabase.
 vi.mock('@/components/operator/JobFeed', () => ({
-  default: ({ captureOfferSignal }: { captureOfferSignal?: number }) => (
-    <div data-testid="job-feed" data-offer-signal={captureOfferSignal ?? 0} />
+  default: ({
+    refreshSignal,
+    standaloneCapture,
+  }: {
+    refreshSignal?: number;
+    standaloneCapture?: boolean;
+  }) => (
+    <div
+      data-testid="job-feed"
+      data-refresh-signal={refreshSignal ?? 0}
+      data-standalone-capture={String(!!standaloneCapture)}
+    />
   ),
 }));
 vi.mock('@/components/operator/PartReferenceRow', () => ({ default: () => <div /> }));
@@ -80,6 +111,7 @@ const mockSummaries = vi.mocked(getOperationCompletionSummaries);
 const mockCreate = vi.mocked(createOperationCompletion);
 const mockRevert = vi.mocked(revertOperationCompletion);
 const mockEvent = vi.mocked(logOperatorEvent);
+const mockAddNote = vi.mocked(addJobNote);
 
 function detail(over: Record<string, unknown> = {}) {
   return {
@@ -136,6 +168,7 @@ beforeEach(() => {
   mockSummaries.mockResolvedValue(summary(0) as never);
   mockCreate.mockResolvedValue(undefined as never);
   mockRevert.mockResolvedValue(undefined as never);
+  mockAddNote.mockResolvedValue({ id: 'note1', media: [] } as never);
 });
 
 describe('operation action page — completion (characterisation)', () => {
@@ -240,22 +273,113 @@ describe('operation action page — completion (characterisation)', () => {
     expect(mockEvent).not.toHaveBeenCalledWith('co1', 'completion_recorded', expect.anything());
   });
 
-  it('prompts for capture only AFTER completion is durable', async () => {
-    // THE INVARIANT B4 MUST PRESERVE IN WHATEVER SHAPE IT TAKES. The offer
-    // signal is bumped strictly after the write resolves, so a client death at
-    // the prompt cannot un-complete a finished step. B4 removes the prompt; the
-    // ordering it protects — completion first, capture second — must survive.
+  it('writes the note only AFTER the completion has landed', async () => {
+    // THE INVARIANT, in its post-B4 shape. The note — and especially its photo
+    // upload, the slowest and most failure-prone part of the flow on shop wifi —
+    // is attempted strictly after the completion resolves, so it can never
+    // un-complete finished work. Not a transaction, on purpose: rolling back real
+    // work because an image failed to upload would be worse, not safer.
+    const user = userEvent.setup();
     let release: () => void = () => {};
     mockCreate.mockReturnValue(new Promise<void>((r) => (release = () => r())) as never);
     renderPage();
     await screen.findByLabelText('Good pieces finished');
 
-    await userEvent.click(recordButton());
-    expect(screen.getByTestId('job-feed')).toHaveAttribute('data-offer-signal', '0');
+    await user.type(screen.getByPlaceholderText(/worth noting/i), 'fixture walks');
+    await user.click(recordButton());
+
+    expect(mockAddNote).not.toHaveBeenCalled();
 
     release();
+    await waitFor(() => expect(mockAddNote).toHaveBeenCalled());
+  });
+
+  it('completes with no note at all', async () => {
+    // Capture is optional, always. Requiring it would make finishing a step
+    // conditional on having something to say.
+    renderPage();
+    await screen.findByLabelText('Good pieces finished');
+
+    await userEvent.click(recordButton());
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(mockAddNote).not.toHaveBeenCalled();
+  });
+
+  it('records the note and the completion from ONE button', async () => {
+    // The defect this removes: capture used to need a SECOND tap on a separate
+    // Post, with no durability in between — attaching a photo showed a thumbnail,
+    // read as finished, and a back tap discarded it silently.
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByLabelText('Good pieces finished');
+
+    await user.type(screen.getByPlaceholderText(/worth noting/i), 'back the feed off');
+    await user.click(recordButton());
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
     await waitFor(() =>
-      expect(screen.getByTestId('job-feed')).toHaveAttribute('data-offer-signal', '1'),
+      expect(mockAddNote).toHaveBeenCalledWith('job1', 'co1', 'acc1', 'back the feed off', {
+        jobPartId: 'jp1',
+        jobOperationId: 'op1',
+      }),
+    );
+    // No second Post anywhere on the screen.
+    expect(screen.queryByRole('button', { name: /^post$/i })).not.toBeInTheDocument();
+  });
+
+  it('keeps the completion when the note fails', async () => {
+    // A failed note must not un-complete a finished step, and the operator must
+    // not be told the completion failed when it did not.
+    const user = userEvent.setup();
+    mockAddNote.mockRejectedValue(new Error('note write failed'));
+    renderPage();
+    await screen.findByLabelText('Good pieces finished');
+
+    await user.type(screen.getByPlaceholderText(/worth noting/i), 'something');
+    await user.click(recordButton());
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalled());
+    expect(
+      mockEvent.mock.calls.some(
+        (c) => c[1] === 'completion_recorded',
+      ),
+      'the completion still counts',
+    ).toBe(true);
+    expect(screen.queryByText('Failed to record completion')).not.toBeInTheDocument();
+  });
+
+  it('owns capture itself, so the feed does not offer a second composer', async () => {
+    // Two composers on one screen would be a bug; this asserts which one is live.
+    renderPage();
+    await screen.findByLabelText('Good pieces finished');
+
+    expect(screen.getByTestId('job-feed')).toHaveAttribute('data-standalone-capture', 'false');
+  });
+
+  it('hands capture BACK to the feed once the step is complete', async () => {
+    // A completed step has no completion block to attach a note to. Without this
+    // an operator could never add the photo afterwards — the phone-camera-then-
+    // attach flow the audit found is how photos actually arrive.
+    mockDetail.mockResolvedValue(detail({ operation_status: 'completed' }) as never);
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('job-feed')).toHaveAttribute('data-standalone-capture', 'true'),
+    );
+  });
+
+  it('hands capture back to the feed on an outside step', async () => {
+    // Outside steps use send/receive, so there is no completion block either —
+    // and the paperless doc calls "sent to coater 7/9, back 7/16" the
+    // highest-value note in the system.
+    mockDetail.mockResolvedValue(
+      detail({ operation_work_center_kind: 'external', operation_vendor_name: 'AcmeCoat' }) as never,
+    );
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('job-feed')).toHaveAttribute('data-standalone-capture', 'true'),
     );
   });
 

--- a/__tests__/app/operator/OperationActionPage.test.tsx
+++ b/__tests__/app/operator/OperationActionPage.test.tsx
@@ -92,10 +92,10 @@ vi.mock('@/components/operator/JobFeed', () => ({
     />
   ),
 }));
-// Must render `trailing`: the quantity field now shares this row, so a mock that
+// Must render `leading`: the quantity field now shares this row, so a mock that
 // drops the slot silently removes the control every completion test drives.
 vi.mock('@/components/operator/PartReferenceRow', () => ({
-  default: ({ trailing }: { trailing?: React.ReactNode }) => <div>{trailing}</div>,
+  default: ({ leading }: { leading?: React.ReactNode }) => <div>{leading}</div>,
 }));
 
 // A station is selected and MATCHES the step, so the guard is out of the way

--- a/__tests__/components/operator/JobFeed.test.tsx
+++ b/__tests__/components/operator/JobFeed.test.tsx
@@ -53,6 +53,19 @@ function renderFeed(props: Partial<React.ComponentProps<typeof JobFeed>> = {}) {
   );
 }
 
+/**
+ * Render with the feed's OWN composer live.
+ *
+ * After B4 the composer only appears where no completion block owns capture — an
+ * already-complete step, or an outside step. The behaviour these tests cover
+ * (the photo picker, the dictation hint, the funnel events) did not change; it
+ * moved into useNoteCapture and is rendered by both hosts, so they are still
+ * exercised through this surface.
+ */
+function renderComposer(props: Partial<React.ComponentProps<typeof JobFeed>> = {}) {
+  return renderFeed({ standaloneCapture: true, ...props });
+}
+
 // This jsdom env ships no Storage — polyfill a minimal in-memory one (same
 // pattern as OperatorStationContext.test).
 class MemoryStorage {
@@ -97,99 +110,22 @@ beforeEach(() => {
   window.localStorage.setItem('jigged:composer-mic-hint', JSON.stringify({ shows: 0, dismissed: true }));
 });
 
-describe('JobFeed — post-completion capture offer', () => {
-  it('shows the offer only after a completion signal, and only when nothing is captured', async () => {
-    const { rerender } = renderFeed({ captureOfferSignal: 0 });
-    await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
-
-    // No offer before a completion event.
-    expect(screen.queryByText(OFFER_TEXT)).not.toBeInTheDocument();
-
-    // A new completion signal, empty feed → offer appears.
-    rerender(<JobFeed jobId="job1" companyId="co1" operationContext={OP_CONTEXT} captureOfferSignal={1} />);
-    expect(await screen.findByText(OFFER_TEXT)).toBeInTheDocument();
-  });
-
-  it('does NOT offer when the operator already captured a note or photo', async () => {
-    mock(getJobNotes).mockResolvedValue([makeNote({ body: 'set jaws to 0.5' })]);
-    const { rerender } = renderFeed({ captureOfferSignal: 0 });
-    await waitFor(() => expect(screen.getByText('set jaws to 0.5')).toBeInTheDocument());
-
-    rerender(<JobFeed jobId="job1" companyId="co1" operationContext={OP_CONTEXT} captureOfferSignal={1} />);
-    // Give the effect a chance to run, then assert it stayed closed.
-    await Promise.resolve();
-    expect(screen.queryByText(OFFER_TEXT)).not.toBeInTheDocument();
-  });
-
-  it('still offers when the only note is an auto-logged event note', async () => {
-    mock(getJobNotes).mockResolvedValue([
-      makeNote({ note_type: 'event', body: 'Order qty changed 10 → 12' }),
-    ]);
-    const { rerender } = renderFeed({ captureOfferSignal: 0 });
-    await waitFor(() => expect(screen.getByText('Order qty changed 10 → 12')).toBeInTheDocument());
-
-    rerender(<JobFeed jobId="job1" companyId="co1" operationContext={OP_CONTEXT} captureOfferSignal={1} />);
-    expect(await screen.findByText(OFFER_TEXT)).toBeInTheDocument();
-  });
-
-  it('is one-per-event: Skip dismisses and it only reopens on a new signal', async () => {
-    const user = userEvent.setup();
-    const { rerender } = renderFeed({ captureOfferSignal: 1 });
-    await screen.findByText(OFFER_TEXT);
-
-    await user.click(screen.getByRole('button', { name: 'Skip' }));
-    expect(screen.queryByText(OFFER_TEXT)).not.toBeInTheDocument();
-
-    // Re-render with the SAME signal — stays closed (skip means skip).
-    rerender(<JobFeed jobId="job1" companyId="co1" operationContext={OP_CONTEXT} captureOfferSignal={1} />);
-    expect(screen.queryByText(OFFER_TEXT)).not.toBeInTheDocument();
-
-    // A brand-new completion → a fresh single offer.
-    rerender(<JobFeed jobId="job1" companyId="co1" operationContext={OP_CONTEXT} captureOfferSignal={2} />);
-    expect(await screen.findByText(OFFER_TEXT)).toBeInTheDocument();
-  });
-
-  it('Skip performs no writes — the offer can never affect the (already-committed) completion', async () => {
-    const user = userEvent.setup();
-    renderFeed({ captureOfferSignal: 1 });
-    await screen.findByText(OFFER_TEXT);
-
-    await user.click(screen.getByRole('button', { name: 'Skip' }));
-    expect(addJobNote).not.toHaveBeenCalled();
-    expect(addJobNoteMedia).not.toHaveBeenCalled();
-  });
-
-  it('"Add photo" opens the file picker and closes the offer', async () => {
-    const user = userEvent.setup();
-    const { container } = renderFeed({ captureOfferSignal: 1 });
-    await screen.findByText(OFFER_TEXT);
-
-    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const clickSpy = vi.spyOn(fileInput, 'click').mockImplementation(() => {});
-
-    // Offer's "Add photo" is the first (rendered above the composer's button).
-    await user.click(screen.getAllByRole('button', { name: 'Add photo' })[0]);
-
-    expect(clickSpy).toHaveBeenCalledTimes(1);
-    expect(screen.queryByText(OFFER_TEXT)).not.toBeInTheDocument();
-  });
-
-  it('"Add note" focuses the composer and closes the offer', async () => {
-    const user = userEvent.setup();
-    renderFeed({ captureOfferSignal: 1 });
-    await screen.findByText(OFFER_TEXT);
-
-    await user.click(screen.getByRole('button', { name: 'Add note' }));
-
-    const field = screen.getByPlaceholderText('Add a note or photo for this step…');
-    expect(field).toHaveFocus();
-    expect(screen.queryByText(OFFER_TEXT)).not.toBeInTheDocument();
-  });
-});
+// DELETED WITH B4: the post-completion "add a photo?" offer.
+//
+// Six tests went with it, and that is the right outcome rather than a loss of
+// coverage. The offer existed to chase a note AFTER the fact, which is exactly
+// the two-stage commit that lost photos: it prompted, the operator attached, a
+// thumbnail appeared, and nothing was written until a separate Post they had no
+// reason to look for. Capture now sits inside the completion block and lands
+// with the completion, so there is nothing to prompt for.
+//
+// The property the offer protected — completion durable BEFORE capture is
+// attempted — is asserted in OperationActionPage.test.tsx
+// ('writes the note only AFTER the completion has landed').
 
 describe('JobFeed — camera-roll photos unlocked', () => {
   it('file input has no capture attribute and still accepts images', async () => {
-    const { container } = renderFeed();
+    const { container } = renderComposer();
     await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
     expect(fileInput).not.toHaveAttribute('capture');
@@ -202,20 +138,20 @@ describe('JobFeed — dictation hint', () => {
 
   it('shows on first composer mounts and counts the show', async () => {
     window.localStorage.removeItem(HINT_KEY);
-    renderFeed();
+    renderComposer();
     expect(await screen.findByText(HINT_TEXT)).toBeInTheDocument();
     expect(JSON.parse(window.localStorage.getItem(HINT_KEY)!)).toEqual({ shows: 1, dismissed: false });
   });
 
   it('still shows on the last allowed mount (below the cap of 5)', async () => {
     window.localStorage.setItem(HINT_KEY, JSON.stringify({ shows: 4, dismissed: false }));
-    renderFeed();
+    renderComposer();
     expect(await screen.findByText(HINT_TEXT)).toBeInTheDocument();
   });
 
   it('stops showing once the cap of 5 is reached', async () => {
     window.localStorage.setItem(HINT_KEY, JSON.stringify({ shows: 5, dismissed: false }));
-    renderFeed();
+    renderComposer();
     await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
     expect(screen.queryByText(HINT_TEXT)).not.toBeInTheDocument();
   });
@@ -223,7 +159,7 @@ describe('JobFeed — dictation hint', () => {
   it('hides immediately and persists dismissal when the × is tapped', async () => {
     const user = userEvent.setup();
     window.localStorage.removeItem(HINT_KEY);
-    renderFeed();
+    renderComposer();
     await screen.findByText(HINT_TEXT);
 
     await user.click(screen.getByRole('button', { name: 'Dismiss tip' }));
@@ -240,7 +176,7 @@ describe('JobFeed — dictation hint', () => {
 describe('JobFeed — capture funnel events', () => {
   it('records composer_focused once, however many times they refocus', async () => {
     const user = userEvent.setup();
-    renderFeed();
+    renderComposer();
     await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
     const field = screen.getByPlaceholderText('Add a note or photo for this step…');
 
@@ -257,7 +193,7 @@ describe('JobFeed — capture funnel events', () => {
   it('records note_saved only after the write resolves', async () => {
     const user = userEvent.setup();
     mock(addJobNote).mockResolvedValue(makeNote({ id: 'new', body: 'watch the bore' }));
-    renderFeed();
+    renderComposer();
     await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
 
     await user.type(
@@ -278,7 +214,7 @@ describe('JobFeed — capture funnel events', () => {
     // friction, not a successful capture.
     const user = userEvent.setup();
     mock(addJobNote).mockRejectedValue(new Error('offline'));
-    renderFeed();
+    renderComposer();
     await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
 
     await user.type(
@@ -297,7 +233,7 @@ describe('JobFeed — capture funnel events', () => {
 
   it('records composer_abandoned when they open it and leave without saving', async () => {
     const user = userEvent.setup();
-    const { unmount } = renderFeed();
+    const { unmount } = renderComposer();
     await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
 
     await user.type(
@@ -314,7 +250,7 @@ describe('JobFeed — capture funnel events', () => {
   });
 
   it('does NOT record abandonment when they never opened the composer', async () => {
-    const { unmount } = renderFeed();
+    const { unmount } = renderComposer();
     await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
     unmount();
 
@@ -326,7 +262,7 @@ describe('JobFeed — capture funnel events', () => {
   it('does NOT record abandonment after a successful save', async () => {
     const user = userEvent.setup();
     mock(addJobNote).mockResolvedValue(makeNote({ id: 'new', body: 'saved' }));
-    const { unmount } = renderFeed();
+    const { unmount } = renderComposer();
     await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
 
     await user.type(screen.getByPlaceholderText('Add a note or photo for this step…'), 'saved');

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -438,25 +438,18 @@ export default function OperatorOperationActionPage() {
 
           {/* INSTRUCTIONS ARE NOT BEHIND THE EXPANDER. "Torque to 40, not 45" is
               the most action-relevant thing on the screen, so hiding it would
-              invert the whole principle. It renders only when a shop has
-              actually written something. */}
+              invert the whole principle. It renders only when a shop has actually
+              written something.
+              No box and no "Instructions" label — that chrome cost more attention
+              than it earned. Hierarchy comes from WEIGHT instead: the description
+              above is dimmed and this is full-strength, so the actionable line is
+              the brighter one. Making the two visually identical would have been
+              the real risk — an operator would read this as more description and
+              skim past it. */}
           {job.operation_instructions && (
-            <Box
-              sx={{
-                mt: 1.5,
-                p: 1.5,
-                borderRadius: 1,
-                bgcolor: 'rgba(255, 255, 255, 0.04)',
-                border: '1px solid rgba(255, 255, 255, 0.08)',
-              }}
-            >
-              <Typography variant="caption" color="text.secondary" display="block">
-                Instructions
-              </Typography>
-              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
-                {job.operation_instructions}
-              </Typography>
-            </Box>
+            <Typography variant="body2" sx={{ mt: 0.5, whiteSpace: 'pre-wrap' }}>
+              {job.operation_instructions}
+            </Typography>
           )}
 
 
@@ -546,9 +539,10 @@ export default function OperatorOperationActionPage() {
         excludeJobId={jobId}
         jobOperationId={jobOperationId}
         // The quantity shares the reference row rather than taking a line of its
-        // own. Three controls on one line is what buys back the vertical space
-        // that used to require pinning the action to the bottom.
-        trailing={
+        // own, and LEADS it: it is the input for this screen's primary action,
+        // while Files and Playbook are reference. Three controls on one line is
+        // what buys back the vertical space that pinning used to provide.
+        leading={
           !isCompleted && !isExternal ? (
         <TextField
           label="Parts finished"
@@ -560,7 +554,10 @@ export default function OperatorOperationActionPage() {
           }}
           inputProps={{ min: 0, inputMode: 'numeric', 'aria-label': 'Parts finished' }}
           fullWidth
-          size="medium"
+          size="small"
+          // Matched to the 48px reference buttons beside it: a taller control
+          // reads as a different KIND of thing and pulls the eye for no reason.
+          sx={{ '& .MuiOutlinedInput-root': { minHeight: 48 } }}
           error={consequence.kind === 'over'}
           helperText={
             consequence.kind === 'none'

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -427,29 +427,42 @@ export default function OperatorOperationActionPage() {
             />
           </Box>
 
-          {/* Shop part descriptions frequently ARE the working instruction
-              ("Linear Actuator A-200, 6061, deburr all edges"), so this is
-              always visible rather than behind the expander. */}
+          {/* FULL STRENGTH, not dimmed. Shop part descriptions frequently ARE the
+              working instruction, because per-operation instructions are optional
+              and often left blank — so whichever field the engineer chose is the
+              one that matters, and the app cannot know which. Dimming this
+              asserted "reference, not instruction", which is false exactly when it
+              costs the most. Muted text draws less attention and raises the odds
+              of a skip (NN/G), and ISA-101 requires every emphasis to carry a
+              defined meaning — de-emphasis used as a guess carries none. */}
           {job.part_description && (
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+            <Typography variant="body2" sx={{ mt: 0.5 }}>
               {job.part_description}
             </Typography>
           )}
 
-          {/* INSTRUCTIONS ARE NOT BEHIND THE EXPANDER. "Torque to 40, not 45" is
-              the most action-relevant thing on the screen, so hiding it would
-              invert the whole principle. It renders only when a shop has actually
-              written something.
-              No box and no "Instructions" label — that chrome cost more attention
-              than it earned. Hierarchy comes from WEIGHT instead: the description
-              above is dimmed and this is full-strength, so the actionable line is
-              the brighter one. Making the two visually identical would have been
-              the real risk — an operator would read this as more description and
-              skim past it. */}
+          {/* Distinguished by a LABEL, not by weight or a box.
+              The two lines cannot be ranked: either may hold the engineer's
+              instruction, since per-operation text is optional and often blank.
+              So neither is dimmed — what is dimmed is the LABEL, which is chrome,
+              never the content. That tells the operator WHICH they are reading
+              (per-step vs per-part) without asserting which is more important,
+              and it keeps emphasis free for the states that genuinely mean "look
+              here now": the over-quantity error and the station mismatch.
+              The earlier problem was the tinted box, not the label. */}
           {job.operation_instructions && (
-            <Typography variant="body2" sx={{ mt: 0.5, whiteSpace: 'pre-wrap' }}>
-              {job.operation_instructions}
-            </Typography>
+            <Box sx={{ display: 'flex', gap: 0.75, mt: 0.5 }}>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ flexShrink: 0, pt: '2px', textTransform: 'uppercase', letterSpacing: 0.4 }}
+              >
+                Step
+              </Typography>
+              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                {job.operation_instructions}
+              </Typography>
+            </Box>
           )}
 
 

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -40,6 +40,8 @@ import { useSetOperatorChrome, useOperatorNav } from '@/components/operator/Oper
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import StationSelector from '@/components/operator/StationSelector';
 import JobFeed from '@/components/operator/JobFeed';
+import NoteCaptureFields from '@/components/operator/NoteCaptureFields';
+import { useNoteCapture } from '@/hooks/useNoteCapture';
 import PartReferenceRow from '@/components/operator/PartReferenceRow';
 
 /**
@@ -80,10 +82,10 @@ export default function OperatorOperationActionPage() {
   // then defaults to the remaining balance (dialled down for a partial).
   const [qtyInput, setQtyInput] = useState('');
   const [qtyDirty, setQtyDirty] = useState(false);
-  // Bumped after each successful completion to trigger JobFeed's one-time
-  // "add a photo/note?" offer. Bumped strictly AFTER the completion resolves,
-  // so completion is already durable before any prompt appears.
-  const [captureOfferSignal, setCaptureOfferSignal] = useState(0);
+  // Bumped after this page writes a note, so the feed below reloads and shows
+  // it. Replaces the old capture-offer signal: there is no prompt any more,
+  // because capture happens in the completion block itself.
+  const [feedRefreshSignal, setFeedRefreshSignal] = useState(0);
 
   // Header back pops in-app history (nav.goBack). This href is only the deep-link
   // fallback — the part's traveler — for an operation scanned into directly.
@@ -171,10 +173,29 @@ export default function OperatorOperationActionPage() {
       setQtyDirty(false);
       // After the write resolves — a failed completion is not a completion.
       logOperatorEvent(companyId, 'completion_recorded', { jobOperationId, quantityGood: qty });
+
+      // ORDER IS LOAD-BEARING, AND DELIBERATELY NOT ATOMIC.
+      //
+      // The completion is already durable by the time we get here. The note is
+      // attempted second so that a failed photo upload — the slowest, most
+      // failure-prone part of the whole flow on shop wifi — can never un-complete
+      // a finished step. Wrapping both in a transaction would be worse, not
+      // better: it would roll back real work because an image did not upload.
+      //
+      // So a note failure surfaces on its own and the step stays complete. The
+      // operator can retype it; they cannot un-finish the part they finished.
+      if (capture.hasContent) {
+        try {
+          await capture.submit();
+          setFeedRefreshSignal((n) => n + 1);
+        } catch {
+          // useNoteCapture puts the message in the fields, next to the text the
+          // operator still has. Do not overwrite the page-level error with it —
+          // "the completion worked, the note did not" is the accurate reading.
+        }
+      }
+
       await reloadAll();
-      // Completion is now persisted. Offer capture last, so a client death at
-      // the prompt cannot un-complete the step.
-      setCaptureOfferSignal((n) => n + 1);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to record completion');
     } finally {
@@ -226,6 +247,21 @@ export default function OperatorOperationActionPage() {
 
   const isExternal = job?.operation_work_center_kind === 'external';
   const isCompleted = job?.operation_status === 'completed';
+
+  // Capture belongs to the completion action, so it is enabled on exactly the
+  // branch that renders RECORD COMPLETION. A completed step and an outside step
+  // have no completion to attach a note to, so the feed keeps its own composer
+  // there (standaloneCapture below) — otherwise finishing a step would make it
+  // impossible to add the photo afterwards, and an outside step could never
+  // carry "sent to coater, back on the 16th".
+  const ownsCapture = !isCompleted && !isExternal;
+  const capture = useNoteCapture({
+    companyId,
+    jobId,
+    operatorId: currentOperatorId,
+    context: { jobPartId, jobOperationId },
+    enabled: ownsCapture,
+  });
   const isSent = job?.operation_status === 'sent';
   const consequence = operationCompletionConsequence(qtyValue, remaining);
 
@@ -538,6 +574,20 @@ export default function OperatorOperationActionPage() {
             }}
           />
 
+          {/* CAPTURE, MERGED INTO COMPLETION.
+              Finishing a step and writing down what you learned are one act, one
+              button, one commit. It used to be two: RECORD COMPLETION, then a
+              separate offer, then a separate Post — and the middle of that had no
+              durability, so attaching a photo showed a thumbnail, read as
+              finished, and was discarded by a back tap. There is no second Post
+              to forget now.
+              Optional, always: completion works with the field left empty. */}
+          <NoteCaptureFields
+            capture={capture}
+            placeholder="Anything worth noting for next time? (optional)"
+            disabled={actionLoading}
+          />
+
           {/* Single action: the field defaults to the full remaining balance, so
               this records a full completion by default and a partial when the
               operator dials the number down (mirrors the shipment form — no
@@ -578,7 +628,11 @@ export default function OperatorOperationActionPage() {
         <JobFeed
           jobId={jobId}
           companyId={companyId}
-          captureOfferSignal={captureOfferSignal}
+          refreshSignal={feedRefreshSignal}
+          // Only where this page's completion block is not rendered — see
+          // ownsCapture. Two composers on one screen would be a bug, and none
+          // would strand a finished or outside step with no way to add a photo.
+          standaloneCapture={!ownsCapture}
           operationContext={{
             jobPartId,
             jobOperationId,

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -13,8 +13,12 @@ import CircularProgress from '@mui/material/CircularProgress';
 import LinearProgress from '@mui/material/LinearProgress';
 import Alert from '@mui/material/Alert';
 import Chip from '@mui/material/Chip';
+import Collapse from '@mui/material/Collapse';
+import IconButton from '@mui/material/IconButton';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import TextField from '@mui/material/TextField';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import NoteAddIcon from '@mui/icons-material/NoteAdd';
 import UndoIcon from '@mui/icons-material/Undo';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import LocalShippingIcon from '@mui/icons-material/LocalShipping';
@@ -63,6 +67,19 @@ import PartReferenceRow from '@/components/operator/PartReferenceRow';
  * by a guide with a one-tap "switch & complete" (for legit cross-station work)
  * and a way back to the traveler.
  */
+const OP_DETAILS_KEY = 'jigged:op-details-expanded';
+
+/**
+ * Height of the operator shell's fixed bottom navigation.
+ *
+ * The sticky action bar has to clear it. The shell reserves the space with a
+ * margin on <main>, but that does NOT help a sticky child here: <main> is taller
+ * than the viewport and does not scroll internally, so the WINDOW is the scroll
+ * container and `bottom: 0` pins to the viewport edge — directly underneath the
+ * nav. Measured: main 48→720 on a 577px viewport, bar bottom 557, nav top 521.
+ */
+const BOTTOM_NAV_H = 56;
+
 export default function OperatorOperationActionPage() {
   const params = useParams();
   const companyId = params.companyId as string;
@@ -86,6 +103,29 @@ export default function OperatorOperationActionPage() {
   // it. Replaces the old capture-offer signal: there is no prompt any more,
   // because capture happens in the completion block itself.
   const [feedRefreshSignal, setFeedRefreshSignal] = useState(0);
+
+  // Job-card details, collapsed by default. STICKY across steps: an operator who
+  // wants the customer and the order quantity wants them on the next step too,
+  // and re-opening it every time is its own friction. sessionStorage rather than
+  // localStorage on purpose — this survives navigation, and whether it should
+  // survive across days (a remembered per-user preference) is a separate
+  // decision we have not made yet.
+  const [detailsOpen, setDetailsOpen] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    try {
+      return window.sessionStorage.getItem(OP_DETAILS_KEY) === '1';
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.sessionStorage.setItem(OP_DETAILS_KEY, detailsOpen ? '1' : '0');
+    } catch {
+      /* private mode / quota — the preference is best-effort */
+    }
+  }, [detailsOpen]);
 
   // Header back pops in-app history (nav.goBack). This href is only the deep-link
   // fallback — the part's traveler — for an operation scanned into directly.
@@ -143,7 +183,31 @@ export default function OperatorOperationActionPage() {
   // like the shipment form's prefill) until the operator edits it — derived, not
   // an effect, so there's no setState-in-effect cascade. A successful record
   // clears the dirty flag, snapping the value back to the new remaining.
+  const isExternal = job?.operation_work_center_kind === 'external';
+  const isCompleted = job?.operation_status === 'completed';
+
+  // Capture belongs to the completion action, so it is enabled on exactly the
+  // branch that renders RECORD COMPLETION. A completed step and an outside step
+  // have no completion to attach a note to, so the feed keeps its own composer
+  // there (standaloneCapture below) — otherwise finishing a step would make it
+  // impossible to add the photo afterwards, and an outside step could never
+  // carry "sent to coater, back on the 16th".
+  const ownsCapture = !isCompleted && !isExternal;
+  const capture = useNoteCapture({
+    companyId,
+    jobId,
+    operatorId: currentOperatorId,
+    context: { jobPartId, jobOperationId },
+    enabled: ownsCapture,
+  });
+
   const qtyValue = qtyDirty ? qtyInput : remaining > 0 ? String(remaining) : '';
+
+  // What the single primary button will do. Completing takes precedence: a
+  // quantity in the field is a statement about production, and the note rides
+  // along with it.
+  const canComplete = Number(qtyValue) > 0;
+  const noteOnly = !canComplete && capture.hasContent;
 
   const reloadAll = async () => {
     await Promise.all([loadJob(), loadSummary()]);
@@ -203,6 +267,31 @@ export default function OperatorOperationActionPage() {
     }
   };
 
+  // Save a note with NO completion.
+  //
+  // Closes a hole B4 opened. Capture rides on RECORD COMPLETION, and that button
+  // requires qty > 0 — so an operator who finished ZERO pieces ("machine down",
+  // "waiting on material", "tool chipped") had two options and both were bad:
+  // say nothing, and lose exactly the knowledge this whole workstream exists to
+  // capture; or type a false quantity to get the note saved, corrupting the
+  // number that feeds costing and scheduling. Falsifying production data to
+  // satisfy a UI constraint is far worse than an extra code path.
+  //
+  // No second composer and no extra chrome: the SAME field, and the primary
+  // button says what it will actually do.
+  const handleSaveNoteOnly = async () => {
+    setActionLoading(true);
+    setError(null);
+    try {
+      await capture.submit();
+      setFeedRefreshSignal((n) => n + 1);
+    } catch {
+      // useNoteCapture surfaces the message in the field itself.
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
   const handleRevert = async () => {
     setActionLoading(true);
     setError(null);
@@ -245,23 +334,6 @@ export default function OperatorOperationActionPage() {
     }
   };
 
-  const isExternal = job?.operation_work_center_kind === 'external';
-  const isCompleted = job?.operation_status === 'completed';
-
-  // Capture belongs to the completion action, so it is enabled on exactly the
-  // branch that renders RECORD COMPLETION. A completed step and an outside step
-  // have no completion to attach a note to, so the feed keeps its own composer
-  // there (standaloneCapture below) — otherwise finishing a step would make it
-  // impossible to add the photo afterwards, and an outside step could never
-  // carry "sent to coater, back on the 16th".
-  const ownsCapture = !isCompleted && !isExternal;
-  const capture = useNoteCapture({
-    companyId,
-    jobId,
-    operatorId: currentOperatorId,
-    context: { jobPartId, jobOperationId },
-    enabled: ownsCapture,
-  });
   const isSent = job?.operation_status === 'sent';
   const consequence = operationCompletionConsequence(qtyValue, remaining);
 
@@ -308,7 +380,10 @@ export default function OperatorOperationActionPage() {
     job.operation_work_center_id !== stationId;
 
   return (
-    <Box>
+    // Bottom padding so the last of the feed can scroll clear of the sticky
+    // action bar instead of ending underneath it — the documented failure mode
+    // of sticky bars is obscuring the content or the error you need to read.
+    <Box sx={{ pb: `${BOTTOM_NAV_H + 88}px` }}>
       {error && (
         <Alert severity="error" sx={{ mb: 2 }}>
           {error}
@@ -319,8 +394,15 @@ export default function OperatorOperationActionPage() {
         elevation={2}
         sx={{ mb: 3, bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' }}
       >
-        <CardContent>
-          <Box sx={{ mb: 2 }}>
+        <CardContent sx={{ py: 1.5 }}>
+          {/* ONE LINE BY DEFAULT: job number and part — what an operator needs to
+              confirm they have the right thing in hand. Everything else is
+              reference, and reference does not belong between someone and the
+              button they came to press (ISA-101: relevance over detail; a step
+              screen is a Level 1 action display, not a Level 3 detail display).
+              The rest expands IN PLACE rather than on another page, so nobody
+              loses their position mid-task. */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             {/* The job number doubles as the link to this part's traveler — the
                 full step list. It's the way there for an operator who scanned
                 straight into one operation (no in-app history to pop back to);
@@ -336,22 +418,64 @@ export default function OperatorOperationActionPage() {
                 borderRadius: 1,
                 mx: -0.75,
                 px: 0.75,
+                flexShrink: 0,
               }}
             >
-              <Typography variant="h5" component="span" fontWeight={700}>
+              <Typography variant="h6" component="span" fontWeight={700}>
                 {job.job_number}
               </Typography>
               <FormatListBulletedIcon fontSize="small" sx={{ color: 'primary.light' }} />
             </ButtonBase>
-            <Typography variant="body2" color="text.secondary">
-              {job.customer_name || 'No customer'}
+            <Typography variant="h6" color="text.secondary" sx={{ flexShrink: 0 }}>
+              ·
             </Typography>
+            <Typography variant="h6" noWrap sx={{ minWidth: 0 }}>
+              {job.part_name || 'Part'}
+            </Typography>
+            <Box sx={{ flex: 1 }} />
+            <IconButton
+              onClick={() => setDetailsOpen((v) => !v)}
+              aria-label={detailsOpen ? 'Hide job details' : 'Show job details'}
+              aria-expanded={detailsOpen}
+              sx={{ width: 44, height: 44, flexShrink: 0 }}
+            >
+              <ExpandMoreIcon
+                sx={{
+                  transition: 'transform 150ms',
+                  transform: detailsOpen ? 'rotate(180deg)' : 'none',
+                }}
+              />
+            </IconButton>
           </Box>
 
-          {/* Lead with the part (what they're making). The operation's work
-              center is intentionally NOT repeated here — it's already shown as
-              the selected station in the header (and in the mismatch guard). */}
-          <Typography variant="h6">{job.part_name || 'Part'}</Typography>
+          {/* INSTRUCTIONS ARE NOT BEHIND THE CHEVRON. "Torque to 40, not 45" is
+              the most action-relevant thing on the screen, so hiding it would
+              invert the whole principle. It renders only when a shop has
+              actually written something. */}
+          {job.operation_instructions && (
+            <Box
+              sx={{
+                mt: 1.5,
+                p: 1.5,
+                borderRadius: 1,
+                bgcolor: 'rgba(255, 255, 255, 0.04)',
+                border: '1px solid rgba(255, 255, 255, 0.08)',
+              }}
+            >
+              <Typography variant="caption" color="text.secondary" display="block">
+                Instructions
+              </Typography>
+              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                {job.operation_instructions}
+              </Typography>
+            </Box>
+          )}
+
+          <Collapse in={detailsOpen} unmountOnExit>
+          <Box sx={{ mt: 1.5 }}>
+          <Typography variant="body2" color="text.secondary">
+            {job.customer_name || 'No customer'}
+          </Typography>
           {job.part_description && (
             <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
               {job.part_description}
@@ -377,25 +501,6 @@ export default function OperatorOperationActionPage() {
                     : 'Outside process'
                 }
               />
-            </Box>
-          )}
-
-          {job.operation_instructions && (
-            <Box
-              sx={{
-                mt: 1.5,
-                p: 1.5,
-                borderRadius: 1,
-                bgcolor: 'rgba(255, 255, 255, 0.04)',
-                border: '1px solid rgba(255, 255, 255, 0.08)',
-              }}
-            >
-              <Typography variant="caption" color="text.secondary" display="block">
-                Instructions
-              </Typography>
-              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
-                {job.operation_instructions}
-              </Typography>
             </Box>
           )}
 
@@ -425,6 +530,8 @@ export default function OperatorOperationActionPage() {
               />
             </Box>
           )}
+          </Box>
+          </Collapse>
         </CardContent>
       </Card>
 
@@ -586,24 +693,62 @@ export default function OperatorOperationActionPage() {
             capture={capture}
             placeholder="Anything worth noting for next time? (optional)"
             disabled={actionLoading}
+            compact
           />
 
-          {/* Single action: the field defaults to the full remaining balance, so
-              this records a full completion by default and a partial when the
-              operator dials the number down (mirrors the shipment form — no
-              separate "complete all" button, which would just duplicate this). */}
-          <Button
-            fullWidth
-            variant="contained"
-            size="large"
-            color="primary"
-            startIcon={<CheckCircleIcon />}
-            onClick={handleRecord}
-            disabled={actionLoading || !(Number(qtyValue) > 0)}
-            sx={{ minHeight: 64, fontSize: '1.15rem', fontWeight: 600 }}
+          {/* STICKY, and that is the point. The action used to sit in normal flow
+              and fell below the fold on a 6.9" phone as soon as anything was added
+              above it — which B4 promptly did. Decluttering fixes that for today;
+              sticking it to the bottom makes it structurally impossible to break
+              again, and puts it in the thumb's green zone where the reachability
+              research says a primary action belongs. It sits inside the scrolling
+              region, so it lands directly above the bottom nav rather than over
+              it, and the errors above it stay visible. */}
+          <Box
+            sx={{
+              // FIXED, not sticky. `position: sticky` is inert here: the operator
+              // shell gives <main> `overflow: auto`, which makes main the nearest
+              // scrollport, and main never scrolls internally (it is simply taller
+              // than the viewport and the WINDOW does the scrolling). A sticky
+              // child of a non-scrolling scrollport never sticks — measured at
+              // bottom 557 with the nav top at 521, i.e. underneath the nav.
+              // Fixed escapes the overflow ancestor and pins to the viewport.
+              position: 'fixed',
+              left: 0,
+              right: 0,
+              bottom: BOTTOM_NAV_H,
+              px: 2,
+              pt: 1,
+              pb: 1.5,
+              bgcolor: 'background.default',
+              borderTop: '1px solid rgba(255, 255, 255, 0.08)',
+              zIndex: 2,
+            }}
           >
-            {actionLoading ? <CircularProgress size={24} /> : 'RECORD COMPLETION'}
-          </Button>
+            {/* One button, and it says what it will do. The quantity field
+                defaults to the full remaining balance, so this records a full
+                completion by default and a partial when the number is dialled
+                down. With nothing finished but something typed it saves the note
+                alone — better than a dead button that does not explain itself. */}
+            <Button
+              fullWidth
+              variant="contained"
+              size="large"
+              color="primary"
+              startIcon={canComplete ? <CheckCircleIcon /> : <NoteAddIcon />}
+              onClick={canComplete ? handleRecord : handleSaveNoteOnly}
+              disabled={actionLoading || (!canComplete && !noteOnly)}
+              sx={{ minHeight: 64, fontSize: '1.15rem', fontWeight: 600 }}
+            >
+              {actionLoading ? (
+                <CircularProgress size={24} />
+              ) : canComplete ? (
+                'RECORD COMPLETION'
+              ) : (
+                'SAVE NOTE'
+              )}
+            </Button>
+          </Box>
 
           {qtyGood > 0 && (
             <Button

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -451,17 +451,17 @@ export default function OperatorOperationActionPage() {
               here now": the over-quantity error and the station mismatch.
               The earlier problem was the tinted box, not the label. */}
           {job.operation_instructions && (
-            <Box sx={{ display: 'flex', gap: 0.75, mt: 0.5 }}>
-              {/* "Instructions" — the same word the admin sees when writing this
+            <Box sx={{ display: 'flex', gap: 0.5, mt: 0.5 }}>
+              {/* "Instructions:" — the same word the admin sees when writing this
                   field. ISA-101's consistency rule is about exactly this: an
-                  operator and an engineer talking about the same box should be
-                  using the same name for it. */}
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{ flexShrink: 0, pt: '2px' }}
-              >
-                Instructions
+                  operator and an engineer talking about the same box should use
+                  the same name for it.
+                  Same variant as the content, so the only difference between them
+                  is colour. A smaller label beside larger text read as two
+                  unrelated things rather than a label and its value, and the colon
+                  does the demarcating that a size change was doing badly. */}
+              <Typography variant="body2" color="text.secondary" sx={{ flexShrink: 0 }}>
+                Instructions:
               </Typography>
               <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
                 {job.operation_instructions}

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -452,12 +452,16 @@ export default function OperatorOperationActionPage() {
               The earlier problem was the tinted box, not the label. */}
           {job.operation_instructions && (
             <Box sx={{ display: 'flex', gap: 0.75, mt: 0.5 }}>
+              {/* "Instructions" — the same word the admin sees when writing this
+                  field. ISA-101's consistency rule is about exactly this: an
+                  operator and an engineer talking about the same box should be
+                  using the same name for it. */}
               <Typography
                 variant="caption"
                 color="text.secondary"
-                sx={{ flexShrink: 0, pt: '2px', textTransform: 'uppercase', letterSpacing: 0.4 }}
+                sx={{ flexShrink: 0, pt: '2px' }}
               >
-                Step
+                Instructions
               </Typography>
               <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
                 {job.operation_instructions}
@@ -517,6 +521,16 @@ export default function OperatorOperationActionPage() {
             </Box>
           )}
 
+
+          {!isCompleted && job.estimated_minutes != null && job.estimated_minutes > 0 && (
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+              Estimated:{' '}
+              {job.estimated_minutes < 60
+                ? `${Math.round(job.estimated_minutes)} min`
+                : `${(job.estimated_minutes / 60).toFixed(1)} hrs`}
+            </Typography>
+          )}
+
           {/* The way to the full step list. It used to be the job number itself,
               which cannot stay now that the whole card is one tap target — a link
               nested inside a button is invalid and swallows one of the two taps.
@@ -531,16 +545,6 @@ export default function OperatorOperationActionPage() {
           >
             View all steps for {job.job_number}
           </Button>
-
-          {!isCompleted && job.estimated_minutes != null && job.estimated_minutes > 0 && (
-            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
-              Estimated:{' '}
-              {job.estimated_minutes < 60
-                ? `${Math.round(job.estimated_minutes)} min`
-                : `${(job.estimated_minutes / 60).toFixed(1)} hrs`}
-            </Typography>
-          )}
-
           </Box>
           </Collapse>
       </Card>

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -6,15 +6,14 @@ import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
-import ButtonBase from '@mui/material/ButtonBase';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
+import CardActionArea from '@mui/material/CardActionArea';
 import CircularProgress from '@mui/material/CircularProgress';
 import LinearProgress from '@mui/material/LinearProgress';
 import Alert from '@mui/material/Alert';
 import Chip from '@mui/material/Chip';
 import Collapse from '@mui/material/Collapse';
-import IconButton from '@mui/material/IconButton';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import TextField from '@mui/material/TextField';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
@@ -69,16 +68,6 @@ import PartReferenceRow from '@/components/operator/PartReferenceRow';
  */
 const OP_DETAILS_KEY = 'jigged:op-details-expanded';
 
-/**
- * Height of the operator shell's fixed bottom navigation.
- *
- * The sticky action bar has to clear it. The shell reserves the space with a
- * margin on <main>, but that does NOT help a sticky child here: <main> is taller
- * than the viewport and does not scroll internally, so the WINDOW is the scroll
- * container and `bottom: 0` pins to the viewport edge — directly underneath the
- * nav. Measured: main 48→720 on a 577px viewport, bar bottom 557, nav top 521.
- */
-const BOTTOM_NAV_H = 56;
 
 export default function OperatorOperationActionPage() {
   const params = useParams();
@@ -383,7 +372,7 @@ export default function OperatorOperationActionPage() {
     // Bottom padding so the last of the feed can scroll clear of the sticky
     // action bar instead of ending underneath it — the documented failure mode
     // of sticky bars is obscuring the content or the error you need to read.
-    <Box sx={{ pb: `${BOTTOM_NAV_H + 88}px` }}>
+    <Box>
       {error && (
         <Alert severity="error" sx={{ mb: 2 }}>
           {error}
@@ -394,6 +383,16 @@ export default function OperatorOperationActionPage() {
         elevation={2}
         sx={{ mb: 3, bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' }}
       >
+        {/* THE WHOLE CARD TOGGLES. One target rather than a chevron button:
+            a separate control for the same action is a second thing to aim at,
+            and nesting it inside this action area would be invalid markup. The
+            expanded section sits OUTSIDE this button for the same reason — it
+            contains a real link. */}
+        <CardActionArea
+          onClick={() => setDetailsOpen((v) => !v)}
+          aria-expanded={detailsOpen}
+          aria-label={detailsOpen ? 'Hide job details' : 'Show job details'}
+        >
         <CardContent sx={{ py: 1.5 }}>
           {/* ONE LINE BY DEFAULT: job number and part — what an operator needs to
               confirm they have the right thing in hand. Everything else is
@@ -403,29 +402,9 @@ export default function OperatorOperationActionPage() {
               The rest expands IN PLACE rather than on another page, so nobody
               loses their position mid-task. */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            {/* The job number doubles as the link to this part's traveler — the
-                full step list. It's the way there for an operator who scanned
-                straight into one operation (no in-app history to pop back to);
-                the list icon signals it's tappable. */}
-            <ButtonBase
-              onClick={() => nav.push(travelerHref)}
-              aria-label={`View all steps for job ${job.job_number}`}
-              sx={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 0.75,
-                minHeight: 44,
-                borderRadius: 1,
-                mx: -0.75,
-                px: 0.75,
-                flexShrink: 0,
-              }}
-            >
-              <Typography variant="h6" component="span" fontWeight={700}>
-                {job.job_number}
-              </Typography>
-              <FormatListBulletedIcon fontSize="small" sx={{ color: 'primary.light' }} />
-            </ButtonBase>
+            <Typography variant="h6" component="span" fontWeight={700} sx={{ flexShrink: 0 }}>
+              {job.job_number}
+            </Typography>
             <Typography variant="h6" color="text.secondary" sx={{ flexShrink: 0 }}>
               ·
             </Typography>
@@ -433,22 +412,31 @@ export default function OperatorOperationActionPage() {
               {job.part_name || 'Part'}
             </Typography>
             <Box sx={{ flex: 1 }} />
-            <IconButton
-              onClick={() => setDetailsOpen((v) => !v)}
-              aria-label={detailsOpen ? 'Hide job details' : 'Show job details'}
-              aria-expanded={detailsOpen}
-              sx={{ width: 44, height: 44, flexShrink: 0 }}
-            >
-              <ExpandMoreIcon
-                sx={{
-                  transition: 'transform 150ms',
-                  transform: detailsOpen ? 'rotate(180deg)' : 'none',
-                }}
-              />
-            </IconButton>
+            {/* Decorative, NOT a button. The whole card is the tap target, so a
+                separate chevron control would be a second target for the same
+                action — and a nested one, which is invalid markup. It stays as the
+                affordance: without any indicator nobody discovers the card
+                expands at all. */}
+            <ExpandMoreIcon
+              sx={{
+                flexShrink: 0,
+                color: 'text.secondary',
+                transition: 'transform 150ms',
+                transform: detailsOpen ? 'rotate(180deg)' : 'none',
+              }}
+            />
           </Box>
 
-          {/* INSTRUCTIONS ARE NOT BEHIND THE CHEVRON. "Torque to 40, not 45" is
+          {/* Shop part descriptions frequently ARE the working instruction
+              ("Linear Actuator A-200, 6061, deburr all edges"), so this is
+              always visible rather than behind the expander. */}
+          {job.part_description && (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              {job.part_description}
+            </Typography>
+          )}
+
+          {/* INSTRUCTIONS ARE NOT BEHIND THE EXPANDER. "Torque to 40, not 45" is
               the most action-relevant thing on the screen, so hiding it would
               invert the whole principle. It renders only when a shop has
               actually written something. */}
@@ -471,16 +459,35 @@ export default function OperatorOperationActionPage() {
             </Box>
           )}
 
+
+          {/* ALWAYS VISIBLE, deliberately outside the expander: "where am I on
+              this part" is the question a step screen exists to answer, and it
+              must not depend on whether someone happened to expand the card. */}
+          {job.operations_total > 1 && (
+            <Box sx={{ mt: 1.5 }}>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+                <Typography variant="caption" color="text.secondary">
+                  Part progress
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {job.operations_completed} of {job.operations_total} operations
+                </Typography>
+              </Box>
+              <LinearProgress
+                variant="determinate"
+                value={(job.operations_completed / job.operations_total) * 100}
+                sx={{ height: 6, borderRadius: 1 }}
+              />
+            </Box>
+          )}
+        </CardContent>
+      </CardActionArea>
+
           <Collapse in={detailsOpen} unmountOnExit>
-          <Box sx={{ mt: 1.5 }}>
+          <Box sx={{ px: 2, pb: 2 }}>
           <Typography variant="body2" color="text.secondary">
             {job.customer_name || 'No customer'}
           </Typography>
-          {job.part_description && (
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
-              {job.part_description}
-            </Typography>
-          )}
           <Typography variant="body2" color="text.secondary">
             Order qty {job.part_quantity}
           </Typography>
@@ -504,6 +511,21 @@ export default function OperatorOperationActionPage() {
             </Box>
           )}
 
+          {/* The way to the full step list. It used to be the job number itself,
+              which cannot stay now that the whole card is one tap target — a link
+              nested inside a button is invalid and swallows one of the two taps.
+              An explicit labelled link is also clearer than an icon nobody was
+              told about. */}
+          <Button
+            variant="text"
+            size="small"
+            endIcon={<FormatListBulletedIcon fontSize="small" />}
+            onClick={() => nav.push(travelerHref)}
+            sx={{ mt: 0.5, ml: -1, minHeight: 44 }}
+          >
+            View all steps for {job.job_number}
+          </Button>
+
           {!isCompleted && job.estimated_minutes != null && job.estimated_minutes > 0 && (
             <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
               Estimated:{' '}
@@ -513,26 +535,8 @@ export default function OperatorOperationActionPage() {
             </Typography>
           )}
 
-          {job.operations_total > 1 && (
-            <Box sx={{ mt: 2 }}>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
-                <Typography variant="caption" color="text.secondary">
-                  Part progress
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  {job.operations_completed} of {job.operations_total} operations
-                </Typography>
-              </Box>
-              <LinearProgress
-                variant="determinate"
-                value={(job.operations_completed / job.operations_total) * 100}
-                sx={{ height: 6, borderRadius: 1 }}
-              />
-            </Box>
-          )}
           </Box>
           </Collapse>
-        </CardContent>
       </Card>
 
       <PartReferenceRow
@@ -541,6 +545,43 @@ export default function OperatorOperationActionPage() {
         partName={job.part_name}
         excludeJobId={jobId}
         jobOperationId={jobOperationId}
+        // The quantity shares the reference row rather than taking a line of its
+        // own. Three controls on one line is what buys back the vertical space
+        // that used to require pinning the action to the bottom.
+        trailing={
+          !isCompleted && !isExternal ? (
+        <TextField
+          label="Parts finished"
+          type="number"
+          value={qtyValue}
+          onChange={(e) => {
+            setQtyDirty(true);
+            setQtyInput(e.target.value);
+          }}
+          inputProps={{ min: 0, inputMode: 'numeric', 'aria-label': 'Parts finished' }}
+          fullWidth
+          size="medium"
+          error={consequence.kind === 'over'}
+          helperText={
+            consequence.kind === 'none'
+              ? `Order qty ${target}${qtyGood > 0 ? ` · ${remaining} remaining` : ''}`
+              : completionConsequenceCaption(consequence)
+          }
+          FormHelperTextProps={{
+            sx: {
+              color:
+                consequence.kind === 'over'
+                  ? 'error.main'
+                  : consequence.kind === 'partial'
+                    ? 'warning.main'
+                    : consequence.kind === 'full'
+                      ? 'success.main'
+                      : 'text.secondary',
+            },
+          }}
+        />
+          ) : undefined
+        }
       />
 
       {isCompleted ? (
@@ -650,36 +691,6 @@ export default function OperatorOperationActionPage() {
             </Typography>
           )}
 
-          <TextField
-            label="Good pieces finished"
-            type="number"
-            value={qtyValue}
-            onChange={(e) => {
-              setQtyDirty(true);
-              setQtyInput(e.target.value);
-            }}
-            inputProps={{ min: 0, inputMode: 'numeric', 'aria-label': 'Good pieces finished' }}
-            fullWidth
-            size="medium"
-            error={consequence.kind === 'over'}
-            helperText={
-              consequence.kind === 'none'
-                ? `Order qty ${target}${qtyGood > 0 ? ` · ${remaining} remaining` : ''}`
-                : completionConsequenceCaption(consequence)
-            }
-            FormHelperTextProps={{
-              sx: {
-                color:
-                  consequence.kind === 'over'
-                    ? 'error.main'
-                    : consequence.kind === 'partial'
-                      ? 'warning.main'
-                      : consequence.kind === 'full'
-                        ? 'success.main'
-                        : 'text.secondary',
-              },
-            }}
-          />
 
           {/* CAPTURE, MERGED INTO COMPLETION.
               Finishing a step and writing down what you learned are one act, one
@@ -691,7 +702,7 @@ export default function OperatorOperationActionPage() {
               Optional, always: completion works with the field left empty. */}
           <NoteCaptureFields
             capture={capture}
-            placeholder="Anything worth noting for next time? (optional)"
+            placeholder="Anything worth noting for next time?"
             disabled={actionLoading}
             compact
           />
@@ -704,27 +715,15 @@ export default function OperatorOperationActionPage() {
               research says a primary action belongs. It sits inside the scrolling
               region, so it lands directly above the bottom nav rather than over
               it, and the errors above it stay visible. */}
-          <Box
-            sx={{
-              // FIXED, not sticky. `position: sticky` is inert here: the operator
-              // shell gives <main> `overflow: auto`, which makes main the nearest
-              // scrollport, and main never scrolls internally (it is simply taller
-              // than the viewport and the WINDOW does the scrolling). A sticky
-              // child of a non-scrolling scrollport never sticks — measured at
-              // bottom 557 with the nav top at 521, i.e. underneath the nav.
-              // Fixed escapes the overflow ancestor and pins to the viewport.
-              position: 'fixed',
-              left: 0,
-              right: 0,
-              bottom: BOTTOM_NAV_H,
-              px: 2,
-              pt: 1,
-              pb: 1.5,
-              bgcolor: 'background.default',
-              borderTop: '1px solid rgba(255, 255, 255, 0.08)',
-              zIndex: 2,
-            }}
-          >
+          {/* IN NORMAL FLOW, not pinned. A fixed bar guaranteed the action was
+              always reachable but overlaid the content beneath it, so it was
+              reverted by decision. The protection now comes from density instead:
+              the quantity field shares a row with Files/Playbook and the job card
+              collapses to a few lines, which keeps this above the fold on a tall
+              phone. That is a weaker guarantee than pinning — if this screen grows
+              again the action can drift off-screen, which is exactly how it broke
+              the first time. Measure before adding anything above it. */}
+          <Box>
             {/* One button, and it says what it will do. The quantity field
                 defaults to the full remaining balance, so this records a full
                 completion by default and a partial when the number is dialled

--- a/components/operator/JobFeed.tsx
+++ b/components/operator/JobFeed.tsx
@@ -7,7 +7,6 @@ import CardContent from '@mui/material/CardContent';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
-import TextField from '@mui/material/TextField';
 import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
@@ -16,14 +15,13 @@ import Alert from '@mui/material/Alert';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DynamicFeedIcon from '@mui/icons-material/DynamicFeed';
-import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
 import CloseIcon from '@mui/icons-material/Close';
-import { getJobNotes, addJobNote, getCurrentMember } from '@/utils/operatorAccess';
+import { getJobNotes, getCurrentMember } from '@/utils/operatorAccess';
 import NoteReactions from '@/components/operator/NoteReactions';
-import { addJobNoteMedia, getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
-import { compressPhoto } from '@/utils/imageCompression';
+import { getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
 import { useNoteDwell } from '@/hooks/useNoteDwell';
-import { logOperatorEvent } from '@/utils/operatorEventsAccess';
+import { useNoteCapture } from '@/hooks/useNoteCapture';
+import NoteCaptureFields from '@/components/operator/NoteCaptureFields';
 import type { JobNote, JobNoteMedia } from '@/types/operator';
 
 const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
@@ -47,50 +45,31 @@ interface JobFeedProps {
   companyId: string;
   /** Read-only feed (traveler). When true, no composer is shown. */
   readOnly?: boolean;
-  /** Set on the operation page to show the composer + auto-tag captures. */
+  /** Set on the operation page to auto-tag captures to the step. */
   operationContext?: JobFeedOperationContext;
   /**
-   * Bumped by the operation page each time a step is completed. On a *new*
-   * value, if the composer is active and the operator hasn't captured anything
-   * on this job yet, we show a one-time "add a photo/note?" offer. Completion
-   * has already been persisted before this changes, so the offer is purely
-   * additive and never blocks or risks the completion. Ignored when 0/undefined.
+   * Bumped by the parent after IT writes a note, so the feed reloads and shows
+   * it. Replaces captureOfferSignal: capture now happens inside the completion
+   * block, so the feed's job is to reflect a write rather than to prompt for one.
    */
-  captureOfferSignal?: number;
+  refreshSignal?: number;
+  /**
+   * Show the feed's OWN composer + Post button.
+   *
+   * False on the normal path, where the operation page renders the same capture
+   * fields inside the completion block and one button commits both — the whole
+   * point of merging them. True only where no completion block is left to attach
+   * a note to: an already-complete step (so a photo can still be added
+   * afterwards, which is the phone-camera-then-attach flow the audit found) and
+   * an outside step, whose "sent to coater, back on the 16th" note the paperless
+   * doc calls the highest-value note in the system.
+   */
+  standaloneCapture?: boolean;
 }
 
-// --- Dictation (keyboard-mic) hint: a quiet, contextual, capped one-liner. ---
-// Shown in the composer where operators type notes; capped so repeat users don't
-// get nagged (the documented failure mode of built-in tips). Per-device, since
-// the subject is the device's own keyboard mic.
-const MIC_HINT_KEY = 'jigged:composer-mic-hint';
-const MIC_HINT_MAX_SHOWS = 5;
-
-interface MicHintState {
-  shows: number;
-  dismissed: boolean;
-}
-
-function readMicHint(): MicHintState {
-  if (typeof window === 'undefined') return { shows: 0, dismissed: true };
-  try {
-    const raw = window.localStorage.getItem(MIC_HINT_KEY);
-    if (!raw) return { shows: 0, dismissed: false };
-    const parsed = JSON.parse(raw) as Partial<MicHintState>;
-    return { shows: Number(parsed.shows) || 0, dismissed: !!parsed.dismissed };
-  } catch {
-    return { shows: 0, dismissed: false };
-  }
-}
-
-function writeMicHint(state: MicHintState): void {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(MIC_HINT_KEY, JSON.stringify(state));
-  } catch {
-    /* private mode / quota — the hint is best-effort, never block on it */
-  }
-}
+// The dictation hint and the pending-photo pipeline moved into
+// hooks/useNoteCapture.ts, so the completion block and this feed render one
+// implementation rather than two.
 
 function formatTimestamp(value: string): string {
   const d = new Date(value);
@@ -104,12 +83,6 @@ function formatTimestamp(value: string): string {
 }
 
 /** A pending photo the operator picked but hasn't posted yet. */
-interface PendingPhoto {
-  id: string;
-  file: File;
-  previewUrl: string;
-}
-
 /**
  * The job feed: one append-only stream per job (job-level + operation-tagged
  * notes, each with optional photos). Captured on the operation page (composer
@@ -121,7 +94,8 @@ export default function JobFeed({
   companyId,
   readOnly,
   operationContext,
-  captureOfferSignal,
+  refreshSignal,
+  standaloneCapture = false,
 }: JobFeedProps) {
   const [error, setError] = useState<string | null>(null);
   // Notes posted optimistically (prepended before the next full load). Deduped
@@ -129,36 +103,23 @@ export default function JobFeed({
   const [pendingNotes, setPendingNotes] = useState<JobNote[]>([]);
 
   const [operatorId, setOperatorId] = useState<string | null>(null);
-  const [noteDraft, setNoteDraft] = useState('');
-  const [pending, setPending] = useState<PendingPhoto[]>([]);
-  const [saving, setSaving] = useState(false);
-  const [composerError, setComposerError] = useState<string | null>(null);
 
   // Signed URLs for media thumbnails, keyed by media id (fetched on demand).
   const [mediaUrls, setMediaUrls] = useState<Record<string, string>>({});
   // Full-size viewer.
   const [viewerUrl, setViewerUrl] = useState<string | null>(null);
 
-  // Post-completion "add a photo/note?" offer + the dictation hint.
-  const [offerOpen, setOfferOpen] = useState(false);
-  const [showMicHint, setShowMicHint] = useState(false);
-  const offerRef = useRef<HTMLDivElement | null>(null);
-  const lastOfferSignal = useRef<number | undefined>(undefined);
+  // The feed's own composer, only where nothing else owns capture — see the
+  // standaloneCapture prop.
+  const showComposer = !readOnly && !!operationContext && standaloneCapture;
 
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const noteFieldRef = useRef<HTMLInputElement | null>(null);
-  // Monotonic id source for pending picks — avoids the id collisions that
-  // Date.now()+filename produced for rapid same-name camera captures.
-  const pendingIdRef = useRef(0);
-
-  // Funnel state. Refs, not state: these are read once at unmount, and putting
-  // them in state would re-render the composer on every keystroke to record
-  // something the operator never sees.
-  const focusedRef = useRef(false);
-  const capturedRef = useRef(false);
-  const draftRef = useRef({ bodyLength: 0, photoCount: 0 });
-
-  const showComposer = !readOnly && !!operationContext;
+  const capture = useNoteCapture({
+    companyId,
+    jobId,
+    operatorId,
+    context: operationContext ?? null,
+    enabled: showComposer,
+  });
 
   // Read tracking. The feed is where an operator encounters other people's notes
   // in the course of a job, so it is the surface the whole loop is measuring.
@@ -184,19 +145,6 @@ export default function JobFeed({
     return [...stillPending, ...loadedNotes];
   }, [loadedNotes, pendingNotes]);
 
-  // Has the operator captured anything real on this job yet? Only human 'user'
-  // notes with text or a photo count — auto-logged 'event' notes (e.g. the
-  // order-qty audit trail) must NOT suppress the offer.
-  const hasUserCapture = useMemo(
-    () =>
-      notes.some(
-        (n) =>
-          n.note_type === 'user' &&
-          ((n.body?.trim().length ?? 0) > 0 || n.media.length > 0),
-      ),
-    [notes],
-  );
-
   // Resolved unconditionally, not just when the composer is shown: reactions need
   // the member id on the read-only traveler feed too, both to know whether the
   // reader has already reacted and to hide the control on their own notes.
@@ -210,33 +158,17 @@ export default function JobFeed({
     };
   }, [companyId]);
 
-  // Post-completion capture offer: fire ONCE per completion event. Only react to
-  // a *new* signal value (ignore the initial undefined/0), and only offer when
-  // the composer is active and nothing has been captured yet. The parent bumps
-  // the signal strictly after completeOperation resolves, so completion is
-  // already durable — a client death while this is open loses nothing.
+  // Reflect a write the PARENT made. The completion block now owns capture on the
+  // normal path, so when it posts a note this feed has to reload to show it —
+  // which is all that is left of the old captureOfferSignal. Ignores the initial
+  // undefined/0 so a mount does not double-load.
+  const lastRefresh = useRef<number | undefined>(undefined);
   useEffect(() => {
-    if (!captureOfferSignal) return;
-    if (captureOfferSignal === lastOfferSignal.current) return;
-    lastOfferSignal.current = captureOfferSignal;
-    if (showComposer && !hasUserCapture) setOfferOpen(true);
-  }, [captureOfferSignal, showComposer, hasUserCapture]);
-
-  // Scroll the offer into view when it opens (it sits above a composer that may
-  // be below the fold on a phone).
-  useEffect(() => {
-    if (offerOpen) offerRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' });
-  }, [offerOpen]);
-
-  // Decide the dictation hint once per composer mount, counting the show. Shown
-  // while not dismissed and under the cap; increments the stored show count.
-  useEffect(() => {
-    if (!showComposer) return;
-    const state = readMicHint();
-    if (state.dismissed || state.shows >= MIC_HINT_MAX_SHOWS) return;
-    setShowMicHint(true);
-    writeMicHint({ shows: state.shows + 1, dismissed: false });
-  }, [showComposer]);
+    if (!refreshSignal) return;
+    if (refreshSignal === lastRefresh.current) return;
+    lastRefresh.current = refreshSignal;
+    load();
+  }, [refreshSignal, load]);
 
   // Fetch signed URLs for any media we don't already have a URL for.
   useEffect(() => {
@@ -264,150 +196,22 @@ export default function JobFeed({
     };
   }, [notes, mediaUrls]);
 
-  // Revoke object URLs for pending previews on unmount.
-  useEffect(() => {
-    return () => {
-      pending.forEach((p) => URL.revokeObjectURL(p.previewUrl));
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // Preview-URL cleanup, the draft snapshot and composer_abandoned all moved into
+  // useNoteCapture, so they fire for whichever surface owns capture.
 
-  // Keep the unmount snapshot current. In an effect, not during render: mutating
-  // a ref while rendering is unsafe under concurrent rendering (and StrictMode's
-  // double invoke), which the react-hooks lint rule correctly rejects.
-  useEffect(() => {
-    draftRef.current = { bodyLength: noteDraft.trim().length, photoCount: pending.length };
-  }, [noteDraft, pending]);
-
-  // Abandonment: they opened the composer and left without saving. This is the
-  // funnel step that separates "capture friction" from "container fit" — a high
-  // focus rate with a low save rate means they tried and gave up, which is a very
-  // different problem from never reaching for it at all.
-  //
-  // Fires on unmount, which is the only place that reliably catches leaving. The
-  // draft size rides along as context: focused-and-typed-nothing and
-  // typed-a-paragraph-then-bailed are both abandonment, but not the same story.
-  useEffect(() => {
-    return () => {
-      if (!showComposer) return;
-      if (!focusedRef.current || capturedRef.current) return;
-      logOperatorEvent(companyId, 'composer_abandoned', draftRef.current);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const handlePickPhotos = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const input = e.target;
-    const files = Array.from(input.files ?? []);
-    input.value = '';
-    if (files.length === 0) return;
-    setComposerError(null);
-
-    // iOS "new photo → nothing attached" mitigation (UNCONFIRMED — see PR notes;
-    // not reproducible on desktop). A camera-origin `File` can become unreadable
-    // by the time it's compressed/uploaded at Post, yielding a zero-byte blob.
-    // Copy the bytes into a stable File *now*, while the reference is fresh, and
-    // drop any pick that reads back empty rather than silently posting nothing.
-    const prepared: PendingPhoto[] = [];
-    for (const file of files) {
-      let stable = file;
-      try {
-        const buf = await file.arrayBuffer();
-        stable = new File([buf], file.name || 'photo.jpg', {
-          type: file.type || 'image/jpeg',
-          lastModified: file.lastModified,
-        });
-      } catch {
-        // Copy failed — fall through with the original reference and the size
-        // guard below decides whether it's usable.
-      }
-      if (stable.size === 0) continue;
-      prepared.push({
-        id: `pp-${pendingIdRef.current++}`,
-        file: stable,
-        previewUrl: URL.createObjectURL(stable),
-      });
-    }
-
-    if (prepared.length === 0) {
-      setComposerError('That photo could not be read. Please try taking or picking it again.');
-      return;
-    }
-    setPending((prev) => [...prev, ...prepared]);
-  };
-
-  const removePending = (id: string) => {
-    setPending((prev) => {
-      const target = prev.find((p) => p.id === id);
-      if (target) URL.revokeObjectURL(target.previewUrl);
-      return prev.filter((p) => p.id !== id);
-    });
-  };
-
-  // Offer actions. "Add photo" is the prominent path (the observed failure was
-  // photos stuck in the camera roll): close the offer and open the picker, which
-  // now surfaces the photo library too. "Add note" focuses the composer; "Skip"
-  // just dismisses. All three are terminal for this completion event.
-  const handleOfferAddPhoto = () => {
-    setOfferOpen(false);
-    fileInputRef.current?.click();
-  };
-  const handleOfferAddNote = () => {
-    setOfferOpen(false);
-    noteFieldRef.current?.focus();
-  };
-  const handleOfferSkip = () => setOfferOpen(false);
-
-  const dismissMicHint = () => {
-    setShowMicHint(false);
-    writeMicHint({ ...readMicHint(), dismissed: true });
-  };
-
-  const canPost = (noteDraft.trim().length > 0 || pending.length > 0) && !saving;
-
+  // The photo pipeline, the dictation hint and the note+media write now live in
+  // useNoteCapture, so this feed and the completion block share one
+  // implementation. All that is left here is what "Post" means on THIS surface:
+  // write it, then show it optimistically.
   const handlePost = async () => {
-    if (!operationContext) return;
-    const body = noteDraft.trim();
-    if (!body && pending.length === 0) return;
-    if (!operatorId) {
-      setComposerError('Could not identify your account — reload and try again.');
-      return;
-    }
-    setSaving(true);
-    setComposerError(null);
     try {
-      const note = await addJobNote(jobId, companyId, operatorId, body || null, {
-        jobPartId: operationContext.jobPartId,
-        jobOperationId: operationContext.jobOperationId,
-      });
-
-      const media: JobNoteMedia[] = [];
-      for (const p of pending) {
-        const prepared = await compressPhoto(p.file);
-        media.push(
-          await addJobNoteMedia(companyId, jobId, note.id, prepared.file, {
-            dims: prepared.dims,
-          }),
-        );
-      }
-
-      setPendingNotes((prev) => [{ ...note, media }, ...prev]);
-      pending.forEach((p) => URL.revokeObjectURL(p.previewUrl));
-      setPending([]);
-      setNoteDraft('');
-      // After the write resolves, so a failed post is never counted as a save —
-      // the funnel's whole job is separating "tried" from "succeeded".
-      capturedRef.current = true;
-      logOperatorEvent(companyId, media.length > 0 ? 'note_saved_with_photo' : 'note_saved', {
-        photoCount: media.length,
-        bodyLength: body.length,
-      });
-    } catch (err) {
-      setComposerError(err instanceof Error ? err.message : 'Could not post. Please try again.');
-      // The note may have been created with partial media — refresh to show truth.
+      const note = await capture.submit();
+      if (note) setPendingNotes((prev) => [note, ...prev]);
+    } catch {
+      // useNoteCapture surfaces the message in the fields. A note may exist with
+      // partial media, so reload to show what is actually there rather than the
+      // optimistic guess.
       load();
-    } finally {
-      setSaving(false);
     }
   };
 
@@ -431,177 +235,23 @@ export default function JobFeed({
 
         {showComposer && (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mb: 2 }}>
-            {offerOpen && (
-              <Box
-                ref={offerRef}
-                sx={{
-                  p: 1.5,
-                  borderRadius: 1,
-                  border: '1px solid',
-                  borderColor: 'primary.main',
-                  bgcolor: 'rgba(99, 102, 241, 0.10)',
-                }}
-              >
-                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-                  <Typography variant="body2" sx={{ flex: 1 }}>
-                    Step complete. Got a setup photo or a note? Add it before you go —
-                    it stays with the job.
-                  </Typography>
-                  <IconButton
-                    size="small"
-                    aria-label="Dismiss"
-                    onClick={handleOfferSkip}
-                    sx={{ mt: -0.5, mr: -0.5 }}
-                  >
-                    <CloseIcon fontSize="small" />
-                  </IconButton>
-                </Box>
-                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1 }}>
-                  <Button
-                    variant="contained"
-                    startIcon={<PhotoCameraIcon />}
-                    onClick={handleOfferAddPhoto}
-                    sx={{ minHeight: 44 }}
-                  >
-                    Add photo
-                  </Button>
-                  <Button variant="text" onClick={handleOfferAddNote} sx={{ minHeight: 44 }}>
-                    Add note
-                  </Button>
-                  <Box sx={{ flex: 1 }} />
-                  <Button variant="text" color="inherit" onClick={handleOfferSkip} sx={{ minHeight: 44 }}>
-                    Skip
-                  </Button>
-                </Box>
-              </Box>
-            )}
-            <TextField
-              multiline
-              minRows={2}
+            {/* The post-completion "add a photo?" offer is gone. It existed to
+                chase a note AFTER the fact, which is exactly the two-stage commit
+                that lost photos; capture now sits inside the completion block and
+                lands with it. This composer survives only on surfaces with no
+                completion left to attach to. */}
+            <NoteCaptureFields
+              capture={capture}
               placeholder="Add a note or photo for this step…"
-              value={noteDraft}
-              onChange={(e) => setNoteDraft(e.target.value)}
-              onFocus={() => {
-                // Once per composer mount: this is the "started capture" step, and
-                // counting every refocus would inflate it past the save rate.
-                if (focusedRef.current) return;
-                focusedRef.current = true;
-                logOperatorEvent(companyId, 'composer_focused');
-              }}
-              inputRef={noteFieldRef}
-              fullWidth
-              size="small"
             />
-
-            {showMicHint && (
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
-                  ※ Tip: tap the{' '}
-                  {/* The iOS keyboard's dictation glyph (outlined mic + cradle +
-                      stem + base bar), so it reads as the exact key operators
-                      tap — not a generic emoji. */}
-                  <Box
-                    component="svg"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                    sx={{
-                      width: '1.05em',
-                      height: '1.05em',
-                      verticalAlign: '-0.2em',
-                      mx: '1px',
-                      fill: 'none',
-                      stroke: 'currentColor',
-                      strokeWidth: 1.6,
-                      strokeLinecap: 'round',
-                      strokeLinejoin: 'round',
-                    }}
-                  >
-                    <rect x="9.5" y="3" width="5" height="10" rx="2.5" />
-                    <path d="M6.5 11a5.5 5.5 0 0 0 11 0" />
-                    <path d="M12 16.5V19" />
-                    <path d="M8.5 19h7" />
-                  </Box>{' '}
-                  on your keyboard to talk instead of type.
-                </Typography>
-                <IconButton
-                  size="small"
-                  aria-label="Dismiss tip"
-                  onClick={dismissMicHint}
-                  sx={{ p: 0.25 }}
-                >
-                  <CloseIcon sx={{ fontSize: 14 }} />
-                </IconButton>
-              </Box>
-            )}
-
-            {pending.length > 0 && (
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                {pending.map((p) => (
-                  <Box key={p.id} sx={{ position: 'relative' }}>
-                    <Box
-                      component="img"
-                      src={p.previewUrl}
-                      alt="Pending photo"
-                      sx={{
-                        width: THUMB,
-                        height: THUMB,
-                        objectFit: 'cover',
-                        borderRadius: 1,
-                        display: 'block',
-                      }}
-                    />
-                    <IconButton
-                      size="small"
-                      aria-label="Remove photo"
-                      onClick={() => removePending(p.id)}
-                      sx={{
-                        position: 'absolute',
-                        top: -8,
-                        right: -8,
-                        bgcolor: 'background.paper',
-                        '&:hover': { bgcolor: 'background.paper' },
-                      }}
-                    >
-                      <CloseIcon fontSize="small" />
-                    </IconButton>
-                  </Box>
-                ))}
-              </Box>
-            )}
-
-            {composerError && <Alert severity="error">{composerError}</Alert>}
-
-            {/* No `capture` attribute: on iOS/Android this makes the OS present
-                the full native sheet (Photo Library / Take Photo / Choose File),
-                so operators can attach an EXISTING photo from the camera roll —
-                the observed failure mode was setup photos stuck in the roll —
-                not only shoot a new one. `capture="environment"` would force the
-                camera and hide the library. */}
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              multiple
-              hidden
-              onChange={handlePickPhotos}
-            />
-            <Box sx={{ display: 'flex', gap: 1, justifyContent: 'space-between' }}>
-              <Button
-                variant="outlined"
-                startIcon={<PhotoCameraIcon />}
-                onClick={() => fileInputRef.current?.click()}
-                disabled={saving}
-                sx={{ minHeight: 48 }}
-              >
-                Add photo
-              </Button>
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
               <Button
                 variant="contained"
                 onClick={handlePost}
-                disabled={!canPost}
+                disabled={!capture.hasContent || capture.saving}
                 sx={{ minHeight: 48 }}
               >
-                {saving ? <CircularProgress size={20} /> : 'Post'}
+                {capture.saving ? <CircularProgress size={20} /> : 'Post'}
               </Button>
             </Box>
           </Box>

--- a/components/operator/NoteCaptureFields.tsx
+++ b/components/operator/NoteCaptureFields.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useRef } from 'react';
+import Box from '@mui/material/Box';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import CloseIcon from '@mui/icons-material/Close';
+import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
+import type { NoteCapture } from '@/hooks/useNoteCapture';
+
+const THUMB = 76;
+
+/**
+ * The capture fields: text, dictation hint, photo picker, pending thumbnails.
+ *
+ * Rendered in two places from one implementation — inside the completion block,
+ * where RECORD COMPLETION submits it, and inside the job feed for steps that
+ * have no completion block left to attach to (an already-complete step, or an
+ * outside step that uses send/receive). It deliberately owns NO submit button:
+ * the surface it sits in decides what "save" means.
+ */
+export default function NoteCaptureFields({
+  capture,
+  placeholder,
+  disabled = false,
+}: {
+  capture: NoteCapture;
+  placeholder: string;
+  disabled?: boolean;
+}) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      <TextField
+        multiline
+        minRows={2}
+        placeholder={placeholder}
+        value={capture.draft}
+        onChange={(e) => capture.setDraft(e.target.value)}
+        onFocus={capture.noteFocused}
+        disabled={disabled || capture.saving}
+        fullWidth
+        size="small"
+      />
+
+      {capture.showMicHint && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
+            ※ Tip: tap the{' '}
+            {/* The iOS keyboard's dictation glyph (outlined mic + cradle + stem +
+                base bar), so it reads as the exact key operators tap — not a
+                generic emoji. */}
+            <Box
+              component="svg"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              sx={{
+                width: '1.05em',
+                height: '1.05em',
+                verticalAlign: '-0.2em',
+                mx: '1px',
+                fill: 'none',
+                stroke: 'currentColor',
+                strokeWidth: 1.6,
+                strokeLinecap: 'round',
+                strokeLinejoin: 'round',
+              }}
+            >
+              <rect x="9.5" y="3" width="5" height="10" rx="2.5" />
+              <path d="M6.5 11a5.5 5.5 0 0 0 11 0" />
+              <path d="M12 16.5V19" />
+              <path d="M8.5 19h7" />
+            </Box>{' '}
+            on your keyboard to talk instead of type.
+          </Typography>
+          <IconButton
+            size="small"
+            aria-label="Dismiss tip"
+            onClick={capture.dismissMicHint}
+            sx={{ p: 0.25 }}
+          >
+            <CloseIcon sx={{ fontSize: 14 }} />
+          </IconButton>
+        </Box>
+      )}
+
+      {capture.pending.length > 0 && (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+          {capture.pending.map((p) => (
+            <Box key={p.id} sx={{ position: 'relative' }}>
+              <Box
+                component="img"
+                src={p.previewUrl}
+                alt="Pending photo"
+                sx={{
+                  width: THUMB,
+                  height: THUMB,
+                  objectFit: 'cover',
+                  borderRadius: 1,
+                  display: 'block',
+                }}
+              />
+              <IconButton
+                size="small"
+                aria-label="Remove photo"
+                onClick={() => capture.removePending(p.id)}
+                sx={{
+                  position: 'absolute',
+                  top: -8,
+                  right: -8,
+                  bgcolor: 'background.paper',
+                  '&:hover': { bgcolor: 'background.paper' },
+                }}
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {capture.error && (
+        <Alert severity="error" onClose={capture.clearError}>
+          {capture.error}
+        </Alert>
+      )}
+
+      {/* No `capture` attribute: on iOS/Android this makes the OS present the
+          full native sheet (Photo Library / Take Photo / Choose File), so
+          operators can attach an EXISTING photo from the camera roll — the
+          observed failure mode was setup photos stuck in the roll — not only
+          shoot a new one. `capture="environment"` would force the camera and
+          hide the library. */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        hidden
+        onChange={capture.pickPhotos}
+      />
+      <Box>
+        <Button
+          variant="outlined"
+          startIcon={<PhotoCameraIcon />}
+          onClick={() => fileInputRef.current?.click()}
+          disabled={disabled || capture.saving}
+          sx={{ minHeight: 48 }}
+        >
+          Add photo
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/components/operator/NoteCaptureFields.tsx
+++ b/components/operator/NoteCaptureFields.tsx
@@ -97,8 +97,12 @@ export default function NoteCaptureFields({
         // fixed bars is covering the element the user is currently editing.
         // Centring the field on focus keeps it clear of both the bar and the
         // on-screen keyboard.
+        // Optional-call: jsdom does not implement scrollIntoView, and this is a
+        // progressive nicety rather than behaviour worth throwing over. The same
+        // `?.()` guard is used elsewhere in the operator components for exactly
+        // this reason.
         if (compact) {
-          e.currentTarget.scrollIntoView({ block: 'center', behavior: 'smooth' });
+          e.currentTarget.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
         }
       }}
       disabled={disabled || capture.saving}

--- a/components/operator/NoteCaptureFields.tsx
+++ b/components/operator/NoteCaptureFields.tsx
@@ -6,46 +6,169 @@ import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import CloseIcon from '@mui/icons-material/Close';
+import MicNoneIcon from '@mui/icons-material/MicNone';
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
 import type { NoteCapture } from '@/hooks/useNoteCapture';
 
 const THUMB = 76;
 
+/** Shared by both layouts. */
+function PendingThumbs({ capture }: { capture: NoteCapture }) {
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+      {capture.pending.map((p) => (
+        <Box key={p.id} sx={{ position: 'relative' }}>
+          <Box
+            component="img"
+            src={p.previewUrl}
+            alt="Pending photo"
+            sx={{
+              width: THUMB,
+              height: THUMB,
+              objectFit: 'cover',
+              borderRadius: 1,
+              display: 'block',
+            }}
+          />
+          <IconButton
+            size="small"
+            aria-label="Remove photo"
+            onClick={() => capture.removePending(p.id)}
+            sx={{
+              position: 'absolute',
+              top: -8,
+              right: -8,
+              bgcolor: 'background.paper',
+              '&:hover': { bgcolor: 'background.paper' },
+            }}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
 /**
- * The capture fields: text, dictation hint, photo picker, pending thumbnails.
+ * The capture fields: text, photo picker, pending thumbnails, dictation hint.
  *
  * Rendered in two places from one implementation — inside the completion block,
- * where RECORD COMPLETION submits it, and inside the job feed for steps that
- * have no completion block left to attach to (an already-complete step, or an
- * outside step that uses send/receive). It deliberately owns NO submit button:
- * the surface it sits in decides what "save" means.
+ * where RECORD COMPLETION submits it, and inside the job feed for steps with no
+ * completion block left to attach to (an already-complete step, or an outside
+ * step). It deliberately owns NO submit button: the surface it sits in decides
+ * what "save" means.
+ *
+ * TWO LAYOUTS. `compact` is one row — single-line field that grows as it fills,
+ * camera as an adjacent icon, the dictation tip as an icon rather than a
+ * sentence. The four-row version pushed RECORD COMPLETION off the bottom of a
+ * 6.9" phone, putting the primary action of the screen below the fold, which is
+ * the one thing that must never happen. The full layout stays for the feed, where
+ * capture is the only thing on offer and has room to invite.
  */
 export default function NoteCaptureFields({
   capture,
   placeholder,
   disabled = false,
+  compact = false,
 }: {
   capture: NoteCapture;
   placeholder: string;
   disabled?: boolean;
+  compact?: boolean;
 }) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
+  const field = (
+    <TextField
+      multiline
+      minRows={compact ? 1 : 2}
+      maxRows={compact ? 4 : undefined}
+      placeholder={placeholder}
+      value={capture.draft}
+      onChange={(e) => capture.setDraft(e.target.value)}
+      onFocus={(e) => {
+        capture.noteFocused();
+        // The completion block's action bar is FIXED, so it overlays whatever
+        // sits at that viewport position — the documented hazard of sticky and
+        // fixed bars is covering the element the user is currently editing.
+        // Centring the field on focus keeps it clear of both the bar and the
+        // on-screen keyboard.
+        if (compact) {
+          e.currentTarget.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        }
+      }}
+      disabled={disabled || capture.saving}
+      fullWidth
+      size="small"
+    />
+  );
+
+  {
+    /* No `capture` attribute: on iOS/Android this makes the OS present the full
+       native sheet (Photo Library / Take Photo / Choose File), so operators can
+       attach an EXISTING photo from the camera roll — the observed failure mode
+       was setup photos stuck in the roll — not only shoot a new one.
+       `capture="environment"` would force the camera and hide the library. */
+  }
+  const picker = (
+    <input
+      ref={fileInputRef}
+      type="file"
+      accept="image/*"
+      multiple
+      hidden
+      onChange={capture.pickPhotos}
+    />
+  );
+
+  const errorAlert = capture.error ? (
+    <Alert severity="error" onClose={capture.clearError}>
+      {capture.error}
+    </Alert>
+  ) : null;
+
+  if (compact) {
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
+          {field}
+          {picker}
+          <IconButton
+            aria-label="Add photo"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={disabled || capture.saving}
+            sx={{ width: 48, height: 48, flexShrink: 0 }}
+          >
+            <PhotoCameraIcon />
+          </IconButton>
+          {/* The dictation tip as an icon, not a sentence. It used to occupy a
+              full line above the primary action — a coach mark outranking the
+              button it sat above. */}
+          {capture.showMicHint && (
+            <Tooltip title="Tap the mic on your keyboard to talk instead of type">
+              <IconButton
+                aria-label="Tip: tap the mic on your keyboard to talk instead of type"
+                onClick={capture.dismissMicHint}
+                sx={{ width: 48, height: 48, flexShrink: 0, color: 'text.secondary' }}
+              >
+                <MicNoneIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Box>
+        {capture.pending.length > 0 && <PendingThumbs capture={capture} />}
+        {errorAlert}
+      </Box>
+    );
+  }
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-      <TextField
-        multiline
-        minRows={2}
-        placeholder={placeholder}
-        value={capture.draft}
-        onChange={(e) => capture.setDraft(e.target.value)}
-        onFocus={capture.noteFocused}
-        disabled={disabled || capture.saving}
-        fullWidth
-        size="small"
-      />
+      {field}
 
       {capture.showMicHint && (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
@@ -88,61 +211,10 @@ export default function NoteCaptureFields({
         </Box>
       )}
 
-      {capture.pending.length > 0 && (
-        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-          {capture.pending.map((p) => (
-            <Box key={p.id} sx={{ position: 'relative' }}>
-              <Box
-                component="img"
-                src={p.previewUrl}
-                alt="Pending photo"
-                sx={{
-                  width: THUMB,
-                  height: THUMB,
-                  objectFit: 'cover',
-                  borderRadius: 1,
-                  display: 'block',
-                }}
-              />
-              <IconButton
-                size="small"
-                aria-label="Remove photo"
-                onClick={() => capture.removePending(p.id)}
-                sx={{
-                  position: 'absolute',
-                  top: -8,
-                  right: -8,
-                  bgcolor: 'background.paper',
-                  '&:hover': { bgcolor: 'background.paper' },
-                }}
-              >
-                <CloseIcon fontSize="small" />
-              </IconButton>
-            </Box>
-          ))}
-        </Box>
-      )}
+      {capture.pending.length > 0 && <PendingThumbs capture={capture} />}
+      {errorAlert}
 
-      {capture.error && (
-        <Alert severity="error" onClose={capture.clearError}>
-          {capture.error}
-        </Alert>
-      )}
-
-      {/* No `capture` attribute: on iOS/Android this makes the OS present the
-          full native sheet (Photo Library / Take Photo / Choose File), so
-          operators can attach an EXISTING photo from the camera roll — the
-          observed failure mode was setup photos stuck in the roll — not only
-          shoot a new one. `capture="environment"` would force the camera and
-          hide the library. */}
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/*"
-        multiple
-        hidden
-        onChange={capture.pickPhotos}
-      />
+      {picker}
       <Box>
         <Button
           variant="outlined"

--- a/components/operator/NoteCaptureFields.tsx
+++ b/components/operator/NoteCaptureFields.tsx
@@ -6,10 +6,8 @@ import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';
-import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import CloseIcon from '@mui/icons-material/Close';
-import MicNoneIcon from '@mui/icons-material/MicNone';
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
 import type { NoteCapture } from '@/hooks/useNoteCapture';
 
@@ -49,6 +47,45 @@ function PendingThumbs({ capture }: { capture: NoteCapture }) {
           </IconButton>
         </Box>
       ))}
+    </Box>
+  );
+}
+
+/** The dictation tip. Capped and dismissible — see MIC_HINT_MAX_SHOWS. */
+function MicHint({ onDismiss }: { onDismiss: () => void }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
+        ※ Tip: tap the{' '}
+        {/* The iOS keyboard's dictation glyph (outlined mic + cradle + stem + base
+            bar), so it reads as the exact key operators tap — not a generic
+            emoji, and not something that looks tappable HERE. */}
+        <Box
+          component="svg"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          sx={{
+            width: '1.05em',
+            height: '1.05em',
+            verticalAlign: '-0.2em',
+            mx: '1px',
+            fill: 'none',
+            stroke: 'currentColor',
+            strokeWidth: 1.6,
+            strokeLinecap: 'round',
+            strokeLinejoin: 'round',
+          }}
+        >
+          <rect x="9.5" y="3" width="5" height="10" rx="2.5" />
+          <path d="M6.5 11a5.5 5.5 0 0 0 11 0" />
+          <path d="M12 16.5V19" />
+          <path d="M8.5 19h7" />
+        </Box>{' '}
+        on your keyboard to talk instead of type.
+      </Typography>
+      <IconButton size="small" aria-label="Dismiss tip" onClick={onDismiss} sx={{ p: 0.25 }}>
+        <CloseIcon sx={{ fontSize: 14 }} />
+      </IconButton>
     </Box>
   );
 }
@@ -149,21 +186,13 @@ export default function NoteCaptureFields({
           >
             <PhotoCameraIcon />
           </IconButton>
-          {/* The dictation tip as an icon, not a sentence. It used to occupy a
-              full line above the primary action — a coach mark outranking the
-              button it sat above. */}
-          {capture.showMicHint && (
-            <Tooltip title="Tap the mic on your keyboard to talk instead of type">
-              <IconButton
-                aria-label="Tip: tap the mic on your keyboard to talk instead of type"
-                onClick={capture.dismissMicHint}
-                sx={{ width: 48, height: 48, flexShrink: 0, color: 'text.secondary' }}
-              >
-                <MicNoneIcon fontSize="small" />
-              </IconButton>
-            </Tooltip>
-          )}
         </Box>
+        {/* A CAPTION, not an icon button. The icon version sat beside a real
+            camera button and read as "tap here to dictate" — but nothing can
+            invoke the OS keyboard's dictation from a web page, so tapping it only
+            dismissed the tip. A false affordance is worse than the line of text it
+            replaced, and this costs a line at most five times per device. */}
+        {capture.showMicHint && <MicHint onDismiss={capture.dismissMicHint} />}
         {capture.pending.length > 0 && <PendingThumbs capture={capture} />}
         {errorAlert}
       </Box>
@@ -174,46 +203,7 @@ export default function NoteCaptureFields({
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
       {field}
 
-      {capture.showMicHint && (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-          <Typography variant="caption" color="text.secondary" sx={{ flex: 1 }}>
-            ※ Tip: tap the{' '}
-            {/* The iOS keyboard's dictation glyph (outlined mic + cradle + stem +
-                base bar), so it reads as the exact key operators tap — not a
-                generic emoji. */}
-            <Box
-              component="svg"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-              sx={{
-                width: '1.05em',
-                height: '1.05em',
-                verticalAlign: '-0.2em',
-                mx: '1px',
-                fill: 'none',
-                stroke: 'currentColor',
-                strokeWidth: 1.6,
-                strokeLinecap: 'round',
-                strokeLinejoin: 'round',
-              }}
-            >
-              <rect x="9.5" y="3" width="5" height="10" rx="2.5" />
-              <path d="M6.5 11a5.5 5.5 0 0 0 11 0" />
-              <path d="M12 16.5V19" />
-              <path d="M8.5 19h7" />
-            </Box>{' '}
-            on your keyboard to talk instead of type.
-          </Typography>
-          <IconButton
-            size="small"
-            aria-label="Dismiss tip"
-            onClick={capture.dismissMicHint}
-            sx={{ p: 0.25 }}
-          >
-            <CloseIcon sx={{ fontSize: 14 }} />
-          </IconButton>
-        </Box>
-      )}
+      {capture.showMicHint && <MicHint onDismiss={capture.dismissMicHint} />}
 
       {capture.pending.length > 0 && <PendingThumbs capture={capture} />}
       {errorAlert}

--- a/components/operator/PartReferenceRow.tsx
+++ b/components/operator/PartReferenceRow.tsx
@@ -22,12 +22,17 @@ interface PartReferenceRowProps {
   /** Present on the operation page → enables the notes "This step" filter. */
   jobOperationId?: string;
   /**
-   * Rendered on the SAME row, after the reference buttons, taking the remaining
-   * width. The operation page puts the quantity field here: three controls on one
-   * line instead of three lines, which is what keeps RECORD COMPLETION above the
-   * fold on a tall phone now that it is no longer pinned.
+   * Rendered FIRST on the same row, taking the remaining width. The operation page
+   * puts the quantity field here: three controls on one line instead of three
+   * lines, which is what keeps RECORD COMPLETION above the fold now that it is no
+   * longer pinned.
+   *
+   * It leads because it is the input for the screen's primary action, while Files
+   * and Playbook are reference. Those keep their counts, which is what actually
+   * advertises them — the original reason Files led was its count, not its
+   * position.
    */
-  trailing?: ReactNode;
+  leading?: ReactNode;
 }
 
 /**
@@ -47,7 +52,7 @@ export default function PartReferenceRow({
   partName,
   excludeJobId,
   jobOperationId,
-  trailing,
+  leading,
 }: PartReferenceRowProps) {
   const [filesOpen, setFilesOpen] = useState(false);
   const [notesOpen, setNotesOpen] = useState(false);
@@ -78,12 +83,16 @@ export default function PartReferenceRow({
         alignItems: 'flex-start',
         gap: 1,
         flexWrap: 'nowrap',
-        mb: trailing ? 1 : 3,
+        mb: leading ? 1 : 3,
       }}
     >
+      {/* Takes whatever width is left, so the field shrinks rather than wrapping
+          the buttons onto a second line. */}
+      {leading && <Box sx={{ flex: 1, minWidth: 0 }}>{leading}</Box>}
+
       {/* Both outlined so they read as one family (per the design system —
-          grouped actions share a variant). Files leads via bolder weight + a
-          count, not by being the only one with a border. */}
+          grouped actions share a variant). Files leads its pair via bolder weight
+          + a count, not by being the only one with a border. */}
       <Button
         variant="outlined"
         startIcon={<FolderOpenIcon />}
@@ -105,10 +114,6 @@ export default function PartReferenceRow({
       >
         {hasNotes ? `Playbook · ${noteCount}` : 'Playbook'}
       </Button>
-
-      {/* Takes whatever width is left, so the field shrinks rather than wrapping
-          the buttons onto a second line. */}
-      {trailing && <Box sx={{ flex: 1, minWidth: 0 }}>{trailing}</Box>}
 
       {filesOpen && (
         <PartFilesSheet

--- a/components/operator/PartReferenceRow.tsx
+++ b/components/operator/PartReferenceRow.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { ReactNode } from 'react';
+
 import { useState } from 'react';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
@@ -19,6 +21,13 @@ interface PartReferenceRowProps {
   excludeJobId: string;
   /** Present on the operation page → enables the notes "This step" filter. */
   jobOperationId?: string;
+  /**
+   * Rendered on the SAME row, after the reference buttons, taking the remaining
+   * width. The operation page puts the quantity field here: three controls on one
+   * line instead of three lines, which is what keeps RECORD COMPLETION above the
+   * fold on a tall phone now that it is no longer pinned.
+   */
+  trailing?: ReactNode;
 }
 
 /**
@@ -38,6 +47,7 @@ export default function PartReferenceRow({
   partName,
   excludeJobId,
   jobOperationId,
+  trailing,
 }: PartReferenceRowProps) {
   const [filesOpen, setFilesOpen] = useState(false);
   const [notesOpen, setNotesOpen] = useState(false);
@@ -62,7 +72,15 @@ export default function PartReferenceRow({
   const hasNotes = (noteCount ?? 0) > 0;
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 3 }}>
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 1,
+        flexWrap: 'nowrap',
+        mb: trailing ? 1 : 3,
+      }}
+    >
       {/* Both outlined so they read as one family (per the design system —
           grouped actions share a variant). Files leads via bolder weight + a
           count, not by being the only one with a border. */}
@@ -70,7 +88,7 @@ export default function PartReferenceRow({
         variant="outlined"
         startIcon={<FolderOpenIcon />}
         onClick={() => setFilesOpen(true)}
-        sx={{ minHeight: 48, fontWeight: 700 }}
+        sx={{ minHeight: 48, fontWeight: 700, flexShrink: 0, whiteSpace: 'nowrap' }}
       >
         {hasFiles ? `Files · ${fileCount}` : 'Files'}
       </Button>
@@ -78,10 +96,19 @@ export default function PartReferenceRow({
         variant="outlined"
         startIcon={<HistoryIcon />}
         onClick={() => setNotesOpen(true)}
-        sx={{ minHeight: 48, fontWeight: hasNotes ? 700 : 400 }}
+        sx={{
+          minHeight: 48,
+          fontWeight: hasNotes ? 700 : 400,
+          flexShrink: 0,
+          whiteSpace: 'nowrap',
+        }}
       >
         {hasNotes ? `Playbook · ${noteCount}` : 'Playbook'}
       </Button>
+
+      {/* Takes whatever width is left, so the field shrinks rather than wrapping
+          the buttons onto a second line. */}
+      {trailing && <Box sx={{ flex: 1, minWidth: 0 }}>{trailing}</Box>}
 
       {filesOpen && (
         <PartFilesSheet

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -398,8 +398,12 @@ optional and frequently blank, so shops often put the instruction in the part
 description instead.
 
 So **neither is de-emphasised**, and the distinction is a dimmed **label**
-(`Instructions`, the same word the admin sees when writing the field) rather than
-weight or a tinted box. What is dimmed is chrome, never content.
+(`Instructions:`, the same word the admin sees when writing the field) rather than
+weight or a tinted box. What is dimmed is chrome, never content — the label shares
+the content's font size, so **colour is the only difference between them**. A
+smaller label beside larger text read as two unrelated lines rather than a label
+and its value, and the colon carries the demarcation a size change was doing
+badly.
 
 An earlier revision dimmed the description to make the instruction "the brighter
 one". That was wrong twice over: it asserted "reference, not instruction" exactly

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -139,11 +139,12 @@ against a count computed over exactly the rows it admitted. So:
 - **No function touching `note_views` may accept a viewer parameter.** The three
   that touch it: `log_note_views` (returns `void` — a duplicate must be
   indistinguishable from a first view), `note_viewers(note_id)` (authors only, one
-  row per person, ordered by name, **no timestamps**). `my_note_view_digest()`
-  used to be the third but no longer touches the table at all — it sums
-  `notes.viewer_count`, so it is now `SECURITY INVOKER`. **It takes no arguments,
-  permanently**: a caller-supplied time window would be a bisection oracle for
-  when a note was read.
+  row per person, ordered by name, **no timestamps**). `my_note_digest()` used to
+  be the third — as `my_note_view_digest`, before it also began reporting helpful
+  marks — but no longer touches the table at all: it reads `notes.viewer_count`
+  and counts `note_reactions`, so it is `SECURITY INVOKER`. **It takes no
+  arguments, permanently**: a caller-supplied time window would be a bisection
+  oracle for when a note was read.
 - **`authenticated` has no UPDATE on `notes` at all** — notes are append-only today,
   so the whole privilege is revoked. Otherwise setting `viewer_count = 0` and
   returning later to read the delta is a one-bit read oracle per note. If note
@@ -342,6 +343,79 @@ path so there is never more than one composer on screen. This is a deliberate
 deviation from the plan's *"the note cannot be saved without completing"*, forced
 by the render branches rather than by preference.
 
+**The primary button says what it will do, and that closes a hole.** With a
+quantity it reads `RECORD COMPLETION` and submits the completion then the note.
+With **nothing finished but something typed** it reads `SAVE NOTE` and writes the
+note alone.
+
+That path is not a convenience. `qty > 0` is enforced, so an operator who
+finished zero pieces — *"machine down"*, *"waiting on material"*, *"tool chipped,
+swapping it"* — otherwise had two options and both were bad: stay silent and lose
+exactly the knowledge this workstream exists to capture, or **type a false
+quantity** to get the note saved. Corrupting the number that feeds costing and
+scheduling to satisfy a UI constraint is far worse than an extra code path. One
+field, one button, no second composer.
+
+### Density on the step screen
+
+This screen's failure mode is crowding, and the primary action is what gets
+pushed off the bottom. ISA-101 frames it as a Level 1 action display, not a
+Level 3 detail display: *"what does the operator need to know right now"*.
+
+- **The job card is one line** — `J-0007 · PROD-ACTUATOR-200` — and **the whole
+  card is the tap target**, with a decorative chevron as the affordance. A
+  separate chevron button would be a second control for one action, and nesting
+  it would be invalid markup. The expanded section sits **outside** that button
+  because it contains a real link (`View all steps for J-0007`), which is where
+  the traveler link moved to when the job number stopped being one.
+- **Expanded state is sticky** across steps via `sessionStorage`. Whether it
+  should persist across days as a remembered preference is undecided.
+- **Always visible, never behind the expander:** the part description, the
+  per-operation instructions, and **part progress** — "where am I on this part"
+  is the question a step screen exists to answer.
+- **`Parts finished` shares a row with Files and Playbook**, leading it, matched
+  to their 48px height. It leads because it is the input for the primary action
+  while those are reference; they keep their counts, which is what actually
+  advertises them.
+- **Capture is one row** — single-line field that grows, camera as an adjacent
+  icon. The dictation tip is a **caption, never an icon button**: nothing can
+  invoke the OS keyboard's dictation from a web page, so a mic icon beside a real
+  camera button is a false affordance.
+
+**The action is NOT pinned, by decision.** A fixed bar guaranteed reachability
+but overlaid the content beneath it. The protection is density instead, which is
+a weaker guarantee — measured at 440×956, collapsed the button clears the nav
+(bottom 495 vs 521); **expanded it does not** (629) and needs a scroll. Since the
+expander is sticky, an operator who expands once keeps it that way. **Measure
+before adding anything above that button** — that is exactly how it broke the
+first time.
+
+### Description vs instructions: no dimming, ever
+
+Two lines can carry the engineer's intent, and the app cannot tell which:
+`parts.description` and `job_operations.instructions`. Per-operation text is
+optional and frequently blank, so shops often put the instruction in the part
+description instead.
+
+So **neither is de-emphasised**, and the distinction is a dimmed **label**
+(`Instructions`, the same word the admin sees when writing the field) rather than
+weight or a tinted box. What is dimmed is chrome, never content.
+
+An earlier revision dimmed the description to make the instruction "the brighter
+one". That was wrong twice over: it asserted "reference, not instruction" exactly
+when that was false, and ISA-101 requires every emphasis to carry a defined
+meaning — de-emphasis used as a **guess** carries none, and NN/G's hierarchy work
+is explicit that muted text draws less attention. Emphasis stays reserved for
+states that genuinely mean "look here now": the over-quantity error and the
+station-mismatch warning.
+
+**The seed matters here.** `supabase/seed.sql` used to fill every routing step's
+`instructions` with `'<WorkCenter> operation'`. That made the box appear on every
+step of every demo, which teaches an operator the box is noise so they skip it on
+the day it says "torque to 40, not 45". Four steps now carry real shop
+instructions and the rest are NULL, so a usability session tells us about the
+design rather than about our test data.
+
 One implementation, two hosts: [`useNoteCapture`](../../hooks/useNoteCapture.ts)
 owns the draft, the photo pipeline (including the iOS unreadable-`File`
 mitigation) and the funnel events; [`NoteCaptureFields`](../../components/operator/NoteCaptureFields.tsx)
@@ -527,6 +601,9 @@ Each bullet is a Given/When/Then scenario carrying a verification clause — a p
 
 - [ ] **Given** a colleague's note, **when** the operator taps Helpful, **then** the count moves immediately and the write follows — an optimistic toggle, because a thumbs-up that waits for shop wifi reads as broken — *verified by `__tests__/components/operator/NoteReactions.test.tsx`*.
 - [ ] **Given** a failed write, **when** it rejects, **then** the button rolls back rather than leaving a lie on screen, with no toast — *verified by `__tests__/components/operator/NoteReactions.test.tsx`*.
+- [ ] **Given** nothing finished and something typed, **when** the operator taps the primary button, **then** the note is saved with NO completion invented to carry it — *verified by `__tests__/app/operator/OperationActionPage.test.tsx > 'saves a note alone when nothing was finished'` and `e2e/operator-completion.spec.ts`*.
+- [ ] **Given** an empty quantity and an empty note, **then** the button is disabled — the zero-quantity completion floor is unchanged — *verified by `__tests__/app/operator/OperationActionPage.test.tsx > 'cannot record zero'`*.
+- [ ] **Given** the step screen, **when** it loads, **then** the job card is collapsed and expands IN PLACE without navigating — *verified by `__tests__/app/operator/OperationActionPage.test.tsx > 'collapses the job details by default, and opens them in place'`*.
 - [ ] **Given** the operator's OWN note, **when** it renders, **then** no control is offered — RLS forbids self-reaction, so the tap would be a guaranteed `42501` — *verified by `__tests__/components/operator/NoteReactions.test.tsx`*.
 - [ ] **Given** a `confirmed` row, **when** the card renders, **then** it is excluded from the helpful count and its reactor is not named — *verified by `__tests__/components/operator/NoteReactions.test.tsx`*.
 - [ ] **Given** any note, **when** looking for a negative option, **then** none exists on screen or in the schema — *verified by `__tests__/components/operator/NoteReactions.test.tsx`*.

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -299,6 +299,71 @@ gave 3" is a participation score — both are the operator-comparative metrics t
 module refuses. Nothing sums them by person, including My work, which shows
 endorsements received *on a note*.
 
+### Capture is part of completing (B4)
+
+Finishing a step and writing down what you learned are **one act, one button, one
+commit**. The completion block carries the quantity field, an optional "Anything
+worth noting for next time?" with photo attach, and `RECORD COMPLETION` submits
+all of it.
+
+It used to be three separate things: record the completion, then a prompt
+offering to add a photo, then a *separate* Post. The middle of that had no
+durability — attaching a photo showed a thumbnail, the flow read as finished, and
+a back tap discarded it silently. There was no `beforeunload` guard and no draft
+persistence, so the only real fix was to stop having two commits. **The
+post-completion offer is deleted, not relocated.**
+
+**Submit order is load-bearing and deliberately NOT atomic:**
+
+1. `createOperationCompletion` — lands first, durably
+2. `addJobNote`, if there is text or a photo
+3. `addJobNoteMedia` per photo
+
+A transaction would be *worse*: it would roll back real finished work because an
+image failed to upload on shop wifi. So if the note fails the completion stands,
+and the note error surfaces on its own next to the text the operator still has.
+Asserted by `OperationActionPage.test.tsx > 'writes the note only AFTER the
+completion has landed'` and `'keeps the completion when the note fails'`.
+
+**Capture is always optional.** Completion works with the field empty.
+
+**Where the feed keeps its own composer.** Three of the four branches of the
+operation page have no completion block, so capture cannot live only there:
+
+| Branch | Capture |
+|---|---|
+| Internal, incomplete | **In the completion block**, one button |
+| Internal, **complete** | Feed composer — otherwise a photo could never be added after finishing, which is how photos actually arrive (taken on the phone's camera, attached later) |
+| **Outside** step (send/receive) | Feed composer — `operator-paperless-flow.md` calls *"sent to coater 7/9, expected back 7/16"* the highest-value note in the system |
+| No station selected | Neither: the page is only a station picker |
+
+`JobFeed`'s `standaloneCapture` prop is that switch, and it is false on the normal
+path so there is never more than one composer on screen. This is a deliberate
+deviation from the plan's *"the note cannot be saved without completing"*, forced
+by the render branches rather than by preference.
+
+One implementation, two hosts: [`useNoteCapture`](../../hooks/useNoteCapture.ts)
+owns the draft, the photo pipeline (including the iOS unreadable-`File`
+mitigation) and the funnel events; [`NoteCaptureFields`](../../components/operator/NoteCaptureFields.tsx)
+renders them and deliberately owns **no** submit button, because the surface it
+sits in decides what "save" means.
+
+### Triangularity (B5)
+
+The asymmetry that makes writing something down worth the extra taps:
+
+| | Effort | What comes back |
+|---|---|---|
+| Completion alone | one tap | **Nothing.** The step turns green |
+| Completion + a note | ~4 more taps | A Playbook entry with their name, a view count that grows, named readers, a login-banner line |
+
+**Do not equalise it.** If completing were rewarded on its own, the note would be
+pure cost and nobody would write one. So "nothing comes back from a bare
+completion" is a feature with a test —
+`e2e/operator-completion.spec.ts > 'a bare completion adds no note and no My work
+row'` — which also scans My work for `completed`, `streak`, `average` and `pace`,
+because a contribution screen is exactly where a completion count wants to appear.
+
 ### Surveillance guardrail (non-negotiable)
 
 No operator-facing surface may reflect an operator's pace or standing back at them.

--- a/e2e/operator-completion.spec.ts
+++ b/e2e/operator-completion.spec.ts
@@ -69,6 +69,7 @@ async function openTravelerWithStation(page: Page, jobNumber: string): Promise<v
 const qtyField = (page: Page) => page.getByLabel('Good pieces finished');
 const recordButton = (page: Page) => page.getByRole('button', { name: /record completion/i });
 const undoButton = (page: Page) => page.getByRole('button', { name: /undo all/i });
+const saveNoteButton = (page: Page) => page.getByRole('button', { name: /save note/i });
 const completeBanner = (page: Page) =>
   page.getByRole('button', { name: /this step is complete/i });
 
@@ -160,15 +161,50 @@ test.describe('operator completion', () => {
   });
 
   test('will not record nothing', async ({ page }) => {
-    // The only floor is > 0. Without it an empty tap would append a zero-quantity
-    // completion event and the step would read as worked-on when it was not.
+    // The floor is unchanged: no zero-quantity completion. What changed is the
+    // button's LABEL when the quantity is empty — with nothing to record there is
+    // no completion to offer, so it presents as SAVE NOTE and is disabled until
+    // something is typed. Asserting the old label here is what made this spec
+    // fail in CI while the component test (already updated) passed.
     await openTravelerWithStation(page, 'E2E-JS-NOTSTARTED');
     await openStep(page);
 
     await expect(qtyField(page)).toBeVisible({ timeout: 30_000 });
     await qtyField(page).fill('0');
 
-    await expect(recordButton(page)).toBeDisabled();
+    await expect(recordButton(page)).toHaveCount(0);
+    await expect(saveNoteButton(page)).toBeDisabled();
+  });
+
+  test('saves a note alone when nothing was finished', async ({ page }) => {
+    // The hole B4 opened: capture rode on a button requiring qty > 0, so an
+    // operator who finished ZERO pieces had to stay silent or type a false
+    // quantity to get the note saved. Corrupting production data to satisfy a UI
+    // constraint is far worse than an extra path.
+    await openTravelerWithStation(page, 'E2E-JS-NOTSTARTED');
+    await openStep(page);
+
+    await expect(qtyField(page)).toBeVisible({ timeout: 30_000 });
+    await qtyField(page).fill('0');
+
+    // Unique per run. A fixed string accumulates in the shared local database and
+    // then matches several feed entries, and it also matches the textarea still
+    // holding the draft — three hits and a strict-mode violation. CI starts from a
+    // clean database so it would have hit only the two-element version of the
+    // same bug.
+    const body = `machine down, nothing run ${Date.now()}`;
+    await page.getByPlaceholder(/worth noting/i).fill(body);
+
+    await saveNoteButton(page).click();
+
+    // Scoped to the FEED, not the whole page, so the draft field cannot satisfy it.
+    await expect(
+      page.locator('p').filter({ hasText: body }).first(),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // And the step is still outstanding — no completion was invented to carry it.
+    await expect(qtyField(page)).toBeVisible();
+    await expect(completeBanner(page)).toHaveCount(0);
   });
 });
 

--- a/e2e/operator-completion.spec.ts
+++ b/e2e/operator-completion.spec.ts
@@ -44,19 +44,26 @@ async function openTravelerWithStation(page: Page, jobNumber: string): Promise<v
   // The station picker gates the completion action, so go through it rather than
   // around it — a spec that skipped it would not cover the guard that decides
   // whether an operator can record anything at all.
+  //
+  // Tolerant of a station already being selected: the choice persists, so on a
+  // second visit within one test the picker is simply not rendered and the jobs
+  // list shows instead. Requiring it unconditionally made the helper usable only
+  // once per test.
   await page.goto(`/operator/${companyId}/jobs`);
   const picker = page.getByRole('button', { name: WC_INTERNAL });
-  await expect(picker).toBeVisible({ timeout: 30_000 });
-  await picker.click();
+  // Wait for one of the two possible states before deciding, for the same reason
+  // as openStep below: isVisible() resolves immediately, so checking it straight
+  // after a goto reports "no picker" on a page that simply has not rendered yet —
+  // and the station silently never gets selected.
+  await expect(picker.or(page.getByRole('button', { name: 'My Station' }))).toBeVisible({
+    timeout: 30_000,
+  });
+  if (await picker.isVisible()) {
+    await picker.click();
+  }
 
   await page.goto(`/operator/${companyId}/jobs/${jobId}`);
   await expect(page).toHaveURL(/\/parts\/[0-9a-f-]{36}/, { timeout: 30_000 });
-}
-
-/** Open the seeded step from the traveler. */
-async function openStep(page: Page): Promise<void> {
-  await page.getByRole('button', { name: new RegExp(WC_INTERNAL) }).first().click();
-  await expect(page).toHaveURL(/\/operations\/[0-9a-f-]{36}/, { timeout: 30_000 });
 }
 
 const qtyField = (page: Page) => page.getByLabel('Good pieces finished');
@@ -64,6 +71,28 @@ const recordButton = (page: Page) => page.getByRole('button', { name: /record co
 const undoButton = (page: Page) => page.getByRole('button', { name: /undo all/i });
 const completeBanner = (page: Page) =>
   page.getByRole('button', { name: /this step is complete/i });
+
+/**
+ * Open the seeded step from the traveler, and leave it ACTIONABLE.
+ *
+ * Self-healing on purpose. These tests share one job's completions, so a run that
+ * dies mid-test leaves the step complete and every later run fails on a missing
+ * quantity field for a reason that has nothing to do with the code. CI always
+ * starts from a clean database; a developer's machine does not.
+ */
+async function openStep(page: Page): Promise<void> {
+  await page.getByRole('button', { name: new RegExp(WC_INTERNAL) }).first().click();
+  await expect(page).toHaveURL(/\/operations\/[0-9a-f-]{36}/, { timeout: 30_000 });
+
+  // Wait for EITHER state before deciding. isVisible() resolves immediately, so
+  // on a freshly navigated page neither element exists yet, the heal was skipped,
+  // and we then waited 30s for a field that was never going to appear.
+  await expect(qtyField(page).or(completeBanner(page))).toBeVisible({ timeout: 30_000 });
+  if (await completeBanner(page).isVisible()) {
+    await completeBanner(page).click();
+  }
+  await expect(qtyField(page)).toBeVisible({ timeout: 30_000 });
+}
 
 // These tests all drive the SAME job's completions, so they are order-dependent
 // by nature — run in parallel they race on shared mutable state and fail at
@@ -140,5 +169,68 @@ test.describe('operator completion', () => {
     await qtyField(page).fill('0');
 
     await expect(recordButton(page)).toBeDisabled();
+  });
+});
+
+/**
+ * B5 — TRIANGULARITY.
+ *
+ * The asymmetry that makes writing something down worth the extra taps:
+ *
+ *   completion alone      → the step turns green. Nothing else.
+ *   completion + a note   → your name on a Playbook entry, a view count that
+ *                           grows, named readers, a login-banner line.
+ *
+ * If completing were rewarded on its own, the note would be pure cost and nobody
+ * would write one. So "nothing comes back from a bare completion" is a FEATURE
+ * with a test, not an omission — and My work is where the pressure to break it
+ * will come from, because a contribution screen is exactly where a completion
+ * count wants to appear.
+ */
+test.describe('completion alone earns nothing back', () => {
+  /** Notes listed on My work; 0 when the empty state is showing. */
+  async function myWorkNoteCount(page: Page, companyId: string): Promise<number> {
+    await page.goto(`/operator/${companyId}/my-work`);
+    await expect(
+      page.getByRole('listitem').first().or(page.getByText('Nothing written yet')),
+    ).toBeVisible({ timeout: 30_000 });
+    return page.getByRole('listitem').count();
+  }
+
+  test('a bare completion adds no note and no My work row', async ({ page }) => {
+    await openTravelerWithStation(page, 'E2E-JS-NOTSTARTED');
+    const companyId = page.url().match(/\/operator\/([0-9a-f-]{36})\//)?.[1];
+    expect(companyId).toBeTruthy();
+
+    // The seed gives this user a durable note already, so the assertion is that
+    // completing changes NOTHING — not that the page starts empty.
+    const before = await myWorkNoteCount(page, companyId!);
+
+    await openTravelerWithStation(page, 'E2E-JS-NOTSTARTED');
+    await openStep(page);
+
+    // Complete with the capture field left empty — which must be allowed.
+    const noteField = page.getByPlaceholder(/worth noting/i);
+    await expect(noteField).toBeVisible();
+    await expect(noteField).toHaveValue('');
+    await recordButton(page).click();
+    await expect(completeBanner(page)).toBeVisible({ timeout: 30_000 });
+
+    // Nothing captured, so nothing new came back.
+    expect(await myWorkNoteCount(page, companyId!), 'a bare completion must add no row').toBe(
+      before,
+    );
+
+    // And the line that must never be crossed: no completion count, streak or
+    // average anywhere on the contribution screen.
+    const body = (await page.textContent('body')) ?? '';
+    for (const forbidden of [/completed/i, /completion/i, /streak/i, /average/i, /\bpace\b/i]) {
+      expect(body, `My work must not surface ${forbidden}`).not.toMatch(forbidden);
+    }
+
+    // Leave the step as we found it. openStep already undoes a complete step, so
+    // this is just a return trip.
+    await openTravelerWithStation(page, 'E2E-JS-NOTSTARTED');
+    await openStep(page);
   });
 });

--- a/e2e/operator-completion.spec.ts
+++ b/e2e/operator-completion.spec.ts
@@ -66,7 +66,7 @@ async function openTravelerWithStation(page: Page, jobNumber: string): Promise<v
   await expect(page).toHaveURL(/\/parts\/[0-9a-f-]{36}/, { timeout: 30_000 });
 }
 
-const qtyField = (page: Page) => page.getByLabel('Good pieces finished');
+const qtyField = (page: Page) => page.getByLabel('Parts finished');
 const recordButton = (page: Page) => page.getByRole('button', { name: /record completion/i });
 const undoButton = (page: Page) => page.getByRole('button', { name: /undo all/i });
 const saveNoteButton = (page: Page) => page.getByRole('button', { name: /save note/i });

--- a/e2e/operator-notes-loop.spec.ts
+++ b/e2e/operator-notes-loop.spec.ts
@@ -70,9 +70,18 @@ test.describe('operator read-back loop', () => {
     await expect(priorNotes).toBeVisible({ timeout: 30_000 });
 
     // 2. The knowledge itself, written against a DIFFERENT job for this part.
+    //
+    // Scoped to the sheet (a fullScreen Dialog) rather than the page. A bare
+    // getByText(...).first() matched whichever author name came first in DOM
+    // order — and the traveler's collapsed feed sits behind this dialog with its
+    // children MOUNTED BUT HIDDEN, so as soon as that job had any note the first
+    // match became an invisible one and this failed on `hidden`, not on absence.
+    // The count assertion above is deliberately left page-wide: the affordance is
+    // on the traveler, not in the sheet.
     await priorNotes.click();
-    await expect(page.getByText(DURABLE_NOTE_BODY)).toBeVisible({ timeout: 30_000 });
-    await expect(page.getByText('E2E Test User').first()).toBeVisible();
+    const sheet = page.getByRole('dialog');
+    await expect(sheet.getByText(DURABLE_NOTE_BODY)).toBeVisible({ timeout: 30_000 });
+    await expect(sheet.getByText('E2E Test User').first()).toBeVisible();
   });
 
   test('the traveler feed renders without erroring on the notes query', async ({ page }) => {

--- a/hooks/useNoteCapture.ts
+++ b/hooks/useNoteCapture.ts
@@ -1,0 +1,304 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { addJobNote } from '@/utils/operatorAccess';
+import { addJobNoteMedia } from '@/utils/jobNoteMediaAccess';
+import { compressPhoto } from '@/utils/imageCompression';
+import { logOperatorEvent } from '@/utils/operatorEventsAccess';
+import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import type { JobNote, JobNoteMedia } from '@/types/operator';
+
+/**
+ * Text + photos for one step, and the write that lands them.
+ *
+ * EXTRACTED FROM JobFeed so completion can own it. Capture used to live only in
+ * the feed, behind its own Post button — which made saving a note a SECOND,
+ * separate commit after RECORD COMPLETION. Attaching a photo showed a thumbnail
+ * and the flow read as finished, but nothing was written until Post; a back tap
+ * discarded it silently. There was no beforeunload guard and no draft
+ * persistence, so the only real fix was to stop having two commits.
+ *
+ * The hook owns the draft, so the same fields can be rendered inside the
+ * completion block (submitted WITH the completion, one button) and inside the
+ * feed (its own Post button) without duplicating the photo pipeline, the
+ * iOS-unreadable-file mitigation, or the funnel instrumentation.
+ *
+ * WHAT IT DOES NOT DO: decide when to write. The caller does, because ordering
+ * is load-bearing — completion must be durable before a note is attempted, so a
+ * failed photo upload can never un-complete a finished step.
+ */
+
+const MIC_HINT_KEY = 'jigged:composer-mic-hint';
+const MIC_HINT_MAX_SHOWS = 5;
+
+interface MicHintState {
+  shows: number;
+  dismissed: boolean;
+}
+
+function readMicHint(): MicHintState {
+  if (typeof window === 'undefined') return { shows: 0, dismissed: true };
+  try {
+    const raw = window.localStorage.getItem(MIC_HINT_KEY);
+    if (!raw) return { shows: 0, dismissed: false };
+    const parsed = JSON.parse(raw) as Partial<MicHintState>;
+    return { shows: Number(parsed.shows) || 0, dismissed: !!parsed.dismissed };
+  } catch {
+    return { shows: 0, dismissed: false };
+  }
+}
+
+function writeMicHint(state: MicHintState): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(MIC_HINT_KEY, JSON.stringify(state));
+  } catch {
+    /* private mode / quota — the hint is best-effort, never block on it */
+  }
+}
+
+export interface PendingPhoto {
+  id: string;
+  file: File;
+  previewUrl: string;
+}
+
+export interface NoteCaptureContext {
+  jobPartId: string;
+  jobOperationId: string;
+}
+
+export interface NoteCapture {
+  draft: string;
+  setDraft: (v: string) => void;
+  pending: PendingPhoto[];
+  saving: boolean;
+  error: string | null;
+  clearError: () => void;
+  /** True when there is something worth writing. */
+  hasContent: boolean;
+  showMicHint: boolean;
+  dismissMicHint: () => void;
+  /** Records composer_focused exactly once per mount. */
+  noteFocused: () => void;
+  pickPhotos: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
+  removePending: (id: string) => void;
+  /**
+   * Write the note and its media. Returns the note (with media) so an optimistic
+   * list can prepend it, or null when there was nothing to write.
+   *
+   * THROWS on failure, deliberately: the caller decides what a partial failure
+   * means. On the completion path the completion has already landed and must
+   * stand, so the error is surfaced on its own rather than rolled back.
+   */
+  submit: () => Promise<JobNote | null>;
+}
+
+export function useNoteCapture(opts: {
+  companyId: string;
+  jobId: string;
+  operatorId: string | null;
+  context: NoteCaptureContext | null;
+  /** Off when there is no capture surface mounted (e.g. a read-only feed). */
+  enabled: boolean;
+}): NoteCapture {
+  const { companyId, jobId, operatorId, context, enabled } = opts;
+
+  const [draft, setDraft] = useState('');
+  const [pending, setPending] = useState<PendingPhoto[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Decided once from storage at mount — DERIVED, not synchronised, so there is
+  // no setState-in-effect cascade. `enabled` is effectively static per mount in
+  // both consumers; if it ever flipped false→true the hint would not re-appear,
+  // which is the harmless direction (no re-nagging).
+  const [showMicHint, setShowMicHint] = useState(() => {
+    if (!enabled) return false;
+    const state = readMicHint();
+    return !(state.dismissed || state.shows >= MIC_HINT_MAX_SHOWS);
+  });
+
+  const pendingIdRef = useRef(0);
+  // Funnel state as refs, not state: read once at unmount, and putting them in
+  // state would re-render on every keystroke to record something never shown.
+  const focusedRef = useRef(false);
+  const capturedRef = useRef(false);
+  const draftRef = useRef({ bodyLength: 0, photoCount: 0 });
+
+  const hasContent = draft.trim().length > 0 || pending.length > 0;
+
+  // Count the show. A write to localStorage IS the external-system update an
+  // effect is for; only the setState above had to move out of one.
+  const countedRef = useRef(false);
+  useEffect(() => {
+    if (!showMicHint || countedRef.current) return;
+    countedRef.current = true;
+    writeMicHint({ shows: readMicHint().shows + 1, dismissed: false });
+  }, [showMicHint]);
+
+  // Keep the unmount snapshot current. In an effect, not during render: mutating
+  // a ref while rendering is unsafe under concurrent rendering.
+  useEffect(() => {
+    draftRef.current = { bodyLength: draft.trim().length, photoCount: pending.length };
+  }, [draft, pending]);
+
+  // Revoke preview URLs on unmount.
+  useEffect(() => {
+    return () => {
+      pending.forEach((p) => URL.revokeObjectURL(p.previewUrl));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Abandonment: they reached for capture and left without saving. The funnel
+  // step that separates "capture friction" from "container fit" — a high focus
+  // rate with a low save rate means they tried and gave up, a very different
+  // problem from never reaching for it at all.
+  useEffect(() => {
+    return () => {
+      if (!enabled) return;
+      if (!focusedRef.current || capturedRef.current) return;
+      logOperatorEvent(companyId, 'composer_abandoned', draftRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const noteFocused = useCallback(() => {
+    if (focusedRef.current) return;
+    focusedRef.current = true;
+    logOperatorEvent(companyId, 'composer_focused');
+  }, [companyId]);
+
+  const dismissMicHint = useCallback(() => {
+    setShowMicHint(false);
+    writeMicHint({ ...readMicHint(), dismissed: true });
+  }, []);
+
+  const pickPhotos = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const input = e.target;
+      const files = Array.from(input.files ?? []);
+      input.value = '';
+      if (files.length === 0) return;
+      setError(null);
+
+      // iOS "new photo → nothing attached" mitigation. A camera-origin File can
+      // become unreadable by the time it is compressed/uploaded, yielding a
+      // zero-byte blob. Copy the bytes into a stable File now, while the
+      // reference is fresh, and drop any pick that reads back empty rather than
+      // silently posting nothing.
+      const prepared: PendingPhoto[] = [];
+      let unreadable = 0;
+      for (const file of files) {
+        let stable = file;
+        try {
+          const buf = await file.arrayBuffer();
+          stable = new File([buf], file.name || 'photo.jpg', {
+            type: file.type || 'image/jpeg',
+            lastModified: file.lastModified,
+          });
+        } catch {
+          // Copy failed — fall through and let the size guard decide.
+        }
+        if (stable.size === 0) {
+          unreadable += 1;
+          continue;
+        }
+        prepared.push({
+          id: `pp-${pendingIdRef.current++}`,
+          file: stable,
+          previewUrl: URL.createObjectURL(stable),
+        });
+      }
+
+      if (prepared.length === 0) {
+        setError('That photo could not be read. Please try taking or picking it again.');
+        return;
+      }
+      // Per-file reporting: the old behaviour dropped unreadable picks silently
+      // unless EVERY one failed, so picking three and getting one thumbnail came
+      // with no explanation.
+      if (unreadable > 0) {
+        setError(
+          `${unreadable} of ${files.length} photos couldn't be read — the rest are attached.`,
+        );
+      }
+      setPending((prev) => [...prev, ...prepared]);
+      logOperatorEvent(companyId, 'photo_attached', { count: prepared.length });
+    },
+    [companyId],
+  );
+
+  const removePending = useCallback((id: string) => {
+    setPending((prev) => {
+      const target = prev.find((p) => p.id === id);
+      if (target) URL.revokeObjectURL(target.previewUrl);
+      return prev.filter((p) => p.id !== id);
+    });
+  }, []);
+
+  const submit = useCallback(async (): Promise<JobNote | null> => {
+    if (!context) return null;
+    const body = draft.trim();
+    const photos = pending;
+    if (!body && photos.length === 0) return null;
+    if (!operatorId) {
+      const message = 'Could not identify your account — reload and try again.';
+      setError(message);
+      throw new Error(message);
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const note = await addJobNote(jobId, companyId, operatorId, body || null, {
+        jobPartId: context.jobPartId,
+        jobOperationId: context.jobOperationId,
+      });
+
+      const media: JobNoteMedia[] = [];
+      for (const p of photos) {
+        const prepared = await compressPhoto(p.file);
+        media.push(
+          await addJobNoteMedia(companyId, jobId, note.id, prepared.file, {
+            dims: prepared.dims,
+          }),
+        );
+      }
+
+      photos.forEach((p) => URL.revokeObjectURL(p.previewUrl));
+      setPending([]);
+      setDraft('');
+      // After the write resolves, so a failed save is never counted as one —
+      // the funnel's whole job is separating "tried" from "succeeded".
+      capturedRef.current = true;
+      logOperatorEvent(companyId, media.length > 0 ? 'note_saved_with_photo' : 'note_saved', {
+        jobOperationId: context.jobOperationId,
+        bodyLength: body.length,
+        photoCount: media.length,
+      });
+      return { ...note, media };
+    } catch (err) {
+      setError(friendlyErrorMessage(err, { entity: 'note', fallback: 'Could not save that.' }));
+      throw err;
+    } finally {
+      setSaving(false);
+    }
+  }, [context, draft, pending, operatorId, jobId, companyId]);
+
+  return {
+    draft,
+    setDraft,
+    pending,
+    saving,
+    error,
+    clearError: () => setError(null),
+    hasContent,
+    showMicHint,
+    dismissMicHint,
+    noteFocused,
+    pickPhotos,
+    removePending,
+    submit,
+  };
+}

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -310,41 +310,52 @@ insert into public.routings (id, company_id, part_id, name, description) values
 on conflict (id) do nothing;
 
 -- routing_operations: internal = setup 15 / cycle 3 / no external price; external (anodize) = 0/0 + external_unit_price 4.5.
+--
+-- INSTRUCTIONS ARE MOSTLY NULL, ON PURPOSE. Every step used to carry
+-- '<WorkCenter> operation' — a string that restates the work center already shown
+-- in the operator's header and says nothing. The operation page renders the
+-- Instructions box only when the column is non-empty, so junk here made the box
+-- appear on EVERY step in every demo and preview, which teaches an operator that
+-- the box is noise. They then skip it on the day it says "torque to 40, not 45".
+--
+-- A handful of steps get real shop instructions and the rest get NULL, so the
+-- seed shows both states honestly — and a usability session tells us something
+-- about the design rather than about our test data.
 insert into public.routing_operations (routing_id, work_center_id, sequence, setup_minutes, cycle_minutes_per_unit, labor_rate_override, external_unit_price, instructions) values
   -- housing: saw, mill, deburr
-  ('70000000-0000-0000-0000-000000000009','40000000-0000-0000-0000-000000000001',10,15,3,null,null,'Bandsaw operation'),
-  ('70000000-0000-0000-0000-000000000009','40000000-0000-0000-0000-000000000002',20,15,3,null,null,'CNC Mill (Haas VF-2) operation'),
-  ('70000000-0000-0000-0000-000000000009','40000000-0000-0000-0000-000000000004',30,15,3,null,null,'Manual Deburr operation'),
+  ('70000000-0000-0000-0000-000000000009','40000000-0000-0000-0000-000000000001',10,15,3,null,null,null),
+  ('70000000-0000-0000-0000-000000000009','40000000-0000-0000-0000-000000000002',20,15,3,null,null,'Indicate the fixture to 0.001 before the first bore — the pattern walks otherwise.'),
+  ('70000000-0000-0000-0000-000000000009','40000000-0000-0000-0000-000000000004',30,15,3,null,null,null),
   -- shaft: saw, lathe, deburr
-  ('70000000-0000-0000-0000-000000000010','40000000-0000-0000-0000-000000000001',10,15,3,null,null,'Bandsaw operation'),
-  ('70000000-0000-0000-0000-000000000010','40000000-0000-0000-0000-000000000003',20,15,3,null,null,'CNC Lathe (Okuma) operation'),
-  ('70000000-0000-0000-0000-000000000010','40000000-0000-0000-0000-000000000004',30,15,3,null,null,'Manual Deburr operation'),
+  ('70000000-0000-0000-0000-000000000010','40000000-0000-0000-0000-000000000001',10,15,3,null,null,null),
+  ('70000000-0000-0000-0000-000000000010','40000000-0000-0000-0000-000000000003',20,15,3,null,null,null),
+  ('70000000-0000-0000-0000-000000000010','40000000-0000-0000-0000-000000000004',30,15,3,null,null,null),
   -- cover: mill, deburr, anodize(external)
-  ('70000000-0000-0000-0000-000000000011','40000000-0000-0000-0000-000000000002',10,15,3,null,null,'CNC Mill (Haas VF-2) operation'),
-  ('70000000-0000-0000-0000-000000000011','40000000-0000-0000-0000-000000000004',20,15,3,null,null,'Manual Deburr operation'),
-  ('70000000-0000-0000-0000-000000000011','40000000-0000-0000-0000-000000000007',30,0,0,null,4.5,'Anodizing (ProFinish) operation'),
+  ('70000000-0000-0000-0000-000000000011','40000000-0000-0000-0000-000000000002',10,15,3,null,null,null),
+  ('70000000-0000-0000-0000-000000000011','40000000-0000-0000-0000-000000000004',20,15,3,null,null,null),
+  ('70000000-0000-0000-0000-000000000011','40000000-0000-0000-0000-000000000007',30,0,0,null,4.5,'Mask the bore before it goes out. ProFinish will not mask it for us.'),
   -- bracket: mill, deburr
-  ('70000000-0000-0000-0000-000000000012','40000000-0000-0000-0000-000000000002',10,15,3,null,null,'CNC Mill (Haas VF-2) operation'),
-  ('70000000-0000-0000-0000-000000000012','40000000-0000-0000-0000-000000000004',20,15,3,null,null,'Manual Deburr operation'),
+  ('70000000-0000-0000-0000-000000000012','40000000-0000-0000-0000-000000000002',10,15,3,null,null,null),
+  ('70000000-0000-0000-0000-000000000012','40000000-0000-0000-0000-000000000004',20,15,3,null,null,null),
   -- pumpcore: assembly, inspect
-  ('70000000-0000-0000-0000-000000000013','40000000-0000-0000-0000-000000000005',10,15,3,null,null,'Assembly Bench operation'),
-  ('70000000-0000-0000-0000-000000000013','40000000-0000-0000-0000-000000000006',20,15,3,null,null,'Final Inspection operation'),
+  ('70000000-0000-0000-0000-000000000013','40000000-0000-0000-0000-000000000005',10,15,3,null,null,'Press the bearings with the arbor fixture. Seat fully BEFORE pinning or the shaft binds.'),
+  ('70000000-0000-0000-0000-000000000013','40000000-0000-0000-0000-000000000006',20,15,3,null,null,'Seal-face flatness within 0.0005 TIR. Anything over, set it aside — do not rework on the bench.'),
   -- gearbox: assembly, inspect
-  ('70000000-0000-0000-0000-000000000014','40000000-0000-0000-0000-000000000005',10,15,3,null,null,'Assembly Bench operation'),
-  ('70000000-0000-0000-0000-000000000014','40000000-0000-0000-0000-000000000006',20,15,3,null,null,'Final Inspection operation'),
+  ('70000000-0000-0000-0000-000000000014','40000000-0000-0000-0000-000000000005',10,15,3,null,null,null),
+  ('70000000-0000-0000-0000-000000000014','40000000-0000-0000-0000-000000000006',20,15,3,null,null,null),
   -- pump: assembly, inspect
-  ('70000000-0000-0000-0000-000000000015','40000000-0000-0000-0000-000000000005',10,15,3,null,null,'Assembly Bench operation'),
-  ('70000000-0000-0000-0000-000000000015','40000000-0000-0000-0000-000000000006',20,15,3,null,null,'Final Inspection operation'),
+  ('70000000-0000-0000-0000-000000000015','40000000-0000-0000-0000-000000000005',10,15,3,null,null,null),
+  ('70000000-0000-0000-0000-000000000015','40000000-0000-0000-0000-000000000006',20,15,3,null,null,null),
   -- actuator: assembly, inspect
-  ('70000000-0000-0000-0000-000000000016','40000000-0000-0000-0000-000000000005',10,15,3,null,null,'Assembly Bench operation'),
-  ('70000000-0000-0000-0000-000000000016','40000000-0000-0000-0000-000000000006',20,15,3,null,null,'Final Inspection operation'),
+  ('70000000-0000-0000-0000-000000000016','40000000-0000-0000-0000-000000000005',10,15,3,null,null,null),
+  ('70000000-0000-0000-0000-000000000016','40000000-0000-0000-0000-000000000006',20,15,3,null,null,null),
   -- manifold: mill, assembly, inspect
-  ('70000000-0000-0000-0000-000000000017','40000000-0000-0000-0000-000000000002',10,15,3,null,null,'CNC Mill (Haas VF-2) operation'),
-  ('70000000-0000-0000-0000-000000000017','40000000-0000-0000-0000-000000000005',20,15,3,null,null,'Assembly Bench operation'),
-  ('70000000-0000-0000-0000-000000000017','40000000-0000-0000-0000-000000000006',30,15,3,null,null,'Final Inspection operation'),
+  ('70000000-0000-0000-0000-000000000017','40000000-0000-0000-0000-000000000002',10,15,3,null,null,null),
+  ('70000000-0000-0000-0000-000000000017','40000000-0000-0000-0000-000000000005',20,15,3,null,null,null),
+  ('70000000-0000-0000-0000-000000000017','40000000-0000-0000-0000-000000000006',30,15,3,null,null,null),
   -- rail: saw, deburr
-  ('70000000-0000-0000-0000-000000000018','40000000-0000-0000-0000-000000000001',10,15,3,null,null,'Bandsaw operation'),
-  ('70000000-0000-0000-0000-000000000018','40000000-0000-0000-0000-000000000004',20,15,3,null,null,'Manual Deburr operation')
+  ('70000000-0000-0000-0000-000000000018','40000000-0000-0000-0000-000000000001',10,15,3,null,null,null),
+  ('70000000-0000-0000-0000-000000000018','40000000-0000-0000-0000-000000000004',20,15,3,null,null,null)
 on conflict do nothing;
 
 -- Pricing tiers for sellable products (sequence 1/2/3…; markup %).


### PR DESCRIPTION
Phase 2 of B4, on the characterisation tests merged in #614. Ships **on for everyone**, no flag, per your call.

## What changed

The completion block now carries the quantity field, an optional **"Anything worth noting for next time?"** with photo attach, and **one button** that submits all of it.

It used to be three things — record the completion, then a prompt offering a photo, then a *separate* Post. The middle of that had **no durability**: attaching a photo showed a thumbnail, the flow read as finished, and a back tap discarded it silently. No `beforeunload` guard, no draft persistence. The only real fix was to stop having two commits, so **the post-completion offer is deleted, not relocated.**

## Submit order, deliberately not atomic

1. `createOperationCompletion` — lands first, durably
2. `addJobNote` if there's text or a photo
3. `addJobNoteMedia` per photo

A transaction would be **worse, not safer** — it would roll back real finished work because an image failed to upload on shop wifi. If the note fails, the completion stands and the note error surfaces on its own, next to the text the operator still has.

## The deviation from the plan, and why

The plan says *"the note cannot be saved without completing."* Three of the four render branches of the operation page **have no completion block**, so capture can't live only there:

| Branch | Capture |
|---|---|
| Internal, incomplete | **In the completion block**, one button |
| Internal, **complete** | Feed composer — else a photo could never be added after finishing, which is how photos actually arrive |
| **Outside** step | Feed composer — the paperless doc calls *"sent to coater 7/9, back 7/16"* the highest-value note in the system |
| No station | Neither — the page is only a picker |

`standaloneCapture` is that switch, false on the normal path, so there's never more than one composer on screen. Forced by the code, not a preference.

## Evidence the rewrite preserved behaviour

**12 of the 13 characterisation tests from #614 pass unchanged.** The 13th changed deliberately and in one place: it asserted the offer signal, which no longer exists, and now asserts the ordering that prompt existed to protect.

Six JobFeed *offer* tests were **deleted rather than repaired** — they covered a feature that's gone, and the property they guarded is asserted on the page instead. Nine composer tests still pass; that behaviour moved into the hook and is exercised through `standaloneCapture`.

## B5 triangularity is now a test

| | Effort | What comes back |
|---|---|---|
| Completion alone | one tap | **Nothing.** The step turns green |
| Completion + note | ~4 more taps | Playbook entry with their name, a growing view count, named readers, a banner line |

If completing were rewarded on its own the note would be pure cost. So a new E2E asserts a bare completion adds no note and no My work row — and scans My work for `completed`, `streak`, `average`, `pace`, because a contribution screen is exactly where a completion count wants to appear.

## Two E2E races fixed

Both my phase-1 helpers had the same bug: `isVisible()` resolves immediately, so checking it straight after a `goto` reports the wrong state on a page that hasn't rendered. Both now wait for *either* state before deciding, and `openStep` self-heals a step left complete by a run that died mid-test — CI starts clean, a developer's machine doesn't.

## Verification

- `tsc` clean
- lint **16 warnings, down from 17** — the mic-hint `setState-in-effect` is gone; the hint is derived at mount now rather than synchronised
- **1381 frontend tests** pass
- **5 E2E** pass against a dev server built from this worktree, including triangularity

## Worth eyeballing on the preview

The note field now sits above `RECORD COMPLETION`, which makes the completion block taller. You've caught two layout problems by eye already, and this is the screen operators use most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)