### PR TITLE
feat(maintenance): schema for the machine logbook (Machine Maintenance PR A)

### DIFF
--- a/__tests__/components/operator/OperatorStationContext.test.tsx
+++ b/__tests__/components/operator/OperatorStationContext.test.tsx
@@ -11,11 +11,14 @@ vi.mock('@/utils/operatorAccess', () => ({
   getStationName: vi.fn().mockResolvedValue('Anca Grinder'),
 }));
 
+import { getStationName } from '@/utils/operatorAccess';
 import {
   OperatorStationProvider,
   useStationContext,
   clearStoredStation,
 } from '@/components/operator/OperatorStationContext';
+
+const mockGetStationName = vi.mocked(getStationName);
 
 const KEY = 'jigged_operator_station';
 
@@ -85,5 +88,31 @@ describe('OperatorStationProvider', () => {
 
     clearStoredStation();
     expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+
+  // An archived machine used to stay selected forever: getStationName ignored
+  // deleted_at, so the id resolved, and even once it stopped resolving the
+  // provider kept the id with a blank name — a station-gated app pointed at a
+  // machine nobody can stand at, with no way out from the floor.
+  it('forgets a stored station whose machine has been archived, dropping back to the picker', async () => {
+    window.localStorage.setItem(KEY, 'st-archived');
+    mockGetStationName.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useStationContext(), { wrapper: OperatorStationProvider });
+
+    await waitFor(() => expect(result.current.stationId).toBeNull());
+    expect(result.current.stationName).toBeNull();
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('keeps the stored station when the lookup fails, because a dropped connection is not an archive', async () => {
+    window.localStorage.setItem(KEY, 'st-anca');
+    mockGetStationName.mockRejectedValueOnce(new Error('network down'));
+
+    const { result } = renderHook(() => useStationContext(), { wrapper: OperatorStationProvider });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.stationId).toBe('st-anca');
+    expect(window.localStorage.getItem(KEY)).toBe('st-anca');
   });
 });

--- a/__tests__/lib/featureFlags.test.ts
+++ b/__tests__/lib/featureFlags.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   isAiInsightsEnabled,
   isInventoryLocationsEnabled,
+  isMachineMaintenanceEnabled,
   readCompanyFeatures,
   KNOWN_FEATURES,
 } from '@/lib/featureFlags';
@@ -67,5 +68,30 @@ describe('featureFlags: ai_insights (opt-out / default-on)', () => {
 
     const disabled = readCompanyFeatures({ settings: { features: { ai_insights: false } } });
     expect(disabled.ai_insights).toBe(false);
+  });
+});
+
+describe('featureFlags: machine_maintenance (opt-in pilot flag)', () => {
+  it('is registered in KNOWN_FEATURES with no defaultEnabled', () => {
+    // The module is an experiment with a written kill criterion, so it must be
+    // on at exactly the shops whose behaviour is being measured. An opt-out
+    // default would silently widen the sample and make the result unreadable.
+    const descriptor = KNOWN_FEATURES.find((f) => f.key === 'machine_maintenance');
+    expect(descriptor).toBeDefined();
+    expect(descriptor?.defaultEnabled).toBeUndefined();
+  });
+
+  it('reads settings.features.machine_maintenance (boolean or "true"), defaulting off', () => {
+    expect(isMachineMaintenanceEnabled({ settings: { features: { machine_maintenance: true } } })).toBe(true);
+    expect(isMachineMaintenanceEnabled({ settings: { features: { machine_maintenance: 'true' } } })).toBe(true);
+    expect(isMachineMaintenanceEnabled({ settings: { features: {} } })).toBe(false);
+    expect(isMachineMaintenanceEnabled(null)).toBe(false);
+    expect(isMachineMaintenanceEnabled(undefined)).toBe(false);
+  });
+
+  it('readCompanyFeatures includes the key', () => {
+    expect(
+      readCompanyFeatures({ settings: { features: { machine_maintenance: true } } }).machine_maintenance,
+    ).toBe(true);
   });
 });

--- a/__tests__/utils/jobNoteMediaAccess.test.ts
+++ b/__tests__/utils/jobNoteMediaAccess.test.ts
@@ -40,6 +40,7 @@ vi.mock('@/utils/storageHelpers', () => ({
 }));
 
 import {
+  addNoteMedia,
   addJobNoteMedia,
   getJobNoteMediaUrl,
   deleteJobNoteMedia,
@@ -116,6 +117,50 @@ describe('addJobNoteMedia', () => {
     expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
       expect.objectContaining({ width: null, height: null }),
     );
+  });
+});
+
+// A machine-subject note has no job to file its photos under, so the folder
+// became a caller decision. addJobNoteMedia is now a wrapper over this — the
+// block above is what pins that the job path did not move.
+describe('addNoteMedia', () => {
+  it('files under whatever folder the caller names', async () => {
+    mockGenerateStoragePath.mockReturnValue('c1/work-centers/wc1/abc_photo.jpg');
+    mockQueryBuilder.data = {
+      id: 'media-2',
+      note_id: 'n9',
+      storage_path: 'c1/work-centers/wc1/abc_photo.jpg',
+      thumbnail_path: null,
+      kind: 'photo',
+      mime_type: 'image/jpeg',
+      width: null,
+      height: null,
+    };
+
+    await addNoteMedia('c1', 'n9', makeFile('photo.jpg', 2048), {
+      folder: { entityType: 'work-centers', entityId: 'wc1' },
+    });
+
+    expect(mockGenerateStoragePath).toHaveBeenCalledWith('c1', 'work-centers', 'wc1', 'photo.jpg');
+    expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        company_id: 'c1',
+        note_id: 'n9',
+        storage_path: 'c1/work-centers/wc1/abc_photo.jpg',
+      }),
+    );
+  });
+
+  it('still rolls the upload back when the row insert fails', async () => {
+    mockGenerateStoragePath.mockReturnValue('c1/work-centers/wc1/abc_photo.jpg');
+    mockQueryBuilder.error = { message: 'insert boom' };
+
+    await expect(
+      addNoteMedia('c1', 'n9', makeFile('photo.jpg', 2048), {
+        folder: { entityType: 'work-centers', entityId: 'wc1' },
+      }),
+    ).rejects.toThrow(/Failed to attach the photo/);
+    expect(mockDeleteFileFromStorage).toHaveBeenCalledWith('c1/work-centers/wc1/abc_photo.jpg');
   });
 });
 

--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // --- Chainable Supabase mock (same shape as partAttachmentsAccess.test.ts) ---
 const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
   const builder: Record<string, ReturnType<typeof vi.fn> | unknown> = {};
-  const chainMethods = ['from', 'select', 'insert', 'update', 'delete', 'eq', 'neq', 'in', 'is', 'not', 'or', 'order', 'limit', 'single'];
+  const chainMethods = ['from', 'select', 'insert', 'update', 'delete', 'eq', 'neq', 'in', 'is', 'not', 'or', 'order', 'limit', 'single', 'maybeSingle'];
   chainMethods.forEach((m) => {
     builder[m] = vi.fn().mockImplementation(() => builder);
   });
@@ -39,6 +39,8 @@ import {
   getAllStationsOperatorJobs,
   getCompletedOperatorJobs,
   getAllStationsCompletedOperatorJobs,
+  getStationOperationTypes,
+  getStationName,
   addReaction,
   removeReaction,
   markOperationSent,
@@ -538,5 +540,44 @@ describe('reactions', () => {
     asMember(null);
 
     await expect(addReaction('c1', 'n1')).rejects.toThrow(/member/i);
+  });
+});
+
+// The station picker is the only entrance to a machine, so a leak here is not
+// cosmetic: an operator who picks an archived machine lands on a station that no
+// longer exists and has no way back except clearing site data.
+describe('station selection', () => {
+  it('offers only live internal machines — archived ones are gone from the shop', async () => {
+    mockQueryBuilder.data = [{ id: 'wc1', name: 'Anca Grinder' }];
+
+    await getStationOperationTypes('c1');
+
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'c1');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('kind', 'internal');
+    expect(mockQueryBuilder.is).toHaveBeenCalledWith('deleted_at', null);
+  });
+
+  it('resolves a live station to its name', async () => {
+    mockQueryBuilder.data = { name: 'Anca Grinder' };
+
+    await expect(getStationName('wc1')).resolves.toBe('Anca Grinder');
+    expect(mockQueryBuilder.is).toHaveBeenCalledWith('deleted_at', null);
+  });
+
+  it('answers null for an archived machine, which is what tells the caller to forget it', async () => {
+    // maybeSingle, not single: "no live row" is an expected answer here, not an
+    // error. The provider clears the stored station on exactly this null.
+    mockQueryBuilder.data = null;
+
+    await expect(getStationName('wc-archived')).resolves.toBeNull();
+    expect(mockQueryBuilder.maybeSingle).toHaveBeenCalled();
+  });
+
+  it('throws on a query failure rather than answering null', async () => {
+    // A dropped connection must not read as "your machine was archived" — that
+    // would wipe a valid station off the device every time the wifi blinked.
+    mockQueryBuilder.error = { message: 'network down' };
+
+    await expect(getStationName('wc1')).rejects.toThrow('network down');
   });
 });

--- a/api/tests/database/test_rls_policies.py
+++ b/api/tests/database/test_rls_policies.py
@@ -43,6 +43,8 @@ follow-up if specific bypass routes are suspected.
 """
 from __future__ import annotations
 
+import os
+
 import pytest
 from postgrest.exceptions import APIError
 
@@ -549,6 +551,91 @@ class TestCompaniesRLS:
             _user_a_table(seeded_user_a, "companies")
             .delete()
             .eq("id", seeded_company_b_graph["company_id"])
+            .execute()
+        )
+        assert result.data == []
+
+
+# work_center_attachments --------------------------------------------------------
+#
+# Machine manuals. Company-scoped like everything else, with one extra rule the
+# other tables here don't have: the uploader is resolved server-side, so a member
+# cannot file an upload under someone else's name.
+
+
+class TestWorkCenterAttachmentsRLS:
+    def test_select_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "work_center_attachments")
+            .select("id")
+            .eq("work_center_id", seeded_company_b_graph["work_center_id"])
+            .execute()
+        )
+        assert result.data == []
+
+    def test_insert_into_other_company_is_blocked(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        _expect_blocked_insert(
+            lambda: _user_a_table(seeded_user_a, "work_center_attachments")
+            .insert(
+                {
+                    "company_id": seeded_company_b_graph["company_id"],
+                    "work_center_id": seeded_company_b_graph["work_center_id"],
+                    "storage_path": "b/work-centers/x/attack.pdf",
+                    "file_name": "attack.pdf",
+                    "kind": "pdf",
+                }
+            )
+            .execute()
+        )
+
+    def test_uploader_cannot_be_someone_else(self, seeded_user_a):
+        """uploaded_by must equal the acting member. Attribution is not a field
+        the client gets to choose — the same rule notes.author_id follows.
+
+        Uses user A's OWN company so the company check cannot be what blocks it:
+        this has to fail on the uploader clause alone.
+        """
+        own_wc = (
+            _user_a_table(seeded_user_a, "work_centers")
+            .insert(
+                {
+                    "company_id": seeded_user_a["company_id"],
+                    "name": f"RLS-WC-{os.urandom(3).hex()}",
+                }
+            )
+            .execute()
+            .data[0]["id"]
+        )
+        try:
+            _expect_blocked_insert(
+                lambda: _user_a_table(seeded_user_a, "work_center_attachments")
+                .insert(
+                    {
+                        "company_id": seeded_user_a["company_id"],
+                        "work_center_id": own_wc,
+                        "storage_path": "a/work-centers/x/manual.pdf",
+                        "file_name": "manual.pdf",
+                        "kind": "pdf",
+                        # Not this caller's user_company_access id.
+                        "uploaded_by": "99999999-9999-9999-9999-999999999999",
+                    }
+                )
+                .execute()
+            )
+        finally:
+            _user_a_table(seeded_user_a, "work_centers").delete().eq("id", own_wc).execute()
+
+    def test_delete_cross_tenant_returns_empty(
+        self, seeded_user_a, seeded_company_b_graph
+    ):
+        result = (
+            _user_a_table(seeded_user_a, "work_center_attachments")
+            .delete()
+            .eq("work_center_id", seeded_company_b_graph["work_center_id"])
             .execute()
         )
         assert result.data == []

--- a/api/tests/database/test_rls_policies.py
+++ b/api/tests/database/test_rls_policies.py
@@ -43,8 +43,6 @@ follow-up if specific bypass routes are suspected.
 """
 from __future__ import annotations
 
-import os
-
 import pytest
 from postgrest.exceptions import APIError
 
@@ -592,42 +590,12 @@ class TestWorkCenterAttachmentsRLS:
             .execute()
         )
 
-    def test_uploader_cannot_be_someone_else(self, seeded_user_a):
-        """uploaded_by must equal the acting member. Attribution is not a field
-        the client gets to choose — the same rule notes.author_id follows.
-
-        Uses user A's OWN company so the company check cannot be what blocks it:
-        this has to fail on the uploader clause alone.
-        """
-        own_wc = (
-            _user_a_table(seeded_user_a, "work_centers")
-            .insert(
-                {
-                    "company_id": seeded_user_a["company_id"],
-                    "name": f"RLS-WC-{os.urandom(3).hex()}",
-                }
-            )
-            .execute()
-            .data[0]["id"]
-        )
-        try:
-            _expect_blocked_insert(
-                lambda: _user_a_table(seeded_user_a, "work_center_attachments")
-                .insert(
-                    {
-                        "company_id": seeded_user_a["company_id"],
-                        "work_center_id": own_wc,
-                        "storage_path": "a/work-centers/x/manual.pdf",
-                        "file_name": "manual.pdf",
-                        "kind": "pdf",
-                        # Not this caller's user_company_access id.
-                        "uploaded_by": "99999999-9999-9999-9999-999999999999",
-                    }
-                )
-                .execute()
-            )
-        finally:
-            _user_a_table(seeded_user_a, "work_centers").delete().eq("id", own_wc).execute()
+    # The "uploaded_by must be the acting member" rule is NOT tested here.
+    # These fixtures' companies are not billing-entitled, so every write is
+    # refused by the billing gate before any other policy is consulted — an
+    # attribution test would pass without ever exercising the clause it names.
+    # It lives in test_note_views_rls.py instead, on a writable fixture, next to
+    # the identical rule for notes.author_id.
 
     def test_delete_cross_tenant_returns_empty(
         self, seeded_user_a, seeded_company_b_graph

--- a/api/tests/integration/test_note_views_rls.py
+++ b/api/tests/integration/test_note_views_rls.py
@@ -143,13 +143,17 @@ def shop(supabase_admin):
         "boss": boss,
         "part_id": part_id,
         "routing_operation_id": routing_op_id,
+        "work_center_id": wc_id,
         "job_a": jobs[0],
         "job_b": jobs[1],
         "admin": admin,
     }
     yield ctx
 
-    for table in ("jobs", "routings", "parts", "work_centers"):
+    # notes first: a machine-subject note holds work_centers with ON DELETE
+    # RESTRICT, so tearing down in the other order leaves the work center behind
+    # and the failure is swallowed by the except.
+    for table in ("notes", "jobs", "routings", "parts", "work_centers"):
         try:
             admin.table(table).delete().eq("company_id", company_id).execute()
         except Exception:
@@ -859,3 +863,201 @@ def test_playbook_returns_author_id_so_the_ui_can_hide_the_control(shop):
         .data
     )
     assert rows and rows[0]["author_id"] == shop["author"]["access_id"]
+
+
+# ── machine maintenance: the machine subject, and derived open state ─────────
+#
+# See docs/modules/machine-maintenance.md. The point of these is that the module
+# stores NO "open" flag: an observation is open exactly while no entry resolves
+# it. That only holds if the database guarantees a resolver always sits on the
+# same machine as its target, because the read derives open-ness from a single
+# work-center result set and would silently mis-report if a resolver could live
+# anywhere else. So the invariant is the trigger's job, and these are the tests
+# that say so.
+
+
+def _machine_note(shop, body: str, kind: str | None = None, resolves: str | None = None) -> str:
+    row = {
+        "company_id": shop["company_id"],
+        "subject_kind": "work_center",
+        "work_center_id": shop["work_center_id"],
+        "author_id": shop["author"]["access_id"],
+        "body": body,
+    }
+    if kind is not None:
+        row["maintenance_kind"] = kind
+    if resolves is not None:
+        row["resolves_note_id"] = resolves
+    return shop["admin"].table("notes").insert(row).execute().data[0]["id"]
+
+
+def test_a_machine_entry_can_be_written_at_all(shop):
+    """The work_center subject has been modelled since the notes rewrite and
+    nothing has ever written one. This is the first row that does."""
+    note_id = _machine_note(shop, "Way cover has started to drag.", kind="noticed")
+
+    row = shop["admin"].table("notes").select("*").eq("id", note_id).single().execute().data
+    assert row["subject_kind"] == "work_center"
+    assert row["work_center_id"] == shop["work_center_id"]
+    assert row["maintenance_kind"] == "noticed"
+    assert row["job_id"] is None and row["part_id"] is None
+
+
+def test_kind_is_optional(shop):
+    """An unclassified entry is still knowledge. A forced taxonomy at capture
+    time is what stops capture, so the column has to accept nothing."""
+    note_id = _machine_note(shop, "Topped up the way lube.")
+    row = shop["admin"].table("notes").select("maintenance_kind").eq("id", note_id).single().execute().data
+    assert row["maintenance_kind"] is None
+
+
+def test_kind_is_limited_to_the_five_verbs(shop):
+    with pytest.raises(Exception):
+        _machine_note(shop, "x", kind="lubricated")
+
+
+def test_a_part_note_cannot_carry_a_maintenance_kind(shop):
+    with pytest.raises(Exception):
+        shop["admin"].table("notes").insert(
+            {
+                "company_id": shop["company_id"],
+                "subject_kind": "part",
+                "part_id": shop["part_id"],
+                "body": "x",
+                "maintenance_kind": "cleaned",
+            }
+        ).execute()
+
+
+def test_open_is_derived_from_the_absence_of_a_resolver(shop):
+    """The whole open-items model in one test. Nothing is written to close an
+    item — a second entry is added, and the first stops being open because of it."""
+    observation = _machine_note(shop, "Coolant smells off.", kind="noticed")
+
+    def resolvers_of(note_id: str) -> list[dict]:
+        return (
+            shop["admin"].table("notes").select("id").eq("resolves_note_id", note_id).execute().data
+        )
+
+    assert resolvers_of(observation) == []
+
+    fix = _machine_note(shop, "Drained and recharged the coolant.", kind="repaired", resolves=observation)
+    assert [r["id"] for r in resolvers_of(observation)] == [fix]
+
+
+def test_deleting_the_fix_reopens_the_observation(shop):
+    """ON DELETE SET NULL, not CASCADE: removing the record of a fix must not
+    remove the observation, and the item legitimately becomes open again."""
+    observation = _machine_note(shop, "Chip conveyor jams on long runs.", kind="noticed")
+    fix = _machine_note(shop, "Cleared the jam and re-tensioned.", resolves=observation)
+
+    shop["admin"].table("notes").delete().eq("id", fix).execute()
+
+    still_there = shop["admin"].table("notes").select("id").eq("id", observation).execute().data
+    assert len(still_there) == 1
+    assert (
+        shop["admin"].table("notes").select("id").eq("resolves_note_id", observation).execute().data
+        == []
+    )
+
+
+def test_a_fix_cannot_point_at_an_entry_on_another_machine(shop):
+    """If this were allowed the open list would be wrong rather than merely
+    incomplete: the resolver would never appear in the target machine's result
+    set, so the item would read as open forever while a fix existed elsewhere."""
+    observation = _machine_note(shop, "Spindle runs warm.", kind="noticed")
+    other_wc = (
+        shop["admin"]
+        .table("work_centers")
+        .insert({"company_id": shop["company_id"], "name": f"LATHE-{os.urandom(2).hex()}"})
+        .execute()
+        .data[0]["id"]
+    )
+    with pytest.raises(Exception):
+        shop["admin"].table("notes").insert(
+            {
+                "company_id": shop["company_id"],
+                "subject_kind": "work_center",
+                "work_center_id": other_wc,
+                "body": "fixed it (on the wrong machine)",
+                "resolves_note_id": observation,
+            }
+        ).execute()
+
+
+def test_a_fix_cannot_point_at_an_entry_that_was_never_noticed(shop):
+    routine = _machine_note(shop, "Wiped it down.", kind="cleaned")
+    with pytest.raises(Exception):
+        _machine_note(shop, "resolving a non-problem", resolves=routine)
+
+
+def test_a_fix_cannot_point_at_a_note_in_another_company(shop, supabase_admin):
+    """And the refusal must not say WHY. The validator is SECURITY DEFINER, so it
+    reads past RLS; a message that distinguished "no such note" from "different
+    company" would be a cross-tenant existence oracle."""
+    other_company = (
+        supabase_admin.table("companies")
+        .insert({"name": f"mm-other-{os.urandom(3).hex()}"})
+        .execute()
+        .data[0]["id"]
+    )
+    try:
+        other_wc = (
+            supabase_admin.table("work_centers")
+            .insert({"company_id": other_company, "name": "FOREIGN MILL"})
+            .execute()
+            .data[0]["id"]
+        )
+        foreign = (
+            supabase_admin.table("notes")
+            .insert(
+                {
+                    "company_id": other_company,
+                    "subject_kind": "work_center",
+                    "work_center_id": other_wc,
+                    "body": "their problem",
+                    "maintenance_kind": "noticed",
+                }
+            )
+            .execute()
+            .data[0]["id"]
+        )
+
+        with pytest.raises(Exception) as exc:
+            _machine_note(shop, "resolving someone else's machine", resolves=foreign)
+        assert "not an open observation on this machine" in str(exc.value)
+
+        # Same message for a uuid that does not exist at all — the two cases are
+        # indistinguishable from outside, which is the point.
+        with pytest.raises(Exception) as exc2:
+            _machine_note(shop, "resolving nothing", resolves="99999999-9999-9999-9999-999999999999")
+        assert "not an open observation on this machine" in str(exc2.value)
+    finally:
+        supabase_admin.table("notes").delete().eq("company_id", other_company).execute()
+        supabase_admin.table("work_centers").delete().eq("company_id", other_company).execute()
+        supabase_admin.table("companies").delete().eq("id", other_company).execute()
+
+
+def test_a_machine_entry_still_cannot_carry_another_subject(shop):
+    with pytest.raises(Exception):
+        shop["admin"].table("notes").insert(
+            {
+                "company_id": shop["company_id"],
+                "subject_kind": "work_center",
+                "work_center_id": shop["work_center_id"],
+                "part_id": shop["part_id"],
+                "body": "two subjects",
+            }
+        ).execute()
+
+
+def test_a_machine_read_never_counts_toward_usage(shop):
+    """usage_count counts DISTINCT JOBS a note was consulted on, and a machine
+    read has no job. §8 of the module doc states this stays zero permanently and
+    must never be displayed there — this is what pins it."""
+    note_id = _machine_note(shop, "Grease points are behind the rear panel.")
+    shop["reader"]["client"].rpc("log_note_views", {"p_note_ids": [note_id]}).execute()
+
+    viewer_count, usage_count = _counts(shop, note_id)
+    assert viewer_count == 1
+    assert usage_count == 0

--- a/api/tests/integration/test_note_views_rls.py
+++ b/api/tests/integration/test_note_views_rls.py
@@ -150,10 +150,11 @@ def shop(supabase_admin):
     }
     yield ctx
 
-    # notes first: a machine-subject note holds work_centers with ON DELETE
-    # RESTRICT, so tearing down in the other order leaves the work center behind
-    # and the failure is swallowed by the except.
-    for table in ("notes", "jobs", "routings", "parts", "work_centers"):
+    # notes and manuals first: both hold work_centers with ON DELETE RESTRICT
+    # (deliberately — archiving a machine must not destroy its history), so
+    # tearing down in the other order leaves the work center behind and the
+    # failure is swallowed by the except.
+    for table in ("notes", "work_center_attachments", "jobs", "routings", "parts", "work_centers"):
         try:
             admin.table(table).delete().eq("company_id", company_id).execute()
         except Exception:
@@ -1061,3 +1062,46 @@ def test_a_machine_read_never_counts_toward_usage(shop):
     viewer_count, usage_count = _counts(shop, note_id)
     assert viewer_count == 1
     assert usage_count == 0
+
+
+def test_a_manual_cannot_be_uploaded_as_someone_else(shop):
+    """Same rule as notes.author_id, on the machine's manuals: uploaded_by is
+    resolved server-side, so attribution is never a field the client chooses.
+
+    Lives here rather than in test_rls_policies.py because this fixture's company
+    IS billing-entitled. On a non-entitled company the billing gate refuses every
+    write first, and the test would pass without touching the clause it names.
+    """
+    with pytest.raises(Exception):
+        shop["author"]["client"].table("work_center_attachments").insert(
+            {
+                "company_id": shop["company_id"],
+                "work_center_id": shop["work_center_id"],
+                "storage_path": f"{shop['company_id']}/work-centers/x/manual.pdf",
+                "file_name": "manual.pdf",
+                "kind": "pdf",
+                "uploaded_by": shop["reader"]["access_id"],
+            }
+        ).execute()
+
+
+def test_a_manual_uploads_fine_under_your_own_name(shop):
+    """The positive half — otherwise the test above could pass because uploads are
+    broken outright."""
+    row = (
+        shop["author"]["client"]
+        .table("work_center_attachments")
+        .insert(
+            {
+                "company_id": shop["company_id"],
+                "work_center_id": shop["work_center_id"],
+                "storage_path": f"{shop['company_id']}/work-centers/x/manual.pdf",
+                "file_name": "manual.pdf",
+                "kind": "pdf",
+                "uploaded_by": shop["author"]["access_id"],
+            }
+        )
+        .execute()
+        .data[0]
+    )
+    assert row["uploaded_by"] == shop["author"]["access_id"]

--- a/components/operator/OperatorStationContext.tsx
+++ b/components/operator/OperatorStationContext.tsx
@@ -125,11 +125,25 @@ export function OperatorStationProvider({ children }: { children: ReactNode }) {
         return;
       }
 
-      // Otherwise fetch it directly
+      // Otherwise fetch it directly.
       try {
         const name = await getStationName(stationId);
-        setStationName(name);
+        if (name === null) {
+          // The stored station names a machine that has been archived (or was
+          // never in this company). Forget it rather than sitting on a station
+          // with no name: the header would read "Select Station" while every
+          // station-gated surface still believed one was chosen, and nothing on
+          // the floor offers a way out of that.
+          clearStoredStation();
+          setStationId(null);
+          setStationName(null);
+        } else {
+          setStationName(name);
+        }
       } catch {
+        // A failed lookup is not evidence the machine is gone — most likely the
+        // shop wifi dropped. Keep the selection and leave the name blank; the
+        // next resolve fixes it.
         setStationName(null);
       }
       setLoading(false);

--- a/docs/modules/machine-maintenance.md
+++ b/docs/modules/machine-maintenance.md
@@ -1,0 +1,331 @@
+# Machine Maintenance Module
+
+> **Status:** Draft proposal · **Date:** 2026-07-29 · **Pilot:** one shop, behind a feature flag
+>
+> **Purpose.** Propose a machine-scoped maintenance logbook, and state in advance the condition
+> under which it gets parked. Nothing in this module is built. The bet is written down together
+> with its kill criterion ([§2](#2-hypothesis-and-kill-criterion)) so that the result cannot be
+> renegotiated once it arrives.
+
+**Dependencies:** [Work Centers](work-centers.md), because a machine is a `work_centers` row with
+`kind='internal'` and there is no separate machine entity. The notes system and its read-back loop
+([Operator View](operator-view.md#the-read-back-loop-attribution)). Station selection, which is
+the only entrance to this module, and the one live defect in it named in
+[§6](#6-phases-and-gates).
+
+---
+
+## 1. Problem
+
+The shop's most technical operator writes almost nothing on job travelers. The reason is not
+reticence and it is not tap count. His knowledge is machine-specific, and every capture surface
+Jigged has built is shaped like a part or like an operation: the durable note is the one rooted at
+a part and a routing step, durable precisely because it answers "how do you run this part here".
+He has been offered a container that does not fit what he knows, and declined it, which is the
+correct response to a container that does not fit.
+
+What operators still text a departed veteran about is how to maintain the equipment. He left a
+year ago. None of it was written down. The channel that replaced the record is one personal
+friendship, which has no owner, no backup and no expiry warning; it decays quietly and nobody
+finds out on a good day.
+
+The industry picture says this is not a local eccentricity. Contaminated coolant and missed
+lubrication are the leading causes of premature bearing and ballscrew failure, and roughly seven
+in ten spindle shutdowns trace back to lubrication that was missed **or not recorded** (industry
+figures, not measured at the pilot shop). The second half of that disjunction is the half that
+makes it a software problem. A shop can be doing the work and still be one departure away from
+losing the knowledge of what the work is.
+
+The capture behavior already exists. Machinists photograph offsets at the end of a shift and carry
+mental lists of things to look into tomorrow. That is a habit with nowhere to land, so this module
+proposes a landing place rather than a new discipline. The canonical failure it targets is the
+handoff where the outgoing operator says the machine ran fine and does not mention the way cover
+that has started to drag. Nothing in that sentence is a lie, and nothing in it is recoverable.
+
+## 2. Hypothesis and kill criterion
+
+**H:** machine-scoped knowledge is a container operators will fill, where part-operation-scoped
+knowledge was not. The part-scoped container exists, it is durable by design, and it is close to
+empty. That is the prior result this module is arguing with.
+
+**Decided:** Phase 1 passes only if at least five entries exist from at least three distinct
+non-founder authors within four weeks. Four entries from four people is a kill. Eight entries from
+two people is a kill; one enthusiast is a person, not a container.
+
+The four weeks start at the **first organic entry**, not at ship date. If no organic entry appears
+within four weeks of the flag going on, that silence is the kill result, but only on one
+condition: machine pages have to have been opened during the window. A container nobody filled and
+a container nobody reached both look like silence from outside, and [§8](#8-measurement) is what
+tells them apart. If page opens are near zero across the four weeks, the result is recorded as
+**not yet tested**, not as a kill, and the clock restarts once the door is demonstrably reachable
+and in use.
+
+That is not a hypothetical escape hatch. This module launches into an operator surface that is not
+yet in daily use ([§6](#6-phases-and-gates)), so the likeliest first result is "not yet tested",
+and that result must not be quietly upgraded to a pass or downgraded to a kill.
+
+**Decided:** no seeded corpus, at all. No backfill, no transcription of the departed veteran's
+texts, no entry written on anyone's behalf. Anyone may write down knowledge they got from him, as
+themselves; nobody writes as him. **Why:** a container that arrives pre-filled cannot answer the
+only question Phase 1 asks, and a demo corpus and an evidence corpus cannot be the same rows.
+
+Reads are the earlier and cheaper signal. `viewer_count` moves the first time somebody opens an
+entry, which will happen before the fifth entry exists. Watch it, and do not promote it to the
+gate: a corpus that is read but not extended is still one person's knowledge with a wider
+audience.
+
+## 3. Who it's for
+
+The design center is the infrequent frontline user at a shop with no maintenance department. The
+requester, the approver and the technician are the same person, standing at the machine, deciding
+in the moment whether the thing they just noticed is worth saying out loud. The pilot shop is
+roughly fifteen people. There is no maintenance role in Jigged today and none is proposed; the
+frontline role is `operator`, and the operator is the technician.
+
+This is where the module parts company with the CMMS category deliberately. CMMS products model a
+requester who raises a request, a manager who approves and assigns it, and a technician who
+performs and closes it. Their strongest mobile experiences split into two profiles for exactly
+that reason: an infrequent operator who reports, and a continuous technician who lives in the
+queue. Jigged builds only the first profile, because the second person does not exist at a shop
+this size. Building the split anyway would add three steps to a one-person action.
+
+The frame is autonomous maintenance, the first pillar of TPM: operator-owned basic care, which is
+cleaning, inspection, lubrication and retightening done by the person at the machine. It is not a
+work order routed to a department. This has a consequence that [§5](#5-what-it-is-not) leans on:
+there is nobody for a request to be sent *to*, so request and approval workflows are rejected on
+structural grounds rather than as scope trimming.
+
+## 4. What it is (Phase 1)
+
+A logbook for a machine, reachable from the floor without a search, written by whoever is standing
+there.
+
+### 4.1 One door
+
+A Maintenance tab, available once a station is selected, opens the logbook for the machine the
+operator is standing at. There is no picker, because a station is a machine: the operator's
+station list is `work_centers` filtered to `kind='internal'`, so selecting a station has already
+answered the only question a picker would ask.
+
+There is deliberately nothing to scan on the machine itself. A shop at this scale has few
+machines, and the operator has already told the app which one they are standing at, so a code
+posted on the machine would solve a navigation problem this product does not have. The in-app path
+is the only entrance, which makes the health of station selection a dependency of this module
+rather than a convenience ([§6](#6-phases-and-gates)).
+
+### 4.2 The timeline
+
+Open items sit pinned at the top, then entries newest first, each attributed and dated. Newest
+first, and not grouped by kind, because the reader's question on arriving at a machine page is
+almost always "what has happened to this machine lately". Any grouping answers a question nobody
+asked, and pushes the recent thing below the fold.
+
+### 4.3 Capture
+
+Free text. Dictation is the phone keyboard's dictation key, which operators already use; no custom
+voice capture is built or proposed. Photos are optional and go through the native sheet, so an
+existing camera-roll photo works: the end-of-shift offset photo is already on the phone. A kind
+chip is offered with five values: cleaned, repaired, replaced, adjusted, noticed.
+
+**Decided:** kind is optional. An unclassified entry is still knowledge, and a forced taxonomy at
+capture time is the thing that stops capture. A person who cannot decide whether they cleaned or
+adjusted something will write nothing rather than choose wrongly.
+
+### 4.4 Noticed, then resolved
+
+An open noticed item offers "log the fix", which is the same composer with the resolution link
+already bound. There is no assignment, no priority and no due date, because each of those needs a
+second person to mean anything ([§3](#3-who-its-for)).
+
+Open state is derived from the existence of a resolving entry and is never stored. So there is no
+state anyone has to remember to close, and no way for the open list to disagree with the timeline
+it is drawn from.
+
+### 4.5 Zero required setup
+
+Machine details (make, model, serial, year, purchase date) and manual attachments are all
+optional. Nothing is gated on any of them, and nothing prompts for them. Asset data-entry time is
+a leading cause of CMMS abandonment: the tool arrives, the shop is asked to describe its equipment
+before it can do anything, and the project dies in the describing. The machines already exist in
+Jigged as work centers, so this module starts with its asset list complete and its asset detail
+empty, which is the right way round.
+
+The enforceable form of that principle: no empty-state nudge, no completeness meter, no prompt to
+finish setting up a machine, and no surface that renders one machine as less ready than another
+because somebody typed a serial number into it.
+
+### 4.6 Attribution
+
+Inherited from the notes system whole, not redesigned. The author is resolved server-side, so an
+entry is written as the person writing it and cannot be attributed to anyone else. Authors see
+named views of their own entries; everyone else sees aggregates. The rule is one sentence with no
+role branch: *you see who viewed your own notes; nobody sees who viewed anyone else's*
+([Operator View](operator-view.md#the-read-back-loop-attribution)).
+
+The container is already modelled. The notes system carries a work-center subject end to end, and
+nothing in the app writes one today.
+
+## 5. What it is not
+
+Each of these is a real product that exists elsewhere and is rejected here for a stated reason,
+not deferred by oversight.
+
+- **Request and approval workflows.** There is no second person for a request to reach
+  ([§3](#3-who-its-for)).
+- **MRO parts inventory.** A second item master with a second counting ritual, while the first one
+  is still being learned ([Inventory](inventory.md)).
+- **Criticality rankings, MTBF, MTTR, PM-compliance dashboards.** All four are ratios computed
+  over a corpus that does not exist yet.
+- **Downtime tracking.** Actual time was deliberately removed from this product and is
+  structurally unrepresentable ([Operator View](operator-view.md#surveillance-guardrail-non-negotiable)).
+- **Lockout/tagout fields.** A compliance artifact, and Jigged is not the shop's compliance system
+  of record.
+- **Bulk asset import.** The machines are already in Jigged; an importer would be a second door
+  into a room that has one.
+- **Any per-operator maintenance scorecard or comparison, visible to anyone.**
+- **Schedules and reminders.** Deferred by sequence, not by taste ([§6](#6-phases-and-gates)).
+
+The surveillance guardrail extends here in full: *no operator-facing surface may reflect an
+operator's pace or standing back at them*
+([Operator View](operator-view.md#surveillance-guardrail-non-negotiable)). Concretely, no surface
+may show who logs how many entries, or how often a given operator files a noticed.
+
+That collides with a real design want, and the collision resolves in one direction. **Decided:**
+the open-items list shows the observation and the date; the author is visible on the entry's own
+card, one tap away. This is a deliberate trade and it costs the list some context. A list of open
+items with names against it is a list of who reports the most problems, read straight down the
+column, and that is the shape of every operator scorecard this product has already refused to
+build. The cost of the trade is a slightly thinner list. The cost of the alternative is that
+filing a noticed becomes an admission.
+
+## 6. Phases and gates
+
+Phase 1 ships behind a per-tenant feature flag (flags live in `companies.settings.features` and
+are registered in `lib/featureFlags.ts`; turning one on for a pilot tenant is a single update).
+Before the clock in [§2](#2-hypothesis-and-kill-criterion) can mean anything, an operator has to
+be able to reach a machine page at all, and what stands in the way is not this module's work.
+
+Station selection is the only entrance ([§4.1](#41-one-door)), so one live defect in it becomes a
+prerequisite here: the station picker leaks archived machines because it does not filter on
+`deleted_at`. It is already known and is being fixed independently. One further fact about the
+floor belongs here rather than in a retrospective:
+
+> Operator adoption of the existing operator surface is currently near zero: operators are not yet
+> marking operations complete. This module launches into a surface that is not yet in daily use,
+> which is a real risk to the four-week clock rather than a footnote to it, and it is why the
+> clock in [§2](#2-hypothesis-and-kill-criterion) carries a precondition.
+
+**Phase 1: the logbook.** Everything in [§4](#4-what-it-is-phase-1), at one pilot shop.
+**Gate:** the bar in [§2](#2-hypothesis-and-kill-criterion).
+
+**Phase 2: standing procedures.** Described at design level only. Any good entry can be promoted
+to a standing procedure, and the original author is preserved on the promotion, because the person
+who knew the thing is the point. Completing a procedure writes an entry on the machine's timeline,
+so the log remains the single record of what happened to the machine and procedures do not become
+a parallel history. **Gate:** at least ten entries, of which at least three describe a repeatable
+how-to. The count alone is not the gate: a procedure library is a distillation, and there is
+nothing to distil until entries start repeating themselves.
+
+**Phase 3: schedules.** Two trigger kinds: a calendar interval, and usage, where usage is measured
+good pieces through the machine since the last entry that satisfied the procedure. This trigger
+needs no sensor, no meter reading and no integration, because the machine record and the job
+record are the same record: good pieces are already recorded against an operation, and that
+operation already names its work center. **Gate:** Phase 2 procedures exist, **and** at least
+three shops have answered whether they run a separate CMMS or track maintenance in their ERP. Only
+one shop is reachable today, so this gate is blocked on access rather than on engineering, and it
+should stay blocked rather than be reinterpreted downward.
+
+Schedules shipped before a corpus exists produce the nagging, surveillance-flavored version of
+this product: a machine page that tells an operator what he is late on, assembled out of nothing
+he wrote. That is the version of a CMMS frontline users abandon, and it would also make the
+[§2](#2-hypothesis-and-kill-criterion) result unreadable in retrospect, because a container nobody
+filled and a container that started nagging on day one fail the same way from outside.
+
+Logs, then procedures, then schedules. That order is not negotiable.
+
+## 7. Competitive position
+
+The category is validated and it is owned. MaintainX was acquired by Autodesk in 2026 for a
+reported figure of roughly $3.6B, builds an AI knowledge base out of the completion notes
+technicians write on work orders, and holds the top ease-of-use ratings in its category. That is
+the same insight this module rests on, executed by a company with a decade of head start and a
+sales motion aimed at exactly this buyer. Jigged does not out-CMMS a CMMS, and any roadmap item
+whose justification is parity with one is rejected on that basis alone.
+
+The wedge is not a feature. It is that maintenance data and job data are one system. A usage
+trigger needs no sensor, no meter reading and no integration, because Jigged already counts good
+pieces through the machine as a by-product of running the shop. "The machine was down Thursday"
+and "that job ran long" become two readings of one record instead of two systems reconciled by
+somebody who happens to remember both. A dedicated CMMS cannot reach that without an integration
+that a fifteen-person shop will never build. Any design choice that requires maintenance data to
+live apart from job data is wrong by definition.
+
+## 8. Measurement
+
+The funnel is the primary instrument, and for a structural reason rather than a preference: with
+an empty starting corpus, every count-based surface is silent at launch. The existing capture
+funnel was built to make exactly this distinction and applies here unchanged, in the form its own
+source states it: page opened but composer never focused means the container does not fit, and
+composer focused but nothing saved means capture friction. Without those, "adoption was poor" is
+unreadable, and unreadable is the one outcome that cannot be acted on. Four moments need
+instrumenting on this path: the machine page opened, the composer focused, an entry saved, and a
+noticed resolved.
+
+Two limitations are known in advance and are not bugs. First, a machine-entry read carries no job
+context, and the per-job usage counter counts distinct jobs and ignores the absent one, so it
+stays at zero for this module permanently. The "used on N jobs" signal that ranks the part
+Playbook does not exist here and must never be displayed here. Second, read logging dedupes per
+person, per entry, per job, and treats the absent job as equal to itself, so a person's repeat
+consultation of the same entry is recorded once, ever. Somebody rereading the way-cover entry six
+months later is invisible, and that reread is precisely the event a maintenance logbook would most
+want to see. `viewer_count`, distinct people, still works; it saturates near shop size, which is
+its meaning.
+
+The consequence is a decision rather than a complaint. Reads can tell us an entry was found; they
+cannot tell us it is still true. `confirmed` is therefore the designated freshness signal for this
+module. The reaction kind already exists alongside `helpful`, with no negative option by design,
+but only `helpful` has a UI today (on an unmerged branch), so this is a prerequisite here rather
+than an inheritance. Its stored meaning is worded part-first, "I ran this part and this note is
+still accurate", where the machine reading is "I did this and it still holds"; that wording
+question comes along with it. None of this is the gate. The gate is
+[§2](#2-hypothesis-and-kill-criterion).
+
+## 9. Open questions
+
+Four questions are closed and are not reopened here: kind is optional
+([§4](#4-what-it-is-phase-1)), there is no seeded corpus
+([§2](#2-hypothesis-and-kill-criterion)), open-items attribution resolves in favor of the guardrail
+([§5](#5-what-it-is-not)), and the module is called Machine Maintenance.
+
+**Does the Maintenance tab appear before a station is selected?** Recommendation: no. Without a
+station the tab needs a picker, and a picker is the ceremony [§4.5](#45-zero-required-setup)
+refuses. Station selection already answers the question a picker would ask. This question is
+load-bearing now that the tab is the only entrance, and it has a visible consequence: an operator
+who notices something on a machine that is not their selected station changes station first, using
+the selector that already exists. At this machine count that is acceptable. If it proves to be
+friction, the answer is revisiting this question, not reviving a code on the machine.
+
+**Do machine details and manual attachments belong in Phase 1 at all, given nothing gates on
+them?** Recommendation: keep both, and never prompt for either. A manual an operator can open on
+the floor is worth having on day one. If this instead resolves to deferring them,
+[§4.5](#45-zero-required-setup) changes with it; the two must not be allowed to disagree.
+
+**Is the flag retired after the pilot, or kept?** Recommendation: retired, on the precedent
+[Shipments](shipments.md) set (gated during rollout, then made core and the key removed), but only
+after a second shop clears the [§2](#2-hypothesis-and-kill-criterion) bar rather than after the
+first one.
+
+**What happens to a machine's timeline when the machine is archived?** Recommendation: the entries
+survive and stay readable, and the page stays reachable by direct link while dropping out of
+lists. Archiving hides a machine from pickers, not its knowledge, and knowledge must not be
+destroyable as a side effect of tidying a list.
+
+**Can a noticed item be resolved by someone other than the person who filed it?** Recommendation:
+yes, and that is most of the point. The resolving entry carries its own author, so both names
+survive and neither is counted. The open part is notification: there is no operator notification
+path today, so in Phase 1 the original author finds out by reading the timeline. State that limit
+rather than designing around it.
+
+**Does Phase 2 promotion leave the original entry on the timeline?** Recommendation: yes, and mark
+it as promoted. A log that loses rows stops being a log, and an unexplained near-duplicate is what
+makes people stop trusting one.

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -72,6 +72,12 @@ export const KNOWN_FEATURES: readonly FeatureFlagDescriptor[] = [
     description:
       'Guided data importer for onboarding: upload legacy ERP CSV exports, review what will come in and what to fix (record counts, duplicates, orphan references, gaps) plus a best-effort source-ERP guess, then import. Opt-in per tenant while onboarding.',
   },
+  {
+    key: 'machine_maintenance',
+    label: 'Machine Maintenance',
+    description:
+      'A maintenance logbook per machine, written by whoever is standing at it: a Maintenance tab on the operator view once a station is selected, with optional machine details and manuals, plus a read-only log on the work-center page. One pilot shop at a time — see docs/modules/machine-maintenance.md.',
+  },
 ] as const;
 
 export type KnownFeatureKey = (typeof KNOWN_FEATURES)[number]['key'];
@@ -122,6 +128,17 @@ export function isDataImportEnabled(
   company: Pick<Company, 'settings'> | null | undefined,
 ): boolean {
   return readFeatureFlag(company, 'data_import');
+}
+
+/**
+ * Machine Maintenance is opt-IN, and stays that way through the pilot: the
+ * module is an experiment with a written kill criterion, so it must be on at
+ * exactly the shops whose behaviour is being measured and nowhere else.
+ */
+export function isMachineMaintenanceEnabled(
+  company: Pick<Company, 'settings'> | null | undefined,
+): boolean {
+  return readFeatureFlag(company, 'machine_maintenance');
 }
 
 /**

--- a/supabase/migrations/20260730015344_machine_maintenance.sql
+++ b/supabase/migrations/20260730015344_machine_maintenance.sql
@@ -1,0 +1,292 @@
+-- Machine Maintenance, Phase 1: the schema for a machine-scoped logbook.
+--
+-- See docs/modules/machine-maintenance.md. The bet is that machine-scoped
+-- knowledge is a container operators will fill where part-scoped knowledge was
+-- not, and §2 of that doc states in advance what result would park the module.
+--
+-- Almost nothing here is new machinery. `notes` has carried a 'work_center'
+-- subject end to end since 20260728040701 — the CHECK branch, the FK, the
+-- cross-tenant trigger, the read index, RLS and the billing gate all exist and
+-- nothing in the app has ever written one. This migration adds the two columns
+-- that make a maintenance entry different from any other note, the machine
+-- attributes a shop might want to record, and a place for manuals.
+--
+-- WHAT IS DELIBERATELY ABSENT: any stored notion of "open". §4.4 of the doc
+-- requires open state to be DERIVED from the existence of a resolving entry, so
+-- that the open list can never disagree with the timeline it is drawn from.
+-- That is also the only design that fits this table: `notes` is append-only
+-- (REVOKE UPDATE ... FROM authenticated, migration 20260728040701), so a stored
+-- resolved flag would have needed an UPDATE grant and broken the invariant.
+
+
+-- ══════════════════════════════════════════════════════════════════════════════
+-- 1. MAINTENANCE COLUMNS ON notes
+-- ══════════════════════════════════════════════════════════════════════════════
+
+ALTER TABLE public.notes
+  ADD COLUMN maintenance_kind text,
+  ADD COLUMN resolves_note_id uuid;
+
+-- OPTIONAL, and that is the whole point (§4.3). A forced taxonomy at capture
+-- time is what stops capture: someone who cannot decide whether they cleaned or
+-- adjusted something writes nothing rather than choosing wrongly. Constrained to
+-- work-center notes so it can never appear on a part or job note, where it would
+-- mean nothing.
+ALTER TABLE public.notes ADD CONSTRAINT notes_maintenance_kind_valid CHECK (
+  maintenance_kind IS NULL
+  OR (subject_kind = 'work_center'
+      AND maintenance_kind IN ('cleaned', 'repaired', 'replaced', 'adjusted', 'noticed'))
+);
+
+-- NOT corrects_note_id, which already exists and means something else: that this
+-- note supersedes an inaccurate one. "I did the fix for the thing you noticed"
+-- is a different claim, and overloading one column would make a future
+-- corrections UI silently close open items.
+--
+-- SET NULL rather than CASCADE: deleting the observation must not delete the
+-- record that somebody fixed it. The fix outlives the complaint.
+ALTER TABLE public.notes ADD CONSTRAINT notes_resolves_fk
+  FOREIGN KEY (resolves_note_id) REFERENCES public.notes(id) ON DELETE SET NULL;
+
+ALTER TABLE public.notes ADD CONSTRAINT notes_no_self_resolution
+  CHECK (resolves_note_id IS NULL OR resolves_note_id <> id);
+ALTER TABLE public.notes ADD CONSTRAINT notes_resolves_is_machine
+  CHECK (resolves_note_id IS NULL OR subject_kind = 'work_center');
+
+COMMENT ON COLUMN public.notes.maintenance_kind IS
+  'cleaned | repaired | replaced | adjusted | noticed, on work-center notes only. OPTIONAL by design: an unclassified entry is still knowledge. Only ''noticed'' can be open.';
+COMMENT ON COLUMN public.notes.resolves_note_id IS
+  'This entry is the fix for that ''noticed'' entry on the same machine. Open state is DERIVED from the absence of such a row and is never stored — see docs/modules/machine-maintenance.md §4.4.';
+
+-- Supports the FK's own delete-time lookup, and any future "what closed this"
+-- query. The timeline read does not need it: resolvers come back in the same
+-- result set as the observations they close.
+CREATE INDEX idx_notes_resolves ON public.notes (resolves_note_id)
+  WHERE resolves_note_id IS NOT NULL;
+
+
+-- ══════════════════════════════════════════════════════════════════════════════
+-- 2. CROSS-ROW VALIDATION FOR THE RESOLUTION LINK
+-- ══════════════════════════════════════════════════════════════════════════════
+-- A resolver must point at a 'noticed' entry ON THE SAME MACHINE. That spans
+-- rows, so no CHECK can express it, and enforcing it only in the access layer
+-- would be exactly the silent runtime fallback the project forbids: the
+-- derived-open read TRUSTS this invariant (it assumes every resolver arrives in
+-- the same work-center result set as its target), so the database has to hold it.
+--
+-- Extends the existing subject validator rather than adding a second trigger:
+-- it is the same class of check, and one BEFORE trigger is easier to reason
+-- about than two.
+
+CREATE OR REPLACE FUNCTION public.notes_validate_subject()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_part uuid;
+  v_ok   boolean;
+BEGIN
+  IF NEW.job_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1 FROM public.jobs j
+      WHERE j.id = NEW.job_id AND j.company_id = NEW.company_id)
+  THEN
+    RAISE EXCEPTION 'job % is not in company %', NEW.job_id, NEW.company_id;
+  END IF;
+
+  IF NEW.part_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1 FROM public.parts p
+      WHERE p.id = NEW.part_id AND p.company_id = NEW.company_id)
+  THEN
+    RAISE EXCEPTION 'part % is not in company %', NEW.part_id, NEW.company_id;
+  END IF;
+
+  IF NEW.work_center_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1 FROM public.work_centers w
+      WHERE w.id = NEW.work_center_id AND w.company_id = NEW.company_id)
+  THEN
+    RAISE EXCEPTION 'work center % is not in company %',
+                    NEW.work_center_id, NEW.company_id;
+  END IF;
+
+  -- routing_operations has NO company_id; tenancy resolves through routings. The same
+  -- query yields the part, so tenancy and part-consistency are checked together.
+  IF NEW.routing_operation_id IS NOT NULL THEN
+    SELECT r.part_id INTO v_part
+    FROM public.routing_operations ro
+    JOIN public.routings r ON r.id = ro.routing_id
+    WHERE ro.id = NEW.routing_operation_id AND r.company_id = NEW.company_id;
+
+    IF v_part IS NULL THEN
+      RAISE EXCEPTION 'routing operation % is not in company %',
+                      NEW.routing_operation_id, NEW.company_id;
+    END IF;
+    IF v_part IS DISTINCT FROM NEW.part_id THEN
+      RAISE EXCEPTION 'routing operation % belongs to part %, not %',
+                      NEW.routing_operation_id, v_part, NEW.part_id;
+    END IF;
+  END IF;
+
+  -- Company, machine and kind in ONE predicate, answered with ONE message. This
+  -- function is SECURITY DEFINER, so it reads past RLS: a message that
+  -- distinguished "no such note" from "different company" from "not a noticed
+  -- item" would be a cross-tenant existence oracle for anyone willing to guess
+  -- uuids. The uniform failure is the point, not laziness.
+  IF NEW.resolves_note_id IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1 FROM public.notes t
+      WHERE t.id = NEW.resolves_note_id
+        AND t.company_id = NEW.company_id
+        AND t.subject_kind = 'work_center'
+        AND t.work_center_id = NEW.work_center_id
+        AND t.maintenance_kind = 'noticed'
+    ) INTO v_ok;
+
+    IF NOT v_ok THEN
+      RAISE EXCEPTION 'that item is not an open observation on this machine';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- The column list decides when the trigger fires on UPDATE. `notes` has no
+-- UPDATE grant for authenticated, so in practice only the INSERT path runs;
+-- naming the new columns keeps that true if the grant ever changes.
+DROP TRIGGER IF EXISTS notes_validate_subject_trg ON public.notes;
+CREATE TRIGGER notes_validate_subject_trg
+  BEFORE INSERT OR UPDATE OF company_id, job_id, part_id, routing_operation_id,
+                             work_center_id, resolves_note_id, maintenance_kind
+  ON public.notes
+  FOR EACH ROW EXECUTE FUNCTION public.notes_validate_subject();
+
+
+-- ══════════════════════════════════════════════════════════════════════════════
+-- 3. FUNNEL: TWO NEW OPERATOR EVENT KINDS
+-- ══════════════════════════════════════════════════════════════════════════════
+-- §8 needs four moments instrumented: machine page opened, composer focused,
+-- entry saved, noticed resolved. The middle two already exist and are reused with
+-- workCenterId in context (which the operator_events comment already anticipates
+-- as a context key). These two are new.
+--
+-- machine_page_opened is load-bearing for §2, not decoration. A container nobody
+-- filled and a container nobody reached both look like silence from outside; this
+-- is the only thing that tells them apart, and without it a null result cannot
+-- honestly be recorded as a kill.
+
+ALTER TABLE public.operator_events DROP CONSTRAINT operator_events_kind_check;
+ALTER TABLE public.operator_events ADD CONSTRAINT operator_events_kind_check CHECK (kind IN (
+  'app_opened',
+  'station_selected',
+  'op_card_opened',
+  'prior_notes_opened',      -- THAT they opened prior notes, never WHICH ones
+  'composer_focused',
+  'composer_abandoned',
+  'note_saved',
+  'note_saved_with_photo',
+  'photo_attached',
+  'completion_recorded',
+  'machine_page_opened',     -- separates "not yet tested" from a kill (§2)
+  'noticed_resolved'
+));
+
+
+-- ══════════════════════════════════════════════════════════════════════════════
+-- 4. MACHINE DETAILS ON work_centers
+-- ══════════════════════════════════════════════════════════════════════════════
+-- Real columns rather than the existing metadata jsonb: types/database.ts is
+-- CI-diff-enforced, so real columns are type-checked through getTypedSupabase()
+-- at every call site, while jsonb degrades to `Json` and checks nothing.
+--
+-- ALL NULLABLE, AND NOTHING EVER PROMPTS FOR THEM (§4.5). Asset data entry is a
+-- leading cause of CMMS abandonment: the tool arrives, the shop is asked to
+-- describe its equipment before it can do anything, and the project dies in the
+-- describing. The machines are already in Jigged as work centers, so this module
+-- starts with its asset list complete and its asset detail empty, which is the
+-- right way round. External/vendor work centers simply leave them null, exactly
+-- as they already do with labor_rate.
+
+ALTER TABLE public.work_centers
+  ADD COLUMN make          text,
+  ADD COLUMN model         text,
+  ADD COLUMN serial_number text,
+  ADD COLUMN year_built    integer,
+  ADD COLUMN purchased_on  date;
+
+ALTER TABLE public.work_centers ADD CONSTRAINT work_centers_year_built_sane
+  CHECK (year_built IS NULL OR year_built BETWEEN 1900 AND 2200);
+
+COMMENT ON COLUMN public.work_centers.make IS
+  'Optional machine detail. Never required, never prompted for, and no surface may render a machine as less ready than another because these are filled in — see docs/modules/machine-maintenance.md §4.5.';
+
+
+-- ══════════════════════════════════════════════════════════════════════════════
+-- 5. MANUALS: work_center_attachments
+-- ══════════════════════════════════════════════════════════════════════════════
+-- A twin of part_attachments rather than a polymorphic widening of it:
+-- part_attachments.part_id is NOT NULL with an FK, so making it polymorphic would
+-- touch every existing call site to buy nothing. job_attachments and
+-- part_attachments already coexist as near-twins; this is the third sibling.
+
+CREATE TABLE public.work_center_attachments (
+    id             uuid NOT NULL DEFAULT gen_random_uuid(),
+    company_id     uuid NOT NULL,
+    work_center_id uuid NOT NULL,
+    storage_path   text NOT NULL,
+    file_name      text NOT NULL,
+    kind           text NOT NULL DEFAULT 'other',
+    mime_type      text,
+    size_bytes     bigint,
+    uploaded_by    uuid,
+    created_at     timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT work_center_attachments_pkey PRIMARY KEY (id),
+    CONSTRAINT work_center_attachments_kind_check
+      CHECK (kind IN ('pdf', 'image', 'other')),
+    CONSTRAINT work_center_attachments_company_fk FOREIGN KEY (company_id)
+      REFERENCES public.companies(id) ON DELETE CASCADE,
+    -- Work centers are soft-deleted, so RESTRICT never actually fires. It is here
+    -- to state the rule: archiving a machine hides it from pickers, not its
+    -- manuals. Knowledge must not be destroyable as a side effect of tidying a
+    -- list (§9).
+    CONSTRAINT work_center_attachments_wc_fk FOREIGN KEY (work_center_id)
+      REFERENCES public.work_centers(id) ON DELETE RESTRICT,
+    CONSTRAINT work_center_attachments_uploader_fk FOREIGN KEY (uploaded_by)
+      REFERENCES public.user_company_access(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_work_center_attachments_wc
+  ON public.work_center_attachments (work_center_id, created_at DESC);
+
+COMMENT ON TABLE public.work_center_attachments IS
+  'Machine manuals and reference images, read on the floor from the Maintenance tab. Optional: a machine with none shows nothing at all, never a prompt to add one.';
+
+ALTER TABLE public.work_center_attachments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY work_center_attachments_select ON public.work_center_attachments
+    FOR SELECT TO authenticated
+    USING (company_id IN (SELECT public.get_user_company_ids()));
+
+CREATE POLICY work_center_attachments_insert ON public.work_center_attachments
+    FOR INSERT TO authenticated
+    WITH CHECK (
+      company_id IN (SELECT public.get_user_company_ids())
+      -- Same rule as notes.author_id: the uploader is the acting member, resolved
+      -- server-side. There is no path to attribute an upload to anyone else.
+      AND uploaded_by = public.get_operator_access_id(company_id)
+    );
+
+CREATE POLICY work_center_attachments_delete ON public.work_center_attachments
+    FOR DELETE TO authenticated
+    USING (uploaded_by = public.get_operator_access_id(company_id)
+           OR public.is_company_admin(company_id));
+
+-- Data API grants. No UPDATE: a manual is replaced by uploading a new one and
+-- deleting the old, which keeps storage_path and the row in step. No anon: the
+-- operator app is always signed in.
+GRANT SELECT, INSERT, DELETE ON public.work_center_attachments TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.work_center_attachments TO service_role;
+
+SELECT public.apply_billing_write_gate('public.work_center_attachments');

--- a/types/database.ts
+++ b/types/database.ts
@@ -1493,8 +1493,10 @@ export type Database = {
           job_id: string | null
           job_operation_id: string | null
           job_part_id: string | null
+          maintenance_kind: string | null
           note_type: string
           part_id: string | null
+          resolves_note_id: string | null
           routing_operation_id: string | null
           subject_kind: string
           usage_count: number
@@ -1513,8 +1515,10 @@ export type Database = {
           job_id?: string | null
           job_operation_id?: string | null
           job_part_id?: string | null
+          maintenance_kind?: string | null
           note_type?: string
           part_id?: string | null
+          resolves_note_id?: string | null
           routing_operation_id?: string | null
           subject_kind: string
           usage_count?: number
@@ -1533,8 +1537,10 @@ export type Database = {
           job_id?: string | null
           job_operation_id?: string | null
           job_part_id?: string | null
+          maintenance_kind?: string | null
           note_type?: string
           part_id?: string | null
+          resolves_note_id?: string | null
           routing_operation_id?: string | null
           subject_kind?: string
           usage_count?: number
@@ -1603,6 +1609,13 @@ export type Database = {
             columns: ["part_id"]
             isOneToOne: false
             referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notes_resolves_fk"
+            columns: ["resolves_note_id"]
+            isOneToOne: false
+            referencedRelation: "notes"
             referencedColumns: ["id"]
           },
           {
@@ -3191,6 +3204,67 @@ export type Database = {
         }
         Relationships: []
       }
+      work_center_attachments: {
+        Row: {
+          company_id: string
+          created_at: string
+          file_name: string
+          id: string
+          kind: string
+          mime_type: string | null
+          size_bytes: number | null
+          storage_path: string
+          uploaded_by: string | null
+          work_center_id: string
+        }
+        Insert: {
+          company_id: string
+          created_at?: string
+          file_name: string
+          id?: string
+          kind?: string
+          mime_type?: string | null
+          size_bytes?: number | null
+          storage_path: string
+          uploaded_by?: string | null
+          work_center_id: string
+        }
+        Update: {
+          company_id?: string
+          created_at?: string
+          file_name?: string
+          id?: string
+          kind?: string
+          mime_type?: string | null
+          size_bytes?: number | null
+          storage_path?: string
+          uploaded_by?: string | null
+          work_center_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "work_center_attachments_company_fk"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_center_attachments_uploader_fk"
+            columns: ["uploaded_by"]
+            isOneToOne: false
+            referencedRelation: "user_company_access"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_center_attachments_wc_fk"
+            columns: ["work_center_id"]
+            isOneToOne: false
+            referencedRelation: "work_centers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       work_centers: {
         Row: {
           company_id: string
@@ -3200,10 +3274,15 @@ export type Database = {
           id: string
           kind: string
           labor_rate: number | null
+          make: string | null
           metadata: Json | null
+          model: string | null
           name: string
+          purchased_on: string | null
+          serial_number: string | null
           updated_at: string
           vendor_id: string | null
+          year_built: number | null
         }
         Insert: {
           company_id: string
@@ -3213,10 +3292,15 @@ export type Database = {
           id?: string
           kind?: string
           labor_rate?: number | null
+          make?: string | null
           metadata?: Json | null
+          model?: string | null
           name: string
+          purchased_on?: string | null
+          serial_number?: string | null
           updated_at?: string
           vendor_id?: string | null
+          year_built?: number | null
         }
         Update: {
           company_id?: string
@@ -3226,10 +3310,15 @@ export type Database = {
           id?: string
           kind?: string
           labor_rate?: number | null
+          make?: string | null
           metadata?: Json | null
+          model?: string | null
           name?: string
+          purchased_on?: string | null
+          serial_number?: string | null
           updated_at?: string
           vendor_id?: string | null
+          year_built?: number | null
         }
         Relationships: [
           {

--- a/utils/jobNoteMediaAccess.ts
+++ b/utils/jobNoteMediaAccess.ts
@@ -5,19 +5,22 @@ import {
   deleteFileFromStorage,
   getSignedUrl,
 } from '@/utils/storageHelpers';
+import type { StorageEntityType } from '@/utils/storageHelpers';
 import type { JobNoteMedia } from '@/types/operator';
 
 /**
  * Access layer for note media — photos (and, later, short videos) attached to a
  * `notes` entry. File bytes live in the private `attachments` storage bucket
- * under {companyId}/jobs/{jobId}/... (see utils/storageHelpers.ts, whose bucket
- * RLS already gates by the company folder); this module manages the `note_media`
- * metadata rows and ties the two together.
+ * under {companyId}/{entityType}/{entityId}/... (see utils/storageHelpers.ts,
+ * whose bucket RLS already gates by the company folder); this module manages the
+ * `note_media` metadata rows and ties the two together.
  *
  * The storage path still keys on the capturing job even for durable
  * part-subject notes: it is only a folder layout, and the company segment (which
  * is what the bucket RLS gates on) is unchanged. Repathing existing objects would
- * be a data migration with no functional benefit.
+ * be a data migration with no functional benefit. A machine-subject note has no
+ * job at all, so it files under work-centers instead — the same reasoning, not an
+ * exception to it.
  *
  * Mirrors partAttachmentsAccess.ts. Heavy media work (compression, EXIF fix,
  * dimension reading) happens in the browser BEFORE these calls — they only see
@@ -55,20 +58,31 @@ function rowToMedia(row: MediaRow): JobNoteMedia {
 }
 
 /**
- * Attach one (already-compressed) photo to a job note. Uploads to
- * {companyId}/jobs/{jobId}/... then records the metadata row. Rolls back the
- * storage object if the row insert fails so a failed attach never leaks an
- * orphaned file. `dims` (the compressed image's pixel size) is optional.
+ * Attach one (already-compressed) photo to a note of ANY subject. Uploads to
+ * {companyId}/{entityType}/{entityId}/... then records the metadata row. Rolls
+ * back the storage object if the row insert fails so a failed attach never leaks
+ * an orphaned file. `dims` (the compressed image's pixel size) is optional.
+ *
+ * The folder is a caller decision because a machine-subject note has no job to
+ * file under — its photos live beside the machine. The company segment, which is
+ * the only one the bucket RLS reads, is unchanged either way.
  */
-export async function addJobNoteMedia(
+export async function addNoteMedia(
   companyId: string,
-  jobId: string,
   noteId: string,
   file: File,
-  opts?: { dims?: { width: number; height: number } },
+  opts: {
+    folder: { entityType: StorageEntityType; entityId: string };
+    dims?: { width: number; height: number };
+  },
 ): Promise<JobNoteMedia> {
   const supabase = getSupabase();
-  const storagePath = generateStoragePath(companyId, 'jobs', jobId, file.name);
+  const storagePath = generateStoragePath(
+    companyId,
+    opts.folder.entityType,
+    opts.folder.entityId,
+    file.name,
+  );
   await uploadFileToStorage(storagePath, file);
 
   const { data, error } = await supabase
@@ -89,11 +103,30 @@ export async function addJobNoteMedia(
   if (error) {
     // Roll back the orphaned upload so a failed insert doesn't leak a file.
     await deleteFileFromStorage(storagePath).catch(() => {});
-    console.error('Error inserting job note media:', error);
+    console.error('Error inserting note media:', error);
     throw new Error('Failed to attach the photo. Please try again.');
   }
 
   return rowToMedia(data as unknown as MediaRow);
+}
+
+/**
+ * Attach a photo to a note captured on a job. Files under the capturing job even
+ * when the note's SUBJECT is a part — see the header: the folder is layout, not
+ * meaning, and repathing existing objects would be a data migration that bought
+ * nothing.
+ */
+export function addJobNoteMedia(
+  companyId: string,
+  jobId: string,
+  noteId: string,
+  file: File,
+  opts?: { dims?: { width: number; height: number } },
+): Promise<JobNoteMedia> {
+  return addNoteMedia(companyId, noteId, file, {
+    folder: { entityType: 'jobs', entityId: jobId },
+    dims: opts?.dims,
+  });
 }
 
 /** A fresh, time-limited URL for rendering a photo/thumbnail in the feed. */

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -1048,6 +1048,10 @@ export async function getStationOperationTypes(
     // Operators only run internal stations; external/vendor work centers are
     // handled through the routing/job workflow, not picked at the station.
     .eq('kind', 'internal')
+    // Archived machines are gone from the shop's point of view. Without this the
+    // picker offers a machine nobody can be standing at, and selecting one is
+    // unrecoverable from the floor.
+    .is('deleted_at', null)
     .order('name');
 
   if (error) throw new Error(error.message);
@@ -1058,16 +1062,34 @@ export async function getStationOperationTypes(
   }));
 }
 
+/**
+ * Resolve a station's display name, or null when there is no live machine with
+ * that id.
+ *
+ * Filters `deleted_at` even though it is a by-id read, which is the opposite of
+ * the usual rule. The distinction is what the read is FOR: a detail page or a
+ * document's retained FK is resolving history and must still render, but this
+ * call is VALIDATING A PERSISTED SELECTION. A null answer is the signal that the
+ * stored station no longer names anywhere an operator can stand, and the caller
+ * drops them back to the picker rather than leaving them on a ghost machine.
+ *
+ * Throws on a query failure so the caller can tell "this machine is gone" (null)
+ * apart from "the network is down" (throw) — the first should clear the stored
+ * station, the second must never touch it.
+ */
 export async function getStationName(
   stationId: string,
 ): Promise<string | null> {
   const supabase = getSupabase();
 
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from('work_centers')
     .select('name')
     .eq('id', stationId)
-    .single();
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
 
   return data?.name || null;
 }

--- a/utils/operatorEventsAccess.ts
+++ b/utils/operatorEventsAccess.ts
@@ -42,7 +42,22 @@ export type OperatorEventKind =
   | 'note_saved'
   | 'note_saved_with_photo'
   | 'photo_attached'
-  | 'completion_recorded';
+  | 'completion_recorded'
+  // Machine Maintenance. The composer moments (composer_focused, note_saved,
+  // note_saved_with_photo, photo_attached, composer_abandoned) are REUSED on the
+  // machine surface with workCenterId in context, so the same friction reading
+  // works across both containers and the two are comparable. Only these two are
+  // genuinely new:
+  //
+  //   machine_page_opened — the precondition for reading any null result. A
+  //     container nobody filled and a container nobody REACHED both look like
+  //     silence from outside; this is what tells them apart, and without it a
+  //     quiet four weeks cannot honestly be recorded as a kill.
+  //   noticed_resolved — the loop closing. Distinct from note_saved because an
+  //     entry that fixes something somebody else flagged is the behaviour the
+  //     module is actually betting on.
+  | 'machine_page_opened'
+  | 'noticed_resolved';
 
 export type OperatorEventContext = Record<string, string | number | boolean | null>;
 

--- a/utils/storageHelpers.ts
+++ b/utils/storageHelpers.ts
@@ -22,11 +22,18 @@ export function sanitizeFilename(filename: string): string {
 }
 
 /**
+ * The folder an upload is filed under. Only the FIRST segment of the path is
+ * load-bearing: the bucket's RLS gates on `foldername[1] = companyId`, so adding
+ * an entity type here needs no new storage policy.
+ */
+export type StorageEntityType = 'quotes' | 'jobs' | 'parts' | 'work-centers';
+
+/**
  * Generate storage path with UUID prefix and sanitized filename
  */
 export function generateStoragePath(
   companyId: string,
-  entityType: 'quotes' | 'jobs' | 'parts',
+  entityType: StorageEntityType,
   entityId: string,
   filename: string
 ): string {


### PR DESCRIPTION
First of three PRs building the Machine Maintenance module described in
`docs/modules/machine-maintenance.md` — a machine-scoped logbook, behind a
per-tenant flag, with a kill criterion written down in advance. **This PR is
schema and prerequisites only; nothing is user-visible yet.**

The doc itself is the first commit here. It had lived as an untracked file in a
worktree since it was drafted — one `git clean` from gone — so it is committed
verbatim, before any amendment, and the changes the build makes to it will land
as a reviewable diff against the proposal.

## What is in it

**The station picker stops offering archived machines.** `getStationOperationTypes`
was the one work-center reader in the codebase with no `deleted_at` filter, so
picking an archived machine stranded an operator on a station that no longer
exists. It matters more now: station selection is about to be the only entrance
to the logbook. `getStationName` now answers `null` for an archived machine and
*throws* on a query failure, and the provider treats those differently — gone
means forget the stored station, network blip means keep it.

**Two columns on `notes`.** The `work_center` subject has been modelled end to
end since the notes rewrite and nothing has ever written one; this adds what
makes a maintenance entry different from any other note:

- `maintenance_kind` — nullable, constrained to five verbs and to work-center
  rows. Optional on purpose: a forced taxonomy at capture time is what stops
  capture.
- `resolves_note_id` — a new column, not a reuse of the unused
  `corrects_note_id`. "This supersedes an inaccurate note" and "I did the fix
  for the thing you noticed" are different claims, and one column holding both
  would let a future corrections UI silently close open items.

**There is no `is_open` column, and there is not meant to be one.** An
observation is open exactly while nothing resolves it, derived at read time
from the same array the timeline is drawn from, so the two can never disagree.
It is also the only design this table permits — `notes` is append-only
(`REVOKE UPDATE`), so a stored flag would have needed an UPDATE grant.

That read *trusts* that a resolver always sits on the same machine as its
target, so the trigger holds that invariant rather than the access layer. It
answers with one uniform message whatever failed: it is `SECURITY DEFINER` and
reads past RLS, so distinguishing "no such note" from "different company" would
be a cross-tenant existence oracle.

**`machine_page_opened` + `noticed_resolved` funnel kinds.** The first is
load-bearing for the kill criterion, not decoration: a container nobody filled
and a container nobody *reached* both look like silence from outside. The
composer events are reused with `workCenterId` in context so the two capture
surfaces stay comparable.

**Machine details and manuals.** Five nullable columns on `work_centers` (real
columns, not `metadata` jsonb, so they type-check at every call site) and a
`work_center_attachments` table mirroring `part_attachments`. Nothing prompts
for either, ever — asset data entry is a leading cause of CMMS abandonment, and
the machines are already in Jigged, so the module starts with a complete asset
list and an empty asset detail.

## Verification

The whole migration history was replayed onto a throwaway Postgres and every
constraint and both trigger branches exercised there — 11 rejections confirmed,
plus the happy path, the derived open state, that deleting a fix re-opens its
observation, the billing gate, and `tenant_tables_missing_write_gate()` clean.
The pytest coverage added here is the permanent version of those checks.

`types/database.ts` was regenerated from that same replay; its diff is purely
additive (89 lines, 0 deletions), which is the proof the `graphql_public` splice
was byte-exact.

Local: `tsc` clean, `pnpm lint` 0 errors, full Vitest suite 1394 passing.
The Supabase preview branch is the real gate for the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)