### PR TITLE
feat(maintenance): the operator logbook (Machine Maintenance PR B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -734,6 +734,7 @@ See [docs/modules/](docs/modules/) for detailed module specs:
 - [Routings](docs/modules/routings.md)
 - [Inventory](docs/modules/inventory.md)
 - [Operator View](docs/modules/operator-view.md)
+- [Machine Maintenance](docs/modules/machine-maintenance.md) (operator-logged machine logbook; flag-gated pilot with a written kill criterion)
 - [Invitation System](docs/modules/invitation-system.md)
 - [Data Import](docs/modules/data-import.md) (guided onboarding import; [Phase 2 design](docs/modules/data-import-phase2-design.md))
 - [Billing & Subscriptions](docs/modules/billing.md) (Stripe-hosted checkout/portal; DB-enforced entitlement)

--- a/__tests__/components/maintenance/MachineDetailsCard.test.tsx
+++ b/__tests__/components/maintenance/MachineDetailsCard.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@/__tests__/test-utils';
+import MachineDetailsCard from '@/components/maintenance/MachineDetailsCard';
+
+const empty = {
+  make: null,
+  model: null,
+  serial_number: null,
+  year_built: null,
+  purchased_on: null,
+};
+
+describe('MachineDetailsCard', () => {
+  // §4.5, enforced. Asset data entry is a leading cause of CMMS abandonment: the
+  // tool arrives, the shop is asked to describe its equipment before it can do
+  // anything, and the project dies in the describing. A machine with nothing
+  // filled in has to look FINISHED, because it is.
+  it('renders nothing when no detail has been filled in', () => {
+    const { container } = render(<MachineDetailsCard details={empty} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the machine has no detail row at all', () => {
+    const { container } = render(<MachineDetailsCard details={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('never prompts, nudges, or measures how complete it is', () => {
+    const { container } = render(<MachineDetailsCard details={empty} />);
+    expect(container.textContent).toBe('');
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('shows only the fields somebody actually filled in', () => {
+    render(<MachineDetailsCard details={{ ...empty, make: 'Haas', serial_number: '1104321' }} />);
+
+    expect(screen.getByText('Haas')).toBeInTheDocument();
+    expect(screen.getByText('1104321')).toBeInTheDocument();
+    // No "Model —" placeholder row: an absent field is absent, not blank.
+    expect(screen.queryByText('Model')).not.toBeInTheDocument();
+    expect(screen.queryByText('Year')).not.toBeInTheDocument();
+  });
+
+  it('shows the year and purchase date when they are known', () => {
+    render(
+      <MachineDetailsCard
+        details={{ ...empty, year_built: 2014, purchased_on: '2016-03-08' }}
+      />,
+    );
+
+    expect(screen.getByText('2014')).toBeInTheDocument();
+    expect(screen.getByText(/2016/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/maintenance/MachineLogPanel.test.tsx
+++ b/__tests__/components/maintenance/MachineLogPanel.test.tsx
@@ -201,4 +201,57 @@ describe('MachineLogPanel', () => {
     expect(screen.queryByRole('button', { name: /add to log/i })).not.toBeInTheDocument();
     expect(screen.queryByPlaceholderText(/what did you do/i)).not.toBeInTheDocument();
   });
+
+  describe('the composer', () => {
+    it('offers one flag, not a taxonomy', async () => {
+      // Four of the original five verbs had no reader anywhere — nothing filtered,
+      // grouped, ranked or counted by them — so they were four extra decisions
+      // asked of somebody in a container whose whole risk is that nobody writes in
+      // it. If they come back, they should come back with a consumer.
+      render(<MachineLogPanel workCenterId="wc1" companyId="c1" />);
+      await screen.findByText(/nothing logged for this machine yet/i);
+
+      expect(screen.getByRole('button', { name: /needs attention/i })).toBeInTheDocument();
+      for (const dead of ['cleaned', 'repaired', 'replaced', 'adjusted']) {
+        expect(screen.queryByRole('button', { name: new RegExp(`^${dead}$`, 'i') })).toBeNull();
+      }
+    });
+
+    it('is off by default, because most entries record work already done', async () => {
+      mockAddMachineNote.mockResolvedValue(note({ id: 'a' }));
+      render(<MachineLogPanel workCenterId="wc1" companyId="c1" />);
+      await screen.findByText(/nothing logged for this machine yet/i);
+
+      await userEvent.type(screen.getByPlaceholderText(/what did you do/i), 'Topped up the lube.');
+      await userEvent.click(screen.getByRole('button', { name: /add to log/i }));
+
+      await waitFor(() =>
+        expect(mockAddMachineNote).toHaveBeenCalledWith(
+          'wc1', 'c1', 'acc-me', 'Topped up the lube.',
+          expect.objectContaining({ maintenanceKind: null }),
+        ),
+      );
+    });
+
+    it('can be turned back off after being turned on', async () => {
+      // Somebody who taps it and reconsiders must be able to undo that without
+      // clearing the sentence they already wrote.
+      mockAddMachineNote.mockResolvedValue(note({ id: 'a' }));
+      render(<MachineLogPanel workCenterId="wc1" companyId="c1" />);
+      await screen.findByText(/nothing logged for this machine yet/i);
+
+      const flag = screen.getByRole('button', { name: /needs attention/i });
+      await userEvent.type(screen.getByPlaceholderText(/what did you do/i), 'Looked at it.');
+      await userEvent.click(flag);
+      await userEvent.click(flag);
+      await userEvent.click(screen.getByRole('button', { name: /add to log/i }));
+
+      await waitFor(() =>
+        expect(mockAddMachineNote).toHaveBeenCalledWith(
+          'wc1', 'c1', 'acc-me', 'Looked at it.',
+          expect.objectContaining({ maintenanceKind: null }),
+        ),
+      );
+    });
+  });
 });

--- a/__tests__/components/maintenance/MachineLogPanel.test.tsx
+++ b/__tests__/components/maintenance/MachineLogPanel.test.tsx
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@/__tests__/test-utils';
+import userEvent from '@testing-library/user-event';
+
+const { mockGetMachineLog, mockGetMachineDetails, mockAddMachineNote, mockLogOperatorEvent } =
+  vi.hoisted(() => ({
+    mockGetMachineLog: vi.fn(),
+    mockGetMachineDetails: vi.fn(),
+    mockAddMachineNote: vi.fn(),
+    mockLogOperatorEvent: vi.fn(),
+  }));
+
+vi.mock('@/utils/machineMaintenanceAccess', () => ({
+  getMachineLog: (...a: unknown[]) => mockGetMachineLog(...a),
+  getMachineDetails: (...a: unknown[]) => mockGetMachineDetails(...a),
+  addMachineNote: (...a: unknown[]) => mockAddMachineNote(...a),
+  addMachineNoteMedia: vi.fn(),
+}));
+vi.mock('@/utils/operatorEventsAccess', () => ({
+  logOperatorEvent: (...a: unknown[]) => mockLogOperatorEvent(...a),
+}));
+vi.mock('@/utils/operatorAccess', () => ({
+  getCurrentMember: vi.fn().mockResolvedValue({ id: 'acc-me', name: 'Me' }),
+  addReaction: vi.fn(),
+  removeReaction: vi.fn(),
+}));
+vi.mock('@/hooks/useNoteDwell', () => ({
+  useNoteDwell: vi.fn(() => ({ observe: () => () => {} })),
+}));
+// NoteMediaGallery reaches jobNoteMediaAccess, which imports lib/supabase and
+// creates its client at MODULE scope — without this the file throws on import
+// rather than on use. Same reason as OperationActionPage.test.tsx.
+vi.mock('@/utils/jobNoteMediaAccess', () => ({
+  addNoteMedia: vi.fn(),
+  getJobNoteMediaUrl: vi.fn(async () => 'blob:x'),
+}));
+vi.mock('@/utils/imageCompression', () => ({
+  compressPhoto: vi.fn(async (f: File) => ({ file: f, dims: { width: 10, height: 10 } })),
+}));
+
+import MachineLogPanel from '@/components/maintenance/MachineLogPanel';
+import { useNoteDwell } from '@/hooks/useNoteDwell';
+import type { MachineNote } from '@/types/machineMaintenance';
+
+function note(over: Partial<MachineNote> & { id: string }): MachineNote {
+  return {
+    work_center_id: 'wc1',
+    body: 'Topped up the way lube.',
+    maintenance_kind: null,
+    resolves_note_id: null,
+    created_at: '2026-07-01T12:00:00Z',
+    author_name: 'Kurtis',
+    author_id: 'acc-1',
+    viewer_count: 4,
+    media: [],
+    reactions: [],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetMachineDetails.mockResolvedValue(null);
+  mockGetMachineLog.mockResolvedValue({ entries: [], open: [] });
+});
+
+describe('MachineLogPanel', () => {
+  it('records that the machine page was opened', async () => {
+    // The precondition for reading any result from the pilot at all. A container
+    // nobody filled and a container nobody REACHED both look like silence from
+    // outside; without this event a quiet four weeks cannot honestly be called a
+    // kill.
+    render(<MachineLogPanel workCenterId="wc1" companyId="c1" />);
+
+    await waitFor(() =>
+      expect(mockLogOperatorEvent).toHaveBeenCalledWith('c1', 'machine_page_opened', {
+        workCenterId: 'wc1',
+      }),
+    );
+  });
+
+  it('does not record a page open when the office is reading the log', async () => {
+    render(<MachineLogPanel workCenterId="wc1" companyId="c1" readOnly />);
+
+    await waitFor(() => expect(mockGetMachineLog).toHaveBeenCalled());
+    expect(mockLogOperatorEvent).not.toHaveBeenCalledWith(
+      'c1',
+      'machine_page_opened',
+      expect.anything(),
+    );
+  });
+
+  it('logs reads with no job, which is what a machine read actually is', async () => {
+    render(<MachineLogPanel workCenterId="wc1" companyId="c1" />);
+    await waitFor(() => expect(useNoteDwell).toHaveBeenCalledWith('c1', null));
+  });
+
+  it('says the machine has no history rather than nudging anyone to start one', async () => {
+    render(<MachineLogPanel workCenterId="wc1" companyId="c1" />);
+
+    expect(await screen.findByText(/nothing logged for this machine yet/i)).toBeInTheDocument();
+    // No completeness meter, no "finish setting up this machine" (§4.5).
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.queryByText(/set up|get started|complete your/i)).not.toBeInTheDocument();
+  });
+
+  it('never renders a usage count', async () => {
+    // usage_count counts distinct JOBS a note was consulted on, so it is
+    // permanently zero here (§8). "Used on 0 jobs" beside real knowledge reads as
+    // a verdict on the entry rather than a gap in the instrument.
+    mockGetMachineLog.mockResolvedValue({ entries: [note({ id: 'a' })], open: [] });
+    render(<MachineLogPanel workCenterId="wc1" companyId="c1" />);
+
+    await screen.findByText('Topped up the way lube.');
+    expect(screen.queryByText(/used on/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\bjobs\b/i)).not.toBeInTheDocument();
+  });
+
+  it('pins open items above the timeline AND leaves them in it', async () => {
+    // Both halves matter. Pinned, because the reader's question on arriving is
+    // "what is outstanding". Still in the timeline, because a log that loses rows
+    // stops being a log — the open list is a VIEW of the timeline, not a
+    // separate inbox that rows move between.
+    const open = note({ id: 'obs', body: 'Coolant smells off.', maintenance_kind: 'noticed' });
+    mockGetMachineLog.mockResolvedValue({ entries: [note({ id: 'a' }), open], open: [open] });
+
+    render(<MachineLogPanel workCenterId="wc1" companyId="c1" />);
+    await screen.findByText('Topped up the way lube.');
+
+    const occurrences = screen.getAllByText('Coolant smells off.');
+    expect(occurrences).toHaveLength(2);
+
+    const [pinned, inTimeline] = occurrences;
+    expect(pinned.compareDocumentPosition(inTimeline)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      pinned.compareDocumentPosition(screen.getByText('Topped up the way lube.')),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it('binds the fix to the item and records the loop closing', async () => {
+    const open = note({ id: 'obs', body: 'Coolant smells off.', maintenance_kind: 'noticed' });
+    mockGetMachineLog.mockResolvedValue({ entries: [open], open: [open] });
+    mockAddMachineNote.mockResolvedValue(note({ id: 'fix', resolves_note_id: 'obs' }));
+
+    render(<MachineLogPanel workCenterId="wc1" companyId="c1" />);
+    await screen.findAllByText('Coolant smells off.');
+
+    await userEvent.click(screen.getAllByRole('button', { name: /log the fix/i })[0]);
+    await userEvent.type(
+      screen.getByPlaceholderText(/what did you do/i),
+      'Drained and recharged.',
+    );
+    await userEvent.click(screen.getByRole('button', { name: /add to log/i }));
+
+    await waitFor(() =>
+      expect(mockAddMachineNote).toHaveBeenCalledWith(
+        'wc1',
+        'c1',
+        'acc-me',
+        'Drained and recharged.',
+        expect.objectContaining({ resolvesNoteId: 'obs' }),
+      ),
+    );
+    await waitFor(() =>
+      expect(mockLogOperatorEvent).toHaveBeenCalledWith('c1', 'noticed_resolved', {
+        workCenterId: 'wc1',
+      }),
+    );
+  });
+
+  it('does not preselect a kind when logging a fix', async () => {
+    // Plenty of fixes are a clean or an adjustment. Defaulting to "repaired"
+    // would be exactly the taxonomy nudge the optional chip exists to avoid.
+    const open = note({ id: 'obs', body: 'Coolant smells off.', maintenance_kind: 'noticed' });
+    mockGetMachineLog.mockResolvedValue({ entries: [open], open: [open] });
+    mockAddMachineNote.mockResolvedValue(note({ id: 'fix' }));
+
+    render(<MachineLogPanel workCenterId="wc1" companyId="c1" />);
+    await screen.findAllByText('Coolant smells off.');
+    await userEvent.click(screen.getAllByRole('button', { name: /log the fix/i })[0]);
+
+    await userEvent.type(screen.getByPlaceholderText(/what did you do/i), 'Done.');
+    await userEvent.click(screen.getByRole('button', { name: /add to log/i }));
+
+    await waitFor(() =>
+      expect(mockAddMachineNote).toHaveBeenCalledWith(
+        'wc1',
+        'c1',
+        'acc-me',
+        'Done.',
+        expect.objectContaining({ maintenanceKind: null }),
+      ),
+    );
+  });
+
+  it('offers no composer when the office is reading', async () => {
+    mockGetMachineLog.mockResolvedValue({ entries: [note({ id: 'a' })], open: [] });
+    render(<MachineLogPanel workCenterId="wc1" companyId="c1" readOnly />);
+
+    await screen.findByText('Topped up the way lube.');
+    expect(screen.queryByRole('button', { name: /add to log/i })).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/what did you do/i)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/maintenance/MachineLogPanel.test.tsx
+++ b/__tests__/components/maintenance/MachineLogPanel.test.tsx
@@ -211,9 +211,9 @@ describe('MachineLogPanel', () => {
       render(<MachineLogPanel workCenterId="wc1" companyId="c1" />);
       await screen.findByText(/nothing logged for this machine yet/i);
 
-      expect(screen.getByRole('button', { name: /needs attention/i })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: /needs attention/i })).toBeInTheDocument();
       for (const dead of ['cleaned', 'repaired', 'replaced', 'adjusted']) {
-        expect(screen.queryByRole('button', { name: new RegExp(`^${dead}$`, 'i') })).toBeNull();
+        expect(screen.queryByRole('checkbox', { name: new RegExp(`^${dead}$`, 'i') })).toBeNull();
       }
     });
 
@@ -240,7 +240,7 @@ describe('MachineLogPanel', () => {
       render(<MachineLogPanel workCenterId="wc1" companyId="c1" />);
       await screen.findByText(/nothing logged for this machine yet/i);
 
-      const flag = screen.getByRole('button', { name: /needs attention/i });
+      const flag = screen.getByRole('checkbox', { name: /needs attention/i });
       await userEvent.type(screen.getByPlaceholderText(/what did you do/i), 'Looked at it.');
       await userEvent.click(flag);
       await userEvent.click(flag);

--- a/__tests__/components/maintenance/MachineOpenItems.test.tsx
+++ b/__tests__/components/maintenance/MachineOpenItems.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@/__tests__/test-utils';
+import userEvent from '@testing-library/user-event';
+import MachineOpenItems from '@/components/maintenance/MachineOpenItems';
+import type { MachineNote } from '@/types/machineMaintenance';
+
+function item(over: Partial<MachineNote> & { id: string }): MachineNote {
+  return {
+    work_center_id: 'wc1',
+    body: 'Way cover has started to drag.',
+    maintenance_kind: 'noticed',
+    resolves_note_id: null,
+    created_at: '2026-07-01T12:00:00Z',
+    author_name: 'Kurtis Vandenberg',
+    author_id: 'acc-1',
+    viewer_count: 0,
+    media: [],
+    reactions: [],
+    ...over,
+  };
+}
+
+describe('MachineOpenItems', () => {
+  it('shows the observation and the date', () => {
+    render(<MachineOpenItems items={[item({ id: 'a' })]} />);
+
+    expect(screen.getByText('Way cover has started to drag.')).toBeInTheDocument();
+    expect(screen.getByText(/Jul 1/)).toBeInTheDocument();
+  });
+
+  // THE test in this file. A list of open items with names down the side is a
+  // list of who reports the most problems, read straight down the column — the
+  // shape of every operator scorecard this product refuses to build. The name is
+  // one tap away on the entry's own card, where it reads as attribution.
+  //
+  // If someone ever "improves" this list by adding the author, this fails, and
+  // the comment above is the argument for leaving it failing.
+  it('never names who filed it', () => {
+    render(<MachineOpenItems items={[item({ id: 'a' }), item({ id: 'b', author_name: 'Dana' })]} />);
+
+    expect(screen.queryByText(/Kurtis/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Dana/)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing at all when there is nothing outstanding', () => {
+    // Not an empty state. A machine with nothing open should look like a machine
+    // with nothing open, not like a section waiting to be filled.
+    const { container } = render(<MachineOpenItems items={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('offers the fix and hands back the item it belongs to', async () => {
+    const onLogFix = vi.fn();
+    const open = item({ id: 'a' });
+    render(<MachineOpenItems items={[open]} onLogFix={onLogFix} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /log the fix/i }));
+    expect(onLogFix).toHaveBeenCalledWith(open);
+  });
+
+  it('offers no action when the log is being read rather than worked', () => {
+    render(<MachineOpenItems items={[item({ id: 'a' })]} />);
+    expect(screen.queryByRole('button', { name: /log the fix/i })).not.toBeInTheDocument();
+  });
+
+  it('shows no priority, no due date and nobody it is assigned to', () => {
+    // Each of those needs a second person to mean anything, and at this shop the
+    // person who notices, decides and fixes is the same person.
+    render(<MachineOpenItems items={[item({ id: 'a' })]} onLogFix={vi.fn()} />);
+
+    expect(screen.queryByText(/priority|due|assigned/i)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/utils/machineMaintenanceAccess.test.ts
+++ b/__tests__/utils/machineMaintenanceAccess.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Chainable Supabase mock (same shape as jobNoteMediaAccess.test.ts) ---
+const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
+  const builder: Record<string, ReturnType<typeof vi.fn> | unknown> = {};
+  const chainMethods = ['from', 'select', 'insert', 'eq', 'is', 'order', 'single', 'maybeSingle'];
+  chainMethods.forEach((m) => {
+    builder[m] = vi.fn().mockImplementation(() => builder);
+  });
+  builder.data = null;
+  builder.error = null;
+  return {
+    mockQueryBuilder: builder,
+    mockSupabase: { from: vi.fn().mockImplementation(() => builder) },
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+
+vi.mock('@/lib/supabaseErrors', () => ({
+  friendlyErrorMessage: (_err: unknown, opts?: { fallback?: string }) => opts?.fallback ?? 'error',
+}));
+
+const { mockAddNoteMedia } = vi.hoisted(() => ({ mockAddNoteMedia: vi.fn() }));
+vi.mock('@/utils/jobNoteMediaAccess', () => ({
+  addNoteMedia: (...a: unknown[]) => mockAddNoteMedia(...a),
+}));
+
+import {
+  addMachineNote,
+  addMachineNoteMedia,
+  deriveOpenItems,
+  getMachineLog,
+} from '@/utils/machineMaintenanceAccess';
+import type { MachineNote } from '@/types/machineMaintenance';
+
+function note(over: Partial<MachineNote> & { id: string }): MachineNote {
+  return {
+    work_center_id: 'wc1',
+    body: 'something',
+    maintenance_kind: null,
+    resolves_note_id: null,
+    created_at: '2026-07-01T00:00:00Z',
+    author_name: 'Kurtis',
+    author_id: 'acc-1',
+    viewer_count: 0,
+    media: [],
+    reactions: [],
+    ...over,
+  };
+}
+
+function row(over: Record<string, unknown> = {}) {
+  return {
+    id: 'n1',
+    work_center_id: 'wc1',
+    body: 'Way cover drags.',
+    maintenance_kind: 'noticed',
+    resolves_note_id: null,
+    created_at: '2026-07-01T00:00:00Z',
+    viewer_count: 3,
+    author_id: 'acc-1',
+    author: { name: 'Kurtis' },
+    reactions: [],
+    media: [],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockQueryBuilder.data = null;
+  mockQueryBuilder.error = null;
+});
+
+// The module stores no "open" flag. This is the whole of the logic that replaces
+// one, so it carries the weight the schema deliberately does not.
+describe('deriveOpenItems', () => {
+  it('treats a noticed entry with nothing resolving it as open', () => {
+    const entries = [note({ id: 'a', maintenance_kind: 'noticed' })];
+    expect(deriveOpenItems(entries).map((e) => e.id)).toEqual(['a']);
+  });
+
+  it('closes it as soon as an entry in the same array resolves it', () => {
+    const entries = [
+      note({ id: 'fix', maintenance_kind: 'repaired', resolves_note_id: 'a' }),
+      note({ id: 'a', maintenance_kind: 'noticed' }),
+    ];
+    expect(deriveOpenItems(entries)).toEqual([]);
+  });
+
+  it('re-opens it when the fix is removed — nothing was stored to go stale', () => {
+    const withFix = [
+      note({ id: 'fix', resolves_note_id: 'a' }),
+      note({ id: 'a', maintenance_kind: 'noticed' }),
+    ];
+    expect(deriveOpenItems(withFix)).toEqual([]);
+    expect(deriveOpenItems(withFix.filter((e) => e.id !== 'fix')).map((e) => e.id)).toEqual(['a']);
+  });
+
+  it('never opens an entry that was not a noticed one', () => {
+    // Only an observation can be outstanding. "Cleaned the chip conveyor"
+    // describes something already done and has nothing to close.
+    const entries = [
+      note({ id: 'a', maintenance_kind: 'cleaned' }),
+      note({ id: 'b', maintenance_kind: null }),
+      note({ id: 'c', maintenance_kind: 'repaired' }),
+    ];
+    expect(deriveOpenItems(entries)).toEqual([]);
+  });
+
+  it('resolves each observation independently', () => {
+    const entries = [
+      note({ id: 'fix-b', resolves_note_id: 'b' }),
+      note({ id: 'a', maintenance_kind: 'noticed' }),
+      note({ id: 'b', maintenance_kind: 'noticed' }),
+    ];
+    expect(deriveOpenItems(entries).map((e) => e.id)).toEqual(['a']);
+  });
+});
+
+describe('getMachineLog', () => {
+  it('scopes to the company and the machine, newest first', async () => {
+    mockQueryBuilder.data = [row()];
+    await getMachineLog('wc1', 'c1');
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('notes');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'c1');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('work_center_id', 'wc1');
+    expect(mockQueryBuilder.order).toHaveBeenCalledWith('created_at', { ascending: false });
+  });
+
+  it('never asks for usage_count', async () => {
+    // It counts distinct JOBS a note was consulted on, and a machine read has no
+    // job, so it is permanently zero here and must never be displayed (§8). Not
+    // fetching it is stronger than remembering not to render it.
+    mockQueryBuilder.data = [row()];
+    await getMachineLog('wc1', 'c1');
+
+    const selectArg = (mockQueryBuilder.select as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(selectArg).not.toContain('usage_count');
+    expect(selectArg).toContain('viewer_count');
+  });
+
+  it('returns the open items drawn from the very same array as the timeline', async () => {
+    mockQueryBuilder.data = [
+      row({ id: 'fix', maintenance_kind: 'repaired', resolves_note_id: 'obs' }),
+      row({ id: 'obs', maintenance_kind: 'noticed' }),
+      row({ id: 'other', maintenance_kind: 'noticed', resolves_note_id: null }),
+    ];
+
+    const log = await getMachineLog('wc1', 'c1');
+
+    expect(log.entries.map((e) => e.id)).toEqual(['fix', 'obs', 'other']);
+    expect(log.open.map((e) => e.id)).toEqual(['other']);
+    // Identity, not a copy: they cannot drift because they are the same objects.
+    expect(log.entries).toContain(log.open[0]);
+  });
+
+  it('drops a maintenance_kind it does not recognise rather than trusting it', async () => {
+    mockQueryBuilder.data = [row({ maintenance_kind: 'lubricated' })];
+    const log = await getMachineLog('wc1', 'c1');
+    expect(log.entries[0].maintenance_kind).toBeNull();
+  });
+
+  it('surfaces a query failure instead of showing an empty machine', async () => {
+    mockQueryBuilder.error = { message: 'boom' };
+    await expect(getMachineLog('wc1', 'c1')).rejects.toThrow('boom');
+  });
+});
+
+describe('addMachineNote', () => {
+  it('writes a work-center-subject row and no other subject', async () => {
+    mockQueryBuilder.data = row();
+    await addMachineNote('wc1', 'c1', 'acc-1', 'Topped up the way lube.');
+
+    expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        company_id: 'c1',
+        subject_kind: 'work_center',
+        work_center_id: 'wc1',
+        author_id: 'acc-1',
+        body: 'Topped up the way lube.',
+        note_type: 'user',
+      }),
+    );
+    const written = (mockQueryBuilder.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(written).not.toHaveProperty('job_id');
+    expect(written).not.toHaveProperty('part_id');
+  });
+
+  it('leaves the kind null when the operator did not choose one', async () => {
+    mockQueryBuilder.data = row();
+    await addMachineNote('wc1', 'c1', 'acc-1', 'x');
+    expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ maintenance_kind: null, resolves_note_id: null }),
+    );
+  });
+
+  it('carries the kind and the resolution link when they are given', async () => {
+    mockQueryBuilder.data = row();
+    await addMachineNote('wc1', 'c1', 'acc-1', 'Replaced the wiper.', {
+      maintenanceKind: 'repaired',
+      resolvesNoteId: 'obs-1',
+    });
+    expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ maintenance_kind: 'repaired', resolves_note_id: 'obs-1' }),
+    );
+  });
+
+  it('writes null rather than whitespace for a photo-only entry', async () => {
+    mockQueryBuilder.data = row({ body: null });
+    await addMachineNote('wc1', 'c1', 'acc-1', '   ');
+    expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ body: null }),
+    );
+  });
+
+  it('surfaces a friendly message when the write is refused', async () => {
+    mockQueryBuilder.error = { code: '42501', message: 'permission denied' };
+    await expect(addMachineNote('wc1', 'c1', 'acc-1', 'x')).rejects.toThrow('Could not save that.');
+  });
+});
+
+describe('addMachineNoteMedia', () => {
+  it('files the photo under the machine, since a machine entry has no job', async () => {
+    await addMachineNoteMedia('c1', 'wc1', 'n1', new File(['x'], 'p.jpg'), {
+      dims: { width: 100, height: 80 },
+    });
+
+    expect(mockAddNoteMedia).toHaveBeenCalledWith('c1', 'n1', expect.any(File), {
+      folder: { entityType: 'work-centers', entityId: 'wc1' },
+      dims: { width: 100, height: 80 },
+    });
+  });
+});

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
@@ -44,7 +44,7 @@ import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import StationSelector from '@/components/operator/StationSelector';
 import JobFeed from '@/components/operator/JobFeed';
 import NoteCaptureFields from '@/components/operator/NoteCaptureFields';
-import { useNoteCapture } from '@/hooks/useNoteCapture';
+import { useNoteCapture, useStepNoteWriter } from '@/hooks/useNoteCapture';
 import PartReferenceRow from '@/components/operator/PartReferenceRow';
 
 /**
@@ -182,11 +182,20 @@ export default function OperatorOperationActionPage() {
   // impossible to add the photo afterwards, and an outside step could never
   // carry "sent to coater, back on the 16th".
   const ownsCapture = !isCompleted && !isExternal;
-  const capture = useNoteCapture({
+  const stepContext = useMemo(
+    () => ({ jobPartId, jobOperationId }),
+    [jobPartId, jobOperationId],
+  );
+  const writer = useStepNoteWriter({
     companyId,
     jobId,
     operatorId: currentOperatorId,
-    context: { jobPartId, jobOperationId },
+    context: stepContext,
+  });
+  const capture = useNoteCapture({
+    companyId,
+    operatorId: currentOperatorId,
+    writer,
     enabled: ownsCapture,
   });
 

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -17,6 +17,7 @@ import ListItemText from '@mui/material/ListItemText';
 import WorkIcon from '@mui/icons-material/Work';
 import PersonIcon from '@mui/icons-material/Person';
 import WarehouseOutlinedIcon from '@mui/icons-material/WarehouseOutlined';
+import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
 import StickyNote2OutlinedIcon from '@mui/icons-material/StickyNote2Outlined';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
@@ -118,6 +119,7 @@ export default function OperatorLayout({
   useEffect(() => {
     if (pathname?.includes('/profile')) setNavValue('profile');
     else if (pathname?.includes('/inventory')) setNavValue('inventory');
+    else if (pathname?.includes('/maintenance')) setNavValue('maintenance');
     else if (pathname?.includes('/my-work')) setNavValue('my-work');
     else setNavValue('jobs');
   }, [pathname]);
@@ -125,6 +127,7 @@ export default function OperatorLayout({
   const handleNavChange = (_event: React.SyntheticEvent, newValue: string) => {
     setNavValue(newValue);
     if (newValue === 'inventory') router.push(`/operator/${companyId}/inventory`);
+    else if (newValue === 'maintenance') router.push(`/operator/${companyId}/maintenance`);
     else if (newValue === 'my-work') router.push(`/operator/${companyId}/my-work`);
     else if (newValue === 'profile') router.push(`/operator/${companyId}/profile`);
     else router.push(`/operator/${companyId}/jobs`);
@@ -204,6 +207,10 @@ function OperatorShell({
   const pathname = usePathname();
   const router = useRouter();
   const showInventory = Boolean(features.inventory_locations);
+  // A machine IS a station, so the logbook only exists once one is selected —
+  // deliberately NOT added to the navVisible escape list below, unlike inventory
+  // and my-work. Without a station there is no machine to have a tab for.
+  const showMaintenance = Boolean(features.machine_maintenance) && Boolean(stationId);
   // The warehouse is station-independent, so keep the nav (and a way out) on
   // inventory routes even before a station is picked.
   const isInventoryRoute = pathname?.includes('/inventory') ?? false;
@@ -399,6 +406,14 @@ function OperatorShell({
                 label="Inventory"
                 value="inventory"
                 icon={<WarehouseOutlinedIcon />}
+                sx={{ minHeight: 56 }}
+              />
+            )}
+            {showMaintenance && (
+              <BottomNavigationAction
+                label="Maintenance"
+                value="maintenance"
+                icon={<BuildOutlinedIcon />}
                 sx={{ minHeight: 56 }}
               />
             )}

--- a/app/operator/[companyId]/maintenance/page.tsx
+++ b/app/operator/[companyId]/maintenance/page.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
+import { useStationContext } from '@/components/operator/OperatorStationContext';
+import StationSelector from '@/components/operator/StationSelector';
+import MachineLogPanel from '@/components/maintenance/MachineLogPanel';
+
+/**
+ * The Maintenance tab: the logbook for the machine the operator is standing at.
+ *
+ * THERE IS NO MACHINE PICKER, and that is the design rather than a shortcut. A
+ * station IS a machine — the station list is work_centers filtered to
+ * kind='internal' — so selecting a station has already answered the only question
+ * a picker would ask. Asking again would be ceremony.
+ *
+ * There is nothing to scan on the machine either. A shop this size has few
+ * machines and the operator has already told the app which one they are at, so a
+ * code posted on the machine would solve a navigation problem this product does
+ * not have.
+ *
+ * The consequence, accepted knowingly: an operator who notices something about a
+ * machine that is not their selected station changes station first, with the
+ * selector that already exists. At this machine count that is fine. If it turns
+ * out not to be, the answer is revisiting THIS question — not reviving a code on
+ * the machine.
+ */
+export default function OperatorMaintenancePage() {
+  const params = useParams();
+  const router = useRouter();
+  const companyId = params.companyId as string;
+
+  const { features, loading: flagsLoading } = useCompanyFeatures();
+  const { stationId, stationName, initializing } = useStationContext();
+  const enabled = features.machine_maintenance;
+
+  // Bounce a company that hasn't opted in, matching the inventory-locations
+  // precedent. The tab is already hidden for them; this covers a stale link.
+  useEffect(() => {
+    if (!flagsLoading && !enabled) router.replace(`/operator/${companyId}/jobs`);
+  }, [flagsLoading, enabled, router, companyId]);
+
+  if (flagsLoading || !enabled || initializing) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  // Reachable without a station only by deep link — the tab itself is
+  // station-gated. The picker is the way forward, not an error.
+  if (!stationId) return <StationSelector />;
+
+  return (
+    <MachineLogPanel
+      workCenterId={stationId}
+      companyId={companyId}
+      machineName={stationName}
+    />
+  );
+}

--- a/components/maintenance/MachineComposer.tsx
+++ b/components/maintenance/MachineComposer.tsx
@@ -6,10 +6,8 @@ import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import ToggleButton from '@mui/material/ToggleButton';
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import Typography from '@mui/material/Typography';
+import ReportProblemOutlinedIcon from '@mui/icons-material/ReportProblemOutlined';
 import NoteCaptureFields from '@/components/operator/NoteCaptureFields';
-import { MAINTENANCE_KINDS } from '@/types/machineMaintenance';
 import type { MaintenanceKind, MachineNote } from '@/types/machineMaintenance';
 import type { NoteCapture } from '@/hooks/useNoteCapture';
 
@@ -20,14 +18,25 @@ const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' 
  *
  * The text field, the photo picker, the dictation hint and the whole iOS
  * unreadable-file mitigation come from NoteCaptureFields — the same component
- * the step composer renders, not a copy of it. Only the kind chip is new here,
- * and it lives in this component rather than in NoteCaptureFields precisely
- * because a maintenance verb means nothing on a step note.
+ * the step composer renders, not a copy of it. Only the one toggle is new here,
+ * and it lives in this component rather than in NoteCaptureFields because
+ * "is this outstanding?" means nothing on a step note.
  *
- * THE CHIP IS OPTIONAL AND DESELECTABLE. Tapping the selected value clears it.
- * Somebody who cannot decide whether they cleaned or adjusted a thing must be
- * able to write the sentence anyway — a forced taxonomy at capture time is the
- * thing that stops capture, and an unclassified entry is still knowledge.
+ * ONE TOGGLE, NOT A TAXONOMY. An earlier draft offered five verbs (cleaned,
+ * repaired, replaced, adjusted, noticed). Four of them had no reader anywhere in
+ * the product — nothing filtered, grouped, ranked or counted by them, and §4.2
+ * forbids grouping the timeline by kind — so they were five choices presented to
+ * somebody in a container whose entire risk is that nobody writes in it. They
+ * also did not match the TPM frame §3 cites (cleaning, inspection, lubrication,
+ * retightening), which is a sign they were invented rather than observed.
+ *
+ * What survives is the one value the system acts on. Flagging pins the entry to
+ * the top of this machine until somebody logs a fix; it notifies nobody, and the
+ * label says the condition rather than promising a response.
+ *
+ * DESELECTABLE, and off by default. Most entries are records of work already
+ * done, and a person who is unsure must be able to write the sentence anyway —
+ * a forced classification at capture time is the thing that stops capture.
  */
 export default function MachineComposer({
   capture,
@@ -78,24 +87,16 @@ export default function MachineComposer({
         />
 
         <Box sx={{ mt: 1.5 }}>
-          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
-            Optional
-          </Typography>
-          <ToggleButtonGroup
-            value={kind}
-            exclusive
-            // MUI hands back null when the selected button is tapped again, which
-            // is exactly the clearing gesture we want — pass it straight through.
-            onChange={(_e, next: MaintenanceKind | null) => onKindChange(next)}
+          <ToggleButton
+            value="noticed"
+            selected={kind === 'noticed'}
+            onChange={() => onKindChange(kind === 'noticed' ? null : 'noticed')}
             size="small"
-            sx={{ flexWrap: 'wrap' }}
+            sx={{ minHeight: 44, textTransform: 'none' }}
           >
-            {MAINTENANCE_KINDS.map((k) => (
-              <ToggleButton key={k} value={k} sx={{ minHeight: 40, textTransform: 'none' }}>
-                {k}
-              </ToggleButton>
-            ))}
-          </ToggleButtonGroup>
+            <ReportProblemOutlinedIcon fontSize="small" sx={{ mr: 0.75 }} />
+            Needs attention
+          </ToggleButton>
         </Box>
 
         <Box sx={{ mt: 1.5 }}>

--- a/components/maintenance/MachineComposer.tsx
+++ b/components/maintenance/MachineComposer.tsx
@@ -5,8 +5,8 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import Chip from '@mui/material/Chip';
-import ReportProblemOutlinedIcon from '@mui/icons-material/ReportProblemOutlined';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import NoteCaptureFields from '@/components/operator/NoteCaptureFields';
 import type { MaintenanceKind, MachineNote } from '@/types/machineMaintenance';
 import type { NoteCapture } from '@/hooks/useNoteCapture';
@@ -18,11 +18,11 @@ const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' 
  *
  * The text field, the photo picker, the dictation hint and the whole iOS
  * unreadable-file mitigation come from NoteCaptureFields — the same component
- * the step composer renders, not a copy of it. Only the one toggle is new here,
+ * the step composer renders, not a copy of it. Only the flag is new here,
  * and it lives in this component rather than in NoteCaptureFields because
  * "is this outstanding?" means nothing on a step note.
  *
- * ONE TOGGLE, NOT A TAXONOMY. An earlier draft offered five verbs (cleaned,
+ * ONE FLAG, NOT A TAXONOMY. An earlier draft offered five verbs (cleaned,
  * repaired, replaced, adjusted, noticed). Four of them had no reader anywhere in
  * the product — nothing filtered, grouped, ranked or counted by them, and §4.2
  * forbids grouping the timeline by kind — so they were five choices presented to
@@ -93,18 +93,40 @@ export default function MachineComposer({
           compact
         />
 
-        {/* One row: the flag and the commit. Two stacked full-width controls
-            cost three lines of a phone screen to say very little. */}
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1.5 }}>
-          <Chip
-            icon={<ReportProblemOutlinedIcon />}
+        {/* A CHECKBOX, matching "Show completed" on the operator jobs list — the
+            one binary control operators already meet, down to the high-contrast
+            styling that reads on this dark background.
+
+            Not a Chip, which is what this was: everywhere else in the app a Chip
+            is a READ-ONLY LABEL (the flag on an entry card, "Internal" on a work
+            center, job statuses), so a tappable stateful one fights a meaning
+            people have already learned and reads as a label that wandered next to
+            a button. Not a Switch either: a switch says "applies now", and
+            nothing here happens until Add to log. A checkbox is exactly the
+            deferred, optional attribute of a form being filled in.
+
+            The label carries the colour when checked; the box alone is a small
+            state change to notice across a shop. */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={kind === 'noticed'}
+                onChange={(e) => onKindChange(e.target.checked ? 'noticed' : null)}
+                sx={{
+                  color: 'rgba(255,255,255,0.6)',
+                  '&.Mui-checked': { color: 'warning.light' },
+                }}
+              />
+            }
             label="Needs attention"
-            onClick={() => onKindChange(kind === 'noticed' ? null : 'noticed')}
-            color={kind === 'noticed' ? 'warning' : 'default'}
-            variant={kind === 'noticed' ? 'filled' : 'outlined'}
-            // 48, not the Chip default: this is a tap target on a shop floor,
-            // often with gloves on, and it sits next to a 48px button.
-            sx={{ height: 48, borderRadius: 3, px: 0.5 }}
+            sx={{
+              mr: 0,
+              minHeight: 48,
+              '& .MuiFormControlLabel-label': {
+                color: kind === 'noticed' ? 'warning.light' : 'text.secondary',
+              },
+            }}
           />
           <Box sx={{ flex: 1 }} />
           <Button

--- a/components/maintenance/MachineComposer.tsx
+++ b/components/maintenance/MachineComposer.tsx
@@ -11,7 +11,21 @@ import NoteCaptureFields from '@/components/operator/NoteCaptureFields';
 import type { MaintenanceKind, MachineNote } from '@/types/machineMaintenance';
 import type { NoteCapture } from '@/hooks/useNoteCapture';
 
-const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
+/**
+ * The composer is the one card on this screen you can act on — every other one
+ * is a record you can only read — and it looked identical to them.
+ *
+ * Differentiated by EDGE, not by fill. The theme is explicit that cards are deep
+ * translucent panels and that "a pale surface goes washed-out/muddy" on the lit
+ * canvas, so lightening this one would fight the design language. A steel-blue
+ * hairline — the app's primary/interactive colour — marks it as the place you
+ * do something, while it stays the same substantial panel as its neighbours.
+ */
+const composerSx = {
+  bgcolor: 'rgba(26, 31, 74, 0.55)',
+  backdropFilter: 'blur(8px)',
+  border: '1px solid rgba(70, 130, 180, 0.55)',
+};
 
 /**
  * Write something down about the machine you are standing at.
@@ -63,7 +77,7 @@ export default function MachineComposer({
   };
 
   return (
-    <Card elevation={2} sx={{ ...cardSx, mb: 2 }}>
+    <Card elevation={2} sx={{ ...composerSx, mb: 2 }}>
       <CardContent sx={{ py: 1.5 }}>
         {resolving && (
           <Alert
@@ -133,7 +147,19 @@ export default function MachineComposer({
             variant="contained"
             onClick={submit}
             disabled={!capture.hasContent || capture.saving}
-            sx={{ minHeight: 48 }}
+            // MUI's default disabled contained button is near-invisible on this
+            // dark panel — it reads as broken rather than as waiting for you to
+            // type, and "readable in bright environments" is a design principle
+            // here, not a nicety. Tinted with the primary and given legible
+            // label contrast, it stays obviously inactive while still looking
+            // like the button it is about to become.
+            sx={{
+              minHeight: 48,
+              '&.Mui-disabled': {
+                bgcolor: 'rgba(70, 130, 180, 0.22)',
+                color: 'rgba(255, 255, 255, 0.55)',
+              },
+            }}
           >
             {capture.saving ? 'Saving…' : 'Add to log'}
           </Button>

--- a/components/maintenance/MachineComposer.tsx
+++ b/components/maintenance/MachineComposer.tsx
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import ToggleButton from '@mui/material/ToggleButton';
+import Chip from '@mui/material/Chip';
 import ReportProblemOutlinedIcon from '@mui/icons-material/ReportProblemOutlined';
 import NoteCaptureFields from '@/components/operator/NoteCaptureFields';
 import type { MaintenanceKind, MachineNote } from '@/types/machineMaintenance';
@@ -81,25 +81,32 @@ export default function MachineComposer({
           </Alert>
         )}
 
+        {/* `compact`: the field grows as it fills and the camera is an adjacent
+            icon, which is the shape the step composer already uses. The full
+            layout's outlined "Add photo" button was the widest thing on the
+            screen and sat above the fold on a phone, pushing the log itself
+            down — for a secondary action on a surface people are meant to
+            SCROLL, that is the wrong thing to be biggest. */}
         <NoteCaptureFields
           capture={capture}
           placeholder="What did you do, or what did you notice?"
+          compact
         />
 
-        <Box sx={{ mt: 1.5 }}>
-          <ToggleButton
-            value="noticed"
-            selected={kind === 'noticed'}
-            onChange={() => onKindChange(kind === 'noticed' ? null : 'noticed')}
-            size="small"
-            sx={{ minHeight: 44, textTransform: 'none' }}
-          >
-            <ReportProblemOutlinedIcon fontSize="small" sx={{ mr: 0.75 }} />
-            Needs attention
-          </ToggleButton>
-        </Box>
-
-        <Box sx={{ mt: 1.5 }}>
+        {/* One row: the flag and the commit. Two stacked full-width controls
+            cost three lines of a phone screen to say very little. */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1.5 }}>
+          <Chip
+            icon={<ReportProblemOutlinedIcon />}
+            label="Needs attention"
+            onClick={() => onKindChange(kind === 'noticed' ? null : 'noticed')}
+            color={kind === 'noticed' ? 'warning' : 'default'}
+            variant={kind === 'noticed' ? 'filled' : 'outlined'}
+            // 48, not the Chip default: this is a tap target on a shop floor,
+            // often with gloves on, and it sits next to a 48px button.
+            sx={{ height: 48, borderRadius: 3, px: 0.5 }}
+          />
+          <Box sx={{ flex: 1 }} />
           <Button
             variant="contained"
             onClick={submit}

--- a/components/maintenance/MachineComposer.tsx
+++ b/components/maintenance/MachineComposer.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Typography from '@mui/material/Typography';
+import NoteCaptureFields from '@/components/operator/NoteCaptureFields';
+import { MAINTENANCE_KINDS } from '@/types/machineMaintenance';
+import type { MaintenanceKind, MachineNote } from '@/types/machineMaintenance';
+import type { NoteCapture } from '@/hooks/useNoteCapture';
+
+const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
+
+/**
+ * Write something down about the machine you are standing at.
+ *
+ * The text field, the photo picker, the dictation hint and the whole iOS
+ * unreadable-file mitigation come from NoteCaptureFields — the same component
+ * the step composer renders, not a copy of it. Only the kind chip is new here,
+ * and it lives in this component rather than in NoteCaptureFields precisely
+ * because a maintenance verb means nothing on a step note.
+ *
+ * THE CHIP IS OPTIONAL AND DESELECTABLE. Tapping the selected value clears it.
+ * Somebody who cannot decide whether they cleaned or adjusted a thing must be
+ * able to write the sentence anyway — a forced taxonomy at capture time is the
+ * thing that stops capture, and an unclassified entry is still knowledge.
+ */
+export default function MachineComposer({
+  capture,
+  kind,
+  onKindChange,
+  resolving,
+  onCancelResolving,
+}: {
+  capture: NoteCapture<MachineNote>;
+  kind: MaintenanceKind | null;
+  onKindChange: (next: MaintenanceKind | null) => void;
+  /** The open item this entry will resolve, when "Log the fix" started it. */
+  resolving?: MachineNote | null;
+  onCancelResolving?: () => void;
+}) {
+  const submit = async () => {
+    try {
+      await capture.submit();
+    } catch {
+      // useNoteCapture already put the message in the fields, next to the text
+      // the operator is about to lose. A second surface for it would only make
+      // the failure louder, not clearer.
+    }
+  };
+
+  return (
+    <Card elevation={2} sx={{ ...cardSx, mb: 2 }}>
+      <CardContent sx={{ py: 1.5 }}>
+        {resolving && (
+          <Alert
+            severity="info"
+            sx={{ mb: 1.5 }}
+            action={
+              onCancelResolving && (
+                <Button color="inherit" size="small" onClick={onCancelResolving}>
+                  Cancel
+                </Button>
+              )
+            }
+          >
+            Logging the fix for: {resolving.body ?? 'that item'}
+          </Alert>
+        )}
+
+        <NoteCaptureFields
+          capture={capture}
+          placeholder="What did you do, or what did you notice?"
+        />
+
+        <Box sx={{ mt: 1.5 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
+            Optional
+          </Typography>
+          <ToggleButtonGroup
+            value={kind}
+            exclusive
+            // MUI hands back null when the selected button is tapped again, which
+            // is exactly the clearing gesture we want — pass it straight through.
+            onChange={(_e, next: MaintenanceKind | null) => onKindChange(next)}
+            size="small"
+            sx={{ flexWrap: 'wrap' }}
+          >
+            {MAINTENANCE_KINDS.map((k) => (
+              <ToggleButton key={k} value={k} sx={{ minHeight: 40, textTransform: 'none' }}>
+                {k}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </Box>
+
+        <Box sx={{ mt: 1.5 }}>
+          <Button
+            variant="contained"
+            onClick={submit}
+            disabled={!capture.hasContent || capture.saving}
+            sx={{ minHeight: 48 }}
+          >
+            {capture.saving ? 'Saving…' : 'Add to log'}
+          </Button>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/maintenance/MachineDetailsCard.tsx
+++ b/components/maintenance/MachineDetailsCard.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import type { MachineDetails } from '@/types/machineMaintenance';
+
+/**
+ * Make, model, serial, year, purchase date — when somebody has bothered to type
+ * them in.
+ *
+ * WHEN THEY ARE ALL EMPTY THIS RENDERS NOTHING AT ALL. Not an empty state, not
+ * an "add machine details" prompt, not a progress meter, not a hint. Asset data
+ * entry is a leading cause of CMMS abandonment: the tool arrives, the shop is
+ * asked to describe its equipment before it can do anything, and the project
+ * dies in the describing. The enforceable form of §4.5 is that no surface may
+ * render one machine as less ready than another because somebody typed a serial
+ * number into it — which means a machine with nothing filled in has to look
+ * finished, because it IS finished.
+ *
+ * Read-only on the floor. Editing lives on the work-center page in the office,
+ * where somebody with a spec sheet in front of them is doing paperwork on
+ * purpose.
+ */
+
+const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
+
+function formatDate(value: string | null): string | null {
+  if (!value) return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short' });
+}
+
+export default function MachineDetailsCard({ details }: { details: MachineDetails | null }) {
+  if (!details) return null;
+
+  const rows: Array<[string, string]> = [];
+  if (details.make) rows.push(['Make', details.make]);
+  if (details.model) rows.push(['Model', details.model]);
+  if (details.serial_number) rows.push(['Serial', details.serial_number]);
+  if (details.year_built) rows.push(['Year', String(details.year_built)]);
+  const purchased = formatDate(details.purchased_on);
+  if (purchased) rows.push(['Purchased', purchased]);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <Card elevation={2} sx={{ ...cardSx, mb: 2 }}>
+      <CardContent sx={{ py: 1.5 }}>
+        {rows.map(([label, value]) => (
+          <Box key={label} sx={{ display: 'flex', gap: 2, py: 0.25 }}>
+            <Typography variant="body2" color="text.secondary" sx={{ minWidth: 84 }}>
+              {label}
+            </Typography>
+            <Typography variant="body2">{value}</Typography>
+          </Box>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/maintenance/MachineEntryCard.tsx
+++ b/components/maintenance/MachineEntryCard.tsx
@@ -71,10 +71,12 @@ export default function MachineEntryCard({
           <Typography variant="caption" color="text.secondary">
             {formatWhen(entry.created_at)}
           </Typography>
-          {entry.maintenance_kind && (
-            <Chip label={entry.maintenance_kind} size="small" variant="outlined" />
-          )}
-          {isOpen && <Chip label="Open" size="small" color="warning" />}
+          {/* The flag is shown as STATE, not as a label. Rendering the stored
+              value too would put "noticed" next to "Needs attention" on the same
+              row, saying one thing twice; and on a resolved entry the bare word
+              "noticed" would read as its category rather than as its history,
+              which "Fixed by …" below already tells better. */}
+          {isOpen && <Chip label="Needs attention" size="small" color="warning" />}
         </Box>
 
         {entry.body && (

--- a/components/maintenance/MachineEntryCard.tsx
+++ b/components/maintenance/MachineEntryCard.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Chip from '@mui/material/Chip';
+import Typography from '@mui/material/Typography';
+import NoteMediaGallery from '@/components/operator/NoteMediaGallery';
+import NoteReactions from '@/components/operator/NoteReactions';
+import type { MachineNote } from '@/types/machineMaintenance';
+
+/**
+ * One entry on a machine's timeline.
+ *
+ * WHAT IS NOT HERE, and must not arrive later:
+ *
+ *   usage_count — counts distinct JOBS a note was consulted on, and a machine
+ *     read carries no job, so it is permanently zero here. The access layer does
+ *     not even fetch it (§8), and "used on 0 jobs" beside real knowledge would
+ *     read as a verdict on the entry rather than a gap in the instrument.
+ *   any per-person total — reactions attach to an ENTRY. "Diego has 12 helpfuls"
+ *     is a leaderboard; "Priya logged 9 items" is a participation score. Both are
+ *     the operator-comparative metrics this product refuses to build.
+ */
+
+const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
+
+function formatWhen(value: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export default function MachineEntryCard({
+  entry,
+  companyId,
+  memberId,
+  isOpen,
+  resolvedBy,
+  onLogFix,
+  readOnly = false,
+}: {
+  entry: MachineNote;
+  companyId: string;
+  /** Current member's user_company_access id; null until resolved. */
+  memberId: string | null;
+  /** True for a 'noticed' entry nothing has resolved yet. */
+  isOpen?: boolean;
+  /** Author of the entry that resolved this one, when there is one. */
+  resolvedBy?: string | null;
+  /** Offered only on an open item. Absent in read-only (office) rendering. */
+  onLogFix?: () => void;
+  readOnly?: boolean;
+}) {
+  return (
+    <Card elevation={2} sx={cardSx}>
+      <CardContent sx={{ py: 1.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 0.5 }}>
+          {/* The author IS shown here. The open-items list is where the name is
+              withheld, because a list of open items with names down the side is
+              a list of who reports the most problems. On the entry's own card it
+              is attribution — the point of the whole system. */}
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            {entry.author_name ?? 'Someone'}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {formatWhen(entry.created_at)}
+          </Typography>
+          {entry.maintenance_kind && (
+            <Chip label={entry.maintenance_kind} size="small" variant="outlined" />
+          )}
+          {isOpen && <Chip label="Open" size="small" color="warning" />}
+        </Box>
+
+        {entry.body && (
+          <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', mb: entry.media.length ? 1 : 0 }}>
+            {entry.body}
+          </Typography>
+        )}
+
+        {entry.media.length > 0 && <NoteMediaGallery media={entry.media} />}
+
+        {resolvedBy && (
+          <Typography variant="caption" color="success.light" sx={{ display: 'block', mt: 0.5 }}>
+            Fixed by {resolvedBy}
+          </Typography>
+        )}
+
+        <NoteReactions
+          companyId={companyId}
+          noteId={entry.id}
+          authorId={entry.author_id}
+          reactions={entry.reactions}
+          memberId={memberId}
+          readOnly={readOnly}
+        />
+
+        {isOpen && onLogFix && !readOnly && (
+          <Box sx={{ mt: 1 }}>
+            <Typography
+              component="button"
+              onClick={onLogFix}
+              variant="button"
+              sx={{
+                background: 'none',
+                border: 'none',
+                color: 'primary.main',
+                cursor: 'pointer',
+                p: 0,
+                minHeight: 40,
+                textTransform: 'none',
+              }}
+            >
+              Log the fix
+            </Typography>
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/maintenance/MachineLogPanel.tsx
+++ b/components/maintenance/MachineLogPanel.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
+import { useLoad } from '@/hooks/useLoad';
+import { useNoteDwell } from '@/hooks/useNoteDwell';
+import { useNoteCapture } from '@/hooks/useNoteCapture';
+import type { NoteWriter } from '@/hooks/useNoteCapture';
+import { getCurrentMember } from '@/utils/operatorAccess';
+import {
+  addMachineNote,
+  addMachineNoteMedia,
+  getMachineDetails,
+  getMachineLog,
+} from '@/utils/machineMaintenanceAccess';
+import { logOperatorEvent } from '@/utils/operatorEventsAccess';
+import MachineComposer from '@/components/maintenance/MachineComposer';
+import MachineDetailsCard from '@/components/maintenance/MachineDetailsCard';
+import MachineEntryCard from '@/components/maintenance/MachineEntryCard';
+import MachineOpenItems from '@/components/maintenance/MachineOpenItems';
+import type { MachineNote, MaintenanceKind } from '@/types/machineMaintenance';
+
+/**
+ * One machine's logbook: open items pinned, then everything, newest first.
+ *
+ * NEWEST FIRST AND NOT GROUPED BY KIND. The reader's question on arriving at a
+ * machine is almost always "what has happened to this machine lately". Any
+ * grouping answers a question nobody asked and pushes the recent thing below the
+ * fold.
+ *
+ * Read logging attaches with a null job, which is correct and also the source of
+ * both limitations §8 records in advance: usage_count stays zero forever (and is
+ * never fetched, let alone shown), and the read log dedupes per person per entry
+ * with the absent job equal to itself — so somebody rereading the way-cover entry
+ * six months later is invisible. That reread is exactly the event a logbook would
+ * most want to see. viewer_count, distinct people, still works.
+ */
+export default function MachineLogPanel({
+  workCenterId,
+  companyId,
+  machineName,
+  readOnly = false,
+}: {
+  workCenterId: string;
+  companyId: string;
+  machineName?: string | null;
+  /** Office rendering: the log without a composer. */
+  readOnly?: boolean;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [memberId, setMemberId] = useState<string | null>(null);
+  const [kind, setKind] = useState<MaintenanceKind | null>(null);
+  const [resolving, setResolving] = useState<MachineNote | null>(null);
+
+  const {
+    data: log,
+    loading,
+    reload,
+  } = useLoad(() => getMachineLog(workCenterId, companyId), [workCenterId, companyId], {
+    onError: (err) => setError(err instanceof Error ? err.message : 'Could not load the log.'),
+  });
+
+  const { data: details } = useLoad(() => getMachineDetails(workCenterId), [workCenterId]);
+
+  // The precondition for reading any result at all: a container nobody filled
+  // and a container nobody reached both look like silence from outside, and this
+  // is what tells them apart.
+  useEffect(() => {
+    if (readOnly) return;
+    logOperatorEvent(companyId, 'machine_page_opened', { workCenterId });
+  }, [companyId, workCenterId, readOnly]);
+
+  useEffect(() => {
+    let active = true;
+    getCurrentMember(companyId).then((m) => {
+      if (active && m) setMemberId(m.id);
+    });
+    return () => {
+      active = false;
+    };
+  }, [companyId]);
+
+  // A machine read has no job, and passing one would be a lie — see the header.
+  const { observe } = useNoteDwell(companyId, null);
+
+  const writer: NoteWriter<MachineNote> | null = useMemo(() => {
+    if (readOnly || !memberId) return null;
+    return {
+      createNote: (body) =>
+        addMachineNote(workCenterId, companyId, memberId, body, {
+          maintenanceKind: kind,
+          resolvesNoteId: resolving?.id ?? null,
+        }),
+      attachMedia: (note, file, dims) =>
+        addMachineNoteMedia(companyId, workCenterId, note.id, file, { dims }),
+      withMedia: (note, media) => ({ ...note, media }),
+      eventContext: { workCenterId, maintenanceKind: kind },
+    };
+  }, [readOnly, memberId, workCenterId, companyId, kind, resolving]);
+
+  const capture = useNoteCapture<MachineNote>({
+    companyId,
+    operatorId: memberId,
+    writer,
+    enabled: !readOnly,
+  });
+
+  // Wrap submit so the surface can reset its own state and reload afterwards.
+  // The hook deliberately does not know what "saved" means to the caller.
+  const captureWithReset = useMemo(
+    () => ({
+      ...capture,
+      submit: async () => {
+        const saved = await capture.submit();
+        if (saved) {
+          if (resolving) {
+            // The loop closing, which is the behaviour the module is betting on:
+            // somebody fixed a thing somebody else flagged.
+            logOperatorEvent(companyId, 'noticed_resolved', { workCenterId });
+          }
+          setKind(null);
+          setResolving(null);
+          reload();
+        }
+        return saved;
+      },
+    }),
+    [capture, resolving, companyId, workCenterId, reload],
+  );
+
+  const startFix = useCallback((item: MachineNote) => {
+    setResolving(item);
+    // Kind stays unset. Pre-selecting "repaired" would be the taxonomy nudge the
+    // optional chip exists to avoid, and plenty of fixes are a clean or an
+    // adjustment.
+    setKind(null);
+    if (typeof window !== 'undefined') window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, []);
+
+  const openIds = useMemo(() => new Set((log?.open ?? []).map((o) => o.id)), [log]);
+  const resolverAuthorById = useMemo(() => {
+    const map = new Map<string, string | null>();
+    for (const e of log?.entries ?? []) {
+      if (e.resolves_note_id) map.set(e.resolves_note_id, e.author_name);
+    }
+    return map;
+  }, [log]);
+
+  if (loading && !log) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  const entries = log?.entries ?? [];
+
+  return (
+    <Box>
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+
+      {machineName && (
+        <Typography variant="h6" sx={{ mb: 1.5 }}>
+          {machineName}
+        </Typography>
+      )}
+
+      <MachineOpenItems items={log?.open ?? []} onLogFix={readOnly ? undefined : startFix} />
+
+      {!readOnly && (
+        <MachineComposer
+          capture={captureWithReset}
+          kind={kind}
+          onKindChange={setKind}
+          resolving={resolving}
+          onCancelResolving={() => setResolving(null)}
+        />
+      )}
+
+      {entries.length === 0 ? (
+        // A plain statement of fact. Not a nudge, not an illustration, not a
+        // "get started" — the machine simply has no history yet, and saying so
+        // is the honest version of an empty container.
+        <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+          Nothing logged for this machine yet.
+        </Typography>
+      ) : (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+          {entries.map((entry) => (
+            // observe() attaches to the BODY element, never the card or a count
+            // badge — a read means somebody actually dwelled on the words.
+            <Box key={entry.id} ref={observe(entry.id)}>
+              <MachineEntryCard
+                entry={entry}
+                companyId={companyId}
+                memberId={memberId}
+                isOpen={openIds.has(entry.id)}
+                resolvedBy={resolverAuthorById.get(entry.id) ?? null}
+                onLogFix={() => startFix(entry)}
+                readOnly={readOnly}
+              />
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      <MachineDetailsCard details={details ?? null} />
+    </Box>
+  );
+}

--- a/components/maintenance/MachineLogPanel.tsx
+++ b/components/maintenance/MachineLogPanel.tsx
@@ -167,11 +167,13 @@ export default function MachineLogPanel({
         </Alert>
       )}
 
-      {machineName && (
-        <Typography variant="h6" sx={{ mb: 1.5 }}>
-          {machineName}
-        </Typography>
-      )}
+      {/* No machine name here. On the operator surface the AppBar already shows
+          it — in orange, with the station switcher attached — so a heading
+          underneath said the same word twice and cost a row on a phone. The
+          office page passes no name at all, because the work-center page it sits
+          on is already titled. `machineName` survives only for the manuals sheet
+          below, which opens fullscreen over both and does need to say which
+          machine it belongs to. */}
 
       <MachineOpenItems items={log?.open ?? []} onLogFix={readOnly ? undefined : startFix} />
 

--- a/components/maintenance/MachineOpenItems.tsx
+++ b/components/maintenance/MachineOpenItems.tsx
@@ -47,8 +47,11 @@ export default function MachineOpenItems({
   return (
     <Card elevation={2} sx={{ ...cardSx, mb: 2 }} data-testid="machine-open-items">
       <CardContent sx={{ py: 1.5 }}>
+        {/* Same words as the toggle that puts things here and the chip on the
+            entry card. Three names for one state is three things to work out for
+            somebody who opens this screen once a fortnight. */}
         <Typography variant="overline" color="text.secondary">
-          Open
+          Needs attention
         </Typography>
         {items.map((item) => (
           <Box

--- a/components/maintenance/MachineOpenItems.tsx
+++ b/components/maintenance/MachineOpenItems.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import type { MachineNote } from '@/types/machineMaintenance';
+
+/**
+ * Things somebody noticed and nobody has fixed yet, pinned above the timeline.
+ *
+ * THE AUTHOR IS NOT SHOWN HERE, and that is a deliberate trade rather than an
+ * oversight. A list of open items with names down the side is a list of who
+ * reports the most problems, read straight down the column — the shape of every
+ * operator scorecard this product has refused to build. The name is one tap away
+ * on the entry's own card, where it reads as attribution instead of a tally.
+ *
+ * The cost is that this list carries less context than it could. The cost of the
+ * alternative is that filing a noticed becomes an admission.
+ *
+ * There is no assignment, no priority and no due date either. Each of those needs
+ * a second person to mean anything, and at a shop this size the person who
+ * notices, decides and fixes is the same person.
+ */
+
+const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
+
+function formatDay(value: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export default function MachineOpenItems({
+  items,
+  onLogFix,
+}: {
+  items: MachineNote[];
+  /** Absent in read-only (office) rendering, where there is nothing to act on. */
+  onLogFix?: (item: MachineNote) => void;
+}) {
+  // No empty state. A machine with nothing outstanding should look like a
+  // machine with nothing outstanding, not like a section waiting to be filled.
+  if (items.length === 0) return null;
+
+  return (
+    <Card elevation={2} sx={{ ...cardSx, mb: 2 }} data-testid="machine-open-items">
+      <CardContent sx={{ py: 1.5 }}>
+        <Typography variant="overline" color="text.secondary">
+          Open
+        </Typography>
+        {items.map((item) => (
+          <Box
+            key={item.id}
+            sx={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: 1,
+              py: 1,
+              borderTop: '1px solid rgba(255,255,255,0.06)',
+            }}
+          >
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography variant="body1">{item.body ?? 'Photo only'}</Typography>
+              <Typography variant="caption" color="text.secondary">
+                {formatDay(item.created_at)}
+              </Typography>
+            </Box>
+            {onLogFix && (
+              <Button
+                size="small"
+                variant="outlined"
+                onClick={() => onLogFix(item)}
+                sx={{ minHeight: 44, flexShrink: 0 }}
+              >
+                Log the fix
+              </Button>
+            )}
+          </Box>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/operator/JobFeed.tsx
+++ b/components/operator/JobFeed.tsx
@@ -20,7 +20,7 @@ import { getJobNotes, getCurrentMember } from '@/utils/operatorAccess';
 import NoteReactions from '@/components/operator/NoteReactions';
 import { getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
 import { useNoteDwell } from '@/hooks/useNoteDwell';
-import { useNoteCapture } from '@/hooks/useNoteCapture';
+import { useNoteCapture, useStepNoteWriter } from '@/hooks/useNoteCapture';
 import NoteCaptureFields from '@/components/operator/NoteCaptureFields';
 import type { JobNote, JobNoteMedia } from '@/types/operator';
 
@@ -113,13 +113,13 @@ export default function JobFeed({
   // standaloneCapture prop.
   const showComposer = !readOnly && !!operationContext && standaloneCapture;
 
-  const capture = useNoteCapture({
+  const writer = useStepNoteWriter({
     companyId,
     jobId,
     operatorId,
     context: operationContext ?? null,
-    enabled: showComposer,
   });
+  const capture = useNoteCapture({ companyId, operatorId, writer, enabled: showComposer });
 
   // Read tracking. The feed is where an operator encounters other people's notes
   // in the course of a job, so it is the surface the whole loop is measuring.

--- a/components/operator/NoteCaptureFields.tsx
+++ b/components/operator/NoteCaptureFields.tsx
@@ -9,12 +9,12 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import CloseIcon from '@mui/icons-material/Close';
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
-import type { NoteCapture } from '@/hooks/useNoteCapture';
+import type { NoteCaptureFieldsState } from '@/hooks/useNoteCapture';
 
 const THUMB = 76;
 
 /** Shared by both layouts. */
-function PendingThumbs({ capture }: { capture: NoteCapture }) {
+function PendingThumbs({ capture }: { capture: NoteCaptureFieldsState }) {
   return (
     <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
       {capture.pending.map((p) => (
@@ -112,7 +112,7 @@ export default function NoteCaptureFields({
   disabled = false,
   compact = false,
 }: {
-  capture: NoteCapture;
+  capture: NoteCaptureFieldsState;
   placeholder: string;
   disabled?: boolean;
   compact?: boolean;

--- a/components/operator/NoteMediaGallery.tsx
+++ b/components/operator/NoteMediaGallery.tsx
@@ -8,6 +8,7 @@ import DialogContent from '@mui/material/DialogContent';
 import IconButton from '@mui/material/IconButton';
 import CircularProgress from '@mui/material/CircularProgress';
 import CloseIcon from '@mui/icons-material/Close';
+import BrokenImageOutlinedIcon from '@mui/icons-material/BrokenImageOutlined';
 import { getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
 import type { JobNoteMedia } from '@/types/operator';
 
@@ -25,8 +26,8 @@ const THUMB = 72;
 export default function NoteMediaGallery({ media }: { media: JobNoteMedia[] }) {
   const [viewerUrl, setViewerUrl] = useState<string | null>(null);
 
-  // Batch-load this note's thumbnail URLs once (a failed one just stays blank).
-  const { data: urls } = useLoad(async () => {
+  // Batch-load this note's thumbnail URLs once.
+  const { data: urls, loading } = useLoad(async () => {
     const pairs = await Promise.all(
       media.map(async (m) => {
         try {
@@ -72,6 +73,13 @@ export default function NoteMediaGallery({ media }: { media: JobNoteMedia[] }) {
                 justifyContent: 'center',
               }}
             >
+              {/* A spinner means "still fetching". It must NOT be the resting
+                  state for a URL that failed: signing can fail for reasons the
+                  operator cannot do anything about (an expired session, a
+                  missing storage read policy on a preview build), and a thumbnail
+                  that spins forever reads as "the app is stuck" — so the photo
+                  gets attached again, and again. A broken-image mark says the
+                  photo is there and this device cannot show it, which is true. */}
               {url ? (
                 <Box
                   component="img"
@@ -79,8 +87,14 @@ export default function NoteMediaGallery({ media }: { media: JobNoteMedia[] }) {
                   alt="Past run photo"
                   sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
                 />
-              ) : (
+              ) : loading ? (
                 <CircularProgress size={16} />
+              ) : (
+                <BrokenImageOutlinedIcon
+                  fontSize="small"
+                  sx={{ color: 'text.disabled' }}
+                  titleAccess="Photo could not be loaded"
+                />
               )}
             </Box>
           );

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -15,6 +15,7 @@ Detailed specifications for each Jigged module.
 | [Routings](routings.md) | Job routing definitions | Should Have |
 | [Inventory](inventory.md) | Inventory tracking | Should Have |
 | [Operator View](operator-view.md) | Shop floor interface | Must Have |
+| [Machine Maintenance](machine-maintenance.md) | Operator-written logbook per machine, reached from the selected station. Flag-gated single-shop pilot with a kill criterion written in advance. | Built (unreleased) |
 | [Shipments](shipments.md) | Packing slips + fulfillment status | Built |
 | [Invitation System](invitation-system.md) | User invitations and referrals | Should Have |
 | [Data Import](data-import.md) | Guided onboarding import (Upload → Map → Review & Fix → Import); idempotent natural-identity upsert. See also the [Phase 2 design](data-import-phase2-design.md). | Built |

--- a/docs/modules/machine-maintenance.md
+++ b/docs/modules/machine-maintenance.md
@@ -9,10 +9,15 @@
 > arrives.
 >
 > This document was committed as a proposal and then amended where building it changed an answer.
-> Three sections carry a revision: [§6](#6-phases-and-gates) (the archived-machines defect was not
-> being fixed elsewhere, so it is fixed here), [§8](#8-measurement) (`confirmed` is cut — Phase 1
-> ships no freshness signal and says why), and [§9](#9-open-questions) (details and manuals ship;
-> the office gets a read-only view). Everything else is as proposed.
+> Four sections carry a revision: [§4.3](#43-capture) (the five-verb kind chip is cut to one
+> "Needs attention" toggle — four of the five had no reader and no research), [§6](#6-phases-and-gates)
+> (the archived-machines defect was not being fixed elsewhere, so it is fixed here),
+> [§8](#8-measurement) (`confirmed` is cut — Phase 1 ships no freshness signal and says why), and
+> [§9](#9-open-questions) (details and manuals ship; the office gets a read-only view). Everything
+> else is as proposed.
+>
+> Three of those four cut something the proposal asked for, each for the same reason: a control
+> whose answer changes nothing is a control that teaches operators this surface is decorative.
 
 **Dependencies:** [Work Centers](work-centers.md), because a machine is a `work_centers` row with
 `kind='internal'` and there is no separate machine entity. The notes system and its read-back loop
@@ -131,12 +136,38 @@ asked, and pushes the recent thing below the fold.
 
 Free text. Dictation is the phone keyboard's dictation key, which operators already use; no custom
 voice capture is built or proposed. Photos are optional and go through the native sheet, so an
-existing camera-roll photo works: the end-of-shift offset photo is already on the phone. A kind
-chip is offered with five values: cleaned, repaired, replaced, adjusted, noticed.
+existing camera-roll photo works: the end-of-shift offset photo is already on the phone. Alongside
+them, one optional toggle: **Needs attention**.
 
-**Decided:** kind is optional. An unclassified entry is still knowledge, and a forced taxonomy at
-capture time is the thing that stops capture. A person who cannot decide whether they cleaned or
-adjusted something will write nothing rather than choose wrongly.
+**Decided (revised at build time): one toggle, not a taxonomy.** This section originally offered a
+kind chip with five values — cleaned, repaired, replaced, adjusted, noticed — asserted in a single
+sentence with nothing behind it. Two things were wrong with that list.
+
+It did not match the frame this document itself argues from. [§3](#3-who-its-for) grounds the module
+in autonomous maintenance, "cleaning, inspection, lubrication and retightening"; only *cleaned*
+appears in both, and **lubrication is missing entirely** — the very thing
+[§1](#1-problem) builds the case on ("roughly seven in ten spindle shutdowns trace back to
+lubrication that was missed or not recorded"). A taxonomy that omits the category its own evidence
+rests on was invented rather than observed.
+
+And four of the five had no reader. Nothing in the product filtered, grouped, ranked or counted by
+kind — [§4.2](#42-the-timeline) forbids grouping the timeline by it — so they were four extra
+decisions asked of somebody in a container whose entire risk is that nobody writes in it at all.
+Only `noticed` ever did anything: it is what pins an entry to the top of the machine
+([§4.4](#44-noticed-then-resolved)).
+
+So the one value with a consumer survives, under a label that says the condition rather than naming
+a category. It is **off by default** — most entries record work already done — and deselectable,
+because a person who is unsure must still be able to write the sentence. The database CHECK keeps
+all five values: widening a constraint later is a migration, narrowing it buys nothing, and if a
+real corpus ever argues for categories they come back as a UI change with a consumer attached.
+
+**"Needs attention" notifies nobody.** There is no notification path in Phase 1
+([§9](#9-open-questions)), and the wording is chosen not to imply one. What it does is keep the
+entry pinned to that machine until somebody logs a fix — so the person who meets it is the next
+operator standing at the machine, which is precisely the handoff [§1](#1-problem) says goes wrong.
+Its only intended exit is a second entry describing what was done: there is no dismiss and no close,
+and `notes` is append-only, so clearing the pin and recording the knowledge are the same act.
 
 ### 4.4 Noticed, then resolved
 
@@ -315,8 +346,8 @@ entries in hand. None of this is the gate. The gate is [§2](#2-hypothesis-and-k
 
 ## 9. Open questions
 
-Four questions are closed and are not reopened here: kind is optional
-([§4](#4-what-it-is-phase-1)), there is no seeded corpus
+Four questions are closed and are not reopened here: classification is optional — and, since
+[§4.3](#43-capture) was revised, is one toggle rather than five verbs; there is no seeded corpus
 ([§2](#2-hypothesis-and-kill-criterion)), open-items attribution resolves in favor of the guardrail
 ([§5](#5-what-it-is-not)), and the module is called Machine Maintenance.
 

--- a/docs/modules/machine-maintenance.md
+++ b/docs/modules/machine-maintenance.md
@@ -1,11 +1,18 @@
 # Machine Maintenance Module
 
-> **Status:** Draft proposal · **Date:** 2026-07-29 · **Pilot:** one shop, behind a feature flag
+> **Status:** Phase 1 built, unreleased · **Date:** 2026-07-30 · **Pilot:** one shop, behind the
+> `machine_maintenance` flag (off everywhere by default)
 >
-> **Purpose.** Propose a machine-scoped maintenance logbook, and state in advance the condition
-> under which it gets parked. Nothing in this module is built. The bet is written down together
-> with its kill criterion ([§2](#2-hypothesis-and-kill-criterion)) so that the result cannot be
-> renegotiated once it arrives.
+> **Purpose.** A machine-scoped maintenance logbook, and the condition under which it gets parked,
+> stated in advance. The bet is written down together with its kill criterion
+> ([§2](#2-hypothesis-and-kill-criterion)) so that the result cannot be renegotiated once it
+> arrives.
+>
+> This document was committed as a proposal and then amended where building it changed an answer.
+> Three sections carry a revision: [§6](#6-phases-and-gates) (the archived-machines defect was not
+> being fixed elsewhere, so it is fixed here), [§8](#8-measurement) (`confirmed` is cut — Phase 1
+> ships no freshness signal and says why), and [§9](#9-open-questions) (details and manuals ship;
+> the office gets a read-only view). Everything else is as proposed.
 
 **Dependencies:** [Work Centers](work-centers.md), because a machine is a `work_centers` row with
 `kind='internal'` and there is no separate machine entity. The notes system and its read-back loop
@@ -206,8 +213,12 @@ Before the clock in [§2](#2-hypothesis-and-kill-criterion) can mean anything, a
 be able to reach a machine page at all, and what stands in the way is not this module's work.
 
 Station selection is the only entrance ([§4.1](#41-one-door)), so one live defect in it becomes a
-prerequisite here: the station picker leaks archived machines because it does not filter on
-`deleted_at`. It is already known and is being fixed independently. One further fact about the
+prerequisite here: the station picker leaked archived machines because it did not filter on
+`deleted_at`. This draft said it "is being fixed independently"; it was not — no branch, issue or PR
+covered it, and `getStationOperationTypes` was the one work-center reader in the codebase without
+the filter. **It is fixed as part of this module's work**, along with the matching gap in
+`getStationName`, which now answers null for an archived machine so the stored station clears itself
+rather than stranding an operator on a machine that no longer exists. One further fact about the
 floor belongs here rather than in a retrospective:
 
 > Operator adoption of the existing operator surface is currently near zero: operators are not yet
@@ -282,13 +293,25 @@ want to see. `viewer_count`, distinct people, still works; it saturates near sho
 its meaning.
 
 The consequence is a decision rather than a complaint. Reads can tell us an entry was found; they
-cannot tell us it is still true. `confirmed` is therefore the designated freshness signal for this
-module. The reaction kind already exists alongside `helpful`, with no negative option by design,
-but only `helpful` has a UI today (on an unmerged branch), so this is a prerequisite here rather
-than an inheritance. Its stored meaning is worded part-first, "I ran this part and this note is
-still accurate", where the machine reading is "I did this and it still holds"; that wording
-question comes along with it. None of this is the gate. The gate is
-[§2](#2-hypothesis-and-kill-criterion).
+cannot tell us it is still true.
+
+**Decided (revised at build time): Phase 1 ships no freshness signal, and accepts the gap.** An
+earlier draft of this section named `confirmed` — a reaction kind that exists in the database
+alongside `helpful`, with no negative option by design, and has never had a UI — as the designated
+freshness signal for this module, and called building that UI a prerequisite. It is not one, and the
+argument against it is the argument this module makes everywhere else. `confirmed` means "I did this
+and it still holds", which needs a second person to re-perform the same maintenance and then say so.
+At a fifteen-person shop, inside a four-week window, against a bar of five entries, that will not
+happen. It would ship as a control nobody taps — which makes the surface look busier than it is and
+teaches operators that some buttons here are decorative, the exact opposite of what a container
+being filled for the first time needs. No product in the category offers one either, which is weak
+evidence but not none.
+
+So `helpful` is inherited unchanged and nothing else is built. The honest position is that Phase 1
+can tell whether an entry was *found* and not whether it is still *true*, and that a corpus small
+enough to fail the [§2](#2-hypothesis-and-kill-criterion) bar is also far too small for staleness to
+be the problem worth solving. If the corpus survives and starts to age, revisit this with real
+entries in hand. None of this is the gate. The gate is [§2](#2-hypothesis-and-kill-criterion).
 
 ## 9. Open questions
 
@@ -297,18 +320,30 @@ Four questions are closed and are not reopened here: kind is optional
 ([§2](#2-hypothesis-and-kill-criterion)), open-items attribution resolves in favor of the guardrail
 ([§5](#5-what-it-is-not)), and the module is called Machine Maintenance.
 
-**Does the Maintenance tab appear before a station is selected?** Recommendation: no. Without a
-station the tab needs a picker, and a picker is the ceremony [§4.5](#45-zero-required-setup)
-refuses. Station selection already answers the question a picker would ask. This question is
-load-bearing now that the tab is the only entrance, and it has a visible consequence: an operator
-who notices something on a machine that is not their selected station changes station first, using
-the selector that already exists. At this machine count that is acceptable. If it proves to be
-friction, the answer is revisiting this question, not reviving a code on the machine.
+**Does the Maintenance tab appear before a station is selected? Decided: no.** Without a station the
+tab needs a picker, and a picker is the ceremony [§4.5](#45-zero-required-setup) refuses. Station
+selection already answers the question a picker would ask. This is load-bearing now that the tab is
+the only entrance, and it has a visible consequence: an operator who notices something on a machine
+that is not their selected station changes station first, using the selector that already exists. At
+this machine count that is acceptable. If it proves to be friction, the answer is revisiting this
+question, not reviving a code on the machine. Built exactly this way: the tab is rendered only when
+a flag is on **and** a station is set, and unlike the Inventory and My work tabs it is deliberately
+not on the list of routes that keep the nav visible before a station exists.
 
-**Do machine details and manual attachments belong in Phase 1 at all, given nothing gates on
-them?** Recommendation: keep both, and never prompt for either. A manual an operator can open on
-the floor is worth having on day one. If this instead resolves to deferring them,
-[§4.5](#45-zero-required-setup) changes with it; the two must not be allowed to disagree.
+**Do machine details and manual attachments belong in Phase 1 at all, given nothing gates on them?
+Decided: both ship, and nothing ever prompts for either.** A manual an operator can open on the
+floor is worth having on day one. Reading happens on the floor; filling either one in happens in the
+office, where somebody with a spec sheet is doing paperwork on purpose. The enforceable half is
+tested rather than merely asserted: a machine with no details renders nothing at all — not an empty
+state, not a completeness meter, not a prompt — and a machine with no manuals shows no manuals row.
+
+**Can the office read a machine's log without an operator device? Decided: yes, read-only.** Not a
+question this draft asked, and it needed answering before build. The work-center page in the
+dashboard carries the same timeline with no composer. "One door" ([§4.1](#41-one-door)) is a rule
+about the operator entrance and about pickers, not a rule against the founder being able to watch
+whether the [§2](#2-hypothesis-and-kill-criterion) corpus is forming. An office **composer** is
+refused for a different reason: the bar counts non-founder authors, and the most convenient way to
+write entries must not be the one seat that would invalidate the result.
 
 **Is the flag retired after the pilot, or kept?** Recommendation: retired, on the precedent
 [Shipments](shipments.md) set (gated during rollout, then made core and the key removed), but only

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -160,6 +160,37 @@ async function ensureCompanyBilling(
   if (error) throw new Error(`company_billing upsert failed: ${error.message}`);
 }
 
+/**
+ * Turn on the pilot flags the specs exercise.
+ *
+ * Merges rather than replaces, and runs on every setup rather than only on
+ * company creation: this seeder is find-or-insert, so a company created before a
+ * flag existed would otherwise never get it, and a local stack keeps whatever
+ * the first run made until someone does a db reset. CI always starts clean;
+ * a developer's machine does not.
+ */
+async function ensureFeatureFlags(
+  supabase: SupabaseClient,
+  companyId: string,
+  flags: Record<string, boolean>,
+): Promise<void> {
+  const { data, error: readErr } = await supabase
+    .from('companies')
+    .select('settings')
+    .eq('id', companyId)
+    .single();
+  if (readErr) throw new Error(`settings read failed: ${readErr.message}`);
+
+  const settings = (data?.settings ?? {}) as Record<string, unknown>;
+  const features = (settings.features ?? {}) as Record<string, unknown>;
+
+  const { error } = await supabase
+    .from('companies')
+    .update({ settings: { ...settings, features: { ...features, ...flags } } })
+    .eq('id', companyId);
+  if (error) throw new Error(`feature flag update failed: ${error.message}`);
+}
+
 async function ensureUserCompanyAccess(
   supabase: SupabaseClient,
   userId: string,
@@ -751,6 +782,11 @@ export default async function globalSetup(): Promise<void> {
 
   // After the jobs, so the note's provenance job resolves.
   await ensureDurableNote(supabase, companyId, mfgPartId, 'E2E-JS-DONE');
+
+  // The Maintenance tab is flag-gated. No maintenance ENTRIES are seeded: the
+  // spec writes its own through the UI, which is the only way to exercise the
+  // capture path the module is actually a bet on.
+  await ensureFeatureFlags(supabase, companyId, { machine_maintenance: true });
 
   console.log(`[e2e/global-setup] Done. user=${TEST_EMAIL} company=${companyId}`);
 }

--- a/e2e/machine-maintenance.spec.ts
+++ b/e2e/machine-maintenance.spec.ts
@@ -102,7 +102,7 @@ test.describe('Machine Maintenance', () => {
 
     const observation = `E2E way cover drags ${stamp()}`;
     await composer(page).fill(observation);
-    await page.getByRole('button', { name: /needs attention/i }).click();
+    await page.getByRole('checkbox', { name: /needs attention/i }).click();
     await addButton(page).click();
 
     // Pinned in the open list AND present on the timeline: two occurrences of one
@@ -136,7 +136,7 @@ test.describe('Machine Maintenance', () => {
 
     const observation = `E2E coolant smells off ${stamp()}`;
     await composer(page).fill(observation);
-    await page.getByRole('button', { name: /needs attention/i }).click();
+    await page.getByRole('checkbox', { name: /needs attention/i }).click();
     await addButton(page).click();
     await expect(page.getByText(observation)).toHaveCount(2, { timeout: 30_000 });
 

--- a/e2e/machine-maintenance.spec.ts
+++ b/e2e/machine-maintenance.spec.ts
@@ -102,7 +102,7 @@ test.describe('Machine Maintenance', () => {
 
     const observation = `E2E way cover drags ${stamp()}`;
     await composer(page).fill(observation);
-    await page.getByRole('button', { name: 'noticed' }).click();
+    await page.getByRole('button', { name: /needs attention/i }).click();
     await addButton(page).click();
 
     // Pinned in the open list AND present on the timeline: two occurrences of one
@@ -136,7 +136,7 @@ test.describe('Machine Maintenance', () => {
 
     const observation = `E2E coolant smells off ${stamp()}`;
     await composer(page).fill(observation);
-    await page.getByRole('button', { name: 'noticed' }).click();
+    await page.getByRole('button', { name: /needs attention/i }).click();
     await addButton(page).click();
     await expect(page.getByText(observation)).toHaveCount(2, { timeout: 30_000 });
 

--- a/e2e/machine-maintenance.spec.ts
+++ b/e2e/machine-maintenance.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * The machine logbook, end to end.
+ *
+ * WHAT THIS COVERS THAT NOTHING ELSE CAN. The module's whole design rests on one
+ * claim: open state is DERIVED, never stored. Unit tests prove the derivation
+ * function is correct given an array; only this spec proves the array that
+ * reaches it is the one the database actually returns, through the real insert,
+ * the real trigger and the real RLS. A stored flag would be provable in a unit
+ * test; this design has to be shown working against Postgres.
+ *
+ * It writes its own entries rather than reading seeded ones, deliberately. The
+ * capture path is what the module is a bet on, and a spec that only read a
+ * fixture would go green while capture was broken.
+ *
+ * It also pins the tab's own gate: the Maintenance tab appears only once a
+ * station is selected, because a station IS a machine and there is no picker.
+ */
+
+const WC_INTERNAL = 'E2E Internal WC';
+
+/** Unique per run: these entries accumulate in a shared local database. */
+const stamp = () => `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+
+async function operatorHome(page: Page): Promise<string> {
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/dashboard\//, { timeout: 30_000 });
+  const companyId = page.url().match(/\/dashboard\/([0-9a-f-]{36})/)?.[1];
+  expect(companyId, 'company id should be in the dashboard URL').toBeTruthy();
+  return companyId as string;
+}
+
+const maintenanceTab = (page: Page) => page.getByRole('button', { name: /^Maintenance$/ });
+const composer = (page: Page) => page.getByPlaceholder(/what did you do/i);
+const addButton = (page: Page) => page.getByRole('button', { name: /add to log/i });
+const openList = (page: Page) => page.getByTestId('machine-open-items');
+
+/**
+ * Select a station, then open its logbook.
+ *
+ * Every test does this rather than one doing it once: the station lives in
+ * localStorage, and Playwright gives each test its own browser context, so a
+ * selection made in an earlier test is simply not there. Skipping it would land
+ * on the station picker and fail on a missing composer for a reason that has
+ * nothing to do with the code.
+ */
+async function selectStationAndOpenLog(page: Page, companyId: string): Promise<void> {
+  await page.goto(`/operator/${companyId}/jobs`);
+
+  const picker = page.getByRole('button', { name: WC_INTERNAL });
+  await expect(picker.or(maintenanceTab(page))).toBeVisible({ timeout: 30_000 });
+  if (await picker.isVisible()) await picker.click();
+
+  await expect(maintenanceTab(page)).toBeVisible({ timeout: 30_000 });
+  await maintenanceTab(page).click();
+  await expect(composer(page)).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Machine Maintenance', () => {
+  test('the Maintenance tab appears only once a station is selected', async ({ page }) => {
+    const companyId = await operatorHome(page);
+    await page.goto(`/operator/${companyId}/jobs`);
+
+    // Wait for one of the two states before asserting — a not-yet-rendered page
+    // reports "no tab" for the wrong reason.
+    const picker = page.getByRole('button', { name: WC_INTERNAL });
+    await expect(picker.or(maintenanceTab(page))).toBeVisible({ timeout: 30_000 });
+
+    if (await picker.isVisible()) {
+      // No station yet: the tab must not be offered. There is no machine to have
+      // a logbook for.
+      await expect(maintenanceTab(page)).toHaveCount(0);
+      await picker.click();
+    }
+
+    await expect(maintenanceTab(page)).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('an entry written on the floor lands on the machine timeline', async ({ page }) => {
+    const companyId = await operatorHome(page);
+    await selectStationAndOpenLog(page, companyId);
+
+    const body = `E2E way lube topped up ${stamp()}`;
+    await composer(page).fill(body);
+    await addButton(page).click();
+
+    await expect(page.getByText(body)).toBeVisible({ timeout: 30_000 });
+
+    // It survives a reload, i.e. it was written rather than only rendered.
+    await page.reload();
+    await expect(page.getByText(body)).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('a noticed item opens, and logging the fix closes it without deleting anything', async ({
+    page,
+  }) => {
+    const companyId = await operatorHome(page);
+    await selectStationAndOpenLog(page, companyId);
+
+    const observation = `E2E way cover drags ${stamp()}`;
+    await composer(page).fill(observation);
+    await page.getByRole('button', { name: 'noticed' }).click();
+    await addButton(page).click();
+
+    // Pinned in the open list AND present on the timeline: two occurrences of one
+    // row, which is the shape the whole design turns on.
+    await expect(page.getByText(observation)).toHaveCount(2, { timeout: 30_000 });
+
+    await page.getByRole('button', { name: /log the fix/i }).first().click();
+    const fix = `E2E replaced the wiper ${stamp()}`;
+    await composer(page).fill(fix);
+    await addButton(page).click();
+
+    await expect(page.getByText(fix)).toBeVisible({ timeout: 30_000 });
+
+    // Down to one occurrence: it left the OPEN list but stayed in the log. A log
+    // that loses rows stops being a log.
+    await expect(page.getByText(observation)).toHaveCount(1, { timeout: 30_000 });
+
+    // And it is still closed after a reload — proving the state came from the
+    // resolving row rather than from anything held in the page.
+    await page.reload();
+    await expect(page.getByText(observation)).toHaveCount(1, { timeout: 30_000 });
+    await expect(page.getByText(fix)).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('the open list names the observation and the date, never who filed it', async ({ page }) => {
+    // The surveillance guardrail, checked in a browser rather than only in jsdom.
+    // A list of open items with names down the side is a list of who reports the
+    // most problems.
+    const companyId = await operatorHome(page);
+    await selectStationAndOpenLog(page, companyId);
+
+    const observation = `E2E coolant smells off ${stamp()}`;
+    await composer(page).fill(observation);
+    await page.getByRole('button', { name: 'noticed' }).click();
+    await addButton(page).click();
+    await expect(page.getByText(observation)).toHaveCount(2, { timeout: 30_000 });
+
+    await expect(openList(page).getByText(observation)).toBeVisible();
+    // The author's name is on the entry card below, one tap away — not here.
+    await expect(openList(page).getByText('E2E Test User')).toHaveCount(0);
+  });
+});

--- a/hooks/useNoteCapture.ts
+++ b/hooks/useNoteCapture.ts
@@ -1,10 +1,11 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { addJobNote } from '@/utils/operatorAccess';
 import { addJobNoteMedia } from '@/utils/jobNoteMediaAccess';
 import { compressPhoto } from '@/utils/imageCompression';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
+import type { OperatorEventContext } from '@/utils/operatorEventsAccess';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type { JobNote, JobNoteMedia } from '@/types/operator';
 
@@ -68,7 +69,40 @@ export interface NoteCaptureContext {
   jobOperationId: string;
 }
 
-export interface NoteCapture {
+/**
+ * WHERE the note goes, injected by the surface that owns the composer.
+ *
+ * The draft, the photo pipeline, the iOS unreadable-File mitigation, the mic
+ * hint and every funnel event are subject-agnostic and must exist exactly once.
+ * The WRITE is the only part that differs between a step note and a machine
+ * maintenance entry, so it is the only part that is passed in.
+ *
+ * Generic over the note type so neither caller loses its return type to a union
+ * it would then have to narrow.
+ */
+export interface NoteWriter<TNote> {
+  createNote: (body: string | null) => Promise<TNote>;
+  attachMedia: (
+    note: TNote,
+    file: File,
+    dims?: { width: number; height: number },
+  ) => Promise<JobNoteMedia>;
+  /** Merge saved media onto the note for the optimistic prepend. */
+  withMedia: (note: TNote, media: JobNoteMedia[]) => TNote;
+  /** Merged into every funnel event this composer emits. */
+  eventContext?: OperatorEventContext;
+}
+
+/**
+ * Everything about a capture that does NOT depend on where the note ends up:
+ * the draft, the pending photos, the dictation hint, the focus signal.
+ *
+ * Split out because it is exactly what NoteCaptureFields renders. That component
+ * is shared by the step composer and the machine composer, and typing it against
+ * this rather than against a particular note type is what makes the sharing
+ * honest rather than a cast.
+ */
+export interface NoteCaptureFieldsState {
   draft: string;
   setDraft: (v: string) => void;
   pending: PendingPhoto[];
@@ -83,6 +117,9 @@ export interface NoteCapture {
   noteFocused: () => void;
   pickPhotos: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
   removePending: (id: string) => void;
+}
+
+export interface NoteCapture<TNote = JobNote> extends NoteCaptureFieldsState {
   /**
    * Write the note and its media. Returns the note (with media) so an optimistic
    * list can prepend it, or null when there was nothing to write.
@@ -91,18 +128,18 @@ export interface NoteCapture {
    * means. On the completion path the completion has already landed and must
    * stand, so the error is surfaced on its own rather than rolled back.
    */
-  submit: () => Promise<JobNote | null>;
+  submit: () => Promise<TNote | null>;
 }
 
-export function useNoteCapture(opts: {
+export function useNoteCapture<TNote = JobNote>(opts: {
   companyId: string;
-  jobId: string;
   operatorId: string | null;
-  context: NoteCaptureContext | null;
+  /** Null when there is nothing to write against yet — the composer stays inert. */
+  writer: NoteWriter<TNote> | null;
   /** Off when there is no capture surface mounted (e.g. a read-only feed). */
   enabled: boolean;
-}): NoteCapture {
-  const { companyId, jobId, operatorId, context, enabled } = opts;
+}): NoteCapture<TNote> {
+  const { companyId, operatorId, writer, enabled } = opts;
 
   const [draft, setDraft] = useState('');
   const [pending, setPending] = useState<PendingPhoto[]>([]);
@@ -124,6 +161,12 @@ export function useNoteCapture(opts: {
   const focusedRef = useRef(false);
   const capturedRef = useRef(false);
   const draftRef = useRef({ bodyLength: 0, photoCount: 0 });
+  // The writer's event context, mirrored into a ref so the unmount handler can
+  // read it without re-registering the effect (and without a stale closure).
+  // Every event from this composer carries it, so a machine capture is
+  // distinguishable from a step capture at every step of the funnel rather than
+  // only at the save.
+  const eventContextRef = useRef<OperatorEventContext>({});
 
   const hasContent = draft.trim().length > 0 || pending.length > 0;
 
@@ -142,6 +185,10 @@ export function useNoteCapture(opts: {
     draftRef.current = { bodyLength: draft.trim().length, photoCount: pending.length };
   }, [draft, pending]);
 
+  useEffect(() => {
+    eventContextRef.current = writer?.eventContext ?? {};
+  }, [writer]);
+
   // Revoke preview URLs on unmount.
   useEffect(() => {
     return () => {
@@ -158,7 +205,10 @@ export function useNoteCapture(opts: {
     return () => {
       if (!enabled) return;
       if (!focusedRef.current || capturedRef.current) return;
-      logOperatorEvent(companyId, 'composer_abandoned', draftRef.current);
+      logOperatorEvent(companyId, 'composer_abandoned', {
+        ...eventContextRef.current,
+        ...draftRef.current,
+      });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -166,7 +216,7 @@ export function useNoteCapture(opts: {
   const noteFocused = useCallback(() => {
     if (focusedRef.current) return;
     focusedRef.current = true;
-    logOperatorEvent(companyId, 'composer_focused');
+    logOperatorEvent(companyId, 'composer_focused', { ...eventContextRef.current });
   }, [companyId]);
 
   const dismissMicHint = useCallback(() => {
@@ -224,7 +274,10 @@ export function useNoteCapture(opts: {
         );
       }
       setPending((prev) => [...prev, ...prepared]);
-      logOperatorEvent(companyId, 'photo_attached', { count: prepared.length });
+      logOperatorEvent(companyId, 'photo_attached', {
+        ...eventContextRef.current,
+        count: prepared.length,
+      });
     },
     [companyId],
   );
@@ -237,8 +290,8 @@ export function useNoteCapture(opts: {
     });
   }, []);
 
-  const submit = useCallback(async (): Promise<JobNote | null> => {
-    if (!context) return null;
+  const submit = useCallback(async (): Promise<TNote | null> => {
+    if (!writer) return null;
     const body = draft.trim();
     const photos = pending;
     if (!body && photos.length === 0) return null;
@@ -251,19 +304,12 @@ export function useNoteCapture(opts: {
     setSaving(true);
     setError(null);
     try {
-      const note = await addJobNote(jobId, companyId, operatorId, body || null, {
-        jobPartId: context.jobPartId,
-        jobOperationId: context.jobOperationId,
-      });
+      const note = await writer.createNote(body || null);
 
       const media: JobNoteMedia[] = [];
       for (const p of photos) {
         const prepared = await compressPhoto(p.file);
-        media.push(
-          await addJobNoteMedia(companyId, jobId, note.id, prepared.file, {
-            dims: prepared.dims,
-          }),
-        );
+        media.push(await writer.attachMedia(note, prepared.file, prepared.dims));
       }
 
       photos.forEach((p) => URL.revokeObjectURL(p.previewUrl));
@@ -273,18 +319,18 @@ export function useNoteCapture(opts: {
       // the funnel's whole job is separating "tried" from "succeeded".
       capturedRef.current = true;
       logOperatorEvent(companyId, media.length > 0 ? 'note_saved_with_photo' : 'note_saved', {
-        jobOperationId: context.jobOperationId,
+        ...(writer.eventContext ?? {}),
         bodyLength: body.length,
         photoCount: media.length,
       });
-      return { ...note, media };
+      return writer.withMedia(note, media);
     } catch (err) {
       setError(friendlyErrorMessage(err, { entity: 'note', fallback: 'Could not save that.' }));
       throw err;
     } finally {
       setSaving(false);
     }
-  }, [context, draft, pending, operatorId, jobId, companyId]);
+  }, [writer, draft, pending, operatorId, companyId]);
 
   return {
     draft,
@@ -301,4 +347,37 @@ export function useNoteCapture(opts: {
     removePending,
     submit,
   };
+}
+
+/**
+ * The writer for a note captured at a step, which is what both job surfaces use.
+ *
+ * `addJobNote` chooses the SUBJECT itself — durable (part, routing step) when the
+ * step has a routing link, this-job-only when it doesn't — so that decision stays
+ * where it was and the operator is still never asked to classify anything.
+ *
+ * Memoized on its inputs: `submit` closes over the writer, so a fresh object each
+ * render would rebuild the callback every keystroke.
+ */
+export function useStepNoteWriter(args: {
+  companyId: string;
+  jobId: string;
+  operatorId: string | null;
+  context: NoteCaptureContext | null;
+}): NoteWriter<JobNote> | null {
+  const { companyId, jobId, operatorId, context } = args;
+  return useMemo(() => {
+    if (!context || !operatorId) return null;
+    return {
+      createNote: (body) =>
+        addJobNote(jobId, companyId, operatorId, body, {
+          jobPartId: context.jobPartId,
+          jobOperationId: context.jobOperationId,
+        }),
+      attachMedia: (note, file, dims) =>
+        addJobNoteMedia(companyId, jobId, note.id, file, { dims }),
+      withMedia: (note, media) => ({ ...note, media }),
+      eventContext: { jobOperationId: context.jobOperationId },
+    };
+  }, [companyId, jobId, operatorId, context]);
 }

--- a/supabase/migrations/20260730045322_storage_read_policy_under_migration_control.sql
+++ b/supabase/migrations/20260730045322_storage_read_policy_under_migration_control.sql
@@ -1,0 +1,45 @@
+-- Bring the attachments SELECT policy under migration control.
+--
+-- **Reading any attachment is broken on every fresh local stack and every Supabase preview
+-- branch.** After a `db reset`, `storage.objects` has exactly two policies — INSERT and DELETE,
+-- both from `20260725210136_stripe_write_enforcement.sql` — and **no SELECT policy at all**, so
+-- `createSignedUrl` answers every request with "Either the object does not exist or you do not have
+-- access to it". Not only the machine-maintenance photos this was reported against: part
+-- attachments (PDF/STEP/DWG), job attachments and operator note photos are equally unreadable.
+--
+-- It works in production only because the policy was created there by hand and then captured in
+-- `supabase/schema.prod.sql` — which is a *snapshot*, not an applied artifact. This is the exact
+-- failure mode `20260728212230_create_attachments_storage_bucket.sql` was written to fix for the
+-- BUCKET, whose header records that it "had existed only in the prod snapshot, so uploads returned
+-- 'Bucket not found' on every preview branch". That migration fixed the bucket and missed the
+-- policy — so uploads started working while reads stayed broken.
+--
+-- Copied from the prod snapshot, so applying it changes nothing in production.
+--
+-- DUPLICATE ON PURPOSE. The same policy is added by
+-- `20260730021430_storage_read_policy_under_migration_control.sql` on feature/inventory-phase-2,
+-- where it was diagnosed first (against location photos). Both start with DROP POLICY IF EXISTS, so
+-- whichever runs second simply re-creates an identical policy and neither branch has to wait for
+-- the other. Delete this file if the branches are ever reconciled before merge; leaving both costs
+-- one redundant statement and nothing else.
+--
+-- Deliberately **no billing gate**: reads stay open for a lapsed shop, matching the standard in
+-- docs/modules/billing.md §4 — you can always look at your own data, you just can't add to it. The
+-- INSERT and DELETE policies alongside this one DO carry `company_can_write`.
+
+DROP POLICY IF EXISTS "Users can read files from their company folder" ON storage.objects;
+
+CREATE POLICY "Users can read files from their company folder"
+    ON storage.objects
+    FOR SELECT
+    TO authenticated
+    USING (
+        bucket_id = 'attachments'
+        -- The first path segment is the company id. The bucket_id check comes first so a non-uuid
+        -- path never reaches the comparison, and every writer namespaces paths this way through
+        -- `generateStoragePath` — `{companyId}/{entityType}/{entityId}/{uuid8}_{name}`.
+        AND (storage.foldername(name))[1] IN (
+            SELECT company_id::text FROM public.user_company_access
+             WHERE user_id = auth.uid()
+        )
+    );

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -79,9 +79,11 @@ insert into public.companies (
   ('22222222-2222-2222-2222-222222222222', 'Vanguard Precision Works',
    '1420 Rand Drive', 'Detroit', 'MI', '48211', 'USA',
    '(313) 555-0142', 'shop@vanguardprecision.test', 'vanguardprecision.test',
-   -- Enable the opt-in data-import tool in dev + preview branches so
-   -- it's visible while the feature rolls out. Seed is local/preview-only, never prod.
-   '{"features": {"data_import": true}}'::jsonb)
+   -- Opt-in features are ON in dev + preview branches. A flag-gated feature that
+   -- no preview deployment can display is a feature nobody can review — the
+   -- reviewer sees an unchanged app and has to take the diff's word for it.
+   -- Seed is local/preview-only, never prod, so this widens nothing real.
+   '{"features": {"data_import": true, "machine_maintenance": true}}'::jsonb)
 on conflict (id) do nothing;
 
 -- Billing cache: the grandfather backfill in the stripe_billing_cache migration

--- a/types/machineMaintenance.ts
+++ b/types/machineMaintenance.ts
@@ -22,21 +22,19 @@ import type { JobNoteMedia, NoteReaction } from '@/types/operator';
  */
 
 /**
- * The five verbs, and the whole taxonomy. OPTIONAL at capture: an unclassified
- * entry is still knowledge, and a forced choice at capture time is what stops
- * capture (§4.3).
+ * Mirrors the notes_maintenance_kind_valid CHECK, which still accepts all five
+ * verbs. **Only 'noticed' has a UI**, and only 'noticed' does anything: it is
+ * what deriveOpenItems filters on, and therefore what pins an entry to the top
+ * of a machine until somebody logs a fix.
  *
- * Only 'noticed' can be open — the others describe something already done.
+ * The other four are deliberately unused rather than pending. They had no reader
+ * anywhere — nothing filtered, grouped, ranked or counted by them — so they were
+ * four extra choices in a container whose whole risk is that nobody writes in
+ * it. They are left in the CHECK because widening a constraint later is a
+ * migration and narrowing it buys nothing; re-introducing them, if a real corpus
+ * ever argues for it, is a UI change with no schema work.
  */
 export type MaintenanceKind = 'cleaned' | 'repaired' | 'replaced' | 'adjusted' | 'noticed';
-
-export const MAINTENANCE_KINDS: readonly MaintenanceKind[] = [
-  'cleaned',
-  'repaired',
-  'replaced',
-  'adjusted',
-  'noticed',
-] as const;
 
 /** One entry on a machine's timeline. */
 export interface MachineNote {

--- a/types/machineMaintenance.ts
+++ b/types/machineMaintenance.ts
@@ -1,0 +1,113 @@
+import type { JobNoteMedia, NoteReaction } from '@/types/operator';
+
+/**
+ * Machine Maintenance — the logbook for one machine.
+ * See docs/modules/machine-maintenance.md.
+ *
+ * A machine IS a `work_centers` row with kind='internal'; there is no separate
+ * machine entity, and an entry is a `notes` row with subject_kind='work_center'.
+ * So this file describes a READ SHAPE, not a new domain.
+ *
+ * MachineNote is deliberately NOT `JobNote`. Two fields are the reason, and both
+ * would be lies rather than merely unused:
+ *
+ *   job_id — JobNote types it as a non-nullable string and the mapper coerces
+ *     the machine case to ''. A machine entry has no job at all. An empty string
+ *     standing in for "there is no such thing" is exactly the sort of value that
+ *     later gets passed to a route builder.
+ *   usage_count — counts DISTINCT JOBS a note was consulted on, so it is
+ *     permanently zero here and must never be displayed (§8). The strongest way
+ *     to enforce that is for the field not to exist; the access layer does not
+ *     even select the column.
+ */
+
+/**
+ * The five verbs, and the whole taxonomy. OPTIONAL at capture: an unclassified
+ * entry is still knowledge, and a forced choice at capture time is what stops
+ * capture (§4.3).
+ *
+ * Only 'noticed' can be open — the others describe something already done.
+ */
+export type MaintenanceKind = 'cleaned' | 'repaired' | 'replaced' | 'adjusted' | 'noticed';
+
+export const MAINTENANCE_KINDS: readonly MaintenanceKind[] = [
+  'cleaned',
+  'repaired',
+  'replaced',
+  'adjusted',
+  'noticed',
+] as const;
+
+/** One entry on a machine's timeline. */
+export interface MachineNote {
+  id: string;
+  work_center_id: string;
+  /** Free text. Null when the entry is photos only. */
+  body: string | null;
+  /** Null when the author didn't classify it, which is a legal and common state. */
+  maintenance_kind: MaintenanceKind | null;
+  /** Set when this entry is the fix for an earlier 'noticed' one on this machine. */
+  resolves_note_id: string | null;
+  created_at: string;
+  author_name: string | null;
+  /**
+   * Author's user_company_access id. Needed because reacting to your own note is
+   * refused by RLS, so the control has to be hidden there rather than fail on tap.
+   */
+  author_id: string | null;
+  /**
+   * Distinct PEOPLE who have read this entry. Saturates near shop size — that is
+   * what it means. Note the read-log dedupes per (note, person, job) with the
+   * absent job equal to itself, so a person's repeat consultation of the same
+   * entry months later is recorded once, ever (§8). That reread is precisely the
+   * event a logbook would most want to see, and it is invisible.
+   */
+  viewer_count: number;
+  media: JobNoteMedia[];
+  reactions: NoteReaction[];
+}
+
+/**
+ * A machine's whole log, read in one query.
+ *
+ * `open` is DERIVED from `entries` — the same array, filtered — and is never
+ * stored anywhere. That is what makes it impossible for the open list to
+ * disagree with the timeline it is drawn from (§4.4). It is complete because the
+ * database guarantees a resolver always sits on the same machine as its target,
+ * so every resolver is already in `entries`.
+ */
+export interface MachineLog {
+  /** Newest first, every entry, not grouped by kind (§4.2). */
+  entries: MachineNote[];
+  /** Unresolved 'noticed' entries, newest first. A subset of `entries`. */
+  open: MachineNote[];
+}
+
+/** A manual or reference image filed against a machine. */
+export interface WorkCenterAttachment {
+  id: string;
+  company_id: string;
+  work_center_id: string;
+  storage_path: string;
+  file_name: string;
+  kind: 'pdf' | 'image' | 'other';
+  mime_type: string | null;
+  size_bytes: number | null;
+  uploaded_by: string | null;
+  uploaded_by_name: string | null;
+  created_at: string;
+}
+
+/**
+ * Optional machine attributes. Every field is nullable and NOTHING EVER PROMPTS
+ * FOR THEM — no empty-state nudge, no completeness meter, no surface that renders
+ * one machine as less ready than another because somebody typed a serial number
+ * into it (§4.5).
+ */
+export interface MachineDetails {
+  make: string | null;
+  model: string | null;
+  serial_number: string | null;
+  year_built: number | null;
+  purchased_on: string | null;
+}

--- a/utils/machineMaintenanceAccess.ts
+++ b/utils/machineMaintenanceAccess.ts
@@ -1,0 +1,237 @@
+import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { mapReactions } from '@/utils/operatorAccess';
+import type { ReactionRel } from '@/utils/operatorAccess';
+import { addNoteMedia } from '@/utils/jobNoteMediaAccess';
+import type { JobNoteMedia } from '@/types/operator';
+import type {
+  MachineDetails,
+  MachineLog,
+  MachineNote,
+  MaintenanceKind,
+} from '@/types/machineMaintenance';
+
+/**
+ * Machine Maintenance — reading and writing one machine's logbook.
+ * See docs/modules/machine-maintenance.md.
+ *
+ * An entry is a `notes` row with subject_kind='work_center', so everything the
+ * notes system already does comes along unchanged: attribution resolved
+ * server-side, photos in note_media, `helpful` reactions, view logging, the
+ * billing gate. Nothing here re-implements any of that.
+ *
+ * WHAT THIS FILE IS ACTUALLY FOR is the one thing the notes system does not
+ * already do: deriving open state. There is no `is_open` column and there must
+ * never be one — see getMachineLog.
+ */
+
+// usage_count is DELIBERATELY ABSENT from this select. It counts distinct JOBS a
+// note was consulted on, and a machine read carries no job, so it is permanently
+// zero here; §8 says it must never be displayed on this surface. Not fetching it
+// is a stronger guarantee than remembering not to render it.
+const MACHINE_NOTE_SELECT =
+  'id, work_center_id, body, maintenance_kind, resolves_note_id, ' +
+  'created_at, viewer_count, author_id, ' +
+  'author:user_company_access(name), ' +
+  'reactions:note_reactions(kind, reactor_id, reactor:user_company_access(name)), ' +
+  'media:note_media(id, note_id, storage_path, thumbnail_path, kind, mime_type, width, height)';
+
+const MACHINE_DETAIL_COLUMNS = 'make, model, serial_number, year_built, purchased_on';
+
+type MachineNoteRow = {
+  id: string;
+  work_center_id: string;
+  body: string | null;
+  maintenance_kind: string | null;
+  resolves_note_id: string | null;
+  created_at: string;
+  viewer_count: number;
+  author_id: string | null;
+  author: { name: string | null } | { name: string | null }[] | null;
+  reactions: ReactionRel[] | null;
+  media: Array<{
+    id: string;
+    note_id: string;
+    storage_path: string;
+    thumbnail_path: string | null;
+    kind: string;
+    mime_type: string | null;
+    width: number | null;
+    height: number | null;
+  }> | null;
+};
+
+const KINDS = new Set<string>(['cleaned', 'repaired', 'replaced', 'adjusted', 'noticed']);
+
+function narrowKind(value: string | null): MaintenanceKind | null {
+  return value != null && KINDS.has(value) ? (value as MaintenanceKind) : null;
+}
+
+function rowToNote(row: MachineNoteRow): MachineNote {
+  const author = Array.isArray(row.author) ? row.author[0] : row.author;
+  const media: JobNoteMedia[] = (row.media ?? []).map((m) => ({
+    id: m.id,
+    note_id: m.note_id,
+    storage_path: m.storage_path,
+    thumbnail_path: m.thumbnail_path,
+    kind: m.kind === 'video' ? 'video' : 'photo',
+    mime_type: m.mime_type,
+    width: m.width,
+    height: m.height,
+  }));
+
+  return {
+    id: row.id,
+    work_center_id: row.work_center_id,
+    body: row.body,
+    maintenance_kind: narrowKind(row.maintenance_kind),
+    resolves_note_id: row.resolves_note_id,
+    created_at: row.created_at,
+    author_name: author?.name ?? null,
+    author_id: row.author_id,
+    viewer_count: row.viewer_count,
+    media,
+    reactions: mapReactions(row.reactions),
+  };
+}
+
+/**
+ * Split a machine's timeline into the whole log and the still-open observations.
+ *
+ * Exported for its own test: this is the module's only real piece of logic, and
+ * it is the reason there is no stored state to go stale.
+ *
+ * OPEN = a 'noticed' entry that nothing in this same array resolves. Two
+ * properties make that trustworthy rather than approximate:
+ *
+ *   - It is COMPLETE. A resolver is required by the database to sit on the same
+ *     work center as its target, so every resolver of anything in `entries` is
+ *     itself in `entries`. There is no second query that could miss one.
+ *   - It CANNOT DISAGREE with the timeline, because it is the timeline. The
+ *     alternative — a stored resolved flag — is two sources of truth for one
+ *     fact, and would also have required an UPDATE grant on an append-only table.
+ */
+export function deriveOpenItems(entries: MachineNote[]): MachineNote[] {
+  const resolved = new Set<string>();
+  for (const e of entries) {
+    if (e.resolves_note_id) resolved.add(e.resolves_note_id);
+  }
+  return entries.filter((e) => e.maintenance_kind === 'noticed' && !resolved.has(e.id));
+}
+
+/**
+ * One machine's whole log, newest first, in a single query.
+ *
+ * Not paginated, and that is a decision rather than an omission: a shop this
+ * size will not accumulate a timeline worth paging for years, and paging would
+ * break the open-items derivation above by letting a resolver fall off the page
+ * its target is on — reopening an item that was in fact fixed.
+ */
+export async function getMachineLog(
+  workCenterId: string,
+  companyId: string,
+): Promise<MachineLog> {
+  const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from('notes')
+    .select(MACHINE_NOTE_SELECT)
+    .eq('company_id', companyId)
+    .eq('work_center_id', workCenterId)
+    .order('created_at', { ascending: false });
+
+  if (error) throw new Error(error.message);
+
+  const entries = ((data ?? []) as unknown as MachineNoteRow[]).map(rowToNote);
+  return { entries, open: deriveOpenItems(entries) };
+}
+
+/**
+ * Append an entry to a machine's log.
+ *
+ * `authorId` is the writer's user_company_access id. RLS re-derives it
+ * server-side, so an entry is always written as the person writing it and cannot
+ * be attributed to anyone else — including by an admin, deliberately.
+ *
+ * `body` may be null for a photos-only entry; callers must guarantee
+ * body-or-photo, since an entirely empty entry says nothing.
+ */
+export async function addMachineNote(
+  workCenterId: string,
+  companyId: string,
+  authorId: string,
+  body: string | null,
+  opts?: {
+    maintenanceKind?: MaintenanceKind | null;
+    /** The 'noticed' entry this one fixes. Must be on this same machine. */
+    resolvesNoteId?: string | null;
+  },
+): Promise<MachineNote> {
+  const supabase = getSupabase();
+  const trimmed = body?.trim() || null;
+
+  const { data, error } = await supabase
+    .from('notes')
+    .insert({
+      company_id: companyId,
+      subject_kind: 'work_center',
+      work_center_id: workCenterId,
+      author_id: authorId,
+      body: trimmed,
+      note_type: 'user',
+      maintenance_kind: opts?.maintenanceKind ?? null,
+      resolves_note_id: opts?.resolvesNoteId ?? null,
+    })
+    .select(MACHINE_NOTE_SELECT)
+    .single();
+
+  if (error) {
+    throw new Error(
+      friendlyErrorMessage(error, { entity: 'entry', fallback: 'Could not save that.' }),
+    );
+  }
+
+  return rowToNote(data as unknown as MachineNoteRow);
+}
+
+/** Attach one already-compressed photo to a machine entry. */
+export function addMachineNoteMedia(
+  companyId: string,
+  workCenterId: string,
+  noteId: string,
+  file: File,
+  opts?: { dims?: { width: number; height: number } },
+): Promise<JobNoteMedia> {
+  return addNoteMedia(companyId, noteId, file, {
+    folder: { entityType: 'work-centers', entityId: workCenterId },
+    dims: opts?.dims,
+  });
+}
+
+/**
+ * A machine's optional attributes.
+ *
+ * A by-id read, so it does NOT filter deleted_at: an archived machine's page
+ * stays reachable by direct link and its knowledge stays readable — archiving
+ * hides a machine from pickers, not its history (§9).
+ */
+export async function getMachineDetails(workCenterId: string): Promise<MachineDetails | null> {
+  const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from('work_centers')
+    .select(MACHINE_DETAIL_COLUMNS)
+    .eq('id', workCenterId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data) return null;
+
+  return {
+    make: data.make,
+    model: data.model,
+    serial_number: data.serial_number,
+    year_built: data.year_built,
+    purchased_on: data.purchased_on,
+  };
+}

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -1309,14 +1309,19 @@ const JOB_NOTE_SELECT =
   'captured_operation:job_operations!notes_captured_job_operation_fk(operation_name, sequence), ' +
   'media:note_media(id, note_id, storage_path, thumbnail_path, kind, mime_type, width, height)';
 
-type ReactionRel = {
+export type ReactionRel = {
   kind: string;
   reactor_id: string;
   reactor: { name: string | null } | { name: string | null }[] | null;
 };
 
-/** Shared decode for both read paths (PostgREST embed and the playbook RPC's jsonb). */
-function mapReactions(rows: ReactionRel[] | null | undefined): NoteReaction[] {
+/**
+ * Shared decode for every read path that carries reactions — the PostgREST
+ * embed, the playbook RPC's jsonb, and the machine log. Exported so the machine
+ * surface decodes reactions the same way rather than growing a second copy that
+ * could drift on the `confirmed` branch.
+ */
+export function mapReactions(rows: ReactionRel[] | null | undefined): NoteReaction[] {
   return (rows ?? []).map((r) => {
     const reactor = Array.isArray(r.reactor) ? r.reactor[0] : r.reactor;
     return {


### PR DESCRIPTION
Stacked on #616 — **review that one first**; this PR's diff is against it, and
merging this before it would drag the schema in sideways.

The operator surface for `docs/modules/machine-maintenance.md`.

## The tab

A Maintenance tab appears once a station is selected, because a station **is** a
machine — the station list is `work_centers` filtered to `kind='internal'`, so a
picker would ask a question already answered. Unlike Inventory and My work it is
deliberately **not** on the list of routes that keep the nav visible before a
station exists: without a station there is no machine to have a logbook for.

## The open list does not name who filed the item

It shows the observation and the date. The author is on the entry's own card,
one tap away. This costs the list context and it is the right trade: a list of
open items with names down the side is a list of who reports the most problems,
read straight down the column — the shape of every operator scorecard this
product has refused to build. The cost of the alternative is that filing a
noticed becomes an admission.

There is a test whose only job is to fail if someone adds the name back, with
the argument written next to it.

## Open state is derived, not stored

`deriveOpenItems` is exported and tested on its own because it is the module's
only real logic — it replaces a column, and earns that by being unable to
disagree with the timeline it is drawn from (they are the same array). The
schema PR's trigger is what makes it *complete*: a resolver is required to sit
on the same machine as its target, so there is no second query that could miss
one.

The access layer does not even `SELECT usage_count`. It counts distinct jobs a
note was consulted on; a machine read has no job, so it is permanently zero here
and "used on 0 jobs" beside real knowledge would read as a verdict on the entry
rather than a gap in the instrument.

## Composer reuse

`useNoteCapture` hard-coded `jobId` and called `addJobNote` directly, which made
it a step-note hook that happened to own a photo pipeline. Now the **write** is
injected and nothing else is — `NoteWriter<TNote>` is generic rather than a
union, so the job callers keep returning `JobNote` and never learn to narrow
something they cannot receive. The event context rides along with the writer, so
a machine capture is distinguishable from a step capture at *every* funnel step
rather than only at the save; without that, "composer focused but nothing saved"
would average the two surfaces into nothing.

**The 32 existing tests across JobFeed and the operation page pass untouched**,
which is the point of doing the refactor before the new surface rather than
after it.

## Nothing prompts, ever

A machine with no details renders nothing at all — not an empty state, not a
completeness meter, not a prompt. Asset data entry is a leading cause of CMMS
abandonment, so a machine nobody has described has to look *finished*, because
it is. Tested.

The kind chip is optional and deselectable, and "Log the fix" preselects
nothing: plenty of fixes are a clean or an adjustment, and defaulting to
"repaired" would be the taxonomy nudge an optional chip exists to avoid.

## Doc amendments

Committed as a diff against the proposal rather than a rewrite of it. §6 (the
archived-machines defect was not being fixed elsewhere, so it is fixed here), §8
(`confirmed` is cut — a control nobody would tap teaches operators that some
buttons here are decorative), §9 (details and manuals ship; the office gets a
read-only view, but never a composer, since the kill criterion counts
non-founder authors).

## Verification

`tsc` clean, `pnpm lint` 0 errors, Vitest **1430 passing** across 120 files (36
new).

**The E2E spec has not run yet.** It writes its own entries through the UI
rather than reading a fixture — capture is what the module is a bet on, and a
spec that only read seeded rows would go green while capture was broken — but it
cannot run from this worktree, because the shared local Supabase stack does not
carry this branch's migration and resetting it would clobber every other
worktree. CI is its first real execution; expect selector churn if it goes red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)