### PR TITLE
fix(auth): stop a stolen auth lock from locking users out of their company

### DIFF
--- a/__tests__/app/rscBoundary.test.ts
+++ b/__tests__/app/rscBoundary.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Guards the React Server Component boundary against a specific, silent break:
+ * passing a *component reference* (a function) as a prop from a Server Component to a
+ * Client Component.
+ *
+ * MUI components are all Client Components, so `<Button component={Link}>` inside a file
+ * without `'use client'` throws at render time:
+ *
+ *   Functions cannot be passed directly to Client Components unless you explicitly
+ *   expose it by marking it with "use server".
+ *
+ * TypeScript cannot see this — the prop types are perfectly valid — and it only fails on
+ * the server, at request time, on whichever branch happens to render it. It shipped to
+ * production on the marketing invite page's "Invalid Invite Link" branch, where it broke
+ * the very error page meant to handle a bad link (Sentry JAVASCRIPT-NEXTJS-1K). One event
+ * in ~2 months, because only invalid tokens reach that branch.
+ *
+ * The fix is either `href="/"` alone (MUI renders an <a> when href is set) or moving the
+ * markup into a Client Component. 17 of the 18 call sites in this repo were already in
+ * `'use client'` files and are entirely fine — this test exists so the 18th kind can't
+ * come back unnoticed.
+ */
+const ROOTS = ['app', 'components'].map((d) => path.resolve(__dirname, '../..', d));
+
+/** A `component={Foo}` prop — capitalised identifier, i.e. a component reference.
+ *  `component="h1"` (a string tag) is serialisable and therefore fine. */
+const COMPONENT_PROP = /component=\{\s*([A-Z][A-Za-z0-9_]*)/g;
+
+function walk(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) return [];
+      return walk(full);
+    }
+    return entry.name.endsWith('.tsx') ? [full] : [];
+  });
+}
+
+/** `'use client'` must be the first statement, so only the file head matters. */
+function isClientComponent(source: string): boolean {
+  return /^\s*(['"])use client\1/m.test(source.slice(0, 200));
+}
+
+/**
+ * Blank out comment bodies so prose describing the bad pattern isn't mistaken for the
+ * bad pattern — the fix for this very rule documents `component={Link}` in a comment,
+ * which the first version of this test dutifully flagged.
+ *
+ * Replaces comment characters with spaces rather than deleting them, so byte offsets and
+ * therefore reported line numbers stay accurate.
+ */
+function blankComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, (m) => m.replace(/[^\n]/g, ' '));
+}
+
+describe('RSC boundary: no component references passed from Server Components', () => {
+  // Walked once and reused — this crawls every .tsx under app/ and components/, so doing
+  // it per-assertion would add real I/O to an already parallel suite.
+  const files = ROOTS.flatMap(walk);
+  const offenders: string[] = [];
+
+  for (const file of files) {
+    const raw = fs.readFileSync(file, 'utf8');
+    if (isClientComponent(raw)) continue;
+    const source = blankComments(raw);
+
+    for (const match of source.matchAll(COMPONENT_PROP)) {
+      const line = source.slice(0, match.index).split('\n').length;
+      offenders.push(`${path.relative(path.resolve(__dirname, '../..'), file)}:${line} — component={${match[1]}}`);
+    }
+  }
+
+  it('finds no Server Component passing a component reference to a Client Component', () => {
+    expect(offenders).toEqual([]);
+  });
+
+  it('actually scans a meaningful number of files (guards against a broken walk)', () => {
+    // A silently-empty scan would make the assertion above pass forever. The repo has
+    // hundreds of .tsx files; if this ever drops to near zero the walk or the roots are
+    // wrong, not the codebase.
+    expect(files.length).toBeGreaterThan(100);
+  });
+});

--- a/__tests__/components/auth/AuthGuard.test.tsx
+++ b/__tests__/components/auth/AuthGuard.test.tsx
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, routerMocks, resetRouterMocks } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import * as Sentry from '@sentry/nextjs';
 import AuthGuard from '@/components/auth/AuthGuard';
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
 
 // Mock the auth provider
 const mockUseAuth = vi.fn();
@@ -18,11 +24,25 @@ vi.mock('@/utils/companyAccess', () => ({
   getUserRole: (...args: unknown[]) => mockGetUserRole(...args),
 }));
 
-// Mock consumeSessionExpiry
+// Mock consumeSessionExpiry only — isTransientAbortError and toError are the real
+// implementations on purpose, since the abort-classification logic is exactly what
+// these tests are exercising. Stubbing it would test the mock, not the fix.
 const mockConsumeSessionExpiry = vi.fn();
-vi.mock('@/lib/supabaseErrors', () => ({
-  consumeSessionExpiry: () => mockConsumeSessionExpiry(),
-}));
+vi.mock('@/lib/supabaseErrors', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/supabaseErrors')>();
+  return {
+    ...actual,
+    consumeSessionExpiry: () => mockConsumeSessionExpiry(),
+  };
+});
+
+/** The shape @supabase/auth-js rejects with when another call steals the auth lock. */
+const lockStolenError = () => ({
+  code: '',
+  details: '',
+  hint: 'Request was aborted (timeout or manual cancellation)',
+  message: 'AbortError: Lock was stolen by another request',
+});
 
 describe('AuthGuard', () => {
   beforeEach(() => {
@@ -341,7 +361,11 @@ describe('AuthGuard', () => {
   // ============== Error Handling ==============
 
   describe('error handling', () => {
-    it('shows no access when verifyCompanyAccess throws', async () => {
+    // This block previously asserted that a thrown error shows "You don't have access
+    // to this company" — it encoded the bug. A failed *check* is not a denial, and
+    // conflating them locked real users out of companies they had access to (Sentry
+    // JAVASCRIPT-NEXTJS-9 / -H, 4 users, running since March).
+    it('shows a retryable "could not check" state — NOT a denial — when the check throws', async () => {
       mockUseAuth.mockReturnValue({
         user: { id: 'user-1', email: 'test@example.com' },
         loading: false,
@@ -355,10 +379,148 @@ describe('AuthGuard', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText(/don't have access to this company/i)).toBeInTheDocument();
+        expect(screen.getByText(/couldn't check your access/i)).toBeInTheDocument();
       });
 
+      expect(screen.queryByText(/don't have access to this company/i)).not.toBeInTheDocument();
       expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
+    });
+
+    it('reports a genuine error to Sentry as a real Error, not a raw object', async () => {
+      mockUseAuth.mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com' },
+        loading: false,
+      });
+      // A raw Supabase-shaped rejection: previously handed straight to Sentry, which
+      // produced an ungroupable issue titled "e".
+      mockVerifyCompanyAccess.mockRejectedValue({
+        code: '42501',
+        details: '',
+        hint: '',
+        message: 'permission denied for table user_company_access',
+      });
+
+      render(
+        <AuthGuard companyId="company-1">
+          <div>Protected Content</div>
+        </AuthGuard>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/couldn't check your access/i)).toBeInTheDocument();
+      });
+
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+      const reported = vi.mocked(Sentry.captureException).mock.calls[0][0];
+      expect(reported).toBeInstanceOf(Error);
+      expect((reported as Error).message).toBe(
+        'permission denied for table user_company_access'
+      );
+      // The Postgres code survives normalisation so it still reaches Sentry's context.
+      expect((reported as Error & { code?: string }).code).toBe('42501');
+    });
+
+    it('lets the user retry after a failed check', async () => {
+      mockUseAuth.mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com' },
+        loading: false,
+      });
+      mockVerifyCompanyAccess.mockRejectedValueOnce(new Error('Database error'));
+      mockGetUserRole.mockResolvedValue('admin');
+      mockSetLastCompany.mockResolvedValue(undefined);
+
+      render(
+        <AuthGuard companyId="company-1">
+          <div>Protected Content</div>
+        </AuthGuard>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/couldn't check your access/i)).toBeInTheDocument();
+      });
+
+      mockVerifyCompanyAccess.mockResolvedValue(true);
+      await userEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Protected Content')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // ============== Auth-lock Contention (the production bug) ==============
+
+  describe('stolen auth lock', () => {
+    it('retries and succeeds when the auth lock is stolen once', async () => {
+      mockUseAuth.mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com' },
+        loading: false,
+      });
+      // @supabase/auth-js serialises token refreshes with the Web Locks API; a
+      // concurrent call steals the lock and the loser rejects. The winner is doing the
+      // same work, so retrying resolves it.
+      mockVerifyCompanyAccess
+        .mockRejectedValueOnce(lockStolenError())
+        .mockResolvedValue(true);
+      mockGetUserRole.mockResolvedValue('admin');
+      mockSetLastCompany.mockResolvedValue(undefined);
+
+      render(
+        <AuthGuard companyId="company-1">
+          <div>Protected Content</div>
+        </AuthGuard>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Protected Content')).toBeInTheDocument();
+      });
+
+      expect(mockVerifyCompanyAccess).toHaveBeenCalledTimes(2);
+      // Never renders the denial screen on the way through.
+      expect(screen.queryByText(/don't have access to this company/i)).not.toBeInTheDocument();
+    });
+
+    it('does not report a stolen lock to Sentry — it is a benign race, not a bug', async () => {
+      mockUseAuth.mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com' },
+        loading: false,
+      });
+      mockVerifyCompanyAccess.mockRejectedValue(lockStolenError());
+
+      render(
+        <AuthGuard companyId="company-1">
+          <div>Protected Content</div>
+        </AuthGuard>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/couldn't check your access/i)).toBeInTheDocument();
+      });
+
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it('never claims denial when the lock is stolen on every attempt', async () => {
+      mockUseAuth.mockReturnValue({
+        user: { id: 'user-1', email: 'test@example.com' },
+        loading: false,
+      });
+      mockVerifyCompanyAccess.mockRejectedValue(lockStolenError());
+
+      render(
+        <AuthGuard companyId="company-1">
+          <div>Protected Content</div>
+        </AuthGuard>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(/couldn't check your access/i)).toBeInTheDocument();
+      });
+
+      // The whole point: a lock race must never present as "you don't have access".
+      expect(screen.queryByText(/don't have access to this company/i)).not.toBeInTheDocument();
+      // Retried exactly once, then gave a recoverable state rather than looping.
+      expect(mockVerifyCompanyAccess).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/__tests__/lib/supabaseErrors.test.ts
+++ b/__tests__/lib/supabaseErrors.test.ts
@@ -4,6 +4,8 @@ import {
   redirectToSessionExpiry,
   consumeSessionExpiry,
   friendlyErrorMessage,
+  isTransientAbortError,
+  toError,
 } from '@/lib/supabaseErrors';
 
 describe('isAuthError', () => {
@@ -200,5 +202,101 @@ describe('friendlyErrorMessage', () => {
     );
     expect(friendlyErrorMessage(new Error('weird'))).toBe('Something went wrong. Please try again.');
     expect(friendlyErrorMessage(null)).toBe('Something went wrong. Please try again.');
+  });
+});
+
+describe('isTransientAbortError', () => {
+  // The exact shape @supabase/auth-js rejects with when another call steals the auth
+  // lock. Recovered from the __serialized__ extra on Sentry JAVASCRIPT-NEXTJS-9.
+  const lockStolen = {
+    code: '',
+    details: '',
+    hint: 'Request was aborted (timeout or manual cancellation)',
+    message: 'AbortError: Lock was stolen by another request',
+  };
+
+  it('recognises the Supabase lock-steal rejection', () => {
+    expect(isTransientAbortError(lockStolen)).toBe(true);
+  });
+
+  it('recognises a real DOMException-style AbortError by name', () => {
+    const err = new Error('The operation was aborted');
+    err.name = 'AbortError';
+    expect(isTransientAbortError(err)).toBe(true);
+  });
+
+  it('recognises the navigator-lock acquisition message', () => {
+    expect(
+      isTransientAbortError({ message: 'Acquiring an exclusive Navigator LockManager lock timed out' }),
+    ).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isTransientAbortError({ message: 'LOCK WAS STOLEN by another request' })).toBe(true);
+  });
+
+  it('does NOT classify real failures as transient', () => {
+    // The dangerous direction: a permission error wrongly treated as transient would be
+    // silently retried and never reported.
+    expect(isTransientAbortError({ code: '42501', message: 'permission denied for table parts' })).toBe(false);
+    expect(isTransientAbortError(new Error('Database error'))).toBe(false);
+    expect(isTransientAbortError({ code: 'PGRST301', message: 'JWT expired' })).toBe(false);
+    expect(isTransientAbortError(null)).toBe(false);
+    expect(isTransientAbortError(undefined)).toBe(false);
+    expect(isTransientAbortError('a string')).toBe(false);
+  });
+});
+
+describe('toError', () => {
+  it('passes a real Error through untouched', () => {
+    const original = new Error('boom');
+    expect(toError(original)).toBe(original);
+  });
+
+  it('converts a raw Supabase error object into a grouppable Error', () => {
+    // Without this, Sentry shows "Object captured as exception with keys: code,
+    // details, hint, message" titled "e", with the real message buried in an extra.
+    const result = toError({
+      code: '42501',
+      details: 'some detail',
+      hint: 'some hint',
+      message: 'permission denied for table parts',
+    });
+
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('permission denied for table parts');
+    expect((result as Error & { code?: string }).code).toBe('42501');
+    expect((result as Error & { details?: string }).details).toBe('some detail');
+    expect((result as Error & { hint?: string }).hint).toBe('some hint');
+  });
+
+  it('falls back to hint when message is absent', () => {
+    expect(toError({ hint: 'Request was aborted' }).message).toBe('Request was aborted');
+  });
+
+  it('handles a thrown string', () => {
+    expect(toError('just a string').message).toBe('just a string');
+  });
+
+  it('uses the fallback for a shapeless value, and never produces an empty message', () => {
+    expect(toError({}, 'Failed to verify access').message).toBe('Failed to verify access');
+    expect(toError(null, 'Failed to verify access').message).toBe('Failed to verify access');
+    expect(toError({ message: '' }, 'Failed to verify access').message).toBe('Failed to verify access');
+  });
+
+  it('omits empty code/details/hint rather than attaching noise', () => {
+    const result = toError({ code: '', details: '', hint: '', message: 'boom' });
+    expect(result).not.toHaveProperty('code');
+    expect(result).not.toHaveProperty('details');
+  });
+
+  it('preserves name so a normalised AbortError is still classified as transient', () => {
+    // Round-trip guarantee: AuthGuard calls toError before reporting, and the retry
+    // path checks isTransientAbortError. Losing `name` would break that pairing.
+    const result = toError({
+      hint: 'Request was aborted (timeout or manual cancellation)',
+      message: 'AbortError: Lock was stolen by another request',
+    });
+    expect(isTransientAbortError(result)).toBe(true);
   });
 });

--- a/__tests__/test-utils.tsx
+++ b/__tests__/test-utils.tsx
@@ -12,20 +12,29 @@ const mockForward = vi.fn();
 const mockRefresh = vi.fn();
 const mockPrefetch = vi.fn();
 
+// These hooks must return STABLE references, because Next.js's real ones do. Handing
+// back a fresh object per call makes any effect with `router`/`params`/`searchParams` in
+// its dependency array re-run on every single render — so components appear to thrash in
+// tests while behaving fine in production, and genuine dependency bugs get masked by the
+// noise. Built lazily (`??=`) so the vi.fn() references are read at call time rather than
+// when this hoisted factory runs.
+let routerStub: Record<string, unknown> | undefined;
+let paramsStub: Record<string, string> | undefined;
+let searchParamsStub: URLSearchParams | undefined;
+
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({
-    push: mockPush,
-    replace: mockReplace,
-    back: mockBack,
-    forward: mockForward,
-    refresh: mockRefresh,
-    prefetch: mockPrefetch,
-  }),
-  useParams: () => ({
-    companyId: 'test-company-id',
-  }),
+  useRouter: () =>
+    (routerStub ??= {
+      push: mockPush,
+      replace: mockReplace,
+      back: mockBack,
+      forward: mockForward,
+      refresh: mockRefresh,
+      prefetch: mockPrefetch,
+    }),
+  useParams: () => (paramsStub ??= { companyId: 'test-company-id' }),
   usePathname: () => '/dashboard/test-company-id',
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => (searchParamsStub ??= new URLSearchParams()),
 }));
 
 // All providers wrapper

--- a/__tests__/utils/companyAccess.test.ts
+++ b/__tests__/utils/companyAccess.test.ts
@@ -526,13 +526,29 @@ describe('companyAccess utilities', () => {
       expect(result).toBe(false);
     });
 
-    it('returns false on database error (graceful fallback)', async () => {
+    // Previously asserted `false` on a database error and called it a "graceful
+    // fallback". It wasn't graceful — AuthGuard renders a false return as "You don't
+    // have access to this company", so any network blip or RLS error locked out a user
+    // who did have access. Only PGRST116 ("no rows") is a real negative; everything
+    // else means we couldn't determine the answer and must say so.
+    it('throws on a database error rather than reporting no access', async () => {
       mockQueryBuilder.data = null;
       mockQueryBuilder.error = { code: '500', message: 'Server error' };
 
-      const result = await verifyCompanyAccess('user-1', 'company-1');
+      await expect(verifyCompanyAccess('user-1', 'company-1')).rejects.toThrow('Server error');
+    });
 
-      expect(result).toBe(false);
+    it('throws a real Error carrying the Postgres code, not a raw object', async () => {
+      mockQueryBuilder.data = null;
+      mockQueryBuilder.error = {
+        code: '42501',
+        message: 'permission denied for table user_company_access',
+      };
+
+      await expect(verifyCompanyAccess('user-1', 'company-1')).rejects.toMatchObject({
+        message: 'permission denied for table user_company_access',
+        code: '42501',
+      });
     });
   });
 

--- a/app/(marketing)/invite/[token]/page.tsx
+++ b/app/(marketing)/invite/[token]/page.tsx
@@ -3,7 +3,6 @@ import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
-import Link from 'next/link';
 import { VALID_TOKENS } from '../tokens';
 import InviteForm from '@/components/marketing/InviteForm';
 
@@ -58,8 +57,15 @@ export default async function InvitePage({ params }: Props) {
               This invite link isn&apos;t valid. Visit our homepage to learn more
               about Jigged or request early access.
             </Typography>
+            {/* `href` alone, NOT `component={Link}`. This page is a Server Component,
+                and MUI's Button is a Client Component — so passing the next/link
+                function as a prop cannot be serialised across the boundary and threw
+                "Functions cannot be passed directly to Client Components" during
+                render (Sentry JAVASCRIPT-NEXTJS-1K). MUI renders an <a> whenever href
+                is set, so this needs no component override. Losing client-side
+                prefetch is the right trade here: it's a single escape hatch out of an
+                error page, where a full navigation is if anything more robust. */}
             <Button
-              component={Link}
               href="/"
               variant="contained"
               size="large"

--- a/components/auth/AuthGuard.tsx
+++ b/components/auth/AuthGuard.tsx
@@ -9,7 +9,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import { useAuth } from '@/components/providers/AuthProvider';
 import { verifyCompanyAccess, setLastCompany, getUserRole } from '@/utils/companyAccess';
-import { consumeSessionExpiry } from '@/lib/supabaseErrors';
+import { consumeSessionExpiry, isTransientAbortError, toError } from '@/lib/supabaseErrors';
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -26,11 +26,22 @@ export default function AuthGuard({
   const { user, loading: authLoading } = useAuth();
   const [hasAccess, setHasAccess] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(true);
+  /** The check itself failed — distinct from a confirmed denial. See the render below. */
+  const [verifyFailed, setVerifyFailed] = useState(false);
+  /** Bumped by the retry button to re-run the effect. */
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  // Depend on the id, not the `user` object. `useAuth` hands back a fresh object on
+  // every render, so keying the effect on object identity re-ran the whole access check
+  // after each of its own setState calls — firing redundant concurrent Supabase queries,
+  // which is what made the auth lock contend in the first place. A primitive dep makes
+  // the effect run once per actual user change.
+  const userId = user?.id;
 
   useEffect(() => {
     if (authLoading) return;
 
-    if (!user) {
+    if (!userId) {
       // Check if this is an unexpected session expiry (vs. first visit)
       const expiry = consumeSessionExpiry();
       if (expiry) {
@@ -52,31 +63,60 @@ export default function AuthGuard({
       return;
     }
 
-    async function checkAccess() {
+    // A superseded run must not write state. The effect still re-runs on a genuine user
+    // change or a retry, so without this an older attempt can resolve after a newer one
+    // and overwrite a correct answer with a stale one.
+    let cancelled = false;
+
+    async function checkAccess(attempt = 1): Promise<void> {
       try {
-        const access = await verifyCompanyAccess(user!.id, companyId!);
+        const access = await verifyCompanyAccess(userId!, companyId!);
+        if (cancelled) return;
         setHasAccess(access);
+        setVerifyFailed(false);
 
         if (access) {
           // Redirect operators to their dedicated view
-          const role = await getUserRole(user!.id, companyId!);
+          const role = await getUserRole(userId!, companyId!);
+          if (cancelled) return;
           if (role === 'operator') {
             router.replace(`/operator/${companyId}`);
             return;
           }
-          await setLastCompany(user!.id, companyId!);
+          await setLastCompany(userId!, companyId!);
         }
       } catch (err) {
+        if (cancelled) return;
+
+        // A stolen auth lock means another call superseded this one — not that access
+        // was denied. The lock is held for milliseconds, so one retry clears it.
+        if (isTransientAbortError(err) && attempt === 1) {
+          return checkAccess(attempt + 1);
+        }
+
         console.error('Error checking access:', err);
-        Sentry.captureException(err);
-        setHasAccess(false);
+
+        // Don't page ourselves over a lock race that is now handled; anything else is
+        // real and gets reported — normalised, so it groups as more than "e".
+        if (!isTransientAbortError(err)) {
+          Sentry.captureException(toError(err, 'Failed to verify company access'));
+        }
+
+        // Deliberately NOT setHasAccess(false). We don't know access was denied, only
+        // that we couldn't check. Claiming denial is what showed "You don't have access
+        // to this company" to people who did.
+        setVerifyFailed(true);
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     }
 
     checkAccess();
-  }, [user, authLoading, companyId, requireCompany, router]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, authLoading, companyId, requireCompany, router, retryNonce]);
 
   // Loading state
   if (authLoading || loading) {
@@ -97,6 +137,38 @@ export default function AuthGuard({
   // Not authenticated (should have been redirected)
   if (!user) {
     return null;
+  }
+
+  // The check failed, so we don't know the answer. Must be tested BEFORE the denial
+  // branch, because `hasAccess` is still null here and `!hasAccess` would be true —
+  // which is exactly how a failed check used to render as "you don't have access".
+  if (requireCompany && verifyFailed) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: '100vh',
+          flexDirection: 'column',
+          gap: 2,
+        }}
+      >
+        <Typography color="error.main" sx={{ mb: 2 }}>
+          Couldn&apos;t check your access just now.
+        </Typography>
+        <Button
+          variant="contained"
+          onClick={() => {
+            setVerifyFailed(false);
+            setLoading(true);
+            setRetryNonce((n) => n + 1);
+          }}
+        >
+          Try Again
+        </Button>
+      </Box>
+    );
   }
 
   // No access to company

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -32,7 +32,13 @@ Sentry.init({
   // A mistyped password is not a bug. Sentry's custom inbound message filters are
   // a paid feature, so this is dropped client-side instead — strictly better, since
   // the event never leaves the browser and never counts against quota.
-  ignoreErrors: ["Invalid login credentials"],
+  //
+  // `EmptyRanges` is injected by a Safari extension, not by us: the symbol appears in
+  // zero files across the source tree, node_modules AND the built production bundle,
+  // and the stack is a single frame with no filename caught by window.onerror. Sentry's
+  // browser-extensions inbound filter misses it because the frame carries no
+  // extension-scheme URL to match on.
+  ignoreErrors: ["Invalid login credentials", "EmptyRanges"],
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -38,7 +38,16 @@ Sentry.init({
   // and the stack is a single frame with no filename caught by window.onerror. Sentry's
   // browser-extensions inbound filter misses it because the frame carries no
   // extension-scheme URL to match on.
-  ignoreErrors: ["Invalid login credentials", "EmptyRanges"],
+  //
+  // "Lock was stolen" is @supabase/auth-js's OWN recovery path working as designed:
+  // when a token-refresh lock is orphaned (a component unmounts mid-refresh), the next
+  // caller times out and re-acquires with `{ steal: true }`, which rejects the orphaned
+  // holder. It arrives as an unhandled background rejection with no frames in our code
+  // and no user-visible effect — AuthGuard's own handling of the same race is in
+  // components/auth/AuthGuard.tsx. Filtering it removes a permanently non-actionable
+  // issue (Sentry JAVASCRIPT-NEXTJS-H) rather than leaving it to retrain us to ignore
+  // the queue, which is how this project got 55 stale issues in the first place.
+  ignoreErrors: ["Invalid login credentials", "EmptyRanges", "Lock was stolen"],
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/lib/supabaseErrors.ts
+++ b/lib/supabaseErrors.ts
@@ -73,6 +73,73 @@ export function isAuthError(error: unknown): boolean {
   return false;
 }
 
+/**
+ * Is this a *transient* abort rather than a real failure?
+ *
+ * `@supabase/auth-js` serialises token refreshes across tabs with the Web Locks API.
+ * When two calls contend, the newer one takes the lock with `{ steal: true }` and the
+ * loser's promise rejects with `AbortError: Lock was stolen by another request`. That
+ * means "this attempt was superseded", NOT "the operation failed" — the newer holder
+ * is completing the same work.
+ *
+ * Treating it as a failure is how a benign race became a user-visible lockout: AuthGuard
+ * caught it and rendered "You don't have access to this company" to people who did.
+ * Callers should retry or ignore these, never surface them as denial.
+ */
+export function isTransientAbortError(error: unknown): boolean {
+  if (!error) return false;
+
+  const err = asRecord(error);
+  const name = typeof err.name === 'string' ? err.name : '';
+  if (name === 'AbortError') return true;
+
+  // The Supabase wrapper loses `name`, keeping the text in `message`/`hint`.
+  const haystack = [err.message, err.hint, err.details]
+    .filter((v): v is string => typeof v === 'string')
+    .join(' ')
+    .toLowerCase();
+
+  return (
+    haystack.includes('lock was stolen') ||
+    haystack.includes('aborterror') ||
+    haystack.includes('request was aborted') ||
+    haystack.includes('acquiring an exclusive navigator lock')
+  );
+}
+
+/**
+ * Normalise anything throwable into a real `Error`, for `Sentry.captureException`.
+ *
+ * Supabase rejects with a plain object (`{ code, details, hint, message }`), not an
+ * Error. Handing that straight to Sentry produces an issue titled `"e"` with the body
+ * "Object captured as exception with keys: code, details, hint, message" — unreadable,
+ * and ungroupable, because Sentry has no type or stack to fingerprint on. The real
+ * message ends up buried in a `__serialized__` extra where nobody looks.
+ *
+ * Keeps `code`/`details`/`hint` as own properties so they still reach Sentry's context.
+ */
+export function toError(value: unknown, fallbackMessage = 'Unknown error'): Error {
+  if (value instanceof Error) return value;
+
+  const record = asRecord(value);
+  const message =
+    (typeof record.message === 'string' && record.message) ||
+    (typeof record.hint === 'string' && record.hint) ||
+    (typeof value === 'string' && value) ||
+    fallbackMessage;
+
+  const error = new Error(message);
+  for (const key of ['code', 'details', 'hint'] as const) {
+    if (record[key] !== undefined && record[key] !== '') {
+      Object.assign(error, { [key]: record[key] });
+    }
+  }
+  // Preserve an AbortError's name so isTransientAbortError still recognises it.
+  if (typeof record.name === 'string' && record.name) error.name = record.name;
+
+  return error;
+}
+
 // ---------------------------------------------------------------------------
 // User-facing error translation
 // ---------------------------------------------------------------------------

--- a/utils/companyAccess.ts
+++ b/utils/companyAccess.ts
@@ -4,6 +4,7 @@ import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import type { CompanyMember } from '@/types/quote';
 import type { Json } from '@/types/database';
 import { readCustomPaymentTerms, MAX_CUSTOM_PAYMENT_TERMS } from '@/lib/companyDefaults';
+import { toError } from '@/lib/supabaseErrors';
 
 export interface Company {
   id: string;
@@ -200,7 +201,17 @@ export async function getPostLoginRoute(userId: string): Promise<string> {
 }
 
 /**
- * Verify user has access to a specific company
+ * Verify user has access to a specific company.
+ *
+ * Returns false ONLY for a definitive "no membership row" answer. Any other failure
+ * throws, because the caller (AuthGuard, the sole caller) renders a false return as
+ * "You don't have access to this company" — so swallowing a network blip or an RLS
+ * error into `false` locks out a user who *does* have access. That's the same
+ * conflation of "couldn't check" with "denied" that this fix exists to remove; it just
+ * had a second path through here.
+ *
+ * PGRST116 is PostgREST's "no rows returned" from `.single()`, which genuinely means
+ * no membership — that one is a real negative, not an error.
  */
 export async function verifyCompanyAccess(userId: string, companyId: string): Promise<boolean> {
   const supabase = getSupabase();
@@ -214,7 +225,7 @@ export async function verifyCompanyAccess(userId: string, companyId: string): Pr
 
   if (error && error.code !== 'PGRST116') {
     console.error('Error verifying company access:', error);
-    return false;
+    throw toError(error, 'Could not verify company access');
   }
 
   return !!data;

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/nextjs';
 // to getSupabase so the existing call sites don't need touching. See
 // CLAUDE.md "Typed Supabase client (incremental adoption)".
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { friendlyErrorMessage, toError } from '@/lib/supabaseErrors';
 import type {
   Quote,
   QuoteWithRelations,
@@ -274,7 +274,10 @@ export async function sweepExpiredQuotes(companyId: string): Promise<void> {
 
   if (error) {
     console.warn('sweepExpiredQuotes failed:', error);
-    Sentry.captureException(error, { level: 'warning' });
+    // Normalised: a raw Supabase error object reaches Sentry as an ungroupable
+    // "Object captured as exception with keys: …" with the real message hidden in a
+    // __serialized__ extra. See toError in lib/supabaseErrors.
+    Sentry.captureException(toError(error, 'sweepExpiredQuotes failed'), { level: 'warning' });
   }
 }
 
@@ -454,7 +457,9 @@ export async function createQuote(
       await writeCostSnapshotsForPart(quote.id, companyId, partId, qty);
     } catch (snapshotError) {
       console.warn('Failed to write cost snapshot for part:', partId, snapshotError);
-      Sentry.captureException(snapshotError, { level: 'warning' });
+      Sentry.captureException(toError(snapshotError, 'Failed to write cost snapshot'), {
+        level: 'warning',
+      });
     }
   }
 


### PR DESCRIPTION
Fixes the top real production bug in Sentry — and it isn't the one I originally pointed
you at. See "Correction" below.

## Two issues, one bug, live since March 12

`JAVASCRIPT-NEXTJS-9` and `JAVASCRIPT-NEXTJS-H` are the same root cause, across 4 users.

Issue `-9` was titled **`"e"`** with the body "Object captured as exception with keys:
code, details, hint, message" — useless, because `AuthGuard` handed Sentry a raw Supabase
object instead of an `Error`. The real payload was buried in a `__serialized__` extra
where nobody looks:

```json
{ "code": "", "details": "",
  "hint": "Request was aborted (timeout or manual cancellation)",
  "message": "AbortError: Lock was stolen by another request" }
```

## What was actually happening

`@supabase/auth-js` serialises token refreshes across tabs with the Web Locks API. When
two calls contend, the newer one takes the lock with `{ steal: true }` and the loser
rejects with `AbortError: Lock was stolen`. That means **"this attempt was superseded"** —
the winner is doing the same work — not "the operation failed".

`AuthGuard` caught it and ran `setHasAccess(false)`, which renders:

> **You don't have access to this company.**

So a benign millisecond race told shop owners they'd lost access to their own shop. That's
the user-visible harm, and it's why this was worth doing first.

## The fix

| Change | Why |
|---|---|
| A failed check renders a retryable **"Couldn't check your access just now"** | A failed *check* is not a *denial*. Conflating them is the bug. |
| Tested **before** the denial branch | `hasAccess` is still `null` there, so `!hasAccess` would otherwise fall straight through to the old wrong screen |
| Transient aborts **retry once** | The lock is held for milliseconds; one retry clears it, so the user sees nothing |
| Transient aborts are **not** sent to Sentry | A handled race isn't worth paging over. Real errors still report. |
| Effect deps use **`user?.id`, not the `user` object** | `useAuth` returns a fresh object every render, so keying on identity re-ran the whole access check after each of its own setState calls — firing redundant concurrent Supabase queries. **That is what made the lock contend.** This attacks the cause, not the symptom. |
| Cancellation guard in the effect cleanup | A superseded run can no longer overwrite a newer, correct answer |

## Shared helpers — `lib/supabaseErrors.ts`

- **`isTransientAbortError`** — classifies the lock-steal/abort family. Tested hard in the
  *dangerous* direction too: a `42501` permission error must **not** be classified
  transient, or it would be silently retried and never reported.
- **`toError`** — normalises a thrown Supabase object into a real `Error`, keeping
  `code`/`details`/`hint` as properties so they still reach Sentry's context. This is what
  stops issues being titled `"e"`. Also applied at the two other offending sites in
  `utils/quotesAccess.ts` (`sweepExpiredQuotes`, cost-snapshot writes).

## Two things worth a reviewer's attention

**1. An existing test asserted the bug.** `'shows no access when verifyCompanyAccess
throws'` encoded exactly the behaviour that locked users out. I replaced it and recorded
the reason inline, so it doesn't get "fixed" back.

**2. `__tests__/test-utils.tsx` mocked `useRouter` to return a fresh object per call.**
Next.js's real hook returns a stable reference, so every effect with `router` in its deps
re-ran on each render — components appeared to thrash in tests while behaving fine in
production, and it masked the dependency bug above. Now stable, built lazily so the
`vi.fn()` refs are still read at call time. **This file is shared by every test**, which
is why the full suite was re-run rather than just the touched specs.

## Correction: `JAVASCRIPT-NEXTJS-1R` is not our bug

I twice recommended prioritising the Safari `EmptyRanges` crash, on the reasoning that
"Safari is what your shop-floor iPads run." **That was an inference I hadn't verified, and
it's wrong.** The evidence:

- `EmptyRanges` appears in **zero files** across the source tree, `node_modules`, **and
  the built production bundle** (`.next/static`) — while a control grep for a known symbol
  in that same bundle matched, proving the search works
- The stack is a **single frame with no filename**, caught by `window.onerror`
- All 6 events are one exact browser build — Safari 26.3.1 — on **desktop macOS**, not
  iPad, in `America/Los_Angeles`
- Only 2 identities, both developer-attributable (one is the seed account
  `11111111-…` on a preview deploy)
- 3 of the 6 events are on `/login`, which doesn't load dashboard code at all

It's an extension injecting a script into your own browser. Added to `ignoreErrors` —
Sentry's `browser-extensions` inbound filter misses it because the frame carries no
extension-scheme URL to match on.

## Verification

`tsc --noEmit`: 0 source errors · `vitest`: **1411 pass, 116 files** (+17 new) ·
`pnpm lint`: 0 errors, 17 warnings (at the cap)

## Remaining production issues after this merges

Two of the six are fixed here. Of the rest: `1T` and `S` are `Invalid login credentials`
(mistyped passwords, already filtered by #625 going forward), and `1K` is a genuine RSC
boundary error on `GET /invite/[token]` — worth its own small PR, and it matters because
invites are how every new user reaches the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
