### PR TITLE
docs(observability): capture the Sentry triage runbook for agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,40 @@ If a backfill is genuinely impossible (truly lost history), prefer an explicit "
 
 ---
 
+### Observability: Sentry owns errors, and never lies about them
+
+Full runbook — CLI recipes, triage steps, and the traps that cost real debugging time — is
+in **[docs/observability.md](docs/observability.md)**. Read it before touching Sentry config
+or triaging an issue. The rules that bind while writing code:
+
+- **Sentry is the error tracker; PostHog is product analytics.** Never add a second error
+  tracker — `capture_exceptions` stays `false` in `instrumentation-client.ts`. Vercel has no
+  JS error tracking at all, so it substitutes for neither.
+- **Never pass a raw Supabase error to `Sentry.captureException`.** It rejects with a plain
+  object, which Sentry can't fingerprint — you get an issue titled `"e"` and the real
+  message buried in a `__serialized__` extra. Wrap it: `captureException(toError(err, '…'))`
+  from [`lib/supabaseErrors.ts`](lib/supabaseErrors.ts).
+- **"Couldn't check" is never "denied."** An access check that *fails* must not render as a
+  definitive negative. `verifyCompanyAccess` swallowing errors into `return false` is how one
+  dropped request showed "You don't have access to this company" to a user who did. Return a
+  definitive answer only for a definitive result; otherwise throw and give the UI a distinct
+  retryable state.
+- **Transient aborts are not failures.** `AbortError: Lock was stolen` is `@supabase/auth-js`
+  recovering an orphaned token-refresh lock — it means *superseded*, not *failed*. Classify
+  with `isTransientAbortError` and retry; never report it, never surface it as an error.
+- **The SDKs are off outside a production build** (`enabled: NODE_ENV === "production"`, and
+  a `"pytest" in sys.modules` guard on the backend). Don't remove those — 90% of the issue
+  queue was once this repo's own test runs, which is why nobody read the alerts.
+- **Every `ignoreErrors` entry needs a recorded reason** in `docs/observability.md`. A queue
+  you don't trust is worse than no queue.
+
+**Two gotchas worth knowing before you debug for an hour:** `sentry alert issues edit` is
+broken for this org (alert rules moved to the Workflow Engine — the old `rules/` endpoint is
+retired), and `--json` returns `{"data": [...]}`, so `jq 'length'` silently counts object
+keys. Both are covered in the runbook.
+
+---
+
 ### Deletion is archive (soft-delete), and never blocks
 
 Every user-facing entity (`parts`, `customers`, `vendors`, `work_centers`, `jobs`, `quotes`) has a nullable `deleted_at`. The UI "Delete" action sets `deleted_at` — it must **never** issue a hard `DELETE` and **never** block on a foreign-key reference. The row survives so quotes/jobs/shipments/BOMs that reference it keep resolving. See `docs/architecture.md` §16 for the full standard.
@@ -720,6 +754,7 @@ Product documentation is version-controlled in the `/docs` folder.
 | System Architecture | [docs/architecture.md](docs/architecture.md) |
 | Design System | [docs/design-system.md](docs/design-system.md) |
 | Operator Paperless Flow (journey spec) | [docs/operator-paperless-flow.md](docs/operator-paperless-flow.md) |
+| Observability (Sentry / PostHog / Vercel) | [docs/observability.md](docs/observability.md) |
 
 ### Module Specifications
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,10 @@ or triaging an issue. The rules that bind while writing code:
 - **Sentry is the error tracker; PostHog is product analytics.** Never add a second error
   tracker — `capture_exceptions` stays `false` in `instrumentation-client.ts`. Vercel has no
   JS error tracking at all, so it substitutes for neither.
+- **Vercel Web Analytics (`<Analytics />` in `app/layout.tsx`) is kept on purpose**, even
+  though it overlaps PostHog. It's the free tier and costs one script tag: basic pageview
+  counts and Web Vitals with zero per-feature instrumentation. PostHog owns the journeys,
+  funnels and retention. Don't remove either as "redundant".
 - **Never pass a raw Supabase error to `Sentry.captureException`.** It rejects with a plain
   object, which Sentry can't fingerprint — you get an issue titled `"e"` and the real
   message buried in a `__serialized__` extra. Wrap it: `captureException(toError(err, '…'))`

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,277 @@
+# Observability
+
+Three tools, three layers. They are **not** redundant, but there is exactly one overlap
+you must not re-create.
+
+| Tool | Layer | Answers |
+|---|---|---|
+| **Vercel** (logs + analytics) | Infrastructure | Did the deploy work? Is the function slow? |
+| **Sentry** | Correctness | What broke, where in the code, for whom? |
+| **PostHog** | Behaviour | What did users do? Where did they drop off? |
+
+**Sentry owns error tracking. PostHog must not.** `capture_exceptions` is deliberately
+`false` in [`instrumentation-client.ts`](../instrumentation-client.ts) — Sentry has the
+grouping, breadcrumbs and source-map upload that make a solo triage queue workable, and
+PostHog's error tracking has no advanced grouping. Two trackers means double ingest and
+two places to look during an incident. Vercel has **no** JavaScript error tracking at all,
+so it is not a substitute for either.
+
+---
+
+## Sentry: the CLI is the interface
+
+The `sentry` CLI is installed and authenticated (`sentry auth status`). Prefer it over the
+dashboard — an agent can use it, and it composes.
+
+Two projects:
+
+- `jigged/javascript-nextjs` — frontend
+- `jigged/python-fastapi` — backend
+
+```bash
+sentry issue list jigged/javascript-nextjs --query "is:unresolved" --period 90d
+sentry issue view JAVASCRIPT-NEXTJS-9          # details + latest event
+sentry issue events JAVASCRIPT-NEXTJS-9        # per-event list
+sentry issue explain JAVASCRIPT-NEXTJS-9       # Seer AI root cause
+sentry issue plan JAVASCRIPT-NEXTJS-9          # Seer AI fix plan
+sentry issue archive JAVASCRIPT-NEXTJS-9 --until auto
+```
+
+An MCP server also exists — `https://mcp.sentry.dev/mcp/jigged/javascript-nextjs`, wired in
+the gitignored `.mcp.json`. Its entry **needs `"type": "http"`** or Claude Code silently
+skips it. Authorise via `/mcp` in an interactive session. The CLI does everything the MCP
+does, so this is convenience, not a prerequisite.
+
+### Environments, and how to filter by them
+
+Post-#625 the environment tags are trustworthy:
+
+| Where | Tag |
+|---|---|
+| Frontend, production | `vercel-production` |
+| Frontend, preview | `vercel-preview` |
+| Frontend, local dev / CI E2E | **nothing — the SDK is disabled** |
+| Backend, production | `production` |
+| Backend, preview | `preview` |
+| Backend, local | `development` |
+
+Note the asymmetry: the frontend's tags come from Vercel's Sentry integration
+(`vercel-` prefixed), the backend's from `resolve_sentry_environment()` in
+[`api/index.py`](../api/index.py) reading `VERCEL_ENV`. Issues older than 2026-07-30 may
+carry `staging`, from a since-removed `ENVIRONMENT` variable — that value is legacy, not
+a current environment.
+
+```bash
+sentry issue list jigged/javascript-nextjs --query "is:unresolved environment:vercel-production"
+sentry issue list jigged/python-fastapi    --query "is:unresolved environment:production"
+```
+
+> ### ⚠️ An issue is a *group*: the environment filter matches if ANY event matches
+>
+> Filtering to `environment:vercel-production` returns groups that **also** contain preview
+> and local events, and vice versa. This is the single most dangerous gotcha in this
+> document: a bulk archive scoped by environment nearly silenced two real production bugs,
+> because both groups also had preview events.
+>
+> **Filter to find. Verify per-event before acting.** Check the actual distribution:
+>
+> ```bash
+> for t in environment url browser user; do
+>   sentry api "/api/0/organizations/jigged/issues/<numeric-id>/tags/$t/" \
+>     | jq -r ".topValues[]?|\"\(.count)x \(.value)\""
+> done
+> ```
+>
+> A `localhost` URL, a `HeadlessChrome` user-agent, or a `*.vercel.app` preview host means
+> it isn't production, whatever the group's tag list says.
+
+### Triage runbook
+
+1. **List unresolved production issues** for both projects.
+2. **For each, get the real payload.** Titles lie — see the `toError` rule below. A
+   `"Object captured as exception with keys: …"` body means the real message is hidden in a
+   `__serialized__` extra:
+   ```bash
+   sentry api '/api/0/organizations/jigged/issues/<id>/events/latest/' \
+     | jq -r '.context.__serialized__, (.entries[]?|select(.type=="exception")|.data.values[]?
+              |"mechanism=\(.mechanism.type) handled=\(.mechanism.handled)")'
+   ```
+3. **Check `mechanism` and `handled`.** `onunhandledrejection` with no in-app frames is
+   usually a library's own background recovery, with no user-visible effect.
+   `on_request_error` is a server render that threw — the user saw an error page.
+4. **Confirm it's our code at all.** If a symbol appears nowhere in the source,
+   `node_modules`, *or* a built bundle (`pnpm build` then `grep -rl "<symbol>" .next/static`),
+   it's an injected browser extension. Single stack frame with no filename is the tell.
+5. **Fix, or filter with a reason.** Never archive without recording why.
+
+### Archiving
+
+`--until auto` re-opens the issue if event frequency spikes again, so a fix that didn't
+work resurfaces. Prefer it to archive-forever.
+
+```bash
+sentry issue archive PYTHON-FASTAPI-1N --until auto
+```
+
+Needs a permission rule — `Bash(sentry issue archive:*)` in `.claude/settings.local.json`.
+**A `for` loop does not match that rule** (the command must *start* with `sentry issue
+archive`), so issue individual calls, batched in parallel.
+
+### Alert rules live in the Workflow Engine, not `rules/`
+
+This org has been migrated. The old endpoint is gone:
+
+```
+GET /api/0/projects/jigged/javascript-nextjs/rules/{id}/
+  → {"message": "This API no longer exists."}
+```
+
+**`sentry alert issues edit` is therefore broken here** — it resolves the rule name to the
+correct id, then calls the dead endpoint and 404s. Use the workflows API:
+
+```bash
+sentry api '/api/0/organizations/jigged/workflows/'              # list (id, environment, detectorIds)
+sentry api '/api/0/organizations/jigged/detectors/'              # detector → projectId
+sentry api '/api/0/organizations/jigged/workflows/{id}/' --method PUT --input body.json
+```
+
+The `PUT` requires the **full body** (`name`, `triggers`, `actionFilters`, `config`,
+`detectorIds`, `enabled`, `environment`) — a partial returns `{"name": ["This field is
+required."]}`. Build it from a `GET` with `jq`, and back up first. Also: `sentry alert
+issues list` crashes on an empty list (a CLI rendering bug) — use the API.
+
+Both workflows are scoped to production so local and CI runs can't page anyone. **A rule
+scoped to an environment nothing emits is silent** — only scope after the code that emits
+that tag has actually deployed.
+
+### Inbound filters: what's free and what isn't
+
+Free, per-project, at `/api/0/projects/jigged/<project>/filters/`:
+
+- `localhost` — **on for both projects.** Drops local dev, local backend and CI E2E at
+  ingest. This was off and was most of the historical noise.
+- `browser-extensions`, `web-crawlers`, `legacy-browsers`, `filtered-transaction`
+
+```bash
+sentry api '/api/0/projects/jigged/javascript-nextjs/filters/' | jq -r '.[]|"\(.id) active=\(.active)"'
+sentry api '/api/0/projects/jigged/javascript-nextjs/filters/localhost/' --method PUT --input on.json
+```
+
+Custom **error-message** filters (`filters:error_messages`) are a **paid** feature —
+`{"detail":"You do not have that feature enabled"}`. Use the SDK's `ignoreErrors` instead,
+which is strictly better anyway: the event never leaves the browser and never counts
+against quota.
+
+> **Open question:** `legacy-browsers` is active on the frontend with `safari` in its list.
+> Shop-floor tablets are iPads. If any run an older iOS, this filter may be discarding
+> errors from exactly the devices that matter most. Not yet resolved.
+
+### Plan and budget
+
+Free Developer plan: **5,000 errors/month, 30-day retention.** Measured usage is ~394
+errors/30d (~8%), so quota is not a constraint — but 30-day retention means an issue's
+early events are gone, so act inside the window.
+
+```bash
+sentry api '/api/0/organizations/jigged/stats_v2/?statsPeriod=30d&field=sum(quantity)&category=error&groupBy=outcome' \
+  | jq -r '.groups[]|"\(.by.outcome) \(.totals["sum(quantity)"])"'
+```
+
+---
+
+## Rules for writing code
+
+### Never hand a raw Supabase error to `captureException`
+
+Supabase rejects with a plain object (`{ code, details, hint, message }`), not an `Error`.
+Sentry cannot fingerprint that, so it lands as an issue titled `"e"` or `"<unknown>"` with
+the body *"Object captured as exception with keys: …"*, and the real message is buried in a
+`__serialized__` extra. One such issue went unread for four months.
+
+```ts
+import { toError } from '@/lib/supabaseErrors';
+Sentry.captureException(toError(err, 'Failed to verify company access'));
+```
+
+### "Couldn't check" is not "denied"
+
+A failed check must never render as a definitive negative. `verifyCompanyAccess` used to
+swallow errors into `return false`, and its caller rendered that as *"You don't have access
+to this company"* — so one dropped request locked a user out of their own shop. Return a
+definitive answer only for a definitive result; throw otherwise, and give the UI a
+distinct, retryable state. See [`AuthGuard.tsx`](../components/auth/AuthGuard.tsx).
+
+### Transient aborts are not failures
+
+`@supabase/auth-js` serialises token refreshes with the Web Locks API. When a lock is
+orphaned (a component unmounting mid-refresh), the next caller times out and re-acquires
+with `{ steal: true }`, and the orphan rejects with `AbortError: Lock was stolen by another
+request`. That means *superseded*, not *failed*. Classify with `isTransientAbortError` and
+retry; never report it and never surface it as an error.
+
+### `ignoreErrors` — what's filtered and why
+
+In [`instrumentation-client.ts`](../instrumentation-client.ts):
+
+| Pattern | Why |
+|---|---|
+| `Invalid login credentials` | A mistyped password is not a bug |
+| `EmptyRanges` | A Safari extension. Absent from source, `node_modules` **and** the built bundle |
+| `Lock was stolen` | auth-js's own recovery working as designed; no user-visible effect |
+
+Add to this list only with a verified reason, and record it here.
+
+---
+
+## Python SDK: two traps
+
+Both cost real debugging time. Both look correct and are not.
+
+**1. `dsn=None` does not disable the SDK.** It falls back to reading `SENTRY_DSN` from the
+environment — which `load_dotenv` has already populated from `.env.local`. Disabling needs
+an **empty string**:
+
+```python
+sentry_sdk.init(dsn="" if _UNDER_PYTEST else os.getenv("SENTRY_DSN"), ...)
+```
+
+**2. `client.is_active()` is not a "will it send" check.** It returns `True` for any
+initialised client regardless of DSN. The operative fact is the transport, which
+`make_transport` returns `None` for when the DSN is falsy:
+
+```python
+assert sentry_sdk.get_client().transport is None
+```
+
+`sentry_sdk.init` runs at import time, and `api/tests/conftest.py` does
+`from index import app` — so pytest arms the SDK during collection, before
+`PYTEST_CURRENT_TEST` exists. The guard is `"pytest" in sys.modules`. Without it, tests
+that deliberately provoke failures get filed as High-priority *production* errors.
+Regression-tested in [`test_sentry_config.py`](../api/tests/unit/test_sentry_config.py).
+
+---
+
+## CLI ergonomics
+
+**`--json` returns `{"data": [...]}`, not a bare array.** `jq 'length'` counts object keys
+and silently returns 3 or 4 for any query. Use `jq '.data | length'`.
+
+```bash
+sentry issue list jigged/javascript-nextjs --query 'is:unresolved' --json | jq '.data|length'
+```
+
+`sentry schema` browses the API; `sentry api <endpoint>` is a `curl`-alike that handles
+auth. There is no `--environment` flag on `issue list` — environment goes in `--query`.
+
+---
+
+## Why any of this matters
+
+Sentry sat unread for months because 55 of its 61 issues were this project's own `pytest`
+runs, dev machines and CI E2E — with an unscoped default alert rule emailing on every one.
+That is textbook alert fatigue, and it hid three real bugs, one of which had been live
+since March. The fix was four lines of configuration, not a new tool.
+
+**The lesson to keep:** a queue you don't trust is worse than no queue, because it trains
+you to ignore the one alert that mattered. Every filter added here needs a reason recorded,
+and every archive needs `--until auto` so a wrong call corrects itself.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,20 +1,42 @@
 # Observability
 
-Three tools, three layers. They are **not** redundant, but there is exactly one overlap
-you must not re-create.
+Four surfaces across three vendors. They answer different questions, and the two places
+they *do* overlap are handled deliberately — one avoided, one knowingly accepted.
 
-| Tool | Layer | Answers |
-|---|---|---|
-| **Vercel** (logs + analytics) | Infrastructure | Did the deploy work? Is the function slow? |
-| **Sentry** | Correctness | What broke, where in the code, for whom? |
-| **PostHog** | Behaviour | What did users do? Where did they drop off? |
+| Surface | Layer | Answers | Wired in |
+|---|---|---|---|
+| **Vercel Runtime Logs** | Infrastructure | Did the deploy succeed? Did the function throw or time out? | nothing to wire — platform |
+| **Vercel Web Analytics** | Basic traffic | How many pageviews? Which routes? Web Vitals? | `<Analytics />` in [`app/layout.tsx`](../app/layout.tsx) |
+| **Sentry** | Correctness | What broke, where in the code, for whom? | 3 config files + `instrumentation.ts` |
+| **PostHog** | Behaviour | What did users do? Where did they drop off? | [`instrumentation-client.ts`](../instrumentation-client.ts) |
 
-**Sentry owns error tracking. PostHog must not.** `capture_exceptions` is deliberately
-`false` in [`instrumentation-client.ts`](../instrumentation-client.ts) — Sentry has the
-grouping, breadcrumbs and source-map upload that make a solo triage queue workable, and
-PostHog's error tracking has no advanced grouping. Two trackers means double ingest and
-two places to look during an incident. Vercel has **no** JavaScript error tracking at all,
-so it is not a substitute for either.
+### Overlap 1 — error tracking: avoided
+
+**Sentry owns errors. PostHog must not.** `capture_exceptions` is deliberately `false` in
+[`instrumentation-client.ts`](../instrumentation-client.ts) — Sentry has the grouping,
+breadcrumbs and source-map upload that make a solo triage queue workable, and PostHog's
+error tracking has no advanced grouping. Two trackers means double ingest and two places to
+look during an incident. Turning it on would also make PostHog source-map upload a hard CI
+requirement; leaving it off deletes that work item.
+
+**Vercel has no JavaScript error tracking at all**, so it substitutes for neither. A
+client-side crash is invisible in Vercel logs.
+
+### Overlap 2 — basic web analytics: accepted on purpose
+
+Vercel Web Analytics and PostHog's web-analytics view genuinely overlap. **This is a
+deliberate choice, not an oversight — do not "clean it up".**
+
+- **Vercel Analytics** stays for at-a-glance pageview counts, per-route traffic and Web
+  Vitals. It's the free tier, zero-config, zero-maintenance, and it needs no instrumentation
+  per feature. One component in the root layout and it keeps working.
+- **PostHog** is where the analysis that actually informs product decisions lives: user
+  journeys, funnels, retention, drop-off, session replay, feature flags. Vercel can tell you
+  conversions fell; only PostHog can tell you where.
+
+The redundancy costs one script tag. Removing it would trade a free, always-correct traffic
+number for a marginal bundle saving and a dependency on PostHog events being instrumented
+correctly. Keep both.
 
 ---
 


### PR DESCRIPTION
**Docs only** — 2 files, +338 lines. No code, no tests, no migrations, no dependency changes.

Written because **agents, not humans, will be the ones reading this.** Every item below cost
real debugging time during the #625 / #626 triage, and none of it is discoverable from the
code itself.

---

## `docs/observability.md` (new, 299 lines)

### What the stack is, and where it overlaps

Four surfaces across three vendors, with **both** overlaps named explicitly so neither gets
"cleaned up" by mistake:

| Overlap | Decision |
|---|---|
| **Error tracking** — Sentry vs PostHog | **Avoided.** Sentry owns it; `capture_exceptions` stays `false`. PostHog has no advanced grouping, and enabling it would make PostHog source-map upload a hard CI requirement. Vercel has **no** JS error tracking at all, so it substitutes for neither. |
| **Basic web analytics** — Vercel vs PostHog | **Accepted on purpose.** Vercel Web Analytics (`<Analytics />`, `app/layout.tsx`) stays for at-a-glance pageviews, per-route traffic and Web Vitals: free tier, one script tag, no per-feature instrumentation. PostHog owns journeys, funnels, retention and replay. Vercel can say conversions fell; only PostHog can say where. |

The doc also separates **Vercel Runtime Logs** (infrastructure) from **Vercel Web Analytics**
(traffic), which the first draft wrongly merged into one row.

### The operational content

| Section | Why it's there |
|---|---|
| **Sentry: the CLI is the interface** | The CLI is authenticated and composable; an agent can use it. Includes the MCP entry's `"type": "http"` requirement. |
| **Environments, and how to filter by them** | The full tag map post-#625, and **the most dangerous gotcha in the doc**: a Sentry issue is a *group*, so an environment filter matches if **any** event matches. A bulk archive scoped by environment nearly silenced the AuthGuard lockout and a Safari crash, because both groups also held preview events. *Filter to find; verify per-event before acting.* |
| **Triage runbook** | Five steps, including how to recover a real message from a `__serialized__` extra, and how to prove a symbol isn't ours — absent from source, `node_modules` **and** the built bundle — before writing a fix for someone's browser extension. |
| **Archiving** | `--until auto` so a wrong call self-corrects. Notes that a `for` loop does **not** match the `Bash(sentry issue archive:*)` permission rule. |
| **Alert rules live in the Workflow Engine** | The old `/projects/{org}/{proj}/rules/{id}/` returns `"This API no longer exists."`, which is why **`sentry alert issues edit` is broken for this org** — it resolves the name to the right id, then calls the dead endpoint. The replacement `PUT` needs the *full* body. |
| **Inbound filters: what's free and what isn't** | Custom error-message filters are **paid**; the `localhost` toggle is **free**, was **off**, and was most of the historical noise. |
| **Plan and budget** | Free tier is 5,000 errors/month with 30-day retention; measured usage ~394/30d (~8%). Retention matters: act inside the window. |
| **Rules for writing code** | Four rules with their failure stories: never hand a raw Supabase error to `captureException`; "couldn't check" is never "denied"; transient aborts aren't failures; every `ignoreErrors` entry needs a recorded reason. |
| **Python SDK: two traps** | `dsn=None` does **not** disable the SDK (it falls back to the `SENTRY_DSN` env var `load_dotenv` just populated — an empty string is required), and `is_active()` is not a will-it-send check (`True` for any initialised client; check `client.transport`). |
| **CLI ergonomics** | `--json` returns `{"data": [...]}`, so `jq 'length'` silently counts object keys. This produced wrong issue counts before I caught it. |

### One thing recorded as unresolved

`legacy-browsers` is active on the frontend with `safari` in its list. Shop-floor tablets are
iPads — if any run an older iOS, that filter may be discarding errors from exactly the devices
that matter most. **Flagged, not fixed**, because it's a judgement call about the pilot's
hardware.

---

## `CLAUDE.md` (+39 lines)

A new section under the engineering principles carrying the rules that bind while writing
code, plus a pointer to the runbook. Also added to the key-documents table.

Rules: Sentry owns errors and never add a second tracker · Vercel Analytics is kept on
purpose · wrap Supabase errors with `toError` · "couldn't check" is never "denied" ·
transient aborts aren't failures · the SDKs stay off outside a production build · every
`ignoreErrors` entry needs a recorded reason.

Plus two gotchas surfaced inline so they're visible without opening the runbook: the broken
`sentry alert issues edit`, and the `{"data": [...]}` JSON shape.

---

## Verification

Docs-only, so per CLAUDE.md's smart-scope table this skips pre-PR validation and CI is the
gate. I did confirm **every referenced path resolves**: `instrumentation-client.ts`,
`api/index.py`, `app/layout.tsx`, `components/auth/AuthGuard.tsx`, `lib/supabaseErrors.ts`,
`api/tests/unit/test_sentry_config.py`.

Every claim in the doc was verified against the live org, the installed packages, or a built
bundle during this session — none of it is inferred from documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
