### PR TITLE
fix(pwa): repair the home-screen icon and caption it "Jigged"

### DIFF
--- a/app/icon-192/route.tsx
+++ b/app/icon-192/route.tsx
@@ -1,0 +1,6 @@
+import { brandIconResponse } from '@/lib/brandMark';
+
+/** 192×192 PNG for the web app manifest. Generated, not stored — see `lib/brandMark.tsx`. */
+export function GET() {
+  return brandIconResponse({ size: 192 });
+}

--- a/app/icon-512/route.tsx
+++ b/app/icon-512/route.tsx
@@ -1,0 +1,6 @@
+import { brandIconResponse } from '@/lib/brandMark';
+
+/** 512×512 PNG for the web app manifest (install prompts and splash screens). */
+export function GET() {
+  return brandIconResponse({ size: 512 });
+}

--- a/app/icon-maskable/route.tsx
+++ b/app/icon-maskable/route.tsx
@@ -1,0 +1,11 @@
+import { brandIconResponse } from '@/lib/brandMark';
+
+/**
+ * 512×512 `maskable` PNG.
+ *
+ * Android crops this to the launcher's own shape, so the mark is smaller and the corners are square:
+ * only the inner ~80% is guaranteed to survive, and the launcher supplies the rounding.
+ */
+export function GET() {
+  return brandIconResponse({ size: 512, markRatio: 0.56, rounded: false });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -54,6 +54,28 @@ export const metadata: Metadata = {
     // home-screen icon was broken. Verified against the dev server: `.png` → 404, bare → 200.
     apple: '/apple-icon',
   },
+  /**
+   * The home-screen caption, and nothing else.
+   *
+   * iOS reads `apple-mobile-web-app-title` for the Add to Home Screen label and prefers it over
+   * both the manifest's `short_name` and `<title>`. With no such tag the sheet pre-fills from
+   * `<title>`, which on the marketing home page resolves through the `%s | Jigged` template to
+   * "Jigged — Your whole shop, in one place | Jigged" — a fine `<title>`, and a useless caption
+   * under a 60px icon. `short_name: 'Jigged'` in `app/manifest.ts` covers Android; this covers iOS.
+   *
+   * **`capable: false` is load-bearing, not a spelled-out default.** Next resolves a missing
+   * `capable` to `true` (`resolveAppleWebApp`), which emits `mobile-web-app-capable` and asks the
+   * launcher to install standalone — precisely what `app/manifest.ts` declines to do via
+   * `display: 'browser'` until the iOS camera-permission spike clears. Read the note there before
+   * flipping either. `title` is emitted independently of `capable`, so this costs nothing.
+   *
+   * (Next also emits `apple-mobile-web-app-status-bar-style` unconditionally once this key exists.
+   * It only applies in standalone, and `default` is what we'd pick anyway.)
+   */
+  appleWebApp: {
+    title: 'Jigged',
+    capable: false,
+  },
   openGraph: {
     title: 'Jigged — Manufacturing Operations System',
     description:

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { DM_Sans, Space_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { ThemeProvider, AuthProvider } from "@/components/providers";
@@ -15,6 +15,30 @@ const spaceMono = Space_Mono({
   variable: "--font-space-mono",
 });
 
+/**
+ * Viewport, declared rather than inherited.
+ *
+ * Next injects a default `width=device-width, initial-scale=1`, so the app was never shipping
+ * unscaled — what was missing was *control*. Two things matter for the shop floor:
+ *
+ *  - `viewportFit: 'cover'` lets the layout reach under the iOS home indicator and notch, which is
+ *    the precondition for the `env(safe-area-inset-*)` padding the operator bottom nav uses.
+ *  - `themeColor` tints the browser chrome to match the app instead of leaving a pale bar above a
+ *    dark UI.
+ *
+ * Deliberately NOT setting `maximumScale` or `userScalable: false`: pinch-zoom is an accessibility
+ * affordance, and this audience is 50–60-year-old shop owners reading under fluorescent light.
+ *
+ * It has to live in THIS file. `app/operator/[companyId]/layout.tsx` is `'use client'`, so it
+ * structurally cannot export viewport metadata.
+ */
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
+  themeColor: '#111439', // theme.palette.background.default
+};
+
 export const metadata: Metadata = {
   metadataBase: new URL('https://jigged.app'),
   title: {
@@ -25,7 +49,10 @@ export const metadata: Metadata = {
     'A flexible data platform for small precision manufacturing shops. Real-time visibility, flexible inventory, and operators who actually log their work.',
   icons: {
     icon: '/icon.svg',
-    apple: '/apple-icon.png',
+    // `/apple-icon`, NOT `/apple-icon.png`. The route Next generates from `app/apple-icon.tsx` has
+    // no extension, and no such static file exists in `public/` — so this href 404'd and the
+    // home-screen icon was broken. Verified against the dev server: `.png` → 404, bare → 200.
+    apple: '/apple-icon',
   },
   openGraph: {
     title: 'Jigged — Manufacturing Operations System',

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,55 @@
+import type { MetadataRoute } from 'next';
+
+/**
+ * Web app manifest — so Jigged can be added to a shop-floor home screen.
+ *
+ * ## `display: 'browser'` is the load-bearing line, and it is deliberate
+ *
+ * `docs/modules/inventory.md` §5.10 records why an installed app must NOT run standalone yet: iOS
+ * **does not persist camera permission for a standalone PWA** and Safari re-prompts on route
+ * navigation at the same origin ([WebKit #185448]), which would make the in-app location scanner
+ * ask again on every screen. A scanner that re-asks permission constantly is worse than tapping a
+ * banner.
+ *
+ * §5.10's stated hedge was "drop `apple-mobile-web-app-capable` so the icon opens in Safari". **That
+ * advice is obsolete.** Since iOS 16.4 Safari honours *this* manifest's `display` member for Add to
+ * Home Screen, and the meta tag is the legacy mechanism it superseded — so omitting the tag while
+ * setting `display: 'standalone'` would install standalone anyway and walk straight into the bug.
+ * iOS also treats `standalone`, `fullscreen` and `minimal-ui` alike; **`browser` is the only value
+ * that keeps the icon opening in Safari.**
+ *
+ * So flipping this to `'standalone'` is the concrete deliverable of §5.10's spike, not a tidy-up:
+ * the spike's question is *"does camera permission persist across navigations in standalone mode on
+ * current iOS?"*, and this line is what it gates. Answer it on the shop's actual handsets first.
+ *
+ * (Android has no such problem, and would tolerate standalone. This is a route handler, so it
+ * *could* branch on user-agent — deliberately not done, because a UA-sniffing manifest is hard to
+ * test and easy to get subtly wrong for one line of benefit.)
+ */
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Jigged — Manufacturing Operations System',
+    short_name: 'Jigged',
+    description:
+      'Jobs, inventory and shop-floor status for small precision manufacturing shops.',
+    // See the note above before changing this.
+    display: 'browser',
+    // The operator surface is where a home-screen icon earns its place: it's the only part of the
+    // app designed for a phone, and it's what a scanned QR label opens.
+    start_url: '/',
+    scope: '/',
+    background_color: '#111439', // theme.palette.background.default
+    theme_color: '#111439',
+    orientation: 'any', // job details are deliberately usable in landscape on a tablet
+    icons: [
+      { src: '/icon.svg', sizes: 'any', type: 'image/svg+xml' },
+      // Rendered at request time from the same vector as `app/apple-icon.tsx`, so there are no
+      // binary assets to keep in sync and nothing upscaled from the 96px logo.
+      { src: '/icon-192', sizes: '192x192', type: 'image/png' },
+      { src: '/icon-512', sizes: '512x512', type: 'image/png' },
+      // `maskable` lets Android crop to its own shape without clipping the mark; it needs the
+      // safe-zone padding that `icon-maskable` builds in.
+      { src: '/icon-maskable', sizes: '512x512', type: 'image/png', purpose: 'maskable' },
+    ],
+  };
+}

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -360,7 +360,9 @@ function OperatorShell({
           zIndex: 1, // above the fixed ambient backdrop
           flex: 1,
           mt: '48px', // Single-row AppBar height
-          mb: navVisible ? '56px' : 0, // BottomNavigation height
+          // BottomNavigation height plus whatever the device reserves at the bottom (the iOS home
+          // indicator). `viewportFit: 'cover'` in the root layout is what makes the inset non-zero.
+          mb: navVisible ? 'calc(56px + env(safe-area-inset-bottom))' : 0,
           overflow: 'auto',
           p: 2,
         }}
@@ -377,6 +379,11 @@ function OperatorShell({
             left: 0,
             right: 0,
             zIndex: 1000,
+            // Pad BELOW the tabs rather than shifting them up, so the bar's background still
+            // reaches the bottom edge of the screen. Without this the tabs sit under the iOS home
+            // indicator once the app is on a home screen — a 48px touch target you can't fully
+            // reach. Zero on every device without an inset, so desktop is unaffected.
+            pb: 'env(safe-area-inset-bottom)',
           }}
           elevation={3}
         >

--- a/lib/brandMark.tsx
+++ b/lib/brandMark.tsx
@@ -1,0 +1,64 @@
+/**
+ * The Jigged mark, as one vector, for every generated icon.
+ *
+ * `app/apple-icon.tsx` had this inline, and the PWA manifest needs the same thing at 192, 512 and
+ * 512-maskable. Duplicating the paths four times is how a brand mark quietly drifts between sizes,
+ * so it lives here once and each route only chooses a canvas.
+ *
+ * Rendered at request time via `next/og`'s `ImageResponse` — which means **no binary icon assets in
+ * the repo, and nothing upscaled**: `public/jigged-logo.png` is only 96×96, so a 512 built from it
+ * would be visibly soft.
+ */
+import { ImageResponse } from 'next/og';
+
+/** Brand colours, matching `app/icon.svg` and the design system. */
+const INK = '#151520';
+const AMBER = '#D4872A';
+const STEEL = '#4682B4';
+const TEAL = '#2BBCB3';
+
+function Mark({ size }: { size: number }) {
+  return (
+    <svg viewBox="0 0 64 64" width={size} height={size} fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="14" y="10" width="30" height="10" rx="2" fill={AMBER} />
+      <rect x="30" y="10" width="10" height="32" rx="0" fill={STEEL} />
+      <path d="M40 42 L40 54 L26 54 Q14 54 14 42 L24 42 Q30 42 30 48 L30 54" fill={TEAL} />
+    </svg>
+  );
+}
+
+export interface BrandIconOptions {
+  size: number;
+  /**
+   * Fraction of the canvas the mark occupies.
+   *
+   * Android crops a `maskable` icon to its own shape — a circle on many launchers — and only the
+   * inner ~80% is guaranteed to survive. A maskable icon therefore needs a *smaller* mark on a
+   * full-bleed background; a normal icon can fill more of the canvas.
+   */
+  markRatio?: number;
+  /** Rounded corners. Omitted for maskable, where the launcher supplies the shape. */
+  rounded?: boolean;
+}
+
+/** One generated PNG icon. Each route is a one-liner over this. */
+export function brandIconResponse({ size, markRatio = 0.78, rounded = true }: BrandIconOptions) {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: size,
+          height: size,
+          background: INK,
+          borderRadius: rounded ? size * 0.18 : 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Mark size={Math.round(size * markRatio)} />
+      </div>
+    ),
+    { width: size, height: size },
+  );
+}


### PR DESCRIPTION
Adding Jigged to a phone home screen — the flow we ask operators to use — produced a plain letter tile captioned `Jigged — Your whole shop, in one place | Jigged`. Both halves are now fixed.

## The icon was 404ing in production

`app/layout.tsx` on `main` sets:

```
<link rel="apple-touch-icon" href="/apple-icon.png"/>
```

The route Next generates from `app/apple-icon.tsx` is `/apple-icon`, with **no extension**, and no such file exists in `public/`. Confirmed against live production:

| URL | |
|---|---|
| `https://www.jigged.app/apple-icon.png` | **404** |
| `https://www.jigged.app/apple-icon` | 200 |
| `https://www.jigged.app/manifest.webmanifest` | **404** |

With no icon it can fetch, iOS falls back to auto-generating a tile from the page's first letter — the plain "J" users have been seeing.

This was already fixed by `44fcc65` on `feature/inventory-phase-2` (#622), which also adds the manifest, the 192/512/maskable icon routes, and `lib/brandMark.tsx`. That commit is cherry-picked here so the repair can reach production without waiting on inventory Phase 2. #622 keeps the same commit and will merge cleanly.

## The caption came from `<title>`

iOS reads `apple-mobile-web-app-title` for the Add to Home Screen label and prefers it over both the manifest's `short_name` and `<title>`. Nothing set it, so Safari used the marketing `<title>` resolved through the `%s | Jigged` template. `short_name: 'Jigged'` already covered Android; the new `appleWebApp.title` covers iOS. The `<title>` itself is unchanged — it's still right for search results.

**`capable: false` is deliberate.** Next's `resolveAppleWebApp` resolves a missing `capable` to `true`, so the obvious `appleWebApp: { title }` would emit `mobile-web-app-capable` and ask the launcher to install standalone — exactly what `app/manifest.ts` declines via `display: 'browser'` until the iOS camera-permission spike (WebKit #185448) clears, since standalone Safari re-prompts for camera on every navigation and would break the location scanner. `title` is emitted independently of `capable`, so declining the install costs nothing.

## Verification

Against a dev server on this branch:

```
<meta name="apple-mobile-web-app-title" content="Jigged"/>
<meta name="theme-color" content="#111439"/>
<link rel="manifest" href="/manifest.webmanifest"/>
<link rel="icon" href="/icon.svg"/>
<link rel="apple-touch-icon" href="/apple-icon"/>
```

No `mobile-web-app-capable` — the standalone hedge holds. All six of `/apple-icon`, `/icon.svg`, `/icon-192`, `/icon-512`, `/icon-maskable`, `/manifest.webmanifest` return 200 with the right content types, and the rendered PNGs carry the three-colour mark on ink, matching `public/jigged-logo.png`. `tsc --noEmit` is clean.

No migrations, no schema changes.

## Worth confirming on a real handset

The one thing a dev server can't prove is what iOS actually prints in the Add to Home Screen sheet. Re-run the flow on the preview and check the caption reads `Jigged` with the three-colour mark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
