### PR TITLE
test: stop the suite going red for reasons unrelated to the code

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,53 @@ export default defineConfig({
     setupFiles: ['./__tests__/setup.ts'],
     include: ['__tests__/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['e2e/**', 'node_modules/**'],
+    /**
+     * 15s, not vitest's 5s default.
+     *
+     * The suite was intermittently red with `Error: Test timed out in 5000ms.` on a rotating
+     * cast of tests — `VisualLocationBuilder`, `PartLocationActionModal`, `SignUp`,
+     * `ChangePassword`, `QuoteForm`, `PartTransactionJobTag` — every one of which passed on its
+     * own and every one of which is a multi-step `userEvent` flow. `userEvent` awaits React
+     * settling between each interaction, so a dozen sequential interactions cost real wall-clock,
+     * and under fork contention they crossed 5s.
+     *
+     * This does not hide hangs: a genuinely stuck test still fails, 10s later. What it stops is a
+     * suite that goes red for reasons unrelated to the code — which is worse than slow, because a
+     * red run you re-run out of habit is a red run you have stopped reading.
+     *
+     * Prefer a per-test timeout argument over raising this further; a test that needs more than
+     * 15s is telling you something about the test.
+     */
+    testTimeout: 15_000,
+    /**
+     * Cap concurrency below the machine's core count.
+     *
+     * Vitest defaults to `availableParallelism() - 1` forks, so a 10-core laptop runs 9 jsdom
+     * workers, each with its own React renderer. The timeouts above are contention artefacts, so
+     * this attacks the cause rather than only widening the deadline.
+     *
+     * **Measured, on this 10-core machine.** Wall-clock is unchanged — ~30s either way — but the
+     * aggregate in-worker test time drops from **105–127s to 74–80s**. That figure is summed
+     * across workers, so the fall is contention leaving the system: the same work, less of it
+     * spent waiting on a core. Fewer workers costing no wall-clock is counter-intuitive enough to
+     * be worth recording.
+     *
+     * CI runners have fewer cores than this, so 6 is usually above their default and therefore a
+     * no-op there rather than a throttle.
+     *
+     * Note this is the **vitest 4** spelling, and getting it wrong fails quietly. The first
+     * attempt used the v3 API, `poolOptions: { forks: { maxForks: 6 } }`, which no longer exists
+     * on `InlineConfig`. Vitest **silently ignores an unknown key** — the suite ran green and the
+     * setting did nothing, so the "before and after" timings I took were the same run twice.
+     * Only `tsc` caught it. If you change concurrency here, confirm the aggregate test time
+     * actually moves; a green suite proves nothing about whether the option took effect.
+     *
+     * Honest limitation: three clean runs after this change is not proof it fixed anything —
+     * two runs *before* it were clean too, because the flake is intermittent. What is solid is
+     * the captured error (`Test timed out in 5000ms`), which the timeout above definitively
+     * addresses; this cap is belt-and-braces at no measured cost.
+     */
+    maxWorkers: 6,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
One file, `vitest.config.ts`. No test or source changes.

## The problem

The suite went red intermittently on a rotating cast of tests, **every one of which passed
on its own**: `VisualLocationBuilder`, `PartLocationActionModal`, `SignUp`, `ChangePassword`,
`QuoteForm`, `PartTransactionJobTag`. A red run you re-run out of habit is a red run you have
stopped reading, which is worse than a slow suite.

## Diagnosis — from the captured error, not a guess

```
Error: Test timed out in 5000ms.
```

`vitest.config.ts` set **no `testTimeout`** (so: the 5s default) and **no concurrency cap** (so:
`availableParallelism() - 1` → nine jsdom workers on a ten-core machine, each with its own React
renderer).

Every flaky test is a multi-step `userEvent` flow. `userEvent` awaits React settling between
interactions, so a dozen sequential ones cost real wall-clock — and under nine-way contention they
crossed 5s.

## The fix

| Change | Why |
|---|---|
| `testTimeout: 15_000` | Doesn't hide hangs — a genuinely stuck test still fails, 10s later. Prefer a per-test timeout argument over raising this again; a test needing >15s is telling you something. |
| `maxWorkers: 6` | Attacks the contention rather than only widening the deadline. |

## Measured

Wall-clock is **unchanged**, ~30s either way. But aggregate in-worker test time falls from
**105–127s → 74–80s**. That figure is summed across workers, so the drop is contention leaving the
system: the same work, less of it spent waiting for a core. CI runners have fewer cores, so 6 is
usually above their default and a no-op there rather than a throttle.

## ⚠️ The mistake worth reading

My first attempt used the **vitest 3** API — `poolOptions: { forks: { maxForks: 6 } }` — which no
longer exists on `InlineConfig` in vitest 4.

**Vitest silently ignores an unknown config key.** The suite ran green, the setting did nothing,
and the "before and after" timings I took were literally the same run twice. Only `tsc` caught it,
via `'poolOptions' does not exist in type 'InlineConfig'`.

So: **a green suite proves nothing about whether a config option took effect.** There's a comment
in the file saying to confirm the aggregate test time actually moves if anyone changes concurrency
again.

## What this does NOT prove

Clean runs after the change aren't evidence it worked — runs *before* it were clean too, because
the flake is intermittent. What's solid is that the captured failure mode was a 5s timeout and the
timeout is now 15s.

## One flake deliberately left open

The zxing-wasm decode in `LocationScanner.test.tsx` fails as `expected [] to have a length of 1`
**in 64ms**, despite already carrying a 30s timeout — so it is *not* a timeout and this PR does not
claim to fix it. I checked the library: `prepareZXingModule` does return a Promise when
`fireImmediately: true`, which the test awaits, so my "module readiness race" theory is unproven.
Less contention may incidentally help. If it recurs it deserves its own investigation rather than a
guess, and I'd rather say so than quietly bundle a speculative fix in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
