### PR TITLE
docs: correct the device model — there was never a shop tablet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,11 +230,32 @@ Plain allowlisted single commands (`grep`, `cat`, `ls`, `find`, `awk`, `curl`, `
 
 **Framework:** Material-UI (MUI) v7+ with Material Design 3 principles
 
+### Who uses what, on what — the device model
+
+**There is no single "primary device". There are three surfaces, and two of them are ours.**
+Corrected 2026-07-31 from founder observation: *"no one used a shop tablet in Contour or any
+shop I've seen."* The docs had assumed shop-floor tablets throughout, and that was wrong.
+
+| Surface | Who | Device | What follows from it |
+|---|---|---|---|
+| **Admin & User** — Storage, Parts, Quotes, Jobs, all data setup | owner, salesperson, scheduler | **Office computer**, mouse + keyboard | Hover is available. Drag is viable. Bundle weight is cheap (office wifi). Dense tables are fine. |
+| **Operator** — jobs, scan, notes | shop floor | **Their own phone** | Touch only, no hover. Bundle weight is expensive (cellular). One-handed reach. Bright ambient light. |
+| **Machine control** | machinist at the machine | The machine's own **HMI** (Haas, Fanuc, …) | **Not a Jigged surface at all.** We never render here; don't design for it. |
+
+**How to apply:** decide which surface a change lands on before reasoning about its
+interaction. The two mistakes this table exists to prevent are (a) rejecting a mouse
+interaction on an admin screen because "touch is unreliable", and (b) treating a phone on
+cellular as though it had an office connection.
+
+Most existing touch rules survive the correction unchanged, because **a phone is at least as
+constrained as a tablet** — the 48px floor, no hover-dependent UI, and high contrast all still
+hold on the operator surface, and more strongly than before.
+
 ### Design Principles
 
 1. **Professional, Not Trendy** - Must appeal to 50-60 year old shop owners. Focus on clarity and function.
 2. **Substantial, Not Playful** - Industrial aesthetic. Cards should feel solid and grounded.
-3. **Readable in Bright Environments** - Ensure sufficient contrast for use under bright fluorescent lighting on tablets.
+3. **Readable in Bright Environments** - Ensure sufficient contrast for use under bright fluorescent lighting, on a phone held on the shop floor.
 4. **Single Dark Theme** - Optimized for shop floor environments with consistent dark UI.
 
 ### Quick Reference

--- a/docs/audits/form-validation-audit.md
+++ b/docs/audits/form-validation-audit.md
@@ -22,10 +22,16 @@ Reusable building blocks added: [`lib/validators.ts`](../../lib/validators.ts),
 ## 1. Chosen UX pattern (and why)
 
 **Inline `MissingFieldsNotice` above the submit button**, listing each blocking
-reason — *not* a hover tooltip. Rationale: Jigged targets shop-floor tablets
-(touch) and 50–60-year-old users; hover tooltips aren't discoverable on touch and
-fail the clarity/accessibility goals in CLAUDE.md. We pair the summary notice with
-field-level `required` + `error`/`helperText` markers.
+reason — *not* a hover tooltip. Rationale: 50–60-year-old users, and a hover tooltip is
+**undiscoverable** (you must already suspect something is there to hover over) and
+unreachable by keyboard — failing the clarity/accessibility goals in CLAUDE.md. We pair the
+summary notice with field-level `required` + `error`/`helperText` markers.
+
+> **Corrected 2026-07-31.** This said "Jigged targets shop-floor tablets (touch)" and rested
+> the argument on hover being unavailable. Forms are an admin-surface concern — office
+> computer, mouse — so hover *is* available; see
+> [the device model](../../CLAUDE.md#who-uses-what-on-what--the-device-model). The conclusion
+> is unchanged because discoverability, not touch, was always the real reason.
 
 `ShipmentForm` (info-Alert listing blocking messages) was the pre-existing model
 for this; `QuoteForm` uses a button tooltip, kept as-is since it's a desktop-heavy

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -302,8 +302,15 @@ playful — industrial" principle. Reserve a colored border for a *semantic* sig
 
 When a submit/save button is disabled because the form is incomplete, **tell the
 user what's still missing** — a greyed-out button with no explanation is a dead
-end. The standard is an inline notice, **not** a hover tooltip: the app runs on
-shop-floor tablets where hover isn't available.
+end. The standard is an inline notice, **not** a hover tooltip.
+
+> **Reason corrected 2026-07-31, rule unchanged.** This said hover is unavailable because
+> "the app runs on shop-floor tablets". Forms are an **admin-surface** concern — office
+> computer, mouse — so hover *is* available (see
+> [the device model](../CLAUDE.md#who-uses-what-on-what--the-device-model)). The rule still
+> stands on the stronger argument it always had: a hover tooltip is **undiscoverable** —
+> you have to already suspect there is something to hover over — and it is unreachable by
+> keyboard. That is true of a mouse user at a desk too.
 
 - **`components/common/MissingFieldsNotice`** — render it just above the submit
   button with an `items: string[]` of the blocking reasons (it returns `null`
@@ -326,10 +333,11 @@ shop-floor tablets where hover isn't available.
 
 ### Placeholders
 
-**A placeholder must never resemble real data.** Our users are 50–60 year old
-shop owners on tablets; a greyed `25` in an empty Markup % field reads as a
-*pre-filled value*, not a hint, and ships wrong quotes. The misleading set —
-**banned**:
+**A placeholder must never resemble real data.** Our users are 50–60 year old shop owners;
+a greyed `25` in an empty Markup % field reads as a *pre-filled value*, not a hint, and
+ships wrong quotes. (This argument never depended on the device — it is about how a low-
+contrast number reads to anyone. The original wording said "on tablets", which was wrong
+about the device and irrelevant to the point.) The misleading set — **banned**:
 
 - Bare numbers: `placeholder="1"`, `placeholder="25"`.
 - Currency / value-shaped strings: `placeholder="$0.00"`, `placeholder="e.g. 5.50"`,

--- a/docs/interaction-standards.md
+++ b/docs/interaction-standards.md
@@ -58,7 +58,9 @@ the generic "low-stakes ⇒ no dialog" advice.
 | **Staged (explicit-Save) edit** — pricing-tier removal | Low | **No dialog.** Removal is in-memory until the user clicks Save; the dirty-state indicator + the option to walk away unsaved *is* the safety net. |
 
 > **Audience floor — why not "inline delete + Undo snackbar":** our users are
-> 50–60, often on tablets on a shop floor with divided attention. Auto-dismissing
+> 50–60, and on the operator surface they are on their own phone on a shop floor with
+> divided attention (see [the device model](../CLAUDE.md#who-uses-what-on-what--the-device-model)
+> — not tablets, which the docs used to assume). Auto-dismissing
 > snackbars are a documented accessibility/usability liability for exactly this
 > profile: WCAG 2.2.1 (Level A) treats a short auto-dismiss window as a timing
 > limit when the toast is the *only* recovery path ([W3C](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable.html));
@@ -120,8 +122,16 @@ and always show status ([GitHub Primer — Saving](https://primer.style/product/
 - 🔻 **Navigation guard — low priority, narrow if at all.** The honest dirty-state
   indicator is the real protection. A `beforeunload` guard is a weak backstop:
   browsers show only a generic, non-customizable message (it can't name the
-  unsaved tier) and it is unreliable on mobile/tablet — our primary device — and
-  may not fire at all ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event)).
+  unsaved tier), which is reason enough on its own.
+
+  > **Corrected 2026-07-31.** This also said `beforeunload` "is unreliable on
+  > mobile/tablet — **our primary device**". Both halves were wrong: there is no single
+  > primary device, and pricing tiers are edited on the **office computer**, where
+  > `beforeunload` is perfectly reliable
+  > ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event)).
+  > The mobile-unreliability point still applies to the *operator* surface, which has no
+  > staged-save forms — so it argues for nothing here. The recommendation is unchanged, but
+  > it now rests only on the generic-message argument rather than on a false premise.
   If added at all, use a conditional in-app (Next.js) route guard attached **only
   while genuinely dirty** and removed once saved (MDN), to avoid the false-positive
   that trains users to ignore it (the Figma "already-saved-but-warned" pitfall).

--- a/docs/modules/data-import.md
+++ b/docs/modules/data-import.md
@@ -123,7 +123,7 @@ The same surface serves both the first-time "bring my whole shop in" journey and
     affects and a concrete example, so that I understand it without a data analyst.
 14. As a shop owner, I want each problem to tell me exactly what to do about it, so that I
     can act instead of guess.
-15. As a shop owner with a vision impairment or on a bright shop-floor tablet, I want
+15. As a shop owner with a vision impairment, working at an office computer, I want
     severity shown by icon and words, not just color, so that I can tell what's urgent.
 16. As a shop owner, I do NOT want a wall of AI text or a green "all good" badge sitting
     next to a critical problem, so that I'm not misled or overwhelmed.
@@ -489,9 +489,10 @@ per-entity execute routes behind the pytest seam; one E2E through the whole jour
   - **Presenting AI-fix rationale** to a low-literacy user without inducing blind trust:
     reveal limits/uncertainty rather than confidence scores — the exact UI recipe is
     unvalidated and should be usability-tested with real owners.
-- **Personas.** Primary: the shop owner/admin (non-technical, 50–60, on desktop or a
-  bright-light shop tablet). Secondary: the Jigged white-glove migrator who currently does
-  the actual write, for whom the review is the pre-flight.
+- **Personas.** Primary: the shop owner/admin (non-technical, 50–60, at an **office computer**
+  — importing is data setup, and setup is not a shop-floor activity). Secondary: the Jigged
+  white-glove migrator who currently does the actual write, for whom the review is the
+  pre-flight.
 - **Source systems seen so far.** Tangle (real, from customer #1), plus JobBOSS/E2 and
   spreadsheets expected. The tool must not depend on prebuilt per-ERP signatures; detection
   is AI-first and may return "unknown" without degrading the review.

--- a/docs/modules/inventory.md
+++ b/docs/modules/inventory.md
@@ -1649,6 +1649,33 @@ From multi-day on-site observation at Contour Tool & Machine. **Reliable on stru
 on frequency and pain-ranking**, and it is the founder's model of the shop rather than the
 shop's own words — good enough for the structural decisions below, not for prioritisation.
 
+> ### Device model corrected — founder observation, 2026-07-31
+>
+> *"No one used a shop tablet in Contour or any shop I've seen"* — it is the machine's own **HMI**,
+> a **personal phone**, or the **office computer**.
+>
+> This matters because the docs had assumed shop-floor tablets in about a dozen places, two of
+> which called it *"our primary device"*. The canonical model now lives in
+> [CLAUDE.md](../../CLAUDE.md#who-uses-what-on-what--the-device-model): admin and user work
+> (Storage, Parts, Quotes, Jobs, all data setup) happens at an **office computer with a mouse**;
+> the operator surface is a **personal phone**; machine control is the machine's own HMI and is
+> **not a Jigged surface at all**.
+>
+> **Most touch conclusions survive**, because a phone is at least as constrained as a tablet — the
+> 48px floor, no hover-dependent UI, and high contrast all still hold, more strongly than before.
+> What changes is the reasoning available on the **admin** surface: hover exists there, bundle
+> weight is cheap there, and **drag is a perfectly ordinary interaction there** — which retires
+> §5.5's stated reason for cutting drag-to-reparent (*"drag on a shop tablet is the most
+> failure-prone interaction available"*). That cut may still be right on its other ground — 118 of
+> 121 locations are flat, so a re-parent gesture serves a hierarchy they don't have — but the
+> device half of the argument is withdrawn.
+>
+> Same correction applies to issue **#421**: an argument against a drag-to-place floor planner
+> based on tablet drag reliability does not hold if setup happens at a desk.
+>
+> Still unknown, and only an interview reaches it: **whose** phone, and whether operators mind
+> using a personal device for work.
+
 | Question | Answer | What it decided |
 |---|---|---|
 | Staged before the job, or grabbed at the machine? | **Grabbed at the machine** | [§5.2](#52-is-a-job-a-place--resolved-no) — a job is **not** a place. Cheaper branch. |

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -190,7 +190,7 @@ see this", not "nobody can".
   bank the total. Renders `null` at zero.
 
   **First run on a device announces nothing.** The mark lives in `localStorage`,
-  so it follows the *device*, not the person — a shop tablet, a replacement
+  so it follows the *device*, not the person — a replacement
   phone, a second browser or cleared site data all start empty. Defaulting to
   zero would render the whole history as new ("312 new views" after a year), and
   the banner's only asset is that its number is true. Instead the current total

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -248,8 +248,10 @@ There is **no separate "Pricing tiers" reference section** — the editable quan
 **Actions — one row of standalone buttons (no overflow menu):** a contained
 **primary "Convert to Job"**, an outlined **Edit**, an outlined **View PDF**, and a
 red **Delete** icon button, laid out on a single row. Labelled buttons (rather than
-a hidden `⋮` icon menu) read better for the shop-floor tablet / older-user audience
-([NN/G](https://www.nngroup.com/articles/icon-usability/) on icon ambiguity).
+a hidden `⋮` icon menu) read better for the older-user audience
+([NN/G](https://www.nngroup.com/articles/icon-usability/) on icon ambiguity — which is about
+the icon being ambiguous, not about the device; the original wording said "shop-floor
+tablet", which quotes are not edited on).
 `Back to Quotes` stays top-left. **Edit** is gated by `converted_at` (locked after the first conversion so already-converted lines can't drift), but the convert action follows the **remaining unconverted lines**, not the binary flag:
 
 | Current State | Buttons shown |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -185,7 +185,11 @@ which is strictly better anyway: the event never leaves the browser and never co
 against quota.
 
 > **Open question:** `legacy-browsers` is active on the frontend with `safari` in its list.
-> Shop-floor tablets are iPads. If any run an older iOS, this filter may be discarding
+> Operators are on **their own phones**, and in a machine shop a good share of those are
+> iPhones — so this is still a Safari exposure, just via personal handsets rather than the
+> shop-floor tablets this note originally assumed (corrected 2026-07-31; see
+> [the device model](../CLAUDE.md#who-uses-what-on-what--the-device-model)). If any run an
+> older iOS, this filter may be discarding
 > errors from exactly the devices that matter most. Not yet resolved.
 
 ### Plan and budget

--- a/docs/usability-tests/usability-test-script-v1.md
+++ b/docs/usability-tests/usability-test-script-v1.md
@@ -241,8 +241,15 @@ Log Johnny into the app and land him on the dashboard. Say nothing for 30 second
 
 #### Follow-up questions
 
-- "Would you actually use this on the floor, or would you rather use a tablet or computer?"
+- "Would you actually use this on the floor, or would you rather use a computer?"
 - "Anything too small or hard to tap?"
+
+> **Partly answered already — 2026-07-31, founder observation.** *"No one used a shop tablet in
+> Contour or any shop I've seen"* — it is the machine's own HMI, a personal phone, or the office
+> computer. So don't ask this one open-ended as though tablets were live; ask it to **confirm the
+> phone**, and spend the time on the question we can't answer from outside: *whose* phone, and
+> whether they mind using it for work. See
+> [the device model](../../CLAUDE.md#who-uses-what-on-what--the-device-model).
 
 ---
 


### PR DESCRIPTION
Docs only, 10 files. Prompted by founder observation:

> *"No one used a shop tablet in Contour or any shop I've seen"* — it is the machine's own HMI, a personal phone, or the office computer.

The docs had assumed shop-floor tablets in about a dozen places, and **two called it "our primary device"**. `HMI` appeared nowhere at all.

## The model, now canonical in CLAUDE.md

| Surface | Who | Device | What follows |
|---|---|---|---|
| **Admin & User** — Storage, Parts, Quotes, Jobs, all data setup | owner, salesperson, scheduler | **Office computer**, mouse + keyboard | Hover exists. Drag is viable. Bundle weight is cheap. |
| **Operator** — jobs, scan, notes | shop floor | **Their own phone** | Touch only. Bundle weight is expensive (cellular). Bright light. |
| **Machine control** | machinist | The machine's own **HMI** | **Not a Jigged surface.** We never render here. |

## Most conclusions survive — several of the *reasons* didn't

A phone is at least as constrained as a tablet, so the 48px floor, no hover-dependent UI and high contrast all still hold on the operator surface — more strongly than before. What changed is which arguments are available, and a few rules were resting on the wrong one:

| File | Was resting on | Now |
|---|---|---|
| `design-system.md`, `form-validation-audit.md` | "tablets, where hover isn't available" | Forms are admin-surface, so hover **is** available. Rule stands on what was always the stronger argument: a hover tooltip is **undiscoverable** and keyboard-unreachable — true at a desk too. |
| `interaction-standards.md` | `beforeunload` "unreliable on mobile/tablet — our primary device" | Both halves wrong. Pricing tiers are edited at a desk, where it's reliable. Recommendation unchanged, now resting only on the generic-message argument. |
| `quotes.md`, `design-system.md` placeholders | tablets | Icon ambiguity and low-contrast-number legibility were never about the device. |
| `data-import.md` | "bright-light shop tablet" persona | Importing is data setup; it happens at a desk. |
| `observability.md` | "shop-floor tablets are iPads" | Survives **retargeted** — personal iPhones. Same Safari exposure, different route. |

## What genuinely changes

**Drag is an ordinary interaction on the admin surface.** That retires the stated reason for §5.5's drag-to-reparent cut — *"drag on a shop tablet is the most failure-prone interaction available"*. The cut may still be right on its other ground (118 of 121 locations flat, so a re-parent gesture serves a hierarchy they don't have), but **the device half is withdrawn**.

Same correction applies to **#421**: an argument against a drag-to-place floor planner based on tablet drag reliability doesn't hold if setup happens at a desk. I'd made exactly that argument and I'm withdrawing it.

The usability-test script asked "tablet or computer?" open-ended. It now says to use that time confirming the phone, and to spend it on what no observation reaches: **whose** phone, and whether operators mind using a personal device for work.

## Note

§5.5's drag text lives on the #622 branch, not main, so its inline correction lands there rather than here. This PR records the finding and corrects everything currently on main.

Six files link the canonical CLAUDE.md section; relative depths and the GitHub anchor were both verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)