### PR TITLE
test: raise Testing Library's asyncUtilTimeout, and correct #631's diagnosis

### DIFF
--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,5 +1,28 @@
 import '@testing-library/jest-dom';
+import { configure } from '@testing-library/react';
 import { server } from './mocks/server';
+
+/**
+ * 5s, not Testing Library's 1s default — the second half of the fix that `vitest.config.ts`'s
+ * `testTimeout: 15_000` started.
+ *
+ * **`testTimeout` does not govern `findBy*` / `waitFor`.** Those use Testing Library's own
+ * `asyncUtilTimeout`, which defaults to 1000ms
+ * (`@testing-library/dom/dist/config.js`), and when it expires the error is
+ * `Unable to find role="button" and name /…/` — it never says "timed out". So the same fork
+ * contention that used to blow through vitest's 5s test timeout can still blow through this 1s
+ * window, and it reports as a missing element instead of a slow one.
+ *
+ * That mis-reads as a component bug, and it did: #631 recorded the CI failure
+ * `Unable to find role="button" and name /create 16 locations/i` as *"a state race, not a
+ * timeout"*. It is a timeout. Setting `asyncUtilTimeout: 1` reproduces that exact message,
+ * character for character, from `VisualLocationBuilder` — which otherwise passes on its own every
+ * time. Comment corrected in `vitest.config.ts` alongside this.
+ *
+ * Raising it costs nothing on a passing run: `findBy*` resolves as soon as the element appears and
+ * only the failing path waits longer. A genuinely absent element still fails, 4s later.
+ */
+configure({ asyncUtilTimeout: 5_000 });
 
 // Start MSW server before all tests
 beforeAll(() => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,8 +36,16 @@ export default defineConfig({
      * (`availableParallelism() - 1`) is 1–3 workers there; forcing 6 over-subscribed the runner
      * several times over and produced exactly the contention the setting was meant to remove.
      * `VisualLocationBuilder` then failed with `Unable to find role="button" and name
-     * /create 16 locations/i` — a state race, not a timeout, so `testTimeout` above did not
-     * cover it.
+     * /create 16 locations/i`.
+     *
+     * **Correction:** that failure was recorded here as *"a state race, not a timeout."* It is a
+     * timeout — just not this one. `findBy*` and `waitFor` are governed by Testing Library's
+     * `asyncUtilTimeout` (1000ms by default), not by `testTimeout`, and when it expires the error
+     * is a missing-element message that never mentions time. Setting `asyncUtilTimeout: 1`
+     * reproduces that exact message from this exact test. `__tests__/setup.ts` now raises it to
+     * 5s, which is the half of the contention fix this file could not reach. The `maxWorkers`
+     * warning stands regardless — over-subscribing a small runner was real, and the mis-diagnosis
+     * is why it looked like a component bug rather than the contention it caused.
      *
      * If local contention is ever worth capping again, it must be a genuine cap that cannot
      * inflate a small machine — `Math.min(6, availableParallelism() - 1)` — and it must be


### PR DESCRIPTION
Finishes the suite-flakiness work from #630/#631, and corrects a wrong diagnosis those PRs left in the code.

## The gap #630 couldn't reach

`vitest.config.ts` raised `testTimeout` to 15s to stop multi-step `userEvent` flows going red under fork contention. That fixed one of **two** independent timeouts.

`findBy*` and `waitFor` are not governed by `testTimeout`. They use Testing Library's own `asyncUtilTimeout`, which defaults to **1000ms** ([`@testing-library/dom/dist/config.js:15`](https://github.com/testing-library/dom-testing-library/blob/main/src/config.ts)). The same contention that blew through a 5s test timeout blows through a 1s element-wait — and the error it produces is:

```
Unable to find role="button" and name `/create 16 locations/i`
```

which never mentions time. It reads as "the element isn't there," not "the element was late."

## The mis-diagnosis

#631's warning block records that exact CI failure as *"a state race, not a timeout, so `testTimeout` above did not cover it."*

Half right. `testTimeout` genuinely doesn't cover it — but it **is** a timeout, just Testing Library's rather than vitest's. Verified rather than argued: setting `asyncUtilTimeout: 1` reproduces the message character for character from `VisualLocationBuilder`, the same test CI named, which otherwise passes 5/5 in isolation.

So there was never a state race to hunt. Leaving that claim in a ⚠️ block would send the next person after a bug that doesn't exist, which is why the comment is corrected here rather than just the config.

## The change

- `__tests__/setup.ts` — `configure({ asyncUtilTimeout: 5_000 })`, with the reasoning inline.
- `vitest.config.ts` — the "state race" claim replaced with what's actually happening. The `maxWorkers` warning itself stands unchanged; over-subscribing a small runner was real, and this only explains why its symptom looked like a component bug.

## Cost

None on a passing run — `findBy*` resolves the moment the element appears, so only the failing path waits longer. A genuinely absent element still fails, 4s later. No test in the suite relies on `findBy*` rejecting quickly (grepped for `findBy…).rejects`; none exist).

## Verification

- `pnpm exec vitest run` — **121 files / 1467 tests green in 32.6s**, wall-clock unchanged.
- `pnpm exec tsc --noEmit` — clean.
- The reproduction above, which is the actual evidence for the diagnosis.

Per the third-attempt note in that same warning block: this one is measured, not asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
