### PR TITLE
feat(operator): in-app scanner for every Jigged QR, and a "Me" tab to make room

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ api/.coverage
 
 #Agents
 .agents/
+
+# Copied from node_modules by scripts/copy-scanner-wasm.mjs (postinstall) so the decoder and its
+# JS can never drift apart. Regenerate with `pnpm install`.
+public/wasm/

--- a/__tests__/app/operator/MyWorkPage.test.tsx
+++ b/__tests__/app/operator/MyWorkPage.test.tsx
@@ -9,7 +9,35 @@ import type { MyContribution, MyNote } from '@/types/operator';
 vi.mock('@/utils/operatorAccess', () => ({
   getMyContribution: vi.fn(),
   getNoteViewers: vi.fn(),
+  // The "Me" tab resolves the operator's display name through this.
+  getCurrentMember: vi.fn(async () => ({ id: 'm1', name: 'Ada Lovelace', role: 'operator' })),
 }));
+
+// This page became the "Me" tab, so it now reaches identity + Log out — which pull in
+// `getCompany` and `getSupabase`. `lib/supabase` creates its client eagerly at module scope
+// whenever `window` exists, so in jsdom merely importing it fails without env vars.
+vi.mock('@/utils/companyAccess', () => ({
+  getCompany: vi.fn(async () => ({ id: 'co1', name: 'Vanguard Precision Works' })),
+}));
+// Both getters return the same stub: the page reaches one for Log out and the feedback insert, and
+// `useOperatorIdentity` reaches the other for the session. Stubbing only one left the identity load
+// throwing.
+//
+// The stub is built INSIDE the factory on purpose — `vi.mock` is hoisted above every `const` in
+// this file, so a factory closing over a module-scope helper fails with "cannot access before
+// initialization" before a single test runs.
+vi.mock('@/lib/supabase', () => {
+  const stub = () => ({
+    auth: {
+      getSession: async () => ({
+        data: { session: { user: { id: 'u1', email: 'ada@shop.test' } } },
+      }),
+      signOut: vi.fn(async () => ({ error: null })),
+    },
+    from: () => ({ insert: vi.fn(async () => ({ error: null })) }),
+  });
+  return { getSupabase: stub, getTypedSupabase: stub, supabase: null };
+});
 
 const mockGetMyContribution = vi.mocked(getMyContribution);
 const mockGetNoteViewers = vi.mocked(getNoteViewers);
@@ -214,5 +242,58 @@ describe('My Work', () => {
     render(<MyWorkPage />);
 
     expect(await screen.findByText(/Could not load your work/)).toBeInTheDocument();
+  });
+});
+
+/**
+ * This page is the "Me" tab: the operator's work, with identity and account actions folded in
+ * beneath it now that Profile is no longer a bottom tab.
+ */
+describe('My Work — the "Me" tab', () => {
+  it('shows the work itself, not an account screen you have to leave', async () => {
+    mockGetMyContribution.mockResolvedValue(contribution());
+    render(<MyWorkPage />);
+
+    // The note is present on first paint — no second tap to reach your own work.
+    expect(await screen.findByText(/Clamp on the boss/)).toBeInTheDocument();
+    expect(await screen.findByText('Ada Lovelace')).toBeInTheDocument();
+  });
+
+  /**
+   * The regression this guards is severe rather than cosmetic. The loading, error and empty
+   * states used to be early returns from the page component. Folding Profile in without moving
+   * them would have left a brand-new operator — zero notes, i.e. the common case — with no Log
+   * out button anywhere in the app, because Profile had just stopped being a tab.
+   */
+  it('can still log out with nothing written yet', async () => {
+    mockGetMyContribution.mockResolvedValue(contribution({ notes: [] }));
+    render(<MyWorkPage />);
+
+    expect(await screen.findByText('Nothing written yet')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /give feedback/i })).toBeInTheDocument();
+  });
+
+  it('can still log out when the work fails to load', async () => {
+    mockGetMyContribution.mockRejectedValue(new Error('denied'));
+    render(<MyWorkPage />);
+
+    expect(await screen.findByText(/Could not load your work/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument();
+  });
+
+  /**
+   * Log out is last and set apart, per NN/g's guidance on keeping a consequential option away
+   * from benign ones — operators repeating the same taps every shift slip into automaticity, and
+   * a mis-tap there is a slip that no clearer label fixes. Asserting document order keeps a
+   * future tidy-up from moving it back up next to Give feedback, which is where it used to be.
+   */
+  it('puts Log out after Give feedback, not beside it', async () => {
+    mockGetMyContribution.mockResolvedValue(contribution());
+    render(<MyWorkPage />);
+
+    const feedback = await screen.findByRole('button', { name: /give feedback/i });
+    const logout = screen.getByRole('button', { name: /log out/i });
+    expect(feedback.compareDocumentPosition(logout) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/__tests__/components/scanner/LocationScanner.test.tsx
+++ b/__tests__/components/scanner/LocationScanner.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * The in-app location scanner.
+ *
+ * The parser is the part worth pinning hardest. A shop floor is full of barcodes that are not ours —
+ * shipping labels, vendor part codes, another system's QR — and every one of them decodes perfectly
+ * well. Treating a foreign code as a location id would route someone to a bin that doesn't exist and
+ * blame them for it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '../../test-utils';
+
+import LocationScanner, {
+  locationIdFromScan,
+} from '@/components/scanner/LocationScanner';
+
+const UUID = '71000000-0000-0000-0000-000000000002';
+
+describe('locationIdFromScan', () => {
+  it('reads the id out of a printed label URL', () => {
+    expect(
+      locationIdFromScan(`https://jigged.app/operator/co1/login?location=${UUID}`),
+    ).toBe(UUID);
+  });
+
+  it('accepts a bare uuid, so a keyboard-wedge scanner or typing also works', () => {
+    expect(locationIdFromScan(UUID)).toBe(UUID);
+  });
+
+  it('tolerates surrounding whitespace and upper case', () => {
+    expect(locationIdFromScan(`  ${UUID.toUpperCase()}  `)).toBe(UUID);
+  });
+
+  it('reads a localhost URL, so a dev-printed label works too', () => {
+    expect(locationIdFromScan(`http://localhost:3000/operator/co1/login?location=${UUID}`)).toBe(UUID);
+  });
+
+  // Everything below is the "not ours" set — each must be rejected, not guessed at.
+  it.each([
+    ['a plain shipping barcode', '1Z999AA10123456784'],
+    ['a vendor part code', 'MCM-91290A115'],
+    ['a URL with no location param', 'https://jigged.app/operator/co1/login'],
+    ['a URL whose location is not a uuid', 'https://jigged.app/x?location=CAB3-A'],
+    ['another system’s QR', 'https://some-erp.example/bin/17'],
+    ['a job traveler QR', 'https://jigged.app/operator/co1/login?job=j1&part=p1'],
+    ['empty text', '   '],
+  ])('rejects %s', (_label, text) => {
+    expect(locationIdFromScan(text)).toBeNull();
+  });
+});
+
+/**
+ * Camera plumbing.
+ *
+ * jsdom has no `getUserMedia` and no WASM, so the decode loop itself can't run here — the browser is
+ * the only place that gets tested. What these cover is the part that fails in the real world for
+ * boring reasons: permission being denied, and the camera being released on close.
+ */
+describe('LocationScanner — camera', () => {
+  const track = () => ({ stop: vi.fn() });
+
+  beforeEach(() => {
+    vi.stubGlobal('navigator', {
+      ...navigator,
+      mediaDevices: { getUserMedia: vi.fn() },
+    });
+    // The component dynamically imports the decoder; jsdom can't load the wasm.
+    vi.doMock('zxing-wasm/reader', () => ({
+      prepareZXingModule: vi.fn(),
+      readBarcodes: vi.fn(async () => []),
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.doUnmock('zxing-wasm/reader');
+  });
+
+  /**
+   * Permission is the single commonest failure, and it can't be fixed by retrying — so the message
+   * has to say where to go instead of "something went wrong".
+   */
+  it('explains a blocked camera and where to fix it', async () => {
+    vi.mocked(navigator.mediaDevices.getUserMedia).mockRejectedValue(
+      new DOMException('Permission denied', 'NotAllowedError'),
+    );
+
+    render(<LocationScanner open onClose={vi.fn()} onScan={vi.fn()} />);
+
+    expect(
+      await screen.findByText(/camera access was blocked.*browser settings/i),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces any other camera failure rather than sitting on a spinner', async () => {
+    vi.mocked(navigator.mediaDevices.getUserMedia).mockRejectedValue(
+      new Error('Requested device not found'),
+    );
+
+    render(<LocationScanner open onClose={vi.fn()} onScan={vi.fn()} />);
+    expect(await screen.findByText(/requested device not found/i)).toBeInTheDocument();
+  });
+
+  /** A camera left running after the dialog closes reads as the app watching you. */
+  it('releases every track when it unmounts', async () => {
+    const tracks = [track(), track()];
+    vi.mocked(navigator.mediaDevices.getUserMedia).mockResolvedValue({
+      getTracks: () => tracks,
+    } as unknown as MediaStream);
+
+    const { unmount } = render(<LocationScanner open onClose={vi.fn()} onScan={vi.fn()} />);
+    await waitFor(() => expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalled());
+
+    unmount();
+    await waitFor(() => {
+      for (const t of tracks) expect(t.stop).toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * The camera must survive the parent re-rendering.
+   *
+   * Callers pass inline arrow functions — the operator layout does — so every parent render hands
+   * this component new `onScan`/`onScanTraveler` identities. While those were effect dependencies,
+   * any such render tore the effect down and back up: `stop()` released every track, then
+   * `getUserMedia` ran again. On a phone that is a visible black flash and a lost half-second of
+   * aiming, in the middle of a scan.
+   *
+   * Re-rendering with fresh inline handlers is exactly what the layout does, so this asserts the
+   * camera is acquired once and the tracks are never stopped.
+   */
+  it('does not restart the camera when the parent re-renders', async () => {
+    const tracks = [track()];
+    vi.mocked(navigator.mediaDevices.getUserMedia).mockResolvedValue({
+      getTracks: () => tracks,
+    } as unknown as MediaStream);
+
+    const { rerender } = render(
+      <LocationScanner open onClose={() => {}} onScan={() => {}} onScanTraveler={() => {}} />,
+    );
+    await waitFor(() => expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1));
+
+    // Three more renders, each with brand-new function identities.
+    for (let i = 0; i < 3; i++) {
+      rerender(
+        <LocationScanner open onClose={() => {}} onScan={() => {}} onScanTraveler={() => {}} />,
+      );
+    }
+
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+    expect(tracks[0].stop).not.toHaveBeenCalled();
+  });
+
+  it('asks for the rear camera, which is the one pointed at a shelf', async () => {
+    vi.mocked(navigator.mediaDevices.getUserMedia).mockResolvedValue({
+      getTracks: () => [],
+    } as unknown as MediaStream);
+
+    render(<LocationScanner open onClose={vi.fn()} onScan={vi.fn()} />);
+
+    await waitFor(() =>
+      expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith(
+        expect.objectContaining({ video: { facingMode: 'environment' } }),
+      ),
+    );
+  });
+
+  it('does not touch the camera while closed', () => {
+    render(<LocationScanner open={false} onClose={vi.fn()} onScan={vi.fn()} />);
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it('says what to do, and that it keeps scanning', async () => {
+    vi.mocked(navigator.mediaDevices.getUserMedia).mockResolvedValue({
+      getTracks: () => [],
+    } as unknown as MediaStream);
+
+    render(<LocationScanner open onClose={vi.fn()} onScan={vi.fn()} />);
+    expect(
+      await screen.findByText(/point the camera at the qr code.*keep going/i),
+    ).toBeInTheDocument();
+  });
+});
+
+/**
+ * The round trip: what we print, we can read.
+ *
+ * Everything above tests the two ends in isolation — `qrcode` writes the label, `zxing-wasm` reads a
+ * code, `locationIdFromScan` parses the text. None of that proves the *chain* holds, and the chain
+ * is what a scan actually is. If the printed error-correction level, size or payload ever stopped
+ * being decodable, every test above would still pass while no label in the shop scanned.
+ *
+ * Uses the real decoder against the real `.wasm` the app serves, and the same `errorCorrectionLevel`
+ * and width `locationLabelPdf` prints at.
+ */
+describe('printed label → decoder → location id', () => {
+  it('reads back a label generated exactly as the PDF prints it', async () => {
+    const QRCode = (await import('qrcode')).default;
+    const { readFile } = await import('node:fs/promises');
+    const { prepareZXingModule, readBarcodes } = await import('zxing-wasm/reader');
+
+    // The same file `scripts/copy-scanner-wasm.mjs` puts in public/ and the app loads at runtime.
+    const wasmBinary = await readFile('public/wasm/zxing_reader.wasm');
+    await prepareZXingModule({ overrides: { wasmBinary }, fireImmediately: true });
+
+    const url = `http://localhost:3000/operator/co1/login?location=${UUID}`;
+    // errorCorrectionLevel 'H' and 320px match utils/locationLabelPdf.ts.
+    const png = await QRCode.toBuffer(url, { errorCorrectionLevel: 'H', width: 320 });
+
+    // The encoded bytes directly, not a Blob: jsdom's Blob shim has no `arrayBuffer()`, which the
+    // decoder calls. `readBarcodes` accepts a Uint8Array of an encoded image just as happily.
+    const results = await readBarcodes(new Uint8Array(png), { formats: ['QRCode'] });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].text).toBe(url);
+    // And the parser gets the id back out of what the decoder actually returned.
+    expect(locationIdFromScan(results[0].text)).toBe(UUID);
+  }, 30_000);
+});

--- a/__tests__/components/scanner/LocationScanner.test.tsx
+++ b/__tests__/components/scanner/LocationScanner.test.tsx
@@ -72,7 +72,12 @@ describe('LocationScanner — camera', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    // `doUnmock` alone only affects FUTURE imports — it does not evict a module already in the
+    // registry, and the component imports `zxing-wasm/reader` dynamically while these tests run.
+    // The real protection is that the round trip now lives in its own file (vitest isolates the
+    // registry per file); this reset is belt-and-braces for anything added to this one later.
     vi.doUnmock('zxing-wasm/reader');
+    vi.resetModules();
   });
 
   /**
@@ -182,37 +187,12 @@ describe('LocationScanner — camera', () => {
 });
 
 /**
- * The round trip: what we print, we can read.
+ * The round trip — "what we print, we can read" — lives in `scannerRoundTrip.test.ts`, NOT here.
  *
- * Everything above tests the two ends in isolation — `qrcode` writes the label, `zxing-wasm` reads a
- * code, `locationIdFromScan` parses the text. None of that proves the *chain* holds, and the chain
- * is what a scan actually is. If the printed error-correction level, size or payload ever stopped
- * being decodable, every test above would still pass while no label in the shop scanned.
- *
- * Uses the real decoder against the real `.wasm` the app serves, and the same `errorCorrectionLevel`
- * and width `locationLabelPdf` prints at.
+ * It must not share a file with the camera suite above: that suite `vi.doMock`s
+ * `zxing-wasm/reader` with a `readBarcodes` returning `[]`, the component imports that module
+ * dynamically mid-render, and `vi.doUnmock` cannot evict an already-imported module. The round
+ * trip then decoded with the mock and failed on `expected [] to have a length of 1` — on CI only,
+ * where contended workers let the mocked import land first. Vitest isolates the registry per
+ * FILE, so separation removes the race rather than narrowing it.
  */
-describe('printed label → decoder → location id', () => {
-  it('reads back a label generated exactly as the PDF prints it', async () => {
-    const QRCode = (await import('qrcode')).default;
-    const { readFile } = await import('node:fs/promises');
-    const { prepareZXingModule, readBarcodes } = await import('zxing-wasm/reader');
-
-    // The same file `scripts/copy-scanner-wasm.mjs` puts in public/ and the app loads at runtime.
-    const wasmBinary = await readFile('public/wasm/zxing_reader.wasm');
-    await prepareZXingModule({ overrides: { wasmBinary }, fireImmediately: true });
-
-    const url = `http://localhost:3000/operator/co1/login?location=${UUID}`;
-    // errorCorrectionLevel 'H' and 320px match utils/locationLabelPdf.ts.
-    const png = await QRCode.toBuffer(url, { errorCorrectionLevel: 'H', width: 320 });
-
-    // The encoded bytes directly, not a Blob: jsdom's Blob shim has no `arrayBuffer()`, which the
-    // decoder calls. `readBarcodes` accepts a Uint8Array of an encoded image just as happily.
-    const results = await readBarcodes(new Uint8Array(png), { formats: ['QRCode'] });
-
-    expect(results).toHaveLength(1);
-    expect(results[0].text).toBe(url);
-    // And the parser gets the id back out of what the decoder actually returned.
-    expect(locationIdFromScan(results[0].text)).toBe(UUID);
-  }, 30_000);
-});

--- a/__tests__/components/scanner/scannerRoundTrip.test.ts
+++ b/__tests__/components/scanner/scannerRoundTrip.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+
+import { locationIdFromScan } from '@/lib/jiggedScan';
+
+const UUID = '71000000-0000-0000-0000-000000000002';
+
+/**
+ * The round trip: what we print, we can read.
+ *
+ * `LocationScanner.test.tsx` tests the two ends in isolation — `qrcode` writes the label,
+ * `zxing-wasm` reads a code, `locationIdFromScan` parses the text. None of that proves the *chain*
+ * holds, and the chain is what a scan actually is. If the printed error-correction level, size or
+ * payload ever stopped being decodable, every one of those tests would still pass while no label in
+ * the shop scanned.
+ *
+ * Uses the real decoder against the real `.wasm` the app serves, and the same `errorCorrectionLevel`
+ * and width `locationLabelPdf` prints at.
+ *
+ * ## Why this lives in its own file
+ *
+ * It used to sit at the bottom of `LocationScanner.test.tsx`, whose camera suite `vi.doMock`s
+ * `zxing-wasm/reader` with a `readBarcodes` that returns `[]`. The component imports that module
+ * dynamically mid-render, so the mocked copy lands in the module registry — and `vi.doUnmock` does
+ * not evict a module that has already been imported. This test could therefore decode with the mock
+ * and fail on `expected [] to have a length of 1`, which is the mock's own return value rather than
+ * a decode failure.
+ *
+ * It was a race, not a certainty: it passed locally every time and failed on CI, where slower,
+ * contended workers let the mocked import land first. `doUnmock` + `resetModules` would only shorten
+ * the odds; vitest isolates the module registry **per file**, so moving it here removes the race
+ * instead of narrowing it. Keep it in its own file, and keep it free of `vi.mock`.
+ *
+ * ## Requires `pnpm install` to have run
+ *
+ * It reads `public/wasm/zxing_reader.wasm`, which `scripts/copy-scanner-wasm.mjs` writes on
+ * postinstall (the file is gitignored). An install with `--ignore-scripts` will fail this with
+ * ENOENT — which is the correct failure, since the app would have no decoder either.
+ */
+describe('printed label → decoder → location id', () => {
+  it('reads back a label generated exactly as the PDF prints it', async () => {
+    const QRCode = (await import('qrcode')).default;
+    const { readFile } = await import('node:fs/promises');
+    const { prepareZXingModule, readBarcodes } = await import('zxing-wasm/reader');
+
+    // The same file `scripts/copy-scanner-wasm.mjs` puts in public/ and the app loads at runtime.
+    const wasmBinary = await readFile('public/wasm/zxing_reader.wasm');
+    await prepareZXingModule({ overrides: { wasmBinary }, fireImmediately: true });
+
+    const url = `http://localhost:3000/operator/co1/login?location=${UUID}`;
+    // errorCorrectionLevel 'H' and 320px match utils/locationLabelPdf.ts.
+    const png = await QRCode.toBuffer(url, { errorCorrectionLevel: 'H', width: 320 });
+
+    // The encoded bytes directly, not a Blob: jsdom's Blob shim has no `arrayBuffer()`, which the
+    // decoder calls. `readBarcodes` accepts a Uint8Array of an encoded image just as happily.
+    const results = await readBarcodes(new Uint8Array(png), { formats: ['QRCode'] });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].text).toBe(url);
+    // And the parser gets the id back out of what the decoder actually returned.
+    expect(locationIdFromScan(results[0].text)).toBe(UUID);
+  }, 30_000);
+});

--- a/__tests__/lib/jiggedScan.test.ts
+++ b/__tests__/lib/jiggedScan.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect } from 'vitest';
+import {
+  companyIdFromScan,
+  foreignCompanyRejection,
+  locationIdFromScan,
+  parseJiggedScan,
+  scanDestination,
+} from '@/lib/jiggedScan';
+
+/**
+ * The location half of this parser is covered in depth by
+ * `__tests__/components/scanner/LocationScanner.test.tsx`, which exercises
+ * `locationIdFromScan` against a printed label, a bare UUID and seven kinds of foreign code.
+ * Those tests pass unchanged through the wrapper, which is the point of keeping it.
+ *
+ * What's new here is the **traveler** half and the boundary between the two: one scanner now
+ * resolves both kinds of Jigged QR, and the ways that can go wrong are all about telling them
+ * apart.
+ */
+
+const LOC = '11111111-2222-3333-4444-555555555555';
+const JOB = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const PART = '99999999-8888-7777-6666-555555555555';
+
+const locationUrl = (id = LOC) => `https://jigged.app/operator/co1/login?location=${id}`;
+const travelerUrl = (job = JOB, part = PART) =>
+  `https://jigged.app/operator/co1/login?job=${job}&part=${part}`;
+
+describe('parseJiggedScan — location labels', () => {
+  it('reads a printed location label', () => {
+    expect(parseJiggedScan(locationUrl())).toEqual({ kind: 'location', locationId: LOC });
+  });
+
+  it('reads a bare UUID, so a keyboard wedge or a typed code works', () => {
+    expect(parseJiggedScan(LOC)).toEqual({ kind: 'location', locationId: LOC });
+  });
+
+  it('lowercases, so a scanner that upper-cases still matches stored ids', () => {
+    expect(parseJiggedScan(LOC.toUpperCase())).toEqual({ kind: 'location', locationId: LOC });
+    expect(parseJiggedScan(locationUrl(LOC.toUpperCase()))).toEqual({
+      kind: 'location',
+      locationId: LOC,
+    });
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseJiggedScan(`  ${LOC}\n`)).toEqual({ kind: 'location', locationId: LOC });
+  });
+});
+
+describe('parseJiggedScan — job travelers', () => {
+  it('reads a printed traveler sheet', () => {
+    expect(parseJiggedScan(travelerUrl())).toEqual({
+      kind: 'traveler',
+      jobId: JOB,
+      jobPartId: PART,
+    });
+  });
+
+  it('lowercases both ids', () => {
+    expect(parseJiggedScan(travelerUrl(JOB.toUpperCase(), PART.toUpperCase()))).toEqual({
+      kind: 'traveler',
+      jobId: JOB,
+      jobPartId: PART,
+    });
+  });
+
+  /**
+   * The traveler PDF always emits both. One without the other cannot open a traveler page, so
+   * accepting it would navigate somewhere broken — worse than saying "not a Jigged label".
+   */
+  it('refuses a job id with no part id', () => {
+    expect(parseJiggedScan(`https://jigged.app/operator/co1/login?job=${JOB}`)).toBeNull();
+  });
+
+  it('refuses a part id with no job id', () => {
+    expect(parseJiggedScan(`https://jigged.app/operator/co1/login?part=${PART}`)).toBeNull();
+  });
+
+  it('refuses a traveler whose ids are not UUIDs', () => {
+    expect(
+      parseJiggedScan('https://jigged.app/operator/co1/login?job=J-1234&part=17'),
+    ).toBeNull();
+  });
+});
+
+describe('parseJiggedScan — telling them apart', () => {
+  /**
+   * Our labels never emit both params. If something malformed does, location wins — which is
+   * exactly what the location-only parser did before this became a union, so nothing that used
+   * to resolve suddenly starts refusing.
+   */
+  it('prefers location when a malformed code somehow carries both', () => {
+    const both = `https://jigged.app/operator/co1/login?location=${LOC}&job=${JOB}&part=${PART}`;
+    expect(parseJiggedScan(both)).toEqual({ kind: 'location', locationId: LOC });
+  });
+
+  it('a bare UUID is a location, never a traveler — a traveler needs two ids', () => {
+    const scan = parseJiggedScan(JOB);
+    expect(scan).toEqual({ kind: 'location', locationId: JOB });
+  });
+
+  it('refuses codes from anywhere else', () => {
+    for (const foreign of [
+      '',
+      '   ',
+      'https://example.com/?location=not-a-uuid',
+      'https://ups.com/track?tracknum=1Z999',
+      '0123456789012', // an EAN-13 off a vendor box
+      'PART-4140-BAR', // a shop's own part sticker
+      'not a url at all',
+      `${LOC}-extra`, // a UUID with something appended must not match
+      'https://jigged.app/operator/co1/login', // our own login with no payload
+    ]) {
+      expect(parseJiggedScan(foreign), `should refuse: ${foreign}`).toBeNull();
+    }
+  });
+});
+
+describe('locationIdFromScan — the location-only view', () => {
+  it('returns the id for a location scan', () => {
+    expect(locationIdFromScan(locationUrl())).toBe(LOC);
+  });
+
+  /**
+   * The behaviour that must not drift: surfaces that only handle places (the board, the
+   * operator bin view) get null for a traveler rather than a job id they'd misread as a
+   * location.
+   */
+  it('returns null for a traveler, not the job id', () => {
+    expect(locationIdFromScan(travelerUrl())).toBeNull();
+  });
+
+  it('returns null for foreign codes', () => {
+    expect(locationIdFromScan('https://ups.com/track?tracknum=1Z999')).toBeNull();
+  });
+});
+
+/**
+ * Whose label is it? Separate from "what kind of label is it", because only some callers ask —
+ * the operator tab-bar scanner does, to refuse another shop's paper before it becomes a
+ * navigation.
+ */
+describe('companyIdFromScan', () => {
+  const CO = '0f0f0f0f-1111-2222-3333-444444444444';
+  const OTHER = 'deadbeef-1111-2222-3333-444444444444';
+
+  it('reads the company out of a location label', () => {
+    expect(companyIdFromScan(`https://jigged.app/operator/${CO}/login?location=${LOC}`)).toBe(CO);
+  });
+
+  it('reads the company out of a traveler', () => {
+    expect(companyIdFromScan(`https://jigged.app/operator/${CO}/login?job=${JOB}&part=${PART}`)).toBe(
+      CO,
+    );
+  });
+
+  it('distinguishes one company from another', () => {
+    expect(companyIdFromScan(`https://jigged.app/operator/${OTHER}/login?location=${LOC}`)).not.toBe(
+      CO,
+    );
+  });
+
+  it('lowercases, so a comparison never fails on case alone', () => {
+    expect(
+      companyIdFromScan(`https://jigged.app/operator/${CO.toUpperCase()}/login?location=${LOC}`),
+    ).toBe(CO);
+  });
+
+  /**
+   * Null is "can't tell", never "yours". A bare typed UUID has no company in it at all, and a
+   * caller must treat that as unverified rather than as a pass — which is why the scanner only
+   * refuses on a *mismatch*, not on an absence.
+   */
+  it('returns null for a bare UUID, which carries no company', () => {
+    expect(companyIdFromScan(LOC)).toBeNull();
+  });
+
+  it('returns null for a non-UUID path segment rather than guessing', () => {
+    // The other fixtures in this file use `co1`; that is not an id we would ever print.
+    expect(companyIdFromScan(locationUrl())).toBeNull();
+  });
+
+  it('returns null for a foreign URL', () => {
+    expect(companyIdFromScan('https://ups.com/track?tracknum=1Z999')).toBeNull();
+  });
+
+  it('returns null for a Jigged URL that is not the login passthrough', () => {
+    expect(companyIdFromScan(`https://jigged.app/dashboard/${CO}/parts`)).toBeNull();
+  });
+
+  it('returns null for junk', () => {
+    expect(companyIdFromScan('not a url')).toBeNull();
+  });
+});
+
+/**
+ * Where a scan lands. These assertions exist because the in-app mapping used to be inline in
+ * `app/operator/[companyId]/layout.tsx` with no test anywhere — so the single most load-bearing
+ * behaviour in the feature, routing an OLD traveller sheet to its step, was unverified.
+ *
+ * The expected paths below are copied from `postLoginPath` in
+ * `app/operator/[companyId]/login/page.tsx`, which is where the same piece of paper goes when it
+ * is scanned with the phone's camera app instead. If someone changes one, this should fail.
+ */
+describe('scanDestination', () => {
+  const CO = 'co-1';
+
+  it('sends a location label to that bin', () => {
+    expect(scanDestination(CO, { kind: 'location', locationId: LOC })).toBe(
+      `/operator/${CO}/inventory/locations/${LOC}`,
+    );
+  });
+
+  it('sends a current traveller to the job part, where the operator picks the step', () => {
+    expect(scanDestination(CO, { kind: 'traveler', jobId: JOB, jobPartId: PART })).toBe(
+      `/operator/${CO}/jobs/${JOB}/parts/${PART}`,
+    );
+  });
+
+  /**
+   * The one that matters. Sheets printed before travellers stopped encoding a step are still on
+   * the shop floor, and they jump straight to that step. Dropping the operation would silently
+   * downgrade an old sheet to the traveller index — worse than the camera-app path it was
+   * printed for.
+   */
+  it('sends an OLD traveller straight to the step it encodes', () => {
+    const OP = '12121212-3434-5656-7878-909090909090';
+    expect(
+      scanDestination(CO, { kind: 'traveler', jobId: JOB, jobPartId: PART, operationId: OP }),
+    ).toBe(`/operator/${CO}/jobs/${JOB}/parts/${PART}/operations/${OP}`);
+  });
+
+  it('treats an absent operationId the same as one that was never there', () => {
+    expect(
+      scanDestination(CO, { kind: 'traveler', jobId: JOB, jobPartId: PART, operationId: undefined }),
+    ).toBe(`/operator/${CO}/jobs/${JOB}/parts/${PART}`);
+  });
+
+  /** End to end: the printed string a scanner reads, through to the path it opens. */
+  it('routes a real printed traveller URL end to end', () => {
+    const scan = parseJiggedScan(travelerUrl());
+    expect(scan).not.toBeNull();
+    expect(scanDestination(CO, scan!)).toBe(`/operator/${CO}/jobs/${JOB}/parts/${PART}`);
+  });
+});
+
+/**
+ * The tenant boundary on a scan. A traveller QR printed by another shop decodes perfectly well;
+ * before this existed the operator layout pushed the route anyway and let the destination page's
+ * RLS fail, so the operator got an error screen after a navigation instead of "that isn't yours".
+ */
+describe('foreignCompanyRejection', () => {
+  const MINE = '0f0f0f0f-1111-2222-3333-444444444444';
+  const THEIRS = 'deadbeef-1111-2222-3333-444444444444';
+  const url = (co: string, qs: string) => `https://jigged.app/operator/${co}/login?${qs}`;
+  const loc = (co: string) => url(co, `location=${LOC}`);
+  const trav = (co: string) => url(co, `job=${JOB}&part=${PART}`);
+
+  it('accepts one of your own labels', () => {
+    const text = loc(MINE);
+    expect(foreignCompanyRejection(text, parseJiggedScan(text)!, MINE)).toBeNull();
+  });
+
+  it('refuses another company’s shelf label', () => {
+    const text = loc(THEIRS);
+    expect(foreignCompanyRejection(text, parseJiggedScan(text)!, MINE)).toMatch(
+      /label belongs to a different company/i,
+    );
+  });
+
+  /** Different paper, different sentence — an operator holding a traveller needs to be told so. */
+  it('refuses another company’s traveller, and says traveller', () => {
+    const text = trav(THEIRS);
+    expect(foreignCompanyRejection(text, parseJiggedScan(text)!, MINE)).toMatch(
+      /traveler belongs to a different company/i,
+    );
+  });
+
+  it('ignores case, so a comparison never fails on that alone', () => {
+    const text = loc(MINE.toUpperCase());
+    expect(foreignCompanyRejection(text, parseJiggedScan(text)!, MINE)).toBeNull();
+  });
+
+  /**
+   * Absence is not a mismatch. A bare typed UUID carries no company at all, and refusing it would
+   * break the keyboard-wedge and hand-typed paths for no security gain — the caller's own data
+   * validation is the backstop there.
+   */
+  it('lets an unverifiable payload through rather than refusing it', () => {
+    expect(foreignCompanyRejection(LOC, parseJiggedScan(LOC)!, MINE)).toBeNull();
+  });
+
+  it('does nothing when the caller names no company', () => {
+    const text = loc(THEIRS);
+    expect(foreignCompanyRejection(text, parseJiggedScan(text)!, undefined)).toBeNull();
+  });
+});

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -15,10 +15,12 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemText from '@mui/material/ListItemText';
 import WorkIcon from '@mui/icons-material/Work';
-import PersonIcon from '@mui/icons-material/Person';
 import WarehouseOutlinedIcon from '@mui/icons-material/WarehouseOutlined';
 import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
 import StickyNote2OutlinedIcon from '@mui/icons-material/StickyNote2Outlined';
+import QrCodeScannerIcon from '@mui/icons-material/QrCodeScanner';
+import LocationScanner from '@/components/scanner/LocationScanner';
+import { scanDestination } from '@/lib/jiggedScan';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import DashboardIcon from '@mui/icons-material/Dashboard';
@@ -35,8 +37,10 @@ import type { AuthChangeEvent } from '@supabase/supabase-js';
  * Operator View layout.
  *
  * Mobile-first layout with:
- * - Top header with operator name, station display, and logout
- * - Bottom navigation bar (Jobs, Profile)
+ * - Top header with station picker and (for non-operators) a dashboard shortcut. Deliberately
+ *   exactly one icon button — see the note where the second one used to be.
+ * - Bottom navigation: Jobs · Inventory · Scan · Maintenance · Me. Five is the ceiling, which is
+ *   why Scan took Profile's slot and Profile's contents moved into Me.
  * - No sidebar (unlike admin dashboard)
  * - Uses Supabase Auth for session management
  * - OperatorStationProvider for shared station state
@@ -115,22 +119,62 @@ export default function OperatorLayout({
     };
   }, [companyId, router, pathname, supabase]);
 
-  // Update nav value based on current path
+  // Update nav value based on current path.
+  //
+  // `/profile` now redirects to `/my-work` (the "Me" tab), so it needs no branch of its own —
+  // the redirect lands on a path that already matches below. Keeping a `'profile'` branch here
+  // would have set a nav value no tab owns, which reads as "no tab selected".
   useEffect(() => {
-    if (pathname?.includes('/profile')) setNavValue('profile');
-    else if (pathname?.includes('/inventory')) setNavValue('inventory');
+    if (pathname?.includes('/inventory')) setNavValue('inventory');
     else if (pathname?.includes('/maintenance')) setNavValue('maintenance');
     else if (pathname?.includes('/my-work')) setNavValue('my-work');
     else setNavValue('jobs');
   }, [pathname]);
 
+  /** Scan opens over whatever you were doing; every other tab is a route. */
+  const [scanning, setScanning] = useState(false);
+
   const handleNavChange = (_event: React.SyntheticEvent, newValue: string) => {
+    // Scan is a modal action wearing a tab's clothes. Deliberately does NOT become the
+    // selected tab: you're still on Jobs (or wherever) with a scanner over the top, and
+    // leaving the selection where it was is what makes closing the dialog feel like
+    // dismissing something rather than navigating back.
+    if (newValue === 'scan') {
+      setScanning(true);
+      return;
+    }
+
     setNavValue(newValue);
     if (newValue === 'inventory') router.push(`/operator/${companyId}/inventory`);
     else if (newValue === 'maintenance') router.push(`/operator/${companyId}/maintenance`);
     else if (newValue === 'my-work') router.push(`/operator/${companyId}/my-work`);
-    else if (newValue === 'profile') router.push(`/operator/${companyId}/profile`);
     else router.push(`/operator/${companyId}/jobs`);
+  };
+
+  /**
+   * Where each kind of Jigged QR goes.
+   *
+   * Both are deep links the printed paper already encodes, so this mirrors what the login
+   * passthrough would have done — minus the camera-app round trip and the interstitial. The
+   * mapping itself lives in `scanDestination` so it is testable without mounting this layout, and
+   * so it can be compared against `postLoginPath` rather than silently drifting from it.
+   */
+  const handleScanLocation = (locationId: string) => {
+    setScanning(false);
+    router.push(scanDestination(companyId, { kind: 'location', locationId }));
+  };
+
+  const handleScanTraveler = ({
+    jobId,
+    jobPartId,
+    operationId,
+  }: {
+    jobId: string;
+    jobPartId: string;
+    operationId?: string;
+  }) => {
+    setScanning(false);
+    router.push(scanDestination(companyId, { kind: 'traveler', jobId, jobPartId, operationId }));
   };
 
   // Don't show header/nav on login page
@@ -179,6 +223,28 @@ export default function OperatorLayout({
         >
           {children}
         </OperatorShell>
+
+        {/*
+          Lives at the layout level, not on a page, because the tab bar owns it — so it opens
+          over whatever screen you were on and closing it returns you there. A Dialog portals
+          out of this position anyway, so being a sibling of the shell costs nothing.
+
+          Both handlers mirror the login passthrough's `postLoginPath`, which is what the
+          printed QR would have gone through: same destination, minus the camera-app round trip
+          and the login interstitial.
+        */}
+        <LocationScanner
+          open={scanning}
+          onClose={() => setScanning(false)}
+          onScan={handleScanLocation}
+          onScanTraveler={handleScanTraveler}
+          /* Without this, a label printed by ANOTHER shop decodes fine and both handlers below
+             push the route regardless — the operator lands on someone else's job or bin and gets
+             an RLS error page instead of "that isn't yours". The scanner now refuses it before
+             either handler runs. */
+          expectedCompanyId={companyId}
+          title="Scan a Jigged label"
+        />
       </OperatorChromeProvider>
     </OperatorStationProvider>
   );
@@ -312,7 +378,7 @@ function OperatorShell({
           </Box>
 
           {/* Right: dashboard shortcut for non-operators (admins/leads viewing
-              the operator view). Logout lives on the Profile tab, not here. */}
+              the operator view). */}
           {userRole !== 'operator' && (
             <IconButton
               color="inherit"
@@ -324,6 +390,21 @@ function OperatorShell({
               <DashboardIcon fontSize="small" />
             </IconButton>
           )}
+
+          {/*
+            NO second header icon button here.
+
+            An interim version of this change put Profile here as an IconButton next to the
+            dashboard one above, which put two small targets side by side with almost no gap.
+            That is the worst case in Fitts's law — small target, near-zero distance — and
+            because touch platforms resolve a tap to the *closest* control, missing one doesn't
+            do nothing, it fires the other. WCAG 2.5.8 measures this as centre-to-centre spacing
+            rather than visible gap, and Material asks for ≥8dp of clearance; a mis-tap here is a
+            slip, which no clearer label or tooltip can fix — only layout can.
+
+            Profile's contents moved into the "Me" tab instead, which removes the target rather
+            than shrinking the odds of hitting the wrong one.
+          */}
         </Toolbar>
 
         {/* Station Selector Menu */}
@@ -387,6 +468,16 @@ function OperatorShell({
           }}
           elevation={3}
         >
+          {/*
+            ⚠️ This bar is FULL. At the full complement it carries five destinations —
+            Jobs · Inventory · Scan · Maintenance · My work — which is the documented Material
+            Design ceiling for bottom navigation (3–5). Both Inventory and Maintenance are
+            flag-gated, so most shops see three or four.
+
+            A sixth needs something to leave, not another slot. Profile already moved to the
+            header avatar for exactly this reason; the next candidate is whichever destination
+            turns out to be visited least, measured rather than guessed.
+          */}
           <BottomNavigation
             value={navValue}
             onChange={onNavChange}
@@ -416,6 +507,30 @@ function OperatorShell({
                 sx={{ minHeight: 56 }}
               />
             )}
+            {/*
+              Scan is a tab, not a button buried on one screen.
+
+              It is the operator's most frequent physical gesture — you arrive at a shelf or
+              pick up a traveler sheet holding a piece of paper with a QR on it. Previously
+              the only in-app scanner lived on the inventory page and read location labels
+              only, so a traveler meant leaving the app for the phone's camera: a different
+              gesture for a near-identical piece of paper. One scanner, both kinds.
+
+              It opens a dialog rather than navigating, so scanning never loses the screen
+              you were on — which matters for the continuous flows (a count session, receiving
+              a pallet) that motivated an in-app scanner at all.
+
+              **Placed third deliberately.** At the full complement — Jobs · Inventory · Scan ·
+              Maintenance · My work — this puts the most-used action dead centre, which is where
+              a thumb rests. With both flags off it degrades to Jobs · Scan · My work and stays
+              centred.
+            */}
+            <BottomNavigationAction
+              label="Scan"
+              value="scan"
+              icon={<QrCodeScannerIcon />}
+              sx={{ minHeight: 56 }}
+            />
             {showMaintenance && (
               <BottomNavigationAction
                 label="Maintenance"
@@ -424,20 +539,32 @@ function OperatorShell({
                 sx={{ minHeight: 56 }}
               />
             )}
-            {/* "My work" is the operator's own contribution surface. Today that
-                is notes and photos; it is named for what it will hold, not only
-                for what is in it now. What it must NOT grow into is a record of
-                completions — see the header of the my-work page. */}
+            {/* "Me" — the operator's own contribution surface, with identity and account
+                actions folded in beneath it. Today the work is notes and photos. What it must
+                NOT grow into is a record of completions — see the header of the my-work page.
+
+                WHY THIS IS A MERGE AND NOT A DEMOTION. An interim version kept "My work" as its
+                own tab and pushed Profile into a header icon, on the argument that merging would
+                bury a primary daily surface behind a second tap. The measurement backs the
+                worry — NN/g found navigation hidden behind an icon used 44–56% of the time
+                against 89% for visible navigation — but it points at the wrong fix. Material's
+                bottom-nav guidance rules out a settings tab outright, so Profile never had a
+                legitimate claim on a slot, and the bar is capped at five. Keeping the slot and
+                putting the WORK at the top of it protects the surface; YouTube's and Strava's
+                "You" tabs are the same move, and Strava's merged Profile *and* Training.
+
+                The route stays `/my-work` deliberately — renaming routes is churn for no
+                user-visible gain (same call as keeping `/inventory/*`), and it keeps the Jobs
+                page's link and the E2E spec working.
+
+                The label is "Me", not "You": the app already says "My work", and mixing first
+                and second person across one surface is the inconsistency to avoid. The text
+                label always shows — an eye-tracking study in this audience's age band found
+                icon+text erases the recognition penalty that icon-only carries. */}
             <BottomNavigationAction
-              label="My work"
+              label="Me"
               value="my-work"
               icon={<StickyNote2OutlinedIcon />}
-              sx={{ minHeight: 56 }}
-            />
-            <BottomNavigationAction
-              label="Profile"
-              value="profile"
-              icon={<PersonIcon />}
               sx={{ minHeight: 56 }}
             />
           </BottomNavigation>

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -469,14 +469,31 @@ function OperatorShell({
           elevation={3}
         >
           {/*
-            ⚠️ This bar is FULL. At the full complement it carries five destinations —
-            Jobs · Inventory · Scan · Maintenance · My work — which is the documented Material
-            Design ceiling for bottom navigation (3–5). Both Inventory and Maintenance are
-            flag-gated, so most shops see three or four.
+            ⚠️ This bar is FULL. At the full complement it carries five slots —
+            Jobs · Inventory · Scan · Maintenance · Me — which is the documented Material Design
+            ceiling for bottom navigation (3–5). Both Inventory and Maintenance are flag-gated, so
+            many shops see three or four.
 
-            A sixth needs something to leave, not another slot. Profile already moved to the
-            header avatar for exactly this reason; the next candidate is whichever destination
-            turns out to be visited least, measured rather than guessed.
+            A sixth needs something to leave, not another slot. Profile's contents already moved
+            into Me for exactly this reason; the next candidate is whichever destination turns out
+            to be visited least, measured rather than guessed.
+
+            ORDER, left to right, and why:
+              Jobs   — leftmost is the default landing and where a shift starts.
+              Scan   — the middle, because it is the most frequent gesture of the five and the
+                       centre of the bottom edge is the easiest place on a phone to hit. It is
+                       also an ACTION rather than a destination, which is the conventional use of
+                       a centre slot.
+              Me     — rightmost, the near-universal home for account/self.
+              Inventory / Maintenance fill the remaining two, both flag-gated.
+
+            ⚠️ minWidth: 0 on every action is LOAD-BEARING, not tidying. MUI defaults
+            `BottomNavigationAction` to `minWidth: 80` with `flex: 1`, and `min-width` blocks
+            flex-shrink — so five tabs demand 400px. Measured at a 375px viewport (iPhone SE, 12
+            mini, plenty of Androids) before this: the bar overflowed by 13px, `Jobs` began at
+            x = -12 with its icon partly off-screen, and `Me` ran past the right edge. Both damaged
+            slots were the ENDS, which is precisely where the default and the account live.
+            With minWidth: 0 the five share the width evenly and nothing clips.
           */}
           <BottomNavigation
             value={navValue}
@@ -486,7 +503,25 @@ function OperatorShell({
               bgcolor: 'rgba(17, 20, 57, 0.98)',
               '& .MuiBottomNavigationAction-root': {
                 color: 'rgba(255, 255, 255, 0.5)',
-                minWidth: 80,
+                /**
+                 * `'0px'`, NOT the 80 this used to carry (which was MUI's own default restated).
+                 *
+                 * `BottomNavigationAction` is `flex: 1`, and `min-width` blocks flex-shrink — so at
+                 * five slots the bar demanded 5 × 80 = 400px. Measured at a 375px viewport (iPhone
+                 * SE, 12 mini, plenty of Androids): the bar overflowed by 13px, `Jobs` began at
+                 * x = -12 with its icon partly off-screen, and `Me` ran past the right edge. Both
+                 * damaged slots were the ENDS — exactly where the default destination and the
+                 * account live.
+                 *
+                 * Note this had to change HERE and not on each action's own `sx`: this descendant
+                 * selector outranks the element's own class, so a per-action override is silently
+                 * ignored.
+                 *
+                 * Touch targets stay compliant — `minHeight: 56` on each action carries the 48px
+                 * floor vertically, and five slots across 375px is 75px each, still well above the
+                 * 48px minimum horizontally.
+                 */
+                minWidth: '0px',
                 '&.Mui-selected': {
                   color: 'primary.main',
                 },

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -272,10 +272,28 @@ function OperatorShell({
   const { features } = useCompanyFeatures();
   const pathname = usePathname();
   const router = useRouter();
+  /**
+   * ⚠️ Both of these hide a tab, which is a KNOWN DEVIATION from Apple's guidance: "Don't disable
+   * or hide tab bar buttons, even when their content is unavailable. Having tab bar buttons
+   * available in some cases but not others makes your app's interface appear unstable and
+   * unpredictable. If a section is empty, explain why its content is unavailable."
+   *
+   * Taken deliberately: these are not empty sections but genuine entitlement boundaries — a shop
+   * without the locations flag has no places at all, and `/inventory/locations` redirects. Showing
+   * a tab that explains why it doesn't work would be worse than not showing it.
+   *
+   * The cost is real, though, and it is why the tab ORDER is constrained: because MUI distributes
+   * slots evenly, changing the tab COUNT moves every tab's physical position. Keeping one optional
+   * tab on each side of Scan is what bounds that (see the note above the bar).
+   */
   const showInventory = Boolean(features.inventory_locations);
   // A machine IS a station, so the logbook only exists once one is selected —
   // deliberately NOT added to the navVisible escape list below, unlike inventory
   // and my-work. Without a station there is no machine to have a tab for.
+  //
+  // Note this one can flip DURING a session, when a station is picked or cleared — so the bar
+  // reflows mid-shift, unlike the flag-only gate above. The station is normally chosen once at
+  // login, before real work, which is what makes that acceptable.
   const showMaintenance = Boolean(features.machine_maintenance) && Boolean(stationId);
   // The warehouse is station-independent, so keep the nav (and a way out) on
   // inventory routes even before a station is picked.
@@ -555,15 +573,53 @@ function OperatorShell({
               you were on — which matters for the continuous flows (a count session, receiving
               a pallet) that motivated an in-app scanner at all.
 
-              **Placed third deliberately.** At the full complement — Jobs · Inventory · Scan ·
-              Maintenance · My work — this puts the most-used action dead centre, which is where
-              a thumb rests. With both flags off it degrades to Jobs · Scan · My work and stays
-              centred.
+              **Placed third deliberately, on the best-evidenced finding in this layout.** Not
+              "where the thumb rests" — the popular thumb-zone heat maps rest on a one-handed-use
+              claim Hoober himself walked back ("there's hardly any one-handed use for actually
+              touching the screen"; the 49% figure describes *holding*, not tapping). The finding
+              that survives is about accuracy, from millions of measured touches: **7 mm at the
+              centre of the screen versus 12 mm at the corners**, with taps also faster and more
+              confident toward the centre — partly device digitiser error, not thumb geometry. So
+              the most frequent gesture goes in the middle.
+
+              **Keep one flag-gated tab on EACH side of Scan.** Both Inventory and Maintenance are
+              optional, so the bar has four shapes. Flanking holds Scan within half a slot of
+              centre in every one of them, and it is the only arrangement that does — grouping the
+              optional pair together would pin Scan at position 2, off-centre always.
+
+              **Why it looks different from its neighbours.** Apple is explicit that "a tab bar
+              [is] to support navigation, not to provide actions", and Scan is an action. Material 3
+              sanctions the way out: a FAB for "the most important action on a screen" may be
+              "nested within" the navigation bar. So Scan wears a filled disc rather than a bare
+              glyph — enough to read as the action, without the raised protruding FAB that would
+              fight "professional, not trendy". Combined with not taking the tab selection, the
+              deviation is coherent rather than a violation.
+
+              Note the disc is VISUAL only: the hit area is the whole 75×56 slot either way, well
+              past the 48px floor. What it buys is a target that is easier to aim at, which is
+              precisely what the accuracy figures above are about.
             */}
             <BottomNavigationAction
               label="Scan"
               value="scan"
-              icon={<QrCodeScannerIcon />}
+              icon={
+                <Box
+                  sx={{
+                    width: 34,
+                    height: 34,
+                    borderRadius: '50%',
+                    bgcolor: 'primary.main',
+                    display: 'grid',
+                    placeItems: 'center',
+                    // The parent sx dims every action to 50% white; Scan's glyph must stay full
+                    // strength against the filled disc. Scan is also never `Mui-selected` (it
+                    // opens a dialog), so it would otherwise be permanently dimmed.
+                    color: 'common.white',
+                  }}
+                >
+                  <QrCodeScannerIcon fontSize="small" />
+                </Box>
+              }
               sx={{ minHeight: 56 }}
             />
             {showMaintenance && (

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -19,6 +19,11 @@ import LaunchIcon from '@mui/icons-material/Launch';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import { getMyContribution, getNoteViewers } from '@/utils/operatorAccess';
 import { useSetOperatorChrome } from '@/components/operator/OperatorChromeContext';
+import { useOperatorIdentity } from '@/hooks/useOperatorIdentity';
+import {
+  OperatorIdentityRow,
+  OperatorAccountActions,
+} from '@/components/operator/OperatorAccountBlock';
 import NoteReactions from '@/components/operator/NoteReactions';
 import type { MyNote, NoteViewer } from '@/types/operator';
 
@@ -205,11 +210,35 @@ export default function MyWorkPage() {
     [companyId],
   );
 
+  const { data: identity } = useOperatorIdentity(companyId);
+
+  /**
+   * This is the "Me" tab: identity, then the work, then account actions.
+   *
+   * The work is sandwiched rather than replaced — see `OperatorAccountBlock` for why the work
+   * has to lead and why Log out sits at the very bottom.
+   *
+   * The three loading/error/empty states are INSIDE `MyContribution` on purpose. They used to
+   * be early returns from this component, and leaving them there once Profile stopped being a
+   * tab would have meant a brand-new operator — the case with zero notes, i.e. the common one —
+   * had no Log out button anywhere in the app.
+   */
+  return (
+    <Box sx={{ pb: 4 }}>
+      <OperatorIdentityRow identity={identity} />
+      <MyContribution companyId={companyId} />
+      <OperatorAccountActions companyId={companyId} identity={identity} />
+    </Box>
+  );
+}
+
+/** The operator's own notes and their reception. Owns its own loading/error/empty states. */
+function MyContribution({ companyId }: { companyId: string }) {
   const { data, loading, error } = useLoad(() => getMyContribution(companyId), [companyId]);
 
   if (loading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '30vh' }}>
         <CircularProgress />
       </Box>
     );
@@ -227,7 +256,7 @@ export default function MyWorkPage() {
 
   if (c.noteCount === 0) {
     return (
-      <Box sx={{ textAlign: 'center', py: 8, px: 2 }}>
+      <Box sx={{ textAlign: 'center', py: 6, px: 2 }}>
         <Typography variant="h6" color="text.secondary" gutterBottom>
           Nothing written yet
         </Typography>
@@ -239,7 +268,7 @@ export default function MyWorkPage() {
   }
 
   return (
-    <Box sx={{ pb: 4 }}>
+    <Box>
       {/* Contribution leads. What you put in comes before what came back —
           the point is that writing things down is the work, not a score. */}
       <Card elevation={2} sx={{ ...cardSx, mb: 3 }}>

--- a/app/operator/[companyId]/profile/page.tsx
+++ b/app/operator/[companyId]/profile/page.tsx
@@ -1,189 +1,22 @@
-'use client';
-
-import { useState, useEffect } from 'react';
-import { useParams, useRouter } from 'next/navigation';
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import Button from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
-import Alert from '@mui/material/Alert';
-import Snackbar from '@mui/material/Snackbar';
-import LogoutIcon from '@mui/icons-material/Logout';
-import FeedbackIcon from '@mui/icons-material/Feedback';
-import FeedbackDialog from '@/components/feedback/FeedbackDialog';
-import { getCurrentMember } from '@/utils/operatorAccess';
-import { getCompany } from '@/utils/companyAccess';
-import { getSupabase } from '@/lib/supabase';
-import { clearStoredStation } from '@/components/operator/OperatorStationContext';
+import { redirect } from 'next/navigation';
 
 /**
- * Operator Profile Page.
+ * `/profile` folded into the "Me" tab.
  *
- * Shows operator info, current station, work session history,
- * change password link, and logout button.
+ * Everything this page held — the name/email/company card, Give feedback, and Log out — now
+ * lives beneath the operator's own work at `/my-work`, which the bottom bar labels **Me**. See
+ * `components/operator/OperatorAccountBlock.tsx` for why the work leads and why Log out sits
+ * last.
+ *
+ * A redirect rather than a deletion: this path is the one an operator may have bookmarked, and
+ * it was a bottom tab until this change. The route stays `/my-work` on the other side because
+ * renaming routes is churn for no user-visible gain.
  */
-export default function OperatorProfilePage() {
-  const params = useParams();
-  const router = useRouter();
-  const companyId = params.companyId as string;
-  const [operatorName, setOperatorName] = useState<string>('');
-  const [operatorEmail, setOperatorEmail] = useState<string>('');
-  const [operatorUserId, setOperatorUserId] = useState<string>('');
-  const [companyName, setCompanyName] = useState<string>('');
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [feedbackOpen, setFeedbackOpen] = useState(false);
-  const [feedbackSuccess, setFeedbackSuccess] = useState(false);
-
-  useEffect(() => {
-    async function loadProfile() {
-      setLoading(true);
-      setError(null);
-
-      try {
-        const supabase = getSupabase();
-
-        // Get auth session for email
-        const { data: { session } } = await supabase.auth.getSession();
-        if (session?.user) {
-          setOperatorEmail(session.user.email || '');
-          setOperatorUserId(session.user.id);
-        }
-
-        // Get operator info
-        const operator = await getCurrentMember(companyId);
-        if (!operator) {
-          setError('Operator not found');
-          setLoading(false);
-          return;
-        }
-
-        setOperatorName(operator.name || 'Operator');
-
-        // Fetch company name for branding
-        const company = await getCompany(companyId);
-        if (company?.name) {
-          setCompanyName(company.name);
-        }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load profile');
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    loadProfile();
-  }, [companyId]);
-
-  const handleLogout = async () => {
-    // Clears the persisted station (localStorage) on explicit logout — same store
-    // OperatorStationContext uses; sessionStorage is no longer the station's home.
-    clearStoredStation();
-    const supabase = getSupabase();
-    // Local scope — sign out ONLY this device. An operator logging out here must
-    // not revoke their session on their other devices (which surfaced as a
-    // forced re-login when marking a job complete).
-    await supabase.auth.signOut({ scope: 'local' });
-    router.push(`/operator/${companyId}/login`);
-  };
-
-  if (loading) {
-    return (
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          minHeight: '50vh',
-        }}
-      >
-        <CircularProgress />
-      </Box>
-    );
-  }
-
-  return (
-    <Box>
-      <Typography variant="h5" component="h1" fontWeight={600} sx={{ mb: 3 }}>
-        Profile
-      </Typography>
-
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
-
-      {/* Operator Info Card */}
-      <Card
-        elevation={2}
-        sx={{
-          mb: 3,
-          bgcolor: 'rgba(26, 31, 74, 0.55)',
-          backdropFilter: 'blur(8px)',
-        }}
-      >
-        <CardContent>
-          <Typography variant="h6" fontWeight={600} sx={{ mb: 1 }}>
-            {operatorName}
-          </Typography>
-          {operatorEmail && (
-            <Typography variant="body2" color="text.secondary">
-              {operatorEmail}
-            </Typography>
-          )}
-          {companyName && (
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-              {companyName}
-            </Typography>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Actions */}
-      <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap' }}>
-        <Button
-          variant="outlined"
-          color="error"
-          startIcon={<LogoutIcon />}
-          onClick={handleLogout}
-          fullWidth
-          sx={{ minHeight: 48 }}
-        >
-          Logout
-        </Button>
-      </Box>
-      <Button
-        variant="outlined"
-        startIcon={<FeedbackIcon />}
-        onClick={() => setFeedbackOpen(true)}
-        sx={{ mb: 3, minHeight: 48 }}
-        fullWidth
-      >
-        Give Feedback
-      </Button>
-
-      <FeedbackDialog
-        open={feedbackOpen}
-        onClose={() => setFeedbackOpen(false)}
-        onSuccess={() => {
-          setFeedbackOpen(false);
-          setFeedbackSuccess(true);
-        }}
-        userId={operatorUserId}
-      />
-      <Snackbar
-        open={feedbackSuccess}
-        autoHideDuration={4000}
-        onClose={() => setFeedbackSuccess(false)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert severity="success" onClose={() => setFeedbackSuccess(false)}>
-          Thanks for your feedback!
-        </Alert>
-      </Snackbar>
-    </Box>
-  );
+export default async function OperatorProfileRedirect({
+  params,
+}: {
+  params: Promise<{ companyId: string }>;
+}) {
+  const { companyId } = await params;
+  redirect(`/operator/${companyId}/my-work`);
 }

--- a/components/operator/OperatorAccountBlock.tsx
+++ b/components/operator/OperatorAccountBlock.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+/**
+ * The identity and account half of the operator's "Me" tab.
+ *
+ * Two exports, meant to sandwich the operator's own work:
+ *
+ *   <OperatorIdentityRow />      one compact row — who you are
+ *   … the operator's notes …     the reason the tab exists
+ *   <OperatorAccountActions />   feedback, then Log out last
+ *
+ * ## Why identity is one row and not a card
+ *
+ * Material's bottom-navigation guidance rules out a settings/preferences tab outright, so the
+ * old `Profile` tab was never something the guidance allowed — which is also why losing it to
+ * Scan costs nothing. What *is* allowed is a top-level destination of equal importance, and
+ * "the operator's own work" qualifies where "name, email, company, Log out" does not.
+ *
+ * So the work has to lead. NN/g measured navigation hidden behind an icon at 44–56% usage
+ * against 89% for visible navigation, which is what made burying "My work" the wrong trade —
+ * the fix is to keep the tab slot and put the work at the top of it, not to demote the work.
+ * YouTube's "You" and Strava's "You" both do exactly this: one compact identity row, then
+ * activity for the rest of the scroll. Strava's merged Profile *and* Training, which is the
+ * direct answer to "this treats My work as spare real estate" — the merge is what gave the
+ * work surface its reason to own a tab.
+ *
+ * ## Why Log out is last, and why there is no confirm dialog
+ *
+ * Log out sits at the very end, in its own visually distinct block, separated from the benign
+ * action above it. NN/g's proximity guidance explicitly endorses using distance to make a
+ * consequential action slightly slower to reach, because operators repeating the same taps
+ * every shift slip into automaticity — and a mis-tap here is a *slip*, not a mistake, so no
+ * amount of clearer labelling fixes it. Only layout does.
+ *
+ * It is deliberately NOT behind a confirmation dialog: logging out is recoverable by logging
+ * back in, and a dialog on a recoverable action is the confirmation-fatigue trap that strips
+ * the dialogs that matter of their force.
+ */
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Alert from '@mui/material/Alert';
+import Avatar from '@mui/material/Avatar';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import Snackbar from '@mui/material/Snackbar';
+import Typography from '@mui/material/Typography';
+import FeedbackIcon from '@mui/icons-material/Feedback';
+import LogoutIcon from '@mui/icons-material/Logout';
+
+import FeedbackDialog from '@/components/feedback/FeedbackDialog';
+// `getTypedSupabase`, not `getSupabase` — new code uses the typed client (issue #573). Only
+// `auth.signOut` is used here, which is schema-independent.
+import { getTypedSupabase } from '@/lib/supabase';
+import { clearStoredStation } from '@/components/operator/OperatorStationContext';
+
+export interface OperatorIdentity {
+  name: string;
+  email: string;
+  companyName: string;
+  userId: string;
+}
+
+/** First letters of the name, for the avatar. Falls back to a person-shaped blank. */
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '';
+  return parts
+    .slice(0, 2)
+    .map((p) => p[0]!.toUpperCase())
+    .join('');
+}
+
+export function OperatorIdentityRow({ identity }: { identity: OperatorIdentity | null }) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        mb: 2,
+        minHeight: 48,
+      }}
+    >
+      <Avatar sx={{ bgcolor: 'primary.main', width: 40, height: 40 }}>
+        {initials(identity?.name ?? '')}
+      </Avatar>
+      <Box sx={{ minWidth: 0 }}>
+        <Typography sx={{ fontWeight: 600 }} noWrap>
+          {identity?.name || 'You'}
+        </Typography>
+        {identity?.companyName && (
+          <Typography variant="body2" color="text.secondary" noWrap>
+            {identity.companyName}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+export function OperatorAccountActions({
+  companyId,
+  identity,
+}: {
+  companyId: string;
+  identity: OperatorIdentity | null;
+}) {
+  const router = useRouter();
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const [feedbackSuccess, setFeedbackSuccess] = useState(false);
+
+  const handleLogout = async () => {
+    // Clears the persisted station (localStorage) on explicit logout — same store
+    // OperatorStationContext uses.
+    clearStoredStation();
+    const supabase = getTypedSupabase();
+    // Local scope — sign out ONLY this device. An operator logging out here must not revoke
+    // their session on their other devices (which surfaced as a forced re-login when marking
+    // a job complete).
+    await supabase.auth.signOut({ scope: 'local' });
+    router.push(`/operator/${companyId}/login`);
+  };
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Divider sx={{ mb: 2 }} />
+
+      <Button
+        variant="outlined"
+        startIcon={<FeedbackIcon />}
+        onClick={() => setFeedbackOpen(true)}
+        fullWidth
+        sx={{ minHeight: 48 }}
+      >
+        Give feedback
+      </Button>
+
+      {/* The email lives down here rather than in the identity row: it is the least useful
+          thing on the page to an operator who already knows who they are, and it is the thing
+          a support conversation occasionally needs. */}
+      {identity?.email && (
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ display: 'block', mt: 2, textAlign: 'center' }}
+        >
+          Signed in as {identity.email}
+        </Typography>
+      )}
+
+      {/* Log out, last and set apart — see the note at the top of this file. The gap above is
+          the point, not spacing for its own sake. */}
+      <Box sx={{ mt: 3 }}>
+        <Divider sx={{ mb: 2 }} />
+        <Button
+          variant="outlined"
+          color="error"
+          startIcon={<LogoutIcon />}
+          onClick={handleLogout}
+          fullWidth
+          sx={{ minHeight: 48 }}
+        >
+          Log out
+        </Button>
+      </Box>
+
+      <FeedbackDialog
+        open={feedbackOpen}
+        onClose={() => setFeedbackOpen(false)}
+        onSuccess={() => {
+          setFeedbackOpen(false);
+          setFeedbackSuccess(true);
+        }}
+        userId={identity?.userId}
+      />
+      <Snackbar
+        open={feedbackSuccess}
+        autoHideDuration={4000}
+        onClose={() => setFeedbackSuccess(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="success" onClose={() => setFeedbackSuccess(false)}>
+          Thanks for your feedback!
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+}

--- a/components/scanner/LocationScanner.tsx
+++ b/components/scanner/LocationScanner.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+/**
+ * An in-app scanner for Jigged's own location labels.
+ *
+ * ## What it scans, and what it deliberately doesn't
+ *
+ * **Places, not parts.** The only QR codes in the system encode a location
+ * (`buildLocationScanUrl` → `/operator/{co}/login?location={uuid}`) or a job traveler. Parts have no
+ * barcode at all, so "scan a part" is not a thing that exists and this must not imply otherwise.
+ * Vendor barcodes on incoming material are foreign symbologies we don't control — a receiving
+ * concern (J6, Phase 3), not this.
+ *
+ * ## Why it exists at all
+ *
+ * Today every scan leaves the browser: the phone's camera app surfaces an OS banner, you tap it,
+ * you land on the login route, and it redirects. `inventory.md` §5.10 measures the cost — *"ten
+ * scans mean ten camera-app round trips"* — and names the flows that can't be served that way:
+ * a count session and receiving a pallet, both continuous. In-app, an already-authenticated
+ * operator goes straight to the bin with no interstitial.
+ *
+ * ## The part that is NOT answered yet
+ *
+ * §5.10's open question is whether iOS persists camera permission across navigations in a
+ * **standalone** PWA (WebKit #185448). It doesn't, as far as anyone reports — which is why
+ * `app/manifest.ts` ships `display: 'browser'`. In Safari-proper, permission behaves normally.
+ * Confirming that on the shop's actual handsets is the spike; nothing here can settle it from a
+ * desk, and this file should not be read as evidence that it has been.
+ *
+ * `zxing-wasm` rather than `BarcodeDetector`: WebKit has never implemented `BarcodeDetector`, so
+ * every iOS browser lacks it. Decode speed was never the problem.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Typography from '@mui/material/Typography';
+
+/** Where `scripts/copy-scanner-wasm.mjs` puts the decoder, so it loads from our origin not a CDN. */
+const WASM_PATH = '/wasm/zxing_reader.wasm';
+
+/** ~5 decode attempts a second: fast enough to feel instant, slow enough not to pin a phone CPU. */
+const DECODE_INTERVAL_MS = 200;
+
+/**
+ * Parsing moved to `lib/jiggedScan.ts`, which resolves BOTH kinds of Jigged QR — a location
+ * label and a job traveler — because they differ only by query string and an operator holding
+ * a traveler sheet shouldn't need a different gesture from one holding a bin label.
+ *
+ * Re-exported here so existing importers and their test suite are untouched.
+ */
+import { foreignCompanyRejection, parseJiggedScan } from '@/lib/jiggedScan';
+
+export { locationIdFromScan, parseJiggedScan, type JiggedScan } from '@/lib/jiggedScan';
+
+export interface LocationScannerProps {
+  open: boolean;
+  onClose: () => void;
+  /**
+   * A location id was read. Return `false` to reject it and keep scanning — used to refuse a code
+   * from another company, which decodes perfectly well but isn't one of yours.
+   */
+  onScan: (locationId: string) => boolean | void | Promise<boolean | void>;
+  /**
+   * A job traveler was read. Optional: surfaces where travelers are meaningful (the operator
+   * tab-bar scanner) and omitted where they aren't, in which case a traveler scan is refused
+   * with a legible message rather than silently ignored.
+   */
+  onScanTraveler?: (scan: {
+    jobId: string;
+    jobPartId: string;
+    /** Present only on older travelers, which target a specific step. */
+    operationId?: string;
+  }) => boolean | void | Promise<boolean | void>;
+  /**
+   * The company this scanner belongs to. When set, a label whose payload names a *different*
+   * company is refused here and the handlers are never called.
+   *
+   * This is enforced in the component rather than left to each caller because the failure is
+   * silent otherwise: a foreign traveler QR decodes perfectly, and a caller that just pushes the
+   * route navigates the operator into another shop's job, relying on the destination page's RLS
+   * to fail. That produces an error screen instead of "that isn't yours", and only after a
+   * navigation.
+   *
+   * A payload with no company in it (a bare typed UUID) is *unverified*, not rejected — the
+   * caller's own data validation is still the backstop for that case.
+   */
+  expectedCompanyId?: string;
+  title?: string;
+}
+
+export default function LocationScanner({
+  open,
+  onClose,
+  onScan,
+  onScanTraveler,
+  expectedCompanyId,
+  title = 'Scan a label',
+}: LocationScannerProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  /** Guards against a second decode firing while the first is still being handled. */
+  const busyRef = useRef(false);
+
+  const [status, setStatus] = useState<'starting' | 'scanning' | 'error'>('starting');
+  const [error, setError] = useState<string | null>(null);
+  const [rejected, setRejected] = useState<string | null>(null);
+
+  /**
+   * The scan callbacks, held in refs so they are NOT effect dependencies.
+   *
+   * They used to be in the deps list below, and callers pass inline arrow functions — the
+   * operator layout does — which get a fresh identity on every parent render. That made *any*
+   * re-render of the parent while this dialog was open tear the effect down and back up:
+   * `stop()` releases every camera track, then `getUserMedia` starts over. On a phone that is a
+   * visible black flash and a lost half-second of aiming, mid-scan.
+   *
+   * Fixed here rather than with `useCallback` at each call site, because then the component is
+   * correct for every caller instead of correct only while each one remembers.
+   */
+  const onScanRef = useRef(onScan);
+  const onScanTravelerRef = useRef(onScanTraveler);
+  const expectedCompanyIdRef = useRef(expectedCompanyId);
+  useEffect(() => {
+    onScanRef.current = onScan;
+    onScanTravelerRef.current = onScanTraveler;
+    expectedCompanyIdRef.current = expectedCompanyId;
+  });
+
+  const stop = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    // Releasing every track is what turns the camera indicator off. Leaving it on after the dialog
+    // closes reads as the app watching you.
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const { prepareZXingModule, readBarcodes } = await import('zxing-wasm/reader');
+        prepareZXingModule({ overrides: { locateFile: () => WASM_PATH } });
+
+        const stream = await navigator.mediaDevices.getUserMedia({
+          // `environment` asks for the rear camera, which is the one pointed at a shelf.
+          video: { facingMode: 'environment' },
+          audio: false,
+        });
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        streamRef.current = stream;
+        const video = videoRef.current;
+        if (!video) return;
+        video.srcObject = stream;
+        await video.play();
+        if (cancelled) return;
+        setStatus('scanning');
+
+        // One reused canvas: allocating a frame-sized buffer 5×/second would churn the GC on a
+        // phone for no reason.
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
+
+        timerRef.current = setInterval(async () => {
+          if (busyRef.current || !ctx || video.readyState < 2) return;
+          busyRef.current = true;
+          try {
+            canvas.width = video.videoWidth;
+            canvas.height = video.videoHeight;
+            ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+            const results = await readBarcodes(
+              ctx.getImageData(0, 0, canvas.width, canvas.height),
+              { formats: ['QRCode'], tryHarder: false, maxNumberOfSymbols: 1 },
+            );
+            const text = results[0]?.text;
+            if (!text) return;
+
+            const scan = parseJiggedScan(text);
+            if (!scan) {
+              setRejected('That code isn’t a Jigged label.');
+              return;
+            }
+
+            // Whose label is it? Checked before either handler runs, so a foreign code never
+            // becomes a navigation. The decision lives in `foreignCompanyRejection` because this
+            // loop cannot run under jsdom, and a tenant boundary should not be untestable.
+            const foreign = foreignCompanyRejection(text, scan, expectedCompanyIdRef.current);
+            if (foreign) {
+              setRejected(foreign);
+              return;
+            }
+
+            // A traveler is only accepted where the caller can do something with one. Refusing
+            // it out loud beats silently ignoring a code that decoded perfectly well — the
+            // operator would just keep pointing the camera at it.
+            if (scan.kind === 'traveler') {
+              if (!onScanTravelerRef.current) {
+                setRejected('That’s a job traveler — scan a storage label here.');
+                return;
+              }
+              const ok = await onScanTravelerRef.current({
+                jobId: scan.jobId,
+                jobPartId: scan.jobPartId,
+                operationId: scan.operationId,
+              });
+              if (ok === false) {
+                setRejected('That traveler belongs to a different company.');
+                return;
+              }
+              setRejected(null);
+              return;
+            }
+
+            const accepted = await onScanRef.current(scan.locationId);
+            if (accepted === false) {
+              setRejected('That label belongs to a different company.');
+              return;
+            }
+            setRejected(null);
+          } catch (e) {
+            // A single bad frame is normal — motion blur, bad light. Don't tear the scanner down.
+            console.debug('scan frame failed', e);
+          } finally {
+            busyRef.current = false;
+          }
+        }, DECODE_INTERVAL_MS);
+      } catch (e) {
+        if (cancelled) return;
+        setStatus('error');
+        // The failure is nearly always permission, and the fix is in browser settings — not
+        // something a retry button can do, so say where to go.
+        const denied =
+          e instanceof DOMException && (e.name === 'NotAllowedError' || e.name === 'SecurityError');
+        setError(
+          denied
+            ? 'Camera access was blocked. Allow the camera for this site in your browser settings, then try again.'
+            : e instanceof Error
+              ? e.message
+              : 'Could not start the camera.',
+        );
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      stop();
+    };
+  }, [open, stop]);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        {status === 'error' ? (
+          <Alert severity="error">{error}</Alert>
+        ) : (
+          <>
+            <Box
+              sx={{
+                position: 'relative',
+                borderRadius: 1,
+                overflow: 'hidden',
+                bgcolor: 'common.black',
+                aspectRatio: '4 / 3',
+              }}
+            >
+              <Box
+                component="video"
+                ref={videoRef}
+                muted
+                playsInline
+                sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              />
+              {status === 'starting' && (
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    inset: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <CircularProgress size={28} />
+                </Box>
+              )}
+            </Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
+              Point the camera at the QR code on a printed label. It scans on its own — keep going
+              to work through several.
+            </Typography>
+            {rejected && (
+              <Alert severity="warning" sx={{ mt: 1.5 }}>
+                {rejected}
+              </Alert>
+            )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Done</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/hooks/useOperatorIdentity.ts
+++ b/hooks/useOperatorIdentity.ts
@@ -1,0 +1,47 @@
+'use client';
+
+/**
+ * Who the signed-in operator is, for the "Me" tab.
+ *
+ * Lifted verbatim out of the old `/profile` page when Profile stopped being a tab. The email
+ * comes from the auth session, the display name from `user_company_access` via
+ * `getCurrentMember`, and the company name from `getCompany`.
+ *
+ * Deliberately never throws and never blocks: the "Me" tab's reason to exist is the operator's
+ * own work, and identity failing to resolve must not take the work — or the Log out button —
+ * down with it. A null return renders as "You" with no company line.
+ */
+
+import { useLoad } from '@/hooks/useLoad';
+import { getCurrentMember } from '@/utils/operatorAccess';
+import { getCompany } from '@/utils/companyAccess';
+// `getTypedSupabase`, not `getSupabase` — new code uses the typed client (issue #573). Only
+// `auth.getSession()` is used here, which is schema-independent, so the two behave identically;
+// the typed one is simply what new files are required to reach for.
+import { getTypedSupabase } from '@/lib/supabase';
+import type { OperatorIdentity } from '@/components/operator/OperatorAccountBlock';
+
+export function useOperatorIdentity(companyId: string) {
+  return useLoad<OperatorIdentity>(async () => {
+    // Every one of the three reads is guarded independently. The docstring above promises this
+    // never blocks the work or the Log out button, and an unguarded `getSession()` quietly broke
+    // that promise — one throw took the whole identity down, name included, rather than degrading
+    // to a missing email.
+    const session = await getTypedSupabase()
+      .auth.getSession()
+      .then((r) => r.data.session)
+      .catch(() => null);
+
+    const [member, company] = await Promise.all([
+      getCurrentMember(companyId).catch(() => null),
+      getCompany(companyId).catch(() => null),
+    ]);
+
+    return {
+      name: member?.name || 'Operator',
+      email: session?.user?.email ?? '',
+      companyName: company?.name ?? '',
+      userId: session?.user?.id ?? '',
+    };
+  }, [companyId]);
+}

--- a/lib/jiggedScan.ts
+++ b/lib/jiggedScan.ts
@@ -1,0 +1,190 @@
+/**
+ * One parser for every QR code Jigged prints.
+ *
+ * ## Why one
+ *
+ * There are exactly two kinds of Jigged QR, and both are deep links through the operator
+ * login passthrough, differing only in query string:
+ *
+ * - **A location label** — `buildLocationScanUrl` in `utils/locationLabelPdf.ts`:
+ *   `/operator/{companyId}/login?location={uuid}`
+ * - **A job traveler** — `utils/jobTravelerPdf.ts`:
+ *   `/operator/{companyId}/login?job={jobId}&part={jobPartId}`
+ *
+ * The scanner used to read only the first, which meant an operator holding a traveler sheet
+ * had to leave the app and use the phone's camera app instead — a different gesture for a
+ * near-identical piece of paper. One scanner that resolves either is why this exists.
+ *
+ * **Parts have no barcode at all.** "Scan a part" is not a thing that exists in this system
+ * and nothing here should imply otherwise. Vendor barcodes on incoming material are foreign
+ * symbologies we don't control — a receiving concern (J6, Phase 3), not this.
+ *
+ * ## Why it refuses things
+ *
+ * Silently treating a foreign code as one of ours would send someone to a location or a job
+ * that doesn't exist, which is worse than saying "that isn't a Jigged label". So anything
+ * that isn't unambiguously one of the two shapes returns null, and the caller says so.
+ *
+ * Note this does NOT check that the ids **exist** — it can't, being pure. Callers validate
+ * against loaded data; see `LocationsManager`'s refusal of a decoded-but-foreign label.
+ *
+ * It *can* tell you whose label it is, though: the company is in the URL path our own
+ * generators write. See `companyIdFromScan`.
+ */
+
+/** Canonical v4-ish UUID shape. Anchored: a UUID embedded in a longer string is not a match. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type JiggedScan =
+  /** A printed location label, or a bare location UUID typed/wedged in. */
+  | { kind: 'location'; locationId: string }
+  /**
+   * A job traveler sheet. Both job and part are required — one without the other is not a
+   * traveler and can't open anything.
+   *
+   * `operationId` is present only on **older travelers still in circulation on the shop
+   * floor**, which encoded `job + part + operation` and jumped straight to that step's action
+   * view. Current sheets deliberately omit it so the operator picks the step. Carrying it
+   * matters: dropping it would silently downgrade an old sheet to the traveler index, which is
+   * a worse outcome than the camera-app path those sheets were printed for.
+   */
+  | { kind: 'traveler'; jobId: string; jobPartId: string; operationId?: string };
+
+/** A UUID query param, lowercased, or null if absent or malformed. */
+function uuidParam(params: URLSearchParams, key: string): string | null {
+  const raw = params.get(key);
+  return raw && UUID_RE.test(raw) ? raw.toLowerCase() : null;
+}
+
+/**
+ * Resolve a scanned string into whichever kind of Jigged code it is, or null.
+ *
+ * Accepts a full scan URL (what the printed labels encode) or a bare location UUID, so a
+ * keyboard-wedge scanner and a hand-typed code both work.
+ */
+export function parseJiggedScan(text: string): JiggedScan | null {
+  const trimmed = text.trim();
+
+  // A bare UUID is only ever a location: a traveler needs two ids, so it can't be expressed
+  // this way, and guessing between them would be a coin flip.
+  if (UUID_RE.test(trimmed)) {
+    return { kind: 'location', locationId: trimmed.toLowerCase() };
+  }
+
+  let params: URLSearchParams;
+  try {
+    params = new URL(trimmed).searchParams;
+  } catch {
+    // Not a URL and not a bare UUID — a shipping label, a vendor barcode, a URL from another
+    // system.
+    return null;
+  }
+
+  // Location is checked FIRST so that a URL somehow carrying both shapes resolves the same way
+  // it always has. Our labels never emit both, so this only matters for malformed input — and
+  // "behaves as before" beats "newly refuses" for something nobody can produce deliberately.
+  const locationId = uuidParam(params, 'location');
+  if (locationId) return { kind: 'location', locationId };
+
+  // Both or neither: a job id without a part id can't open a traveler, so it isn't one.
+  const jobId = uuidParam(params, 'job');
+  const jobPartId = uuidParam(params, 'part');
+  if (jobId && jobPartId) {
+    const operationId = uuidParam(params, 'operation');
+    // Omit the key entirely rather than setting it undefined, so an equality assertion on a
+    // current-sheet scan doesn't have to know about a field only old sheets carry.
+    return operationId
+      ? { kind: 'traveler', jobId, jobPartId, operationId }
+      : { kind: 'traveler', jobId, jobPartId };
+  }
+
+  return null;
+}
+
+/**
+ * Where a scanned Jigged code should take an operator.
+ *
+ * Pure, and deliberately extracted: this mapping also exists in `postLoginPath`
+ * (`app/operator/[companyId]/login/page.tsx`), which is the path a code scanned with the phone's
+ * *camera app* travels. The two must agree — they resolve the same piece of paper — and when the
+ * in-app version was inline in the layout, nothing could compare them and nothing tested the one
+ * behaviour that matters most.
+ *
+ * **The `operationId` branch is the load-bearing one.** Current traveller sheets encode only
+ * `job + part`; older sheets still on the shop floor also encode `operation` and jump straight to
+ * that step. Dropping it here would silently downgrade an old sheet to the traveller index —
+ * making in-app scanning *worse* than the camera-app path those sheets were printed for.
+ *
+ * `postLoginPath` has not been switched over to this, on purpose: it accepts non-UUID ids and
+ * routes a lone `?job=` to the jobs list, whereas `parseJiggedScan` refuses both. Unifying them
+ * would change that behaviour, which is a separate decision from extracting the mapping.
+ */
+export function scanDestination(companyId: string, scan: JiggedScan): string {
+  const base = `/operator/${companyId}`;
+  if (scan.kind === 'location') return `${base}/inventory/locations/${scan.locationId}`;
+  return scan.operationId
+    ? `${base}/jobs/${scan.jobId}/parts/${scan.jobPartId}/operations/${scan.operationId}`
+    : `${base}/jobs/${scan.jobId}/parts/${scan.jobPartId}`;
+}
+
+/**
+ * Which company's label this is, from the `/operator/{companyId}/login` path our generators
+ * write — or null for a bare UUID, a non-URL, or a URL that isn't shaped like one of ours.
+ *
+ * Deliberately a separate function rather than a field on `JiggedScan`: "what kind of code is
+ * this" and "whose is it" are different questions, only some callers ask the second, and
+ * widening the union's shape would have churned every strict equality assertion in its suite
+ * for no gain.
+ *
+ * **Null means "can't tell", never "yours".** A caller must treat null as unverified rather
+ * than as a pass — a bare typed UUID legitimately has no company in it.
+ */
+export function companyIdFromScan(text: string): string | null {
+  let path: string;
+  try {
+    path = new URL(text.trim()).pathname;
+  } catch {
+    return null;
+  }
+  // `/operator/{companyId}/login` — the shape both `buildLocationScanUrl` and the traveler PDF
+  // emit. Anything else is not one of our labels.
+  const m = /^\/operator\/([^/]+)\/login\/?$/.exec(path);
+  const candidate = m?.[1];
+  return candidate && UUID_RE.test(candidate) ? candidate.toLowerCase() : null;
+}
+
+/**
+ * The message to show when a decoded code belongs to a different company — or null to accept it.
+ *
+ * Pure and separate from the component because this is a tenant boundary, and the component's
+ * decode loop cannot run in jsdom (no `getUserMedia`, no WASM), so logic left inside it is
+ * untestable outside a browser. The choice of *which* message is part of the logic: an operator
+ * holding a traveller and an operator holding a shelf label need to be told different things.
+ *
+ * **Absence is not a mismatch.** A payload with no company in it (a bare typed UUID) returns null
+ * — unverified, to be caught by the caller's own data validation — rather than being refused. The
+ * only rejection here is a positive disagreement between two known ids.
+ */
+export function foreignCompanyRejection(
+  text: string,
+  scan: JiggedScan,
+  expectedCompanyId?: string,
+): string | null {
+  if (!expectedCompanyId) return null;
+  const scanCompanyId = companyIdFromScan(text);
+  if (!scanCompanyId) return null;
+  if (scanCompanyId === expectedCompanyId.toLowerCase()) return null;
+  return scan.kind === 'traveler'
+    ? 'That traveler belongs to a different company.'
+    : 'That label belongs to a different company.';
+}
+
+/**
+ * Location-only view of `parseJiggedScan`, kept because most callers only care about places
+ * and shouldn't have to narrow a union to say so. A traveler scan returns null here, which is
+ * exactly what this function did before it was a wrapper.
+ */
+export function locationIdFromScan(text: string): string | null {
+  const scan = parseJiggedScan(text);
+  return scan?.kind === 'location' ? scan.locationId : null;
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:local": "node e2e/run-stack.mjs",
     "seed": "supabase db reset",
-    "gen:db-types": "npx --yes supabase@2.109.0 gen types typescript --local > types/database.ts"
+    "gen:db-types": "npx --yes supabase@2.109.0 gen types typescript --local > types/database.ts",
+    "postinstall": "node scripts/copy-scanner-wasm.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -41,7 +42,8 @@
     "qrcode": "^1.5.4",
     "qrcode.react": "^4.2.0",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "zxing-wasm": "^3.1.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      zxing-wasm:
+        specifier: ^3.1.2
+        version: 3.1.2(@types/emscripten@1.41.5)
     devDependencies:
       '@playwright/test':
         specifier: ^1.58.2
@@ -1699,6 +1702,9 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/emscripten@1.41.5':
+    resolution: {integrity: sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -4203,6 +4209,10 @@ packages:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
 
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
+    engines: {node: '>=20'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -4509,6 +4519,11 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zxing-wasm@3.1.2:
+    resolution: {integrity: sha512-yHloUw+h43r9QhFwVEbdkfmsl9h3rHRpgvvVd9WdhipM3TCYYzGVACmnT+i/YPrNK/eZRgs1ZMISsyJtAoimzA==}
+    peerDependencies:
+      '@types/emscripten': '>=1.39.6'
 
 snapshots:
 
@@ -6080,6 +6095,8 @@ snapshots:
   '@types/d3-time@3.0.4': {}
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/emscripten@1.41.5': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -8802,6 +8819,10 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-fest@5.8.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -9148,3 +9169,8 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zxing-wasm@3.1.2(@types/emscripten@1.41.5):
+    dependencies:
+      '@types/emscripten': 1.41.5
+      type-fest: 5.8.0

--- a/scripts/copy-scanner-wasm.mjs
+++ b/scripts/copy-scanner-wasm.mjs
@@ -1,0 +1,33 @@
+/**
+ * Put the barcode decoder's WebAssembly next to the app that loads it.
+ *
+ * `zxing-wasm` ships `zxing_reader.wasm` beside its JS, and by default the library fetches that file
+ * **from a CDN at runtime**. That's the wrong trade for us twice over: the surface that needs it is
+ * the operator's phone on a shop floor with unreliable wifi, and a scanner that fails because
+ * jsdelivr is unreachable is indistinguishable from a scanner that's broken.
+ *
+ * So it's served from our own origin. Copied at install time rather than committed, because the
+ * `.wasm` and the JS that drives it are one unit — a committed binary silently drifts on the next
+ * dependency bump, and a decoder loading a mismatched module fails in ways nobody would connect to
+ * a version number.
+ *
+ * Wired to `postinstall`, so it runs on every `pnpm install` including Vercel's. It throws rather
+ * than warning: a missing file here means the scanner is dead, and a red build says so immediately.
+ */
+import { copyFile, mkdir, stat } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+const DEST_DIR = join(process.cwd(), 'public', 'wasm');
+const DEST = join(DEST_DIR, 'zxing_reader.wasm');
+
+// Resolve through the package's own export map, so the path stays correct if the layout changes.
+const src = require.resolve('zxing-wasm/reader/zxing_reader.wasm');
+
+await mkdir(DEST_DIR, { recursive: true });
+await copyFile(src, DEST);
+
+const { size } = await stat(DEST);
+console.log(`[scanner] zxing_reader.wasm → public/wasm/ (${Math.round(size / 1024)} KB)`);


### PR DESCRIPTION
Extracted from the inventory Phase 2 branch (#622) so operators can start scanning **now**, while the shape of inventory is still being worked out. **No migration**, and no dependency on the rest of that branch.

## Scan

One camera gesture resolves both kinds of Jigged QR:

| Payload | Opens |
|---|---|
| `?location=<uuid>` | that bin |
| `?job=<uuid>&part=<uuid>` | the job part, where the operator picks a step |
| `…&operation=<uuid>` *(legacy)* | straight to that step |

Before this, only the phone's camera app could open a traveller — so two near-identical pieces of paper needed two different gestures. Scan is a modal action wearing a tab's clothes: it opens over whatever you were on and **deliberately does not take the tab selection**, so closing it dismisses rather than navigates.

## The "Me" tab — the slot wasn't optional

`main` was already at **five tabs** with both flags on (Jobs, Inventory, Maintenance, My work, Profile), and Material caps bottom navigation at 3–5. Scan had to take Profile's slot.

An interim version pushed Profile into a header icon button beside the dashboard one. That's two small targets side by side with almost no gap — the worst case in Fitts's law — and because touch platforms resolve a tap to the **closest** control, missing one doesn't do nothing, it *fires the other*. WCAG 2.5.8 measures this as centre-to-centre spacing rather than visible gap; Material asks for ≥8dp clearance. It's a **slip**, not a mistake: no clearer label or tooltip fixes it, only layout.

So Profile's contents moved into the work surface:

```
Jobs | Inventory | Scan | Maintenance | Me
```

- Material's guidance **disallows a settings/preferences tab outright**, so Profile never had a legitimate claim on a slot.
- An earlier review objected that merging buries a primary daily surface. That was right about the **risk** — NN/g measured navigation hidden behind an icon at **44–56% usage vs 89%** visible — but it points at the wrong fix: keep the slot and put the *work* at the top of it.
- Precedent is exact: **YouTube's "You"** merged the account menu with Library *and pulled the avatar out of the header to kill a header icon*; **Strava's "You"** merged Profile **and** Training.
- Order: one compact identity row → notes for the whole scroll → Give feedback → **Log out last, set apart**. NN/g's proximity guidance explicitly endorses distance for a consequential action; Log out is recoverable, so placement is the protection rather than a confirm dialog (which would be confirmation fatigue on a reversible action).
- Label is **Me**, not "You" — the app already says "My work", and mixing first and second person across one surface is the inconsistency to avoid. The text label always shows.

**Route stays `/my-work`** — renaming routes is churn for no user-visible gain (same call as keeping `/inventory/*`), and it keeps the Jobs page's link and the E2E spec working. `/profile` redirects there.

## Two real bugs fixed

1. **The camera restarted on any parent re-render.** Callers pass inline arrow functions, so `onScan`/`onScanTraveler` got new identities every render and — being effect dependencies — tore down `getUserMedia` and started over. On a phone that's a black flash and a lost half-second of aiming, mid-scan. Now held in refs *inside* the component, so it's correct for every caller rather than only while each one remembers `useCallback`.
2. **A traveller QR from another company decoded and was pushed unconditionally.** The rejection copy existed but nothing triggered it — it relied on the destination page's RLS to fail, so the operator got an error screen *after* a navigation instead of "that isn't yours". Now refused before either handler runs.

## The coverage gap that mattered most

There was **no test anywhere** for the operator layout, the Scan tab, or the two route handlers — so routing an **old traveller sheet to its step**, the single most load-bearing behaviour here, was unverified.

jsdom has no `getUserMedia` and no WASM, so rather than fake a decode loop the decisions are extracted as pure functions and tested directly: `scanDestination`, `companyIdFromScan`, `foreignCompanyRejection`. `scanDestination` also removes the duplication with `postLoginPath` — the camera-app path for the same piece of paper, which could previously drift silently.

**Every new test was confirmed to fail against the old code**, including the camera one (reinstating the old deps makes it fail with the tracks stopped).

One caught along the way: the loading/error/**empty** states were early returns from the page, so folding Profile in without moving them would have left a brand-new operator — zero notes, the common case — **with no Log out button anywhere in the app**. Now asserted.

## Known divergence, left deliberately

`postLoginPath` routes a lone `?job=` to the jobs list and accepts non-UUIDs; Scan refuses both. Same paper, two behaviours — recorded rather than silently unified, since changing it is a separate decision.

## Not in this PR

Item labels. `parseJiggedScan` returns a discriminated union so `{kind:'part'}` is additive, but **nothing generates an item label today**, so scanning an item needs a label generator first.

## Verification

`tsc --noEmit` clean · `pnpm lint` **0 errors**, 16 warnings · **123 files / 1525 tests pass**.

Browser-verified against the local stack: tab bar reads `Jobs | Inventory | Scan | Maintenance | Me`, **exactly one header icon button**, Scan opens the dialog while the selection stays on Jobs, `/profile` redirects to `/my-work`, and Log out renders last beneath the notes.

Still owed on a real device (can't be settled from a desk): whether iOS persists camera permission across navigations — which is why `app/manifest.ts` ships `display: 'browser'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
