### PR TITLE
feat(notes): make notes editable and deletable everywhere, without resetting reach

### DIFF
--- a/__tests__/components/notes/NoteEditDialog.test.tsx
+++ b/__tests__/components/notes/NoteEditDialog.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@/__tests__/test-utils';
+import userEvent from '@testing-library/user-event';
+
+import NoteEditDialog from '@/components/notes/NoteEditDialog';
+import type { JobNoteMedia } from '@/types/operator';
+
+// Signed-URL lookup builds a Supabase client at module scope.
+vi.mock('@/utils/jobNoteMediaAccess', () => ({
+  getJobNoteMediaUrl: vi.fn().mockResolvedValue('blob:thumb'),
+}));
+
+const onSave = vi.fn();
+const onClose = vi.fn();
+
+function photo(over: Partial<JobNoteMedia> = {}): JobNoteMedia {
+  return {
+    id: 'm1',
+    note_id: 'n1',
+    storage_path: 'c1/n1/a.jpg',
+    thumbnail_path: null,
+    kind: 'photo',
+    mime_type: 'image/jpeg',
+    width: 100,
+    height: 100,
+    ...over,
+  };
+}
+
+function setup(props: Partial<React.ComponentProps<typeof NoteEditDialog>> = {}) {
+  return render(
+    <NoteEditDialog
+      open
+      initialBody="original text"
+      onSave={onSave}
+      onClose={onClose}
+      {...props}
+    />,
+  );
+}
+
+const saveButton = () => screen.getByRole('button', { name: /^Save$/ });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('NoteEditDialog', () => {
+  it('seeds the field with the existing body', () => {
+    setup();
+    expect(screen.getByRole('textbox')).toHaveValue('original text');
+  });
+
+  it('disables Save until something actually changes', async () => {
+    const user = userEvent.setup();
+    setup();
+    expect(saveButton()).toBeDisabled();
+
+    await user.type(screen.getByRole('textbox'), '!');
+    expect(saveButton()).toBeEnabled();
+  });
+
+  it('treats a whitespace-only difference as no change', async () => {
+    const user = userEvent.setup();
+    setup();
+    await user.type(screen.getByRole('textbox'), '   ');
+    // Trimmed on both sides before comparing, so padding is not an edit and
+    // cannot stamp edited_at on a note nobody changed.
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it('blocks an emptied body on a note with no photos, and says to delete instead', async () => {
+    const user = userEvent.setup();
+    setup();
+    await user.clear(screen.getByRole('textbox'));
+
+    expect(saveButton()).toBeDisabled();
+    expect(screen.getByText(/can't be empty — delete it instead/i)).toBeInTheDocument();
+  });
+
+  it('ALLOWS an emptied body while a photo remains, and returns null', async () => {
+    const user = userEvent.setup();
+    setup({ media: [photo()] });
+    await user.clear(screen.getByRole('textbox'));
+
+    // A media-only note is legal: notes_body_blank_or_null permits NULL.
+    expect(screen.queryByText(/delete it instead/i)).not.toBeInTheDocument();
+    await user.click(saveButton());
+    expect(onSave).toHaveBeenCalledWith({ body: null, removedMediaIds: [] });
+  });
+
+  it('blocks emptying the body once the LAST photo is also marked for removal', async () => {
+    const user = userEvent.setup();
+    setup({ media: [photo()] });
+    await user.clear(screen.getByRole('textbox'));
+    await user.click(screen.getByRole('button', { name: /Remove this photo/i }));
+
+    // Nothing would be left of the note at all.
+    expect(saveButton()).toBeDisabled();
+    expect(screen.getByText(/can't be empty — delete it instead/i)).toBeInTheDocument();
+  });
+
+  it('marks a photo for removal without deleting it, and can undo', async () => {
+    const user = userEvent.setup();
+    setup({ media: [photo({ id: 'm1' }), photo({ id: 'm2' })] });
+
+    await user.click(screen.getAllByRole('button', { name: /Remove this photo/i })[0]);
+    expect(screen.getByText(/1 photo will be removed when you save/i)).toBeInTheDocument();
+
+    // Undo is offered in place — nothing has been destroyed yet.
+    await user.click(screen.getByRole('button', { name: /Keep this photo/i }));
+    expect(screen.queryByText(/will be removed when you save/i)).not.toBeInTheDocument();
+  });
+
+  it('reports removals only on Save — the deferral that keeps Cancel honest', async () => {
+    const user = userEvent.setup();
+    setup({ media: [photo({ id: 'm1' }), photo({ id: 'm2' })] });
+
+    await user.click(screen.getAllByRole('button', { name: /Remove this photo/i })[0]);
+    // Marking alone is a change, so Save unlocks without touching the text.
+    await user.click(saveButton());
+
+    expect(onSave).toHaveBeenCalledWith({ body: 'original text', removedMediaIds: ['m1'] });
+  });
+
+  it('does not call onSave when cancelled', async () => {
+    const user = userEvent.setup();
+    setup({ media: [photo()] });
+
+    await user.click(screen.getAllByRole('button', { name: /Remove this photo/i })[0]);
+    await user.click(screen.getByRole('button', { name: /Cancel/i }));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('uses the caller’s noun in the title and the empty-body helper', async () => {
+    const user = userEvent.setup();
+    setup({ noun: 'comment' });
+    expect(screen.getByText('Edit comment')).toBeInTheDocument();
+
+    await user.clear(screen.getByRole('textbox'));
+    expect(screen.getByText(/A comment can't be empty/i)).toBeInTheDocument();
+  });
+
+  it('locks the controls while saving', () => {
+    setup({ saving: true });
+    // The label switches to "Saving…" so the button is its own progress
+    // indicator — there is no separate spinner to find.
+    expect(screen.getByRole('button', { name: /Saving/ })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Cancel/i })).toBeDisabled();
+  });
+
+  it('surfaces a save error', () => {
+    setup({ error: 'permission denied' });
+    expect(screen.getByText('permission denied')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/operator/JobFeed.test.tsx
+++ b/__tests__/components/operator/JobFeed.test.tsx
@@ -13,10 +13,13 @@ vi.mock('@/utils/operatorAccess', () => ({
   getJobNotes: vi.fn(),
   addJobNote: vi.fn(),
   getCurrentMember: vi.fn(),
+  updateNoteBody: vi.fn(),
 }));
 vi.mock('@/utils/jobNoteMediaAccess', () => ({
   addJobNoteMedia: vi.fn(),
   getJobNoteMediaUrl: vi.fn(),
+  deleteJobNote: vi.fn(),
+  deleteJobNoteMedia: vi.fn(),
 }));
 vi.mock('@/utils/imageCompression', () => ({ compressPhoto: vi.fn() }));
 // Dwell tracking imports the Supabase client at module scope; it has its own
@@ -39,6 +42,7 @@ function makeNote(over: Partial<JobNote> = {}): JobNote {
     body: 'existing note',
     note_type: 'user',
     created_at: '2026-07-01T10:00:00.000Z',
+    edited_at: null,
     author_name: 'Op',
     author_id: 'them',
     reactions: [],
@@ -273,5 +277,82 @@ describe('JobFeed — capture funnel events', () => {
     expect(
       mock(logOperatorEvent).mock.calls.some((c: unknown[]) => c[1] === 'composer_abandoned'),
     ).toBe(false);
+  });
+});
+
+// ============================================================================
+// Edit / delete affordances (#628)
+// ============================================================================
+// The permission rules are the part worth testing here: getting them wrong
+// offers an action that RLS will refuse, which reads to an operator as a broken
+// button rather than as a boundary.
+
+describe('note actions', () => {
+  const menuFor = () => screen.queryByRole('button', { name: /Actions for this note/i });
+
+  it('offers no actions on somebody else’s note', async () => {
+    mock(getJobNotes).mockResolvedValue([makeNote({ author_id: 'them' })]);
+    renderFeed();
+    await screen.findByText('existing note');
+
+    expect(menuFor()).not.toBeInTheDocument();
+  });
+
+  it('offers Edit and Delete on your own note', async () => {
+    const user = userEvent.setup();
+    mock(getJobNotes).mockResolvedValue([makeNote({ author_id: 'op1' })]);
+    renderFeed();
+    await screen.findByText('existing note');
+
+    await user.click(menuFor()!);
+    expect(screen.getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('offers Delete but NOT Edit to an admin on somebody else’s note', async () => {
+    const user = userEvent.setup();
+    mock(getCurrentMember).mockResolvedValue({ id: 'boss', name: 'Boss', role: 'admin' });
+    mock(getJobNotes).mockResolvedValue([makeNote({ author_id: 'them' })]);
+    renderFeed();
+    await screen.findByText('existing note');
+
+    await user.click(menuFor()!);
+    // Deliberately asymmetric: an admin rewriting somebody else's note would
+    // change what it says without changing whose name is on it.
+    expect(screen.queryByRole('menuitem', { name: 'Edit' })).not.toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('offers nothing on an auto-logged event note, even to its own author', async () => {
+    mock(getJobNotes).mockResolvedValue([
+      makeNote({ author_id: 'op1', note_type: 'event', body: 'Order quantity changed' }),
+    ]);
+    renderFeed();
+    await screen.findByText('Order quantity changed');
+
+    // 'event' rows are the audit trail. RLS refuses them too, so the control
+    // would be a guaranteed 42501.
+    expect(menuFor()).not.toBeInTheDocument();
+  });
+
+  it('offers nothing on the read-only traveler feed', async () => {
+    mock(getJobNotes).mockResolvedValue([makeNote({ author_id: 'op1' })]);
+    renderFeed({ readOnly: true });
+    await screen.findByText('existing note');
+
+    expect(menuFor()).not.toBeInTheDocument();
+  });
+
+  it('marks an edited note, and leaves an unedited one unmarked', async () => {
+    mock(getJobNotes).mockResolvedValue([
+      makeNote({ id: 'a', body: 'was corrected', edited_at: '2026-08-01T10:00:00Z' }),
+      makeNote({ id: 'b', body: 'never touched', edited_at: null }),
+    ]);
+    renderFeed();
+    await screen.findByText('was corrected');
+
+    // One mark for the one edited note — the counter deliberately does not
+    // reset on an edit, so this is what tells a reader the words changed.
+    expect(screen.getAllByText(/edited/)).toHaveLength(1);
   });
 });

--- a/__tests__/components/operator/PartNotesSheet.test.tsx
+++ b/__tests__/components/operator/PartNotesSheet.test.tsx
@@ -7,8 +7,20 @@ import { getPartPreviousNotes } from '@/utils/operatorAccess';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import type { PartPreviousNote } from '@/types/operator';
 
-vi.mock('@/utils/operatorAccess', () => ({ getPartPreviousNotes: vi.fn() }));
+vi.mock('@/utils/operatorAccess', () => ({
+  getPartPreviousNotes: vi.fn(),
+  getCurrentMember: vi.fn().mockResolvedValue(null),
+  updateNoteBody: vi.fn(),
+}));
 vi.mock('@/utils/operatorEventsAccess', () => ({ logOperatorEvent: vi.fn() }));
+// The sheet gained edit/delete (#628), which pulls in jobNoteMediaAccess — that
+// module builds a Supabase client at import time, so it has to be mocked here the
+// same way JobFeed's suite does it.
+vi.mock('@/utils/jobNoteMediaAccess', () => ({
+  deleteJobNote: vi.fn(),
+  deleteJobNoteMedia: vi.fn(),
+  getJobNoteMediaUrl: vi.fn().mockResolvedValue('blob:thumb'),
+}));
 vi.mock('@/components/operator/NoteMediaGallery', () => ({ default: () => null }));
 // Dwell tracking imports the Supabase client at module scope; it has its own
 // suite in __tests__/hooks/useNoteDwell.test.tsx.
@@ -25,6 +37,7 @@ function note(over: Partial<PartPreviousNote> = {}): PartPreviousNote {
     body: 'indicate the fixture to 0.001 before the first bore',
     note_type: 'user',
     created_at: '2026-04-19T00:00:00Z',
+    edited_at: null,
     author_name: 'Diego Alvarez',
     subject_kind: 'part',
     viewer_count: 0,

--- a/__tests__/utils/machineMaintenanceAccess.test.ts
+++ b/__tests__/utils/machineMaintenanceAccess.test.ts
@@ -61,6 +61,7 @@ function row(over: Record<string, unknown> = {}) {
     maintenance_kind: 'noticed',
     resolves_note_id: null,
     created_at: '2026-07-01T00:00:00Z',
+    edited_at: null,
     viewer_count: 3,
     author_id: 'acc-1',
     author: { name: 'Kurtis' },
@@ -170,6 +171,24 @@ describe('getMachineLog', () => {
     mockQueryBuilder.error = { message: 'boom' };
     await expect(getMachineLog('wc1', 'c1')).rejects.toThrow('boom');
   });
+});
+
+describe('edited entries (#628)', () => {
+  it('carries edited_at through to the mapped entry', async () => {
+    mockQueryBuilder.data = [row({ edited_at: '2026-08-01T09:00:00Z' })];
+    const log = await getMachineLog('wc1', 'c1');
+    expect(log.entries[0].edited_at).toBe('2026-08-01T09:00:00Z');
+  });
+
+  it('leaves edited_at null on an entry nobody has corrected', async () => {
+    mockQueryBuilder.data = [row()];
+    const log = await getMachineLog('wc1', 'c1');
+    expect(log.entries[0].edited_at).toBeNull();
+  });
+
+  // The delete-a-resolver case — an item returning to "Needs attention" — is
+  // already covered by deriveOpenItems' "re-opens it when the fix is removed",
+  // which is that behaviour as pure logic. Not duplicated here.
 });
 
 describe('addMachineNote', () => {

--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -36,6 +36,7 @@ vi.mock('@/lib/supabaseErrors', () => ({
 import {
   getJobNotes,
   addJobNote,
+  updateNoteBody,
   getAllStationsOperatorJobs,
   getCompletedOperatorJobs,
   getAllStationsCompletedOperatorJobs,
@@ -338,6 +339,63 @@ describe('addJobNote', () => {
     await expect(addJobNote('j1', 'c1', 'acc1', 'x', { jobOperationId: 'op1' })).rejects.toThrow(
       /Failed to add note/,
     );
+  });
+});
+
+describe('updateNoteBody', () => {
+  beforeEach(() => {
+    mockQueryBuilder.data = { body: 'corrected', edited_at: '2026-08-01T10:00:00Z' };
+    mockQueryBuilder.error = null;
+  });
+
+  it('updates ONLY the body column', async () => {
+    await updateNoteBody('n1', 'corrected');
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('notes');
+    // THE SECURITY ASSERTION OF THIS WHOLE FEATURE, expressed at the unit level.
+    //
+    // The browser holds GRANT UPDATE (body) and nothing else, so viewer_count,
+    // usage_count, author_id and every subject column are unwritable at the
+    // database. This test guards the layer above that: if anyone later adds a
+    // second key to this payload — a counter reset, an edited_at the client
+    // authors itself, a note_type — it fails here rather than at a 42501 in
+    // production. Deliberately an exact key-set check, not objectContaining.
+    const payload = mockQueryBuilder.update.mock.calls[0][0];
+    expect(Object.keys(payload)).toEqual(['body']);
+    expect(payload.body).toBe('corrected');
+
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'n1');
+    expect(mockQueryBuilder.select).toHaveBeenCalledWith('body, edited_at');
+  });
+
+  it('trims the body', async () => {
+    await updateNoteBody('n1', '   corrected   ');
+    expect(mockQueryBuilder.update).toHaveBeenCalledWith({ body: 'corrected' });
+  });
+
+  it.each([['', 'empty string'], ['   ', 'whitespace only']])(
+    'normalises %s to null so a media-only note stays legal',
+    async (input) => {
+      await updateNoteBody('n1', input);
+      expect(mockQueryBuilder.update).toHaveBeenCalledWith({ body: null });
+    },
+  );
+
+  it('passes a null body straight through', async () => {
+    await updateNoteBody('n1', null);
+    expect(mockQueryBuilder.update).toHaveBeenCalledWith({ body: null });
+  });
+
+  it('returns the row the database gives back, including the server-stamped edited_at', async () => {
+    const result = await updateNoteBody('n1', 'corrected');
+    // edited_at is never sent by the client — it comes back from the BEFORE
+    // UPDATE trigger, which is what makes the "edited" marker unforgeable.
+    expect(result).toEqual({ body: 'corrected', edited_at: '2026-08-01T10:00:00Z' });
+  });
+
+  it('throws a friendly error when the update is refused', async () => {
+    mockQueryBuilder.error = { message: 'permission denied for column viewer_count' };
+    await expect(updateNoteBody('n1', 'x')).rejects.toThrow(/Could not save that change/);
   });
 });
 

--- a/__tests__/utils/partsAccess.test.ts
+++ b/__tests__/utils/partsAccess.test.ts
@@ -71,6 +71,7 @@ import {
   getPartNotes,
   addPartNote,
   deletePartNote,
+  updatePartNote,
   getPartActivity,
 } from '@/utils/partsAccess';
 
@@ -284,6 +285,44 @@ describe('partsAccess utilities', () => {
     it('throws on error', async () => {
       mockQueryBuilder.error = { message: 'boom' };
       await expect(deletePartNote('n1')).rejects.toBeTruthy();
+    });
+  });
+
+  describe('updatePartNote', () => {
+    it('rejects an empty/whitespace body before hitting the DB', async () => {
+      await expect(updatePartNote('n1', '   ')).rejects.toThrow(/empty/i);
+      expect(mockQueryBuilder.update).not.toHaveBeenCalled();
+    });
+
+    it('updates ONLY the body column, trimmed', async () => {
+      mockQueryBuilder.data = {
+        id: 'n1',
+        part_id: 'p1',
+        body: 'fixed',
+        created_at: '2026-02-01T00:00:00Z',
+        edited_at: '2026-08-01T10:00:00Z',
+        author_id: 'a1',
+        note_type: 'user',
+        author: { name: 'Sam' },
+      };
+
+      const note = await updatePartNote('n1', '  fixed  ');
+
+      expect(mockSupabase.from).toHaveBeenCalledWith('part_comments');
+      // Exact key-set, not objectContaining: part_comments also carries a
+      // column-scoped UPDATE grant on `body` alone, so a second key here would be
+      // a 42501 in production. Fail in the unit test instead.
+      const payload = mockQueryBuilder.update.mock.calls[0][0];
+      expect(Object.keys(payload)).toEqual(['body']);
+      expect(payload.body).toBe('fixed');
+      expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'n1');
+      // edited_at comes back from the trigger; the client never sends it.
+      expect(note).toMatchObject({ id: 'n1', edited_at: '2026-08-01T10:00:00Z' });
+    });
+
+    it('throws on error', async () => {
+      mockQueryBuilder.error = { message: 'boom' };
+      await expect(updatePartNote('n1', 'x')).rejects.toBeTruthy();
     });
   });
 

--- a/api/tests/integration/test_note_views_rls.py
+++ b/api/tests/integration/test_note_views_rls.py
@@ -1105,3 +1105,331 @@ def test_a_manual_uploads_fine_under_your_own_name(shop):
         .data[0]
     )
     assert row["uploaded_by"] == shop["author"]["access_id"]
+
+
+# ── editing a note (#628): what the column-scoped grant actually buys ────────
+# Notes became editable, and the whole design rests on ONE claim: an edit can
+# change the words and NOTHING else. That claim is enforced by a column-scoped
+# GRANT plus a BEFORE UPDATE trigger, and neither is observable from the
+# frontend — a Vitest test can only assert what the client SENDS, never what the
+# database would have allowed. So it is asserted here.
+
+
+def test_the_author_can_edit_their_own_note(shop):
+    note_id = _make_note(shop, "back the feed off")
+    shop["author"]["client"].table("notes").update({"body": "back the feed WAY off"}).eq(
+        "id", note_id
+    ).execute()
+
+    row = (
+        shop["admin"].table("notes").select("body, edited_at").eq("id", note_id).single().execute().data
+    )
+    assert row["body"] == "back the feed WAY off"
+    assert row["edited_at"] is not None
+
+
+def test_a_colleague_cannot_edit_someone_elses_note(shop):
+    note_id = _make_note(shop, "original")
+    shop["reader"]["client"].table("notes").update({"body": "vandalised"}).eq(
+        "id", note_id
+    ).execute()
+
+    body = shop["admin"].table("notes").select("body").eq("id", note_id).single().execute().data
+    assert body["body"] == "original"
+
+
+def test_an_ADMIN_cannot_edit_someone_elses_note(shop):
+    """Deliberately asymmetric with delete, which an admin CAN do.
+
+    An admin who could reword somebody else's note would change what it says
+    without changing whose name is on it — the note would still be attributed to
+    its author. Deleting is visibly destructive and the author notices; a silent
+    rewrite under their name is neither. Mirrors notes_insert, which already
+    refuses admin-on-behalf-of authoring.
+    """
+    note_id = _make_note(shop, "original")
+    shop["boss"]["client"].table("notes").update({"body": "the boss says otherwise"}).eq(
+        "id", note_id
+    ).execute()
+
+    body = shop["admin"].table("notes").select("body").eq("id", note_id).single().execute().data
+    assert body["body"] == "original"
+
+
+def test_editing_does_not_move_the_counters(shop):
+    """THE headline assertion of #628.
+
+    The tempting design was to reset viewer_count on an edit, so a note that
+    changed would not carry reach earned by its old wording. It is refused
+    because a resettable counter is a timed read-oracle: edit at 9:00, glance at
+    9:15, and any increment says somebody read it in those fifteen minutes —
+    then note_viewers() supplies the name, defeating the no-timestamps rule.
+
+    So reach survives an edit, and the "· edited" marker carries the honesty
+    instead.
+    """
+    note_id = _make_note(shop)
+    shop["reader"]["client"].rpc(
+        "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+    ).execute()
+    shop["reader2"]["client"].rpc(
+        "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_b"]}
+    ).execute()
+    before = _counts(shop, note_id)
+    assert before == (2, 2), f"precondition failed, counters were {before}"
+
+    shop["author"]["client"].table("notes").update({"body": "reworded entirely"}).eq(
+        "id", note_id
+    ).execute()
+
+    assert _counts(shop, note_id) == before
+
+
+def test_a_note_update_cannot_carry_a_counter(shop):
+    """The column-scoped grant, tested at the wire.
+
+    An UPDATE naming viewer_count is refused by the EXECUTOR before RLS or any
+    trigger runs, because the privilege to name that column does not exist. That
+    placement is the point: a future careless permissive policy cannot re-open
+    it.
+    """
+    note_id = _make_note(shop)
+
+    with pytest.raises(Exception) as exc:
+        shop["author"]["client"].table("notes").update(
+            {"body": "x", "viewer_count": 999}
+        ).eq("id", note_id).execute()
+    assert "viewer_count" in str(exc.value) or "permission denied" in str(exc.value).lower()
+
+    with pytest.raises(Exception):
+        shop["author"]["client"].table("notes").update({"viewer_count": 0}).eq(
+            "id", note_id
+        ).execute()
+
+    assert _counts(shop, note_id) == (0, 0)
+
+
+def test_a_note_update_cannot_change_its_subject_or_author(shop):
+    """Same grant, the other columns it protects.
+
+    Re-pointing a note at a different part would silently move knowledge onto the
+    wrong job; changing author_id would forge attribution.
+    """
+    note_id = _make_note(shop)
+
+    for payload in (
+        {"author_id": shop["reader"]["access_id"]},
+        {"part_id": shop["part_id"], "subject_kind": "job"},
+        {"note_type": "event"},
+    ):
+        with pytest.raises(Exception):
+            shop["author"]["client"].table("notes").update(payload).eq(
+                "id", note_id
+            ).execute()
+
+
+def test_edited_at_is_stamped_by_the_database_not_the_client(shop):
+    """The marker must be unforgeable by the one party with a motive to suppress it.
+
+    edited_at carries no UPDATE grant, so a client that names it is refused
+    outright; the trigger sets it. If the grant were ever widened, the trigger
+    still overwrites whatever arrived.
+    """
+    note_id = _make_note(shop)
+
+    with pytest.raises(Exception):
+        shop["author"]["client"].table("notes").update(
+            {"body": "x", "edited_at": None}
+        ).eq("id", note_id).execute()
+
+    shop["author"]["client"].table("notes").update({"body": "genuinely changed"}).eq(
+        "id", note_id
+    ).execute()
+    row = shop["admin"].table("notes").select("edited_at").eq("id", note_id).single().execute().data
+    assert row["edited_at"] is not None
+
+
+def test_a_no_op_save_does_not_mark_a_note_edited(shop):
+    """Re-saving identical text is not an edit.
+
+    A marker that appears when nothing changed teaches readers to ignore it.
+    """
+    note_id = _make_note(shop, "unchanged text")
+    shop["author"]["client"].table("notes").update({"body": "unchanged text"}).eq(
+        "id", note_id
+    ).execute()
+
+    row = shop["admin"].table("notes").select("edited_at").eq("id", note_id).single().execute().data
+    assert row["edited_at"] is None
+
+
+def test_view_logging_still_works_with_the_guard_trigger_installed(shop):
+    """REGRESSION TEST for the trap this migration was shaped around.
+
+    note_views_bump_counts() UPDATEs notes.viewer_count from an AFTER INSERT
+    trigger on note_views. It runs SECURITY DEFINER as the table owner, so the
+    guard's `current_user IN ('anon','authenticated')` check is what lets it
+    through. Without that check the guard raises on the counter write and EVERY
+    NOTE READ 500s — a total outage of the read path, from a trigger that looks
+    like it only concerns editing.
+
+    If someone later "simplifies" the role check away, this fails.
+    """
+    note_id = _make_note(shop)
+
+    shop["reader"]["client"].rpc(
+        "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_a"]}
+    ).execute()
+
+    assert _counts(shop, note_id) == (1, 1)
+
+
+def test_auto_logged_notes_are_neither_editable_nor_deletable(shop):
+    """'event' rows are the audit trail, and they carry the acting member as author.
+
+    Without the note_type clause in the policies, an author could delete their own
+    audit line.
+    """
+    note_id = (
+        shop["admin"]
+        .table("notes")
+        .insert(
+            {
+                "company_id": shop["company_id"],
+                "subject_kind": "job",
+                "job_id": shop["job_a"],
+                "author_id": shop["author"]["access_id"],
+                "body": "Order quantity changed 10 -> 12",
+                "note_type": "event",
+            }
+        )
+        .execute()
+        .data[0]["id"]
+    )
+
+    shop["author"]["client"].table("notes").update({"body": "nope"}).eq("id", note_id).execute()
+    shop["author"]["client"].table("notes").delete().eq("id", note_id).execute()
+    shop["boss"]["client"].table("notes").delete().eq("id", note_id).execute()
+
+    row = shop["admin"].table("notes").select("body").eq("id", note_id).execute().data
+    assert len(row) == 1, "an auto-logged audit row was deleted"
+    assert row[0]["body"] == "Order quantity changed 10 -> 12"
+
+
+def test_the_author_and_an_admin_can_delete_a_user_note(shop):
+    """The positive half of the delete policy — otherwise the test above could pass
+    because deleting is broken outright."""
+    own = _make_note(shop, "mine to remove")
+    shop["author"]["client"].table("notes").delete().eq("id", own).execute()
+    assert shop["admin"].table("notes").select("id").eq("id", own).execute().data == []
+
+    theirs = _make_note(shop, "an admin may remove this")
+    shop["boss"]["client"].table("notes").delete().eq("id", theirs).execute()
+    assert shop["admin"].table("notes").select("id").eq("id", theirs).execute().data == []
+
+
+def test_no_browser_role_can_write_a_notes_column_other_than_body(shop):
+    """The whole design in one assertion, and the durable half of it.
+
+    The tests above assert today's behaviour; this asserts the PRIVILEGE, so a
+    future blanket `GRANT ALL ON public.notes TO authenticated` fails the build
+    instead of silently re-opening the read oracle.
+    """
+    leaks = shop["admin"].rpc("note_counter_write_leaks", {}).execute().data
+    assert leaks == [], f"browser roles can write notes columns: {leaks}"
+
+
+def test_the_playbook_rpc_is_not_executable_by_anon(shop):
+    """Guards the ACL that a DROP FUNCTION destroyed once already.
+
+    20260728041800 set REVOKE ... FROM PUBLIC / GRANT ... TO authenticated;
+    20260729133520 then dropped the function to widen RETURNS TABLE and never
+    re-issued either, so it shipped anon-executable. Harmless there (SECURITY
+    INVOKER, and anon is a member of nothing) but invisible without a test —
+    over-granting breaks nothing you would notice.
+
+    See issue #640 for the general case: the ON FUNCTIONS default privileges were
+    never revoked, so `REVOKE ... FROM PUBLIC` alone does not close a function.
+    """
+    leaks = shop["admin"].rpc("playbook_rpc_execute_leaks", {}).execute().data
+    assert leaks == [], f"part_playbook_notes is executable by: {leaks}"
+
+
+# ── part_comments: the office half, same guarantees ──────────────────────────
+
+
+def _make_part_comment(shop, body: str = "quoted from the 2024 print") -> str:
+    return (
+        shop["admin"]
+        .table("part_comments")
+        .insert(
+            {
+                "company_id": shop["company_id"],
+                "part_id": shop["part_id"],
+                "author_id": shop["author"]["access_id"],
+                "body": body,
+                "note_type": "user",
+            }
+        )
+        .execute()
+        .data[0]["id"]
+    )
+
+
+def test_part_comment_edit_follows_the_same_rules(shop):
+    note_id = _make_part_comment(shop, "original")
+
+    # Author may edit.
+    shop["author"]["client"].table("part_comments").update({"body": "corrected"}).eq(
+        "id", note_id
+    ).execute()
+    row = (
+        shop["admin"]
+        .table("part_comments")
+        .select("body, edited_at")
+        .eq("id", note_id)
+        .single()
+        .execute()
+        .data
+    )
+    assert row["body"] == "corrected"
+    assert row["edited_at"] is not None
+
+    # A colleague may not.
+    shop["reader"]["client"].table("part_comments").update({"body": "vandalised"}).eq(
+        "id", note_id
+    ).execute()
+    body = (
+        shop["admin"].table("part_comments").select("body").eq("id", note_id).single().execute().data
+    )
+    assert body["body"] == "corrected"
+
+
+def test_auto_logged_pricing_comments_are_immutable(shop):
+    """The pricing feed is written automatically on a pricing save. It is an audit
+    trail, and it carries the acting member as author — so without the note_type
+    clause its own author could rewrite or remove it."""
+    note_id = (
+        shop["admin"]
+        .table("part_comments")
+        .insert(
+            {
+                "company_id": shop["company_id"],
+                "part_id": shop["part_id"],
+                "author_id": shop["author"]["access_id"],
+                "body": "Markup 30% -> 35%",
+                "note_type": "pricing",
+            }
+        )
+        .execute()
+        .data[0]["id"]
+    )
+
+    shop["author"]["client"].table("part_comments").update({"body": "nope"}).eq(
+        "id", note_id
+    ).execute()
+    shop["author"]["client"].table("part_comments").delete().eq("id", note_id).execute()
+
+    rows = shop["admin"].table("part_comments").select("body").eq("id", note_id).execute().data
+    assert len(rows) == 1
+    assert rows[0]["body"] == "Markup 30% -> 35%"

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -16,8 +16,14 @@ import Alert from '@mui/material/Alert';
 import Collapse from '@mui/material/Collapse';
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
 import LaunchIcon from '@mui/icons-material/Launch';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
-import { getMyContribution, getNoteViewers } from '@/utils/operatorAccess';
+import { getMyContribution, getNoteViewers, updateNoteBody } from '@/utils/operatorAccess';
+import { deleteJobNote } from '@/utils/jobNoteMediaAccess';
+import NoteEditDialog from '@/components/notes/NoteEditDialog';
+import NoteEditedMark from '@/components/notes/NoteEditedMark';
+import NoteDeleteDialog from '@/components/notes/NoteDeleteDialog';
 import { useSetOperatorChrome } from '@/components/operator/OperatorChromeContext';
 import { useOperatorIdentity } from '@/hooks/useOperatorIdentity';
 import {
@@ -67,11 +73,24 @@ function ReachRow({ note }: { note: MyNote }) {
   );
 }
 
-function NoteRow({ note, companyId }: { note: MyNote; companyId: string }) {
+function NoteRow({
+  note,
+  companyId,
+  onChanged,
+}: {
+  note: MyNote;
+  companyId: string;
+  /** Refetch the contribution list after an edit or a delete. */
+  onChanged: () => void;
+}) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [viewers, setViewers] = useState<NoteViewer[] | null>(null);
   const [loading, setLoading] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   // Names are fetched only when the author asks for them. note_viewers() is the
   // one narrow window through which any reader's name is ever exposed — it is
@@ -123,6 +142,7 @@ function NoteRow({ note, companyId }: { note: MyNote; companyId: string }) {
             <Typography variant="caption" color="text.secondary">
               {note.job_number ? `${note.job_number} · ` : ''}
               {formatDate(note.created_at)}
+              <NoteEditedMark editedAt={note.edited_at} />
             </Typography>
           </Box>
 
@@ -171,19 +191,110 @@ function NoteRow({ note, companyId }: { note: MyNote; companyId: string }) {
             </>
           )}
 
+          {/* THE PRIMARY HOME FOR EDIT AND DELETE (#628), and the one surface that
+              needs no permission test at all: getMyContribution already filters to
+              author_id = me AND note_type = 'user', so every note on this screen is
+              unconditionally the caller's own editable note.
+
+              Full-width buttons rather than the kebab used in the feeds, because
+              the card is one big CardActionArea and a button cannot nest inside a
+              button — the same constraint that put navigation down here in the
+              first place. */}
+          <Box
+            sx={{
+              display: 'flex',
+              gap: 1,
+              mt: note.viewer_count > 0 ? 1.5 : 0,
+            }}
+          >
+            <Button
+              variant="outlined"
+              fullWidth
+              startIcon={<EditOutlinedIcon />}
+              onClick={() => setEditing(true)}
+              sx={{ minHeight: 48 }}
+            >
+              Edit
+            </Button>
+            <Button
+              variant="outlined"
+              color="error"
+              fullWidth
+              startIcon={<DeleteOutlineIcon />}
+              onClick={() => setConfirmingDelete(true)}
+              sx={{ minHeight: 48 }}
+            >
+              Delete
+            </Button>
+          </Box>
+
           {note.job_id && note.job_number && (
             <Button
               variant="outlined"
               fullWidth
               startIcon={<LaunchIcon />}
               onClick={() => router.push(`/operator/${companyId}/jobs/${note.job_id}`)}
-              sx={{ minHeight: 48, mt: note.viewer_count > 0 ? 1.5 : 0 }}
+              sx={{ minHeight: 48, mt: 1.5 }}
             >
               Open {note.job_number}
             </Button>
           )}
         </Box>
       </Collapse>
+
+      {/* My work renders photo_count, not thumbnails — you cannot pick a photo to
+          remove that you cannot see — so no media is passed and the dialog is
+          text-only here. Removing individual photos lives on the three surfaces
+          that actually show them. */}
+      <NoteEditDialog
+        open={editing}
+        initialBody={note.body}
+        saving={busy}
+        error={actionError}
+        onClose={() => {
+          setEditing(false);
+          setActionError(null);
+        }}
+        onSave={async ({ body }) => {
+          setBusy(true);
+          setActionError(null);
+          try {
+            await updateNoteBody(note.id, body);
+            setEditing(false);
+            onChanged();
+          } catch (err) {
+            setActionError(err instanceof Error ? err.message : 'Could not save that change.');
+          } finally {
+            setBusy(false);
+          }
+        }}
+      />
+
+      <NoteDeleteDialog
+        open={confirmingDelete}
+        deleting={busy}
+        error={actionError}
+        onClose={() => {
+          setConfirmingDelete(false);
+          setActionError(null);
+        }}
+        onConfirm={async () => {
+          setBusy(true);
+          setActionError(null);
+          try {
+            // Reuses the existing helper, which reads the media storage paths
+            // BEFORE the cascade drops the rows and then removes the files. It has
+            // existed unused since the media work; this is its first caller.
+            await deleteJobNote(note.id);
+            setConfirmingDelete(false);
+            onChanged();
+          } catch (err) {
+            setActionError(err instanceof Error ? err.message : 'Could not delete that note.');
+          } finally {
+            setBusy(false);
+          }
+        }}
+      />
     </Card>
   );
 }
@@ -234,7 +345,10 @@ export default function MyWorkPage() {
 
 /** The operator's own notes and their reception. Owns its own loading/error/empty states. */
 function MyContribution({ companyId }: { companyId: string }) {
-  const { data, loading, error } = useLoad(() => getMyContribution(companyId), [companyId]);
+  const { data, loading, error, reload } = useLoad(
+    () => getMyContribution(companyId),
+    [companyId],
+  );
 
   if (loading) {
     return (
@@ -322,7 +436,7 @@ function MyContribution({ companyId }: { companyId: string }) {
           and each card becomes an addressable item rather than an anonymous div. */}
       <Box component="ul" sx={{ mt: 0.5, listStyle: 'none', p: 0, m: 0 }}>
         {c.notes.map((n) => (
-          <NoteRow key={n.id} note={n} companyId={companyId} />
+          <NoteRow key={n.id} note={n} companyId={companyId} onChanged={reload} />
         ))}
       </Box>
     </Box>

--- a/components/jobs/OperationNotes.tsx
+++ b/components/jobs/OperationNotes.tsx
@@ -11,6 +11,7 @@ import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
 
 import type { JobNote } from '@/types/operator';
 import { getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
+import NoteEditedMark from '@/components/notes/NoteEditedMark';
 
 const THUMB = 64;
 
@@ -67,6 +68,10 @@ export default function OperationNotes({ notes }: { notes: JobNote[] }) {
           <Box key={n.id}>
             <Typography variant="caption" color="text.secondary">
               {n.author_name || 'Operator'} · {formatTimestamp(n.created_at)}
+              {/* Marker only, no actions. This is the office's read-only view of
+                  what the floor wrote; editing somebody else's note is not on
+                  offer anywhere, and delete lives where the note is authored. */}
+              <NoteEditedMark editedAt={n.edited_at} />
             </Typography>
             {n.body && (
               <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>

--- a/components/maintenance/MachineEntry.tsx
+++ b/components/maintenance/MachineEntry.tsx
@@ -5,6 +5,8 @@ import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import NoteMediaGallery from '@/components/operator/NoteMediaGallery';
 import NoteReactions from '@/components/operator/NoteReactions';
+import NoteActionsMenu from '@/components/notes/NoteActionsMenu';
+import NoteEditedMark from '@/components/notes/NoteEditedMark';
 import type { MachineNote } from '@/types/machineMaintenance';
 
 /**
@@ -43,8 +45,11 @@ export default function MachineEntry({
   entry,
   companyId,
   memberId,
+  isAdmin = false,
   isOpen,
   onLogFix,
+  onEdit,
+  onDelete,
   hideAuthor = false,
   readOnly = false,
 }: {
@@ -52,10 +57,16 @@ export default function MachineEntry({
   companyId: string;
   /** Current member's user_company_access id; null until resolved. */
   memberId: string | null;
+  /** Widens delete (not edit) to any entry in the shop. */
+  isAdmin?: boolean;
   /** True for a flagged entry nothing has resolved yet. */
   isOpen?: boolean;
   /** Offered only on an open item. Absent in read-only (office) rendering. */
   onLogFix?: () => void;
+  /** Author-only. Absent in read-only rendering. */
+  onEdit?: () => void;
+  /** Author or company admin. Absent in read-only rendering. */
+  onDelete?: () => void;
   /**
    * Suppress the author line. Set while an entry is pinned as outstanding.
    *
@@ -80,6 +91,7 @@ export default function MachineEntry({
         )}
         <Typography variant="caption" color="text.secondary">
           {formatWhen(entry.created_at)}
+          <NoteEditedMark editedAt={entry.edited_at} />
         </Typography>
         <Box sx={{ flex: 1 }} />
         {/* Right-aligned outlined button, the same affordance in the pinned block
@@ -95,6 +107,32 @@ export default function MachineEntry({
           >
             Log the fix
           </Button>
+        )}
+
+        {/* Edit / Delete (#628). Only the BODY is editable — maintenance_kind and
+            resolves_note_id are immutable under the database guard — so an author
+            can fix the wording of what they noticed but can never un-notice it,
+            and a fix can never be re-pointed at a different item. That is what
+            keeps the derived-open list in §4.4 trustworthy while the text stays
+            correctable.
+
+            DOES NOT UNDERMINE hideAuthor. The menu appears only on your OWN entry
+            (or, for delete, if you are an admin), so a reader still cannot tell
+            who raised any item but their own — which they already knew. §5's
+            concern is a list of open items with names read down the column, and
+            that stays impossible. */}
+        {!readOnly && (
+          <NoteActionsMenu
+            canEdit={Boolean(onEdit) && memberId !== null && entry.author_id === memberId}
+            canDelete={
+              Boolean(onDelete) &&
+              memberId !== null &&
+              (entry.author_id === memberId || isAdmin)
+            }
+            onEdit={() => onEdit?.()}
+            onDelete={() => onDelete?.()}
+            noun="entry"
+          />
         )}
       </Box>
 

--- a/components/maintenance/MachineLogPanel.tsx
+++ b/components/maintenance/MachineLogPanel.tsx
@@ -14,7 +14,8 @@ import { useLoad } from '@/hooks/useLoad';
 import { useNoteDwell } from '@/hooks/useNoteDwell';
 import { useNoteCapture } from '@/hooks/useNoteCapture';
 import type { NoteWriter } from '@/hooks/useNoteCapture';
-import { getCurrentMember } from '@/utils/operatorAccess';
+import { getCurrentMember, updateNoteBody } from '@/utils/operatorAccess';
+import { deleteJobNote, deleteJobNoteMedia } from '@/utils/jobNoteMediaAccess';
 import {
   addMachineNote,
   addMachineNoteMedia,
@@ -29,6 +30,8 @@ import MachineDetailsCard from '@/components/maintenance/MachineDetailsCard';
 import MachineEntry from '@/components/maintenance/MachineEntry';
 import MachineManualsSheet from '@/components/maintenance/MachineManualsSheet';
 import MachineOpenItems from '@/components/maintenance/MachineOpenItems';
+import NoteEditDialog from '@/components/notes/NoteEditDialog';
+import NoteDeleteDialog from '@/components/notes/NoteDeleteDialog';
 import type { MachineNote, MaintenanceKind } from '@/types/machineMaintenance';
 
 const cardSx = { bgcolor: 'rgba(26, 31, 74, 0.55)', backdropFilter: 'blur(8px)' };
@@ -62,9 +65,14 @@ export default function MachineLogPanel({
 }) {
   const [error, setError] = useState<string | null>(null);
   const [memberId, setMemberId] = useState<string | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
   const [kind, setKind] = useState<MaintenanceKind | null>(null);
   const [replyingTo, setReplyingTo] = useState<MachineNote | null>(null);
   const [manualsOpen, setManualsOpen] = useState(false);
+  const [editingEntry, setEditingEntry] = useState<MachineNote | null>(null);
+  const [deletingEntry, setDeletingEntry] = useState<MachineNote | null>(null);
+  const [rowBusy, setRowBusy] = useState(false);
+  const [rowError, setRowError] = useState<string | null>(null);
 
   const {
     data: log,
@@ -95,7 +103,10 @@ export default function MachineLogPanel({
   useEffect(() => {
     let active = true;
     getCurrentMember(companyId).then((m) => {
-      if (active && m) setMemberId(m.id);
+      if (active && m) {
+        setMemberId(m.id);
+        setIsAdmin(m.role === 'admin');
+      }
     });
     return () => {
       active = false;
@@ -145,6 +156,59 @@ export default function MachineLogPanel({
     [capture, reload],
   );
 
+
+  /**
+   * Save an edited entry (#628). Body first, then any photo removals.
+   *
+   * That order is deliberate: the body update is the statement most likely to be
+   * refused (RLS, or the billing gate on a lapsed shop), so it fails before
+   * anything irreversible has happened to the photos.
+   *
+   * Reload rather than patch in place, because `open` is DERIVED server-side by
+   * deriveOpenItems and the thread structure below is computed from `openIds`.
+   * Editing cannot change either — maintenance_kind and resolves_note_id are
+   * immutable under the guard — but delete can, and using one refresh path for
+   * both keeps the pinned block and the log from ever disagreeing (§4.4).
+   */
+  const handleEditSave = useCallback(
+    async (body: string | null, removedMediaIds: string[]) => {
+      if (!editingEntry) return;
+      setRowBusy(true);
+      setRowError(null);
+      try {
+        await updateNoteBody(editingEntry.id, body);
+        for (const id of removedMediaIds) {
+          const m = editingEntry.media.find((x) => x.id === id);
+          if (m) await deleteJobNoteMedia({ id: m.id, storage_path: m.storage_path });
+        }
+        setEditingEntry(null);
+        reload();
+      } catch (err) {
+        setRowError(err instanceof Error ? err.message : 'Could not save that change.');
+      } finally {
+        setRowBusy(false);
+      }
+    },
+    [editingEntry, reload],
+  );
+
+  const handleDelete = useCallback(async () => {
+    if (!deletingEntry) return;
+    setRowBusy(true);
+    setRowError(null);
+    try {
+      await deleteJobNote(deletingEntry.id);
+      setDeletingEntry(null);
+      // MANDATORY, not stylistic — see handleEditSave. Deleting a resolver puts
+      // its target back in Needs attention, and that only shows if the derived
+      // open list is refetched.
+      reload();
+    } catch (err) {
+      setRowError(err instanceof Error ? err.message : 'Could not delete that entry.');
+    } finally {
+      setRowBusy(false);
+    }
+  }, [deletingEntry, reload]);
 
   // Opens a reply directly under the item. No scroll-to-top and no banner: the
   // composer's POSITION says what it answers, which is a thing you cannot lose
@@ -278,6 +342,15 @@ export default function MachineLogPanel({
         items={log?.open ?? []}
         companyId={companyId}
         memberId={memberId}
+        isAdmin={isAdmin}
+        onEditItem={(item) => {
+          setRowError(null);
+          setEditingEntry(item);
+        }}
+        onDeleteItem={(item) => {
+          setRowError(null);
+          setDeletingEntry(item);
+        }}
         onLogFix={readOnly ? undefined : startFix}
         replyingToId={replyingTo?.id ?? null}
         // KEYED BY THE ITEM IT ANSWERS. The draft lives inside this component,
@@ -328,6 +401,15 @@ export default function MachineLogPanel({
                     entry={root}
                     companyId={companyId}
                     memberId={memberId}
+                    isAdmin={isAdmin}
+                    onEdit={() => {
+                      setRowError(null);
+                      setEditingEntry(root);
+                    }}
+                    onDelete={() => {
+                      setRowError(null);
+                      setDeletingEntry(root);
+                    }}
                     readOnly={readOnly}
                   />
                 </Box>
@@ -353,6 +435,15 @@ export default function MachineLogPanel({
                       entry={reply}
                       companyId={companyId}
                       memberId={memberId}
+                      isAdmin={isAdmin}
+                      onEdit={() => {
+                        setRowError(null);
+                        setEditingEntry(reply);
+                      }}
+                      onDelete={() => {
+                        setRowError(null);
+                        setDeletingEntry(reply);
+                      }}
                       readOnly={readOnly}
                     />
                   </Box>
@@ -364,6 +455,44 @@ export default function MachineLogPanel({
       ) : null}
 
       <MachineDetailsCard details={details ?? null} />
+
+      {editingEntry && (
+      <NoteEditDialog
+        key={editingEntry.id}
+        open
+        initialBody={editingEntry.body}
+        media={editingEntry.media}
+        noun="entry"
+        saving={rowBusy}
+        error={rowError}
+        onClose={() => {
+          setEditingEntry(null);
+          setRowError(null);
+        }}
+        onSave={({ body, removedMediaIds }) => handleEditSave(body, removedMediaIds)}
+      />
+      )}
+
+      <NoteDeleteDialog
+        open={deletingEntry !== null}
+        noun="entry"
+        // Said BEFORE the fact rather than discovered after. "Open" is derived
+        // from the absence of a resolver (§4.4), so deleting the record that
+        // something was fixed necessarily returns the item to outstanding. That
+        // is correct behaviour and completely unguessable from the word "delete".
+        consequence={
+          deletingEntry?.resolves_note_id
+            ? 'The item this fixed goes back to Needs attention.'
+            : null
+        }
+        deleting={rowBusy}
+        error={rowError}
+        onClose={() => {
+          setDeletingEntry(null);
+          setRowError(null);
+        }}
+        onConfirm={handleDelete}
+      />
     </Box>
   );
 }

--- a/components/maintenance/MachineOpenItems.tsx
+++ b/components/maintenance/MachineOpenItems.tsx
@@ -39,7 +39,10 @@ export default function MachineOpenItems({
   items,
   companyId,
   memberId,
+  isAdmin = false,
   onLogFix,
+  onEditItem,
+  onDeleteItem,
   replyingToId = null,
   renderReply,
   readOnly = false,
@@ -47,8 +50,20 @@ export default function MachineOpenItems({
   items: MachineNote[];
   companyId: string;
   memberId: string | null;
+  /** Widens delete (not edit) to any entry in the shop. */
+  isAdmin?: boolean;
   /** Absent in read-only (office) rendering, where there is nothing to act on. */
   onLogFix?: (item: MachineNote) => void;
+  /**
+   * Author-only edit of an outstanding item's wording (#628).
+   *
+   * Safe against §5's rule that this block must not name who raised what: the
+   * action menu shows only on the reader's OWN entry, so it reveals nothing they
+   * did not already know, and `hideAuthor` still suppresses every name. What §5
+   * forbids is a column of names read straight down, and that stays impossible.
+   */
+  onEditItem?: (item: MachineNote) => void;
+  onDeleteItem?: (item: MachineNote) => void;
   /** Item whose reply composer is open, if any. */
   replyingToId?: string | null;
   /** Renders the inline reply composer, directly beneath its item. */
@@ -85,6 +100,9 @@ export default function MachineOpenItems({
                 entry={item}
                 companyId={companyId}
                 memberId={memberId}
+                isAdmin={isAdmin}
+                onEdit={onEditItem ? () => onEditItem(item) : undefined}
+                onDelete={onDeleteItem ? () => onDeleteItem(item) : undefined}
                 isOpen
                 hideAuthor
                 // Hidden while its own reply is open: the composer sitting

--- a/components/notes/NoteActionsMenu.tsx
+++ b/components/notes/NoteActionsMenu.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import IconButton from '@mui/material/IconButton';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+
+/**
+ * Edit / Delete for one note on the OPERATOR surfaces — the job feed, the Playbook
+ * sheet and the machine logbook (#628).
+ *
+ * WHY AN OVERFLOW MENU HERE AND TWO BARE ICONS ON THE OFFICE SURFACES. These note
+ * header rows already carry an author name, an optional step chip and a timestamp,
+ * and they already wrap at 375px. Two more 48px targets push every note's header
+ * onto a third line. One overflow target costs a single row of chrome, and MUI
+ * MenuItems are >= 48px under this theme, so the touch-target floor is met at the
+ * point of CHOICE rather than at the point of disclosure — which is where it
+ * actually matters, since a mis-tap on the kebab is harmless and a mis-tap on a
+ * bare trash icon is not.
+ *
+ * The office Activity tab deliberately does NOT use this: docs/interaction-standards.md
+ * requires the destructive control to be an error-coloured trash icon shown at rest,
+ * and burying it behind a kebab would regress a rule that was argued for explicitly.
+ * Desktop has the width and the hover; the phone constraint does not apply there.
+ *
+ * Renders nothing at all when neither action is available, so callers can drop it in
+ * unconditionally rather than duplicating the permission test to decide whether to
+ * mount it.
+ */
+export default function NoteActionsMenu({
+  canEdit,
+  canDelete,
+  onEdit,
+  onDelete,
+  /** Distinguishes "note" from "comment" in the labels and aria text. */
+  noun = 'note',
+}: {
+  canEdit: boolean;
+  canDelete: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+  noun?: string;
+}) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  if (!canEdit && !canDelete) return null;
+
+  const close = () => setAnchorEl(null);
+
+  return (
+    <>
+      <IconButton
+        aria-label={`Actions for this ${noun}`}
+        onClick={(e) => setAnchorEl(e.currentTarget)}
+        // 48px floor (design system). flexShrink so it survives a wrapping header.
+        sx={{ width: 48, height: 48, flexShrink: 0 }}
+      >
+        <MoreVertIcon fontSize="small" />
+      </IconButton>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={close}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+      >
+        {canEdit && (
+          <MenuItem
+            onClick={() => {
+              close();
+              onEdit();
+            }}
+            sx={{ minHeight: 48 }}
+          >
+            <ListItemIcon>
+              <EditOutlinedIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>Edit</ListItemText>
+          </MenuItem>
+        )}
+        {canDelete && (
+          <MenuItem
+            onClick={() => {
+              close();
+              onDelete();
+            }}
+            sx={{ minHeight: 48, color: 'error.main' }}
+          >
+            <ListItemIcon>
+              <DeleteOutlineIcon fontSize="small" color="error" />
+            </ListItemIcon>
+            <ListItemText>Delete</ListItemText>
+          </MenuItem>
+        )}
+      </Menu>
+    </>
+  );
+}

--- a/components/notes/NoteDeleteDialog.tsx
+++ b/components/notes/NoteDeleteDialog.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Typography from '@mui/material/Typography';
+
+/**
+ * Confirm deleting one note (#628).
+ *
+ * A note delete is an immediately-persisted HARD delete — `notes` has no
+ * `deleted_at`, so this is not the archive-everything path in Architecture §16 and
+ * there is no restore. docs/interaction-standards.md puts that squarely in
+ * "immediately-persisted row delete → lightweight confirmation dialog", and its
+ * audience floor explicitly rejects the alternative: an inline delete plus an
+ * auto-dismissing Undo snackbar is a documented accessibility liability for a
+ * 50–60 year old audience, and worse again on a phone on a shop floor with divided
+ * attention. Recovery would have to be durable to replace the dialog, and here it
+ * cannot be.
+ *
+ * Same shape and copy register as the routing-operation confirm, deliberately, so
+ * the two read as one product rather than two.
+ */
+export default function NoteDeleteDialog({
+  open,
+  noun = 'note',
+  /**
+   * Extra consequence beyond losing the text. The machine logbook passes one:
+   * deleting an entry that RESOLVES an open item puts that item back in Needs
+   * attention, because "open" is derived from the absence of a resolver rather
+   * than stored. That is correct behaviour, but it is not guessable from "delete",
+   * so it gets said out loud before the fact rather than discovered after.
+   */
+  consequence,
+  deleting = false,
+  error = null,
+  onConfirm,
+  onClose,
+}: {
+  open: boolean;
+  noun?: string;
+  consequence?: string | null;
+  deleting?: boolean;
+  error?: string | null;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <Dialog open={open} onClose={deleting ? undefined : onClose} fullWidth maxWidth="xs">
+      <DialogTitle>Delete this {noun}?</DialogTitle>
+      <DialogContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+        <Typography>
+          The text and any photos on it go for good. This cannot be undone.
+        </Typography>
+        {consequence && (
+          <Typography sx={{ mt: 1.5 }} color="warning.main">
+            {consequence}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        {/* Delete kept away from Cancel, per the proximity rule in
+            docs/interaction-standards.md. */}
+        <Button onClick={onClose} disabled={deleting} sx={{ minHeight: 48 }}>
+          Cancel
+        </Button>
+        <Button
+          onClick={onConfirm}
+          color="error"
+          variant="contained"
+          disabled={deleting}
+          sx={{ minHeight: 48 }}
+        >
+          {deleting ? 'Deleting…' : 'Delete'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/notes/NoteEditDialog.tsx
+++ b/components/notes/NoteEditDialog.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useLoad } from '@/hooks/useLoad';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormHelperText from '@mui/material/FormHelperText';
+import IconButton from '@mui/material/IconButton';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import CloseIcon from '@mui/icons-material/Close';
+import UndoIcon from '@mui/icons-material/Undo';
+import BrokenImageOutlinedIcon from '@mui/icons-material/BrokenImageOutlined';
+import { getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
+import type { JobNoteMedia } from '@/types/operator';
+
+const THUMB = 72;
+
+/** What Save hands back: the new body, plus any photos marked for removal. */
+export interface NoteEditResult {
+  /** Trimmed; null when emptied (legal only while photos remain). */
+  body: string | null;
+  /** note_media ids to delete. Empty on the common text-only edit. */
+  removedMediaIds: string[];
+}
+
+/**
+ * Edit one note's text, and optionally drop photos from it (#628).
+ *
+ * ONE dialog for all five surfaces — the job feed, the Playbook sheet, My work, the
+ * machine logbook and the office part Activity tab. That is the point rather than
+ * an economy: five surfaces with one editing behaviour, one blank-body rule and one
+ * error string, instead of five that drift.
+ *
+ * WHY A DIALOG AND NOT INLINE EDITING, on both surface families:
+ *
+ *   Phone. NoteCaptureFields already had to add scrollIntoView({block:'center'})
+ *   because the fixed action bar and the on-screen keyboard cover whatever is being
+ *   edited. Swapping a feed row into a text field reproduces exactly that, AND
+ *   collapses the row's height mid-scroll, which loses the reader's place in a list
+ *   they were scrolling. A dialog guarantees a visible field above the keyboard and
+ *   an unambiguous commit.
+ *
+ *   Desktop. The Activity tab's rows are ListItem + ListItemText(primary/secondary)
+ *   with an absolutely-positioned secondaryAction; an inline field fights that
+ *   layout rather than fitting into it.
+ *
+ * PHOTO REMOVAL IS DEFERRED TO SAVE, NEVER APPLIED ON TAP. A tapped photo dims and
+ * offers Undo; Cancel discards the marks and nothing is deleted. Deleting on tap
+ * would make Cancel a lie for photos, and on a phone a mis-tap on a small X would
+ * irreversibly destroy a storage object. A confirm dialog nested inside this one was
+ * the alternative and is worse for the same protection.
+ *
+ * ADDING photos is deliberately out of scope, and the reason is uploads rather than
+ * atomicity — an edit that removes photos is already more than one statement. An
+ * upload is the part that dies mid-flight on cellular and needs progress, retry and
+ * orphan cleanup for a file that reached storage without its row. A delete is one
+ * fast statement with none of that.
+ */
+export default function NoteEditDialog({
+  open,
+  initialBody,
+  media = [],
+  saving = false,
+  error = null,
+  noun = 'note',
+  onSave,
+  onClose,
+}: {
+  open: boolean;
+  initialBody: string | null;
+  /** The note's photos. Omit on surfaces that carry none (part comments). */
+  media?: JobNoteMedia[];
+  saving?: boolean;
+  error?: string | null;
+  /** "note" or "comment" — used in the title and the empty-body helper. */
+  noun?: string;
+  onSave: (result: NoteEditResult) => void;
+  onClose: () => void;
+}) {
+  // Seeded once, at mount. There is deliberately NO effect resyncing this to
+  // `initialBody` — that would be a setState inside an effect (the lint rule this
+  // codebase enforces), and it would also fight the parent whenever a save patches
+  // the note in place.
+  //
+  // Freshness comes from the caller MOUNTING this per note instead:
+  //   {editingNote && <NoteEditDialog key={editingNote.id} … />}
+  // so switching notes, or reopening after a Cancel, is a remount with a clean
+  // draft. Same technique and same reason as MachineReplyComposer, whose draft
+  // must likewise die with the thing it was written about — there, a sentence
+  // about one item could otherwise be filed as the fix for another.
+  const [body, setBody] = useState(initialBody ?? '');
+  const [removed, setRemoved] = useState<string[]>([]);
+
+  const remainingMedia = useMemo(
+    () => media.filter((m) => !removed.includes(m.id)),
+    [media, removed],
+  );
+
+  const trimmed = body.trim();
+
+  // An empty body is legal only while the note still has a photo to be. Falls out
+  // of the media list rather than needing a prop: a part comment has no media, so
+  // empty is never allowed there, which is exactly what
+  // part_comments_body_not_blank enforces server-side.
+  const allowEmpty = remainingMedia.length > 0;
+  const isEmpty = trimmed.length === 0;
+  const emptyBlocked = isEmpty && !allowEmpty;
+
+  const changed = trimmed !== (initialBody ?? '').trim() || removed.length > 0;
+  const canSave = changed && !emptyBlocked && !saving;
+
+  // Batch-load thumbnails once per media set, mirroring NoteMediaGallery.
+  const { data: urls } = useLoad(async () => {
+    const pairs = await Promise.all(
+      media.map(async (m) => {
+        try {
+          return [m.id, await getJobNoteMediaUrl(m.thumbnail_path ?? m.storage_path)] as const;
+        } catch {
+          return null;
+        }
+      }),
+    );
+    const map: Record<string, string> = {};
+    for (const p of pairs) if (p) map[p[0]] = p[1];
+    return map;
+  }, [media]);
+
+  return (
+    <Dialog open={open} onClose={saving ? undefined : onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Edit {noun}</DialogTitle>
+
+      <DialogContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        <TextField
+          autoFocus
+          fullWidth
+          multiline
+          minRows={3}
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          disabled={saving}
+          error={emptyBlocked}
+          placeholder="What should the next person know?"
+          sx={{ mt: 1 }}
+        />
+
+        {emptyBlocked && (
+          // Names the correct action rather than only refusing. Someone emptying the
+          // field is usually trying to get rid of the note, and "you can't do that"
+          // without saying what they can do is where people give up.
+          <FormHelperText error>
+            A {noun} can&apos;t be empty — delete it instead.
+          </FormHelperText>
+        )}
+
+        {media.length > 0 && (
+          <Box sx={{ mt: 2 }}>
+            <Typography variant="caption" color="text.secondary">
+              Photos
+            </Typography>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 0.5 }}>
+              {media.map((m) => {
+                const isRemoved = removed.includes(m.id);
+                const url = urls?.[m.id];
+                return (
+                  <Box key={m.id} sx={{ position: 'relative', width: THUMB, height: THUMB }}>
+                    <Box
+                      sx={{
+                        width: THUMB,
+                        height: THUMB,
+                        borderRadius: 1,
+                        overflow: 'hidden',
+                        bgcolor: 'rgba(255,255,255,0.06)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        // Marked photos stay visible but obviously pending, so the
+                        // state reads as "will go when you save" rather than "gone".
+                        opacity: isRemoved ? 0.25 : 1,
+                      }}
+                    >
+                      {url ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={url}
+                          alt=""
+                          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                        />
+                      ) : (
+                        <BrokenImageOutlinedIcon fontSize="small" color="disabled" />
+                      )}
+                    </Box>
+
+                    <IconButton
+                      aria-label={isRemoved ? 'Keep this photo' : 'Remove this photo'}
+                      disabled={saving}
+                      onClick={() =>
+                        setRemoved((prev) =>
+                          isRemoved ? prev.filter((id) => id !== m.id) : [...prev, m.id],
+                        )
+                      }
+                      size="small"
+                      sx={{
+                        position: 'absolute',
+                        top: -6,
+                        right: -6,
+                        bgcolor: 'background.paper',
+                        '&:hover': { bgcolor: 'background.paper' },
+                      }}
+                    >
+                      {isRemoved ? (
+                        <UndoIcon sx={{ fontSize: 16 }} />
+                      ) : (
+                        <CloseIcon sx={{ fontSize: 16 }} />
+                      )}
+                    </IconButton>
+                  </Box>
+                );
+              })}
+            </Box>
+            {removed.length > 0 && (
+              <FormHelperText>
+                {removed.length} photo{removed.length === 1 ? '' : 's'} will be removed when you
+                save.
+              </FormHelperText>
+            )}
+          </Box>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose} disabled={saving} sx={{ minHeight: 48 }}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          disabled={!canSave}
+          sx={{ minHeight: 48 }}
+          onClick={() => onSave({ body: trimmed || null, removedMediaIds: removed })}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/notes/NoteEditedMark.tsx
+++ b/components/notes/NoteEditedMark.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Typography from '@mui/material/Typography';
+
+/**
+ * "· edited" beside a note's timestamp (#628).
+ *
+ * Notes became editable, and `viewer_count` deliberately does NOT reset when one
+ * is — resetting it would hand an author a timed read-oracle on their own notes
+ * (see 20260801012019_notes_editable_body.sql). So a note can honestly say "7
+ * people read this" while carrying words those 7 never saw. This mark is what
+ * closes that gap: it tells a reader deciding whether to trust a note that the
+ * text in front of them is not the original.
+ *
+ * NO TIMESTAMP, AND NO TOOLTIP, both deliberate:
+ *
+ *   - A tooltip is invisible on the operator surface, which is a phone with no
+ *     hover. Putting the detail there would make it a desktop-only fact, which is
+ *     the wrong way round — the shop floor is who reads notes to do work.
+ *   - "When exactly did they change it" is a per-person audit question this
+ *     product declines to answer elsewhere: note_viewers() returns names with no
+ *     timestamps, precisely so an author cannot reconstruct who read what when.
+ *     An edit time is a weaker version of the same signal and there is no reason
+ *     to start now.
+ *
+ * Renders nothing when the note has never been edited, so callers can drop it in
+ * unconditionally.
+ */
+export default function NoteEditedMark({ editedAt }: { editedAt: string | null }) {
+  if (!editedAt) return null;
+
+  return (
+    <Typography component="span" variant="caption" color="text.secondary">
+      {' · edited'}
+    </Typography>
+  );
+}

--- a/components/operator/JobFeed.tsx
+++ b/components/operator/JobFeed.tsx
@@ -16,9 +16,17 @@ import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DynamicFeedIcon from '@mui/icons-material/DynamicFeed';
 import CloseIcon from '@mui/icons-material/Close';
-import { getJobNotes, getCurrentMember } from '@/utils/operatorAccess';
+import { getJobNotes, getCurrentMember, updateNoteBody } from '@/utils/operatorAccess';
 import NoteReactions from '@/components/operator/NoteReactions';
-import { getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
+import NoteActionsMenu from '@/components/notes/NoteActionsMenu';
+import NoteEditedMark from '@/components/notes/NoteEditedMark';
+import NoteEditDialog from '@/components/notes/NoteEditDialog';
+import NoteDeleteDialog from '@/components/notes/NoteDeleteDialog';
+import {
+  getJobNoteMediaUrl,
+  deleteJobNote,
+  deleteJobNoteMedia,
+} from '@/utils/jobNoteMediaAccess';
 import { useNoteDwell } from '@/hooks/useNoteDwell';
 import { useNoteCapture, useStepNoteWriter } from '@/hooks/useNoteCapture';
 import NoteCaptureFields from '@/components/operator/NoteCaptureFields';
@@ -103,6 +111,11 @@ export default function JobFeed({
   const [pendingNotes, setPendingNotes] = useState<JobNote[]>([]);
 
   const [operatorId, setOperatorId] = useState<string | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [editingNote, setEditingNote] = useState<JobNote | null>(null);
+  const [deletingNote, setDeletingNote] = useState<JobNote | null>(null);
+  const [rowBusy, setRowBusy] = useState(false);
+  const [rowError, setRowError] = useState<string | null>(null);
 
   // Signed URLs for media thumbnails, keyed by media id (fetched on demand).
   const [mediaUrls, setMediaUrls] = useState<Record<string, string>>({});
@@ -151,7 +164,10 @@ export default function JobFeed({
   useEffect(() => {
     let active = true;
     getCurrentMember(companyId).then((op) => {
-      if (active && op) setOperatorId(op.id);
+      if (active && op) {
+        setOperatorId(op.id);
+        setIsAdmin(op.role === 'admin');
+      }
     });
     return () => {
       active = false;
@@ -293,9 +309,33 @@ export default function JobFeed({
                       <Chip size="small" label={note.operation_label} variant="outlined" />
                     )}
                   </Box>
-                  <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
-                    {formatTimestamp(note.created_at)}
-                  </Typography>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0 }}>
+                    <Typography variant="caption" color="text.secondary">
+                      {formatTimestamp(note.created_at)}
+                      <NoteEditedMark editedAt={note.edited_at} />
+                    </Typography>
+                    {/* 'event' notes are the auto-logged audit trail (e.g. an
+                        order-quantity change) — never editable, never deletable.
+                        RLS refuses them too, so this gate stops a guaranteed
+                        42501 rendering as a broken button. */}
+                    {!readOnly && note.note_type === 'user' && (
+                      <NoteActionsMenu
+                        canEdit={operatorId !== null && note.author_id === operatorId}
+                        canDelete={
+                          operatorId !== null &&
+                          (note.author_id === operatorId || isAdmin)
+                        }
+                        onEdit={() => {
+                          setRowError(null);
+                          setEditingNote(note);
+                        }}
+                        onDelete={() => {
+                          setRowError(null);
+                          setDeletingNote(note);
+                        }}
+                      />
+                    )}
+                  </Box>
                 </Box>
 
                 {/* The observed element is the BODY, deliberately. Observing the
@@ -391,6 +431,70 @@ export default function JobFeed({
           )}
         </DialogContent>
       </Dialog>
+
+      {editingNote && (
+      <NoteEditDialog
+        key={editingNote.id}
+        open
+        initialBody={editingNote.body}
+        media={editingNote.media}
+        saving={rowBusy}
+        error={rowError}
+        onClose={() => {
+          setEditingNote(null);
+          setRowError(null);
+        }}
+        onSave={async ({ body, removedMediaIds }) => {
+          if (!editingNote) return;
+          setRowBusy(true);
+          setRowError(null);
+          try {
+            // Body first: it is the statement most likely to be refused (RLS, or
+            // the billing gate on a lapsed shop), so it fails before anything
+            // irreversible happens to the photos.
+            await updateNoteBody(editingNote.id, body);
+            for (const id of removedMediaIds) {
+              const m = editingNote.media.find((x) => x.id === id);
+              if (m) await deleteJobNoteMedia({ id: m.id, storage_path: m.storage_path });
+            }
+            setEditingNote(null);
+            await load();
+          } catch (err) {
+            setRowError(err instanceof Error ? err.message : 'Could not save that change.');
+          } finally {
+            setRowBusy(false);
+          }
+        }}
+      />
+      )}
+
+      <NoteDeleteDialog
+        open={deletingNote !== null}
+        deleting={rowBusy}
+        error={rowError}
+        onClose={() => {
+          setDeletingNote(null);
+          setRowError(null);
+        }}
+        onConfirm={async () => {
+          if (!deletingNote) return;
+          setRowBusy(true);
+          setRowError(null);
+          try {
+            await deleteJobNote(deletingNote.id);
+            setDeletingNote(null);
+            // Also clears any optimistic copy still in pendingNotes: the merge
+            // drops pending entries the reload no longer returns, so a deleted
+            // note cannot linger as a ghost row.
+            setPendingNotes((prev) => prev.filter((n) => n.id !== deletingNote.id));
+            await load();
+          } catch (err) {
+            setRowError(err instanceof Error ? err.message : 'Could not delete that note.');
+          } finally {
+            setRowBusy(false);
+          }
+        }}
+      />
     </Card>
   );
 }

--- a/components/operator/PartNotesSheet.tsx
+++ b/components/operator/PartNotesSheet.tsx
@@ -15,8 +15,13 @@ import CircularProgress from '@mui/material/CircularProgress';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import CloseIcon from '@mui/icons-material/Close';
-import { getPartPreviousNotes, getCurrentMember } from '@/utils/operatorAccess';
+import { getPartPreviousNotes, getCurrentMember, updateNoteBody } from '@/utils/operatorAccess';
+import { deleteJobNote, deleteJobNoteMedia } from '@/utils/jobNoteMediaAccess';
 import NoteReactions from '@/components/operator/NoteReactions';
+import NoteActionsMenu from '@/components/notes/NoteActionsMenu';
+import NoteEditedMark from '@/components/notes/NoteEditedMark';
+import NoteEditDialog from '@/components/notes/NoteEditDialog';
+import NoteDeleteDialog from '@/components/notes/NoteDeleteDialog';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import { useNoteDwell } from '@/hooks/useNoteDwell';
 import NoteMediaGallery from '@/components/operator/NoteMediaGallery';
@@ -52,11 +57,17 @@ function NoteRow({
   observe,
   companyId,
   memberId,
+  isAdmin,
+  onEdit,
+  onDelete,
 }: {
   note: PartPreviousNote;
   observe: (id: string) => (el: HTMLElement | null) => void;
   companyId: string;
   memberId: string | null;
+  isAdmin: boolean;
+  onEdit: (note: PartPreviousNote) => void;
+  onDelete: (note: PartPreviousNote) => void;
 }) {
   return (
     <Box>
@@ -70,7 +81,16 @@ function NoteRow({
         <Box sx={{ flex: 1 }} />
         <Typography variant="caption" color="text.secondary">
           {note.job_number} · {formatTimestamp(note.created_at)}
+          <NoteEditedMark editedAt={note.edited_at} />
         </Typography>
+        {note.note_type === 'user' && (
+          <NoteActionsMenu
+            canEdit={memberId !== null && note.author_id === memberId}
+            canDelete={memberId !== null && (note.author_id === memberId || isAdmin)}
+            onEdit={() => onEdit(note)}
+            onDelete={() => onDelete(note)}
+          />
+        )}
       </Box>
       {note.body && (
         <Typography ref={observe(note.id)} variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
@@ -149,17 +169,31 @@ export default function PartNotesSheet({
   // Who is reading. Needed to know whether they have already marked a note
   // helpful, and to hide the control on their own notes (RLS forbids reacting to
   // them, so the button would be a guaranteed failure).
-  const { data: memberId } = useLoad(
-    async () => (open ? ((await getCurrentMember(companyId))?.id ?? null) : null),
+  const { data: member } = useLoad(
+    async () => (open ? await getCurrentMember(companyId) : null),
     [companyId, open],
   );
+  const memberId = member?.id ?? null;
+  const isAdmin = member?.role === 'admin';
+
+  // Edit / delete state (#628). The Playbook is a READ surface, so these live
+  // behind the per-note overflow menu rather than adding any standing chrome.
+  const [editingNote, setEditingNote] = useState<PartPreviousNote | null>(null);
+  const [deletingNote, setDeletingNote] = useState<PartPreviousNote | null>(null);
+  const [rowBusy, setRowBusy] = useState(false);
+  const [rowError, setRowError] = useState<string | null>(null);
 
   // THE surface the read-back loop exists to measure: knowledge from a previous
   // run, being read on a new one. excludeJobId is the job the operator is
   // standing in, so it is the right read context for the per-job dedupe.
   const { observe } = useNoteDwell(companyId, excludeJobId, open);
 
-  const { data, loading, error } = useLoad(
+  const {
+    data,
+    loading,
+    error,
+    reload,
+  } = useLoad(
     () =>
       getPartPreviousNotes(partId, companyId, {
         excludeJobId,
@@ -249,12 +283,87 @@ export default function PartNotesSheet({
             {notes.map((note, idx) => (
               <Box key={note.id}>
                 {idx > 0 && <Divider sx={{ my: 1.5 }} />}
-                <NoteRow note={note} observe={observe} companyId={companyId} memberId={memberId} />
+                <NoteRow
+                  note={note}
+                  observe={observe}
+                  companyId={companyId}
+                  memberId={memberId}
+                  isAdmin={isAdmin}
+                  onEdit={(n) => {
+                    setRowError(null);
+                    setEditingNote(n);
+                  }}
+                  onDelete={(n) => {
+                    setRowError(null);
+                    setDeletingNote(n);
+                  }}
+                />
               </Box>
             ))}
           </Box>
         )}
       </Box>
+
+      {editingNote && (
+      <NoteEditDialog
+        key={editingNote.id}
+        open
+        initialBody={editingNote.body}
+        media={editingNote.media}
+        saving={rowBusy}
+        error={rowError}
+        onClose={() => {
+          setEditingNote(null);
+          setRowError(null);
+        }}
+        onSave={async ({ body, removedMediaIds }) => {
+          if (!editingNote) return;
+          setRowBusy(true);
+          setRowError(null);
+          try {
+            await updateNoteBody(editingNote.id, body);
+            for (const id of removedMediaIds) {
+              const m = editingNote.media.find((x) => x.id === id);
+              if (m) await deleteJobNoteMedia({ id: m.id, storage_path: m.storage_path });
+            }
+            setEditingNote(null);
+            // Refetch rather than patch: the RPC ranks by usage and helpful marks
+            // with a recency guard, so the list's ORDER is server-owned. Editing
+            // cannot move a note (the ranking reads created_at, never edited_at)
+            // but re-reading keeps one refresh path for both edit and delete.
+            await reload();
+          } catch (err) {
+            setRowError(err instanceof Error ? err.message : 'Could not save that change.');
+          } finally {
+            setRowBusy(false);
+          }
+        }}
+      />
+      )}
+
+      <NoteDeleteDialog
+        open={deletingNote !== null}
+        deleting={rowBusy}
+        error={rowError}
+        onClose={() => {
+          setDeletingNote(null);
+          setRowError(null);
+        }}
+        onConfirm={async () => {
+          if (!deletingNote) return;
+          setRowBusy(true);
+          setRowError(null);
+          try {
+            await deleteJobNote(deletingNote.id);
+            setDeletingNote(null);
+            await reload();
+          } catch (err) {
+            setRowError(err instanceof Error ? err.message : 'Could not delete that note.');
+          } finally {
+            setRowBusy(false);
+          }
+        }}
+      />
     </Dialog>
   );
 }

--- a/components/parts/workspace/tabs/HistoryTab.tsx
+++ b/components/parts/workspace/tabs/HistoryTab.tsx
@@ -23,15 +23,23 @@ import AddCommentIcon from '@mui/icons-material/AddComment';
 import PercentIcon from '@mui/icons-material/Percent';
 import NoteOutlinedIcon from '@mui/icons-material/NoteOutlined';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 
 import {
   getPartActivity,
   addPartNote,
   deletePartNote,
+  updatePartNote,
   type PartActivityEvent,
 } from '@/utils/partsAccess';
 import { getCurrentMember } from '@/utils/operatorAccess';
 import DeleteIconButton from '@/components/common/DeleteIconButton';
+import NoteEditDialog from '@/components/notes/NoteEditDialog';
+import NoteDeleteDialog from '@/components/notes/NoteDeleteDialog';
+import NoteEditedMark from '@/components/notes/NoteEditedMark';
+import type { PartNote } from '@/types/part';
 
 interface HistoryTabProps {
   partId: string;
@@ -82,7 +90,17 @@ function matchesFilter(ev: PartActivityEvent, filter: ActivityFilter): boolean {
 export default function HistoryTab({ partId, companyId, createdAt }: HistoryTabProps) {
   const [events, setEvents] = useState<PartActivityEvent[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [operator, setOperator] = useState<{ id: string; name: string | null } | null>(null);
+  const [operator, setOperator] = useState<{
+    id: string;
+    name: string | null;
+    role: string | null;
+  } | null>(null);
+  /** The comment being edited, or null. Held whole so the dialog can seed itself. */
+  const [editingNote, setEditingNote] = useState<PartNote | null>(null);
+  /** The comment pending delete confirmation. */
+  const [deletingNote, setDeletingNote] = useState<PartNote | null>(null);
+  const [rowBusy, setRowBusy] = useState(false);
+  const [rowError, setRowError] = useState<string | null>(null);
   const [body, setBody] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [composerError, setComposerError] = useState<string | null>(null);
@@ -140,12 +158,35 @@ export default function HistoryTab({ partId, companyId, createdAt }: HistoryTabP
     }
   };
 
-  const handleDelete = async (noteId: string) => {
+  const handleDelete = async () => {
+    if (!deletingNote) return;
+    setRowBusy(true);
+    setRowError(null);
     try {
-      await deletePartNote(noteId);
+      await deletePartNote(deletingNote.id);
+      setDeletingNote(null);
       setRefreshTick((t) => t + 1);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete comment');
+      setRowError(err instanceof Error ? err.message : 'Failed to delete comment');
+    } finally {
+      setRowBusy(false);
+    }
+  };
+
+  const handleEditSave = async (newBody: string | null) => {
+    if (!editingNote) return;
+    setRowBusy(true);
+    setRowError(null);
+    try {
+      // Non-null asserted by the dialog: a part comment has no media, so its
+      // allowEmpty is always false and Save cannot fire with an empty body.
+      await updatePartNote(editingNote.id, newBody ?? '');
+      setEditingNote(null);
+      setRefreshTick((t) => t + 1);
+    } catch (err) {
+      setRowError(err instanceof Error ? err.message : 'Failed to save comment');
+    } finally {
+      setRowBusy(false);
     }
   };
 
@@ -231,19 +272,40 @@ export default function HistoryTab({ partId, companyId, createdAt }: HistoryTabP
             </Typography>
           ) : (
             <List disablePadding>
-              {visible.map((ev) => (
-                <FeedRow
-                  key={ev.id}
-                  ev={ev}
-                  canDelete={
-                    ev.kind === 'note' &&
-                    ev.note.note_type === 'user' &&
-                    !!operator &&
-                    ev.note.author_id === operator.id
-                  }
-                  onDelete={handleDelete}
-                />
-              ))}
+              {visible.map((ev) => {
+                // 'pricing' rows are the auto-logged audit trail — never editable,
+                // never deletable. RLS refuses them too after #628, so this gate is
+                // honesty rather than enforcement: a control that is a guaranteed
+                // 42501 reads as a broken button.
+                const own =
+                  ev.kind === 'note' &&
+                  ev.note.note_type === 'user' &&
+                  !!operator &&
+                  ev.note.author_id === operator.id;
+                return (
+                  <FeedRow
+                    key={ev.id}
+                    ev={ev}
+                    // Edit is AUTHOR-ONLY, deliberately asymmetric with delete: an
+                    // admin who could reword someone else's comment would change
+                    // what it says without changing whose name is on it.
+                    canEdit={own}
+                    canDelete={
+                      ev.kind === 'note' &&
+                      ev.note.note_type === 'user' &&
+                      (own || operator?.role === 'admin')
+                    }
+                    onEdit={() => {
+                      setRowError(null);
+                      if (ev.kind === 'note') setEditingNote(ev.note);
+                    }}
+                    onDelete={() => {
+                      setRowError(null);
+                      if (ev.kind === 'note') setDeletingNote(ev.note);
+                    }}
+                  />
+                );
+              })}
               {showCreated && createdAt && (
                 <ListItem alignItems="flex-start" disableGutters>
                   <ListItemIcon sx={{ minWidth: 40, mt: 0.5 }}>
@@ -259,33 +321,80 @@ export default function HistoryTab({ partId, companyId, createdAt }: HistoryTabP
           )}
         </CardContent>
       </Card>
+
+      {editingNote && (
+      <NoteEditDialog
+        key={editingNote.id}
+        open
+        initialBody={editingNote.body}
+        noun="comment"
+        saving={rowBusy}
+        error={rowError}
+        onClose={() => {
+          setEditingNote(null);
+          setRowError(null);
+        }}
+        onSave={({ body: newBody }) => handleEditSave(newBody)}
+      />
+      )}
+
+      {/* A part comment is a hard delete with no restore, so it gets the
+          lightweight confirmation docs/interaction-standards.md requires for an
+          immediately-persisted row delete. This row previously deleted on a single
+          click with no confirmation — a pre-existing gap against that standard,
+          closed here because #628 is already reworking this row. */}
+      <NoteDeleteDialog
+        open={deletingNote !== null}
+        noun="comment"
+        deleting={rowBusy}
+        error={rowError}
+        onClose={() => {
+          setDeletingNote(null);
+          setRowError(null);
+        }}
+        onConfirm={handleDelete}
+      />
     </Box>
   );
 }
 
 function FeedRow({
   ev,
+  canEdit,
   canDelete,
+  onEdit,
   onDelete,
 }: {
   ev: PartActivityEvent;
+  canEdit: boolean;
   canDelete: boolean;
-  onDelete: (noteId: string) => void;
+  onEdit: () => void;
+  onDelete: () => void;
 }) {
+  // Both controls sit at rest, and the delete stays a bare error-coloured trash
+  // icon rather than moving into an overflow menu: docs/interaction-standards.md
+  // requires the destructive control shown at rest, and this is a desktop surface
+  // with the width and the hover to carry two icons. The operator surfaces use a
+  // kebab instead, because their note headers already wrap on a 375px phone.
+  const actions =
+    ev.kind === 'note' && (canEdit || canDelete) ? (
+      <>
+        {canEdit && (
+          <Tooltip title="Edit comment">
+            <IconButton size="small" aria-label="Edit comment" onClick={onEdit}>
+              <EditOutlinedIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        )}
+        {/* Delete last — the destructive option is predictably rightmost. */}
+        {canDelete && (
+          <DeleteIconButton edge="end" ariaLabel="Delete comment" onClick={onDelete} />
+        )}
+      </>
+    ) : undefined;
+
   return (
-    <ListItem
-      alignItems="flex-start"
-      disableGutters
-      secondaryAction={
-        canDelete && ev.kind === 'note' ? (
-          <DeleteIconButton
-            edge="end"
-            ariaLabel="Delete comment"
-            onClick={() => onDelete(ev.note.id)}
-          />
-        ) : undefined
-      }
-    >
+    <ListItem alignItems="flex-start" disableGutters secondaryAction={actions}>
       <ListItemIcon sx={{ minWidth: 40, mt: 0.5 }}>
         <FeedIcon ev={ev} />
       </ListItemIcon>
@@ -327,5 +436,10 @@ function FeedSecondary({ ev }: { ev: PartActivityEvent }) {
   if (ev.kind === 'transaction') {
     return <>{ev.txn.notes ? `${when} · ${ev.txn.notes}` : when}</>;
   }
-  return <>{`${ev.note.author_name ?? 'Unknown'} · ${when}`}</>;
+  return (
+    <>
+      {`${ev.note.author_name ?? 'Unknown'} · ${when}`}
+      <NoteEditedMark editedAt={ev.note.edited_at} />
+    </>
+  );
 }

--- a/docs/interaction-standards.md
+++ b/docs/interaction-standards.md
@@ -87,6 +87,26 @@ the generic "low-stakes ⇒ no dialog" advice.
   and it does **not** alter existing quotes (line items snapshot `unit_price`; the
   `source_tier_id` FK is `ON DELETE SET NULL`), so it is not the financial hazard
   it appears to be.
+- ✅ Note / comment delete ([#628](https://github.com/debola31/Jigged/issues/628)):
+  confirmation dialog on every surface. `notes` and `part_comments` have no
+  `deleted_at`, so this is a hard delete outside the Architecture §16 archive
+  standard and there is no restore — squarely the "immediately-persisted row
+  delete" row above. The part Activity tab previously deleted a comment on a single
+  click with no confirmation at all; that gap was closed in the same PR.
+- ✅ Note / comment **edit** affordance is deliberately shaped per surface, and this
+  is the one place the standard splits by device rather than by stakes:
+  - *Operator surfaces* (job feed, Playbook sheet, machine log) use a single 48px
+    overflow (kebab) opening Edit / Delete. Those note headers already carry an
+    author, an optional step chip and a timestamp, and already wrap at 375px; two
+    more 48px targets push every header onto a third line. MUI `MenuItem`s clear
+    48px, so the touch floor is met at the point of *choice* — which is where it
+    matters, since a mis-tap on a kebab is harmless and a mis-tap on a bare trash
+    icon is not.
+  - *Office surfaces* (part Activity) keep the destructive control **shown at rest**
+    as an error-coloured trash icon, with a plain edit icon beside it and delete
+    rightmost. Burying delete in a kebab there would regress the red-at-rest and
+    delete-sits-last rules above; desktop has the width and the hover, so the phone
+    constraint does not apply.
 - 🔄 **Superseded:** the earlier target of "drop the BOM dialog + add Undo
   snackbars to BOM/tier/operation" is reversed after UX research (the audience
   floor above). We keep dialogs on destructive row deletes; ephemeral Undo is not

--- a/docs/modules/machine-maintenance.md
+++ b/docs/modules/machine-maintenance.md
@@ -189,7 +189,12 @@ real corpus ever argues for categories they come back as a UI change with a cons
 entry pinned to that machine until somebody logs a fix — so the person who meets it is the next
 operator standing at the machine, which is precisely the handoff [§1](#1-problem) says goes wrong.
 Its only intended exit is a second entry describing what was done: there is no dismiss and no close,
-and `notes` is append-only, so clearing the pin and recording the knowledge are the same act.
+so clearing the pin and recording the knowledge are the same act. That used to rest on `notes` being
+append-only; since [#628](https://github.com/debola31/Jigged/issues/628) it rests on something
+narrower and more durable — an entry's **body** is editable by its author, but `maintenance_kind` and
+`resolves_note_id` are immutable under a database guard trigger. So an operator can fix the wording of
+what they noticed and can never un-notice it, and a fix can never be re-pointed at a different item.
+The derived-open list stays trustworthy while the text stays correctable.
 
 ### 4.4 Noticed, then resolved
 
@@ -214,8 +219,14 @@ every outstanding item, and its draft was cleared in exactly one place: a succes
 starting a fix on one item, typing, then tapping "log the fix" on a second item moved the composer
 without moving the text — and submitting filed the first item's sentence as the second item's
 resolution. The second closes on a sentence written about something else, the first stays
-outstanding forever, and because the log is append-only nobody can correct it; the only remedy is a
-second entry saying the first was misfiled.
+outstanding forever. When this was written the log was append-only and nobody could correct it, so the
+only remedy was a second entry saying the first was misfiled. Since
+[#628](https://github.com/debola31/Jigged/issues/628) the author can delete the misfiled fix outright,
+which returns the item it wrongly closed to **Needs attention** — the open list is derived from the
+absence of a resolver, so removing the resolver restores the state with nothing stored to go stale.
+Note the shape of the remedy, because it is not "edit the link": `resolves_note_id` is immutable, so a
+fix filed against the wrong item is deleted and re-logged rather than re-pointed. The prevention below
+still matters more than the cure.
 
 The lesson is about where state lives, not how many composers there are. A draft must not outlive the
 thing it was written about, so the draft now lives **with the target**: the reply composer is mounted

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -145,12 +145,32 @@ against a count computed over exactly the rows it admitted. So:
   and counts `note_reactions`, so it is `SECURITY INVOKER`. **It takes no
   arguments, permanently**: a caller-supplied time window would be a bisection
   oracle for when a note was read.
-- **`authenticated` has no UPDATE on `notes` at all** — notes are append-only today,
-  so the whole privilege is revoked. Otherwise setting `viewer_count = 0` and
-  returning later to read the delta is a one-bit read oracle per note. If note
-  editing is ever added it needs a permissive policy **and** a column-scoped grant
-  that excludes `viewer_count`, `usage_count`, `company_id`, `author_id` and every
-  subject column.
+- **`authenticated` has UPDATE on exactly one column of `notes`: `body`.** Notes were
+  append-only until #628; editing was added on the terms this section set in advance —
+  a permissive author-only policy **and** a column-scoped grant. The grant *names* the
+  one editable column rather than *excluding* a list, which is the stronger form: a
+  column added to `notes` next year is non-updatable by default instead of relying on
+  somebody remembering to extend a denylist. `viewer_count` and `usage_count` remain
+  unwritable by any browser role, so setting `viewer_count = 0` and returning later to
+  read the delta is still impossible.
+  - **An edit never resets a note's reach**, and that was the live design question.
+    A reset is superficially fairer — "7 people read this" after a rewrite refers to
+    7 people who read different words — but it is the exact oracle this section
+    exists to deny: an author edits at 9:00, glances at 9:15, and any increment says
+    somebody read it in those fifteen minutes; `note_viewers()` then supplies the
+    name, defeating its no-timestamps rule. It would also not have worked
+    mechanically, since `note_views_bump_counts()` recounts rather than increments
+    and the next read restores the true total. The honesty cost is carried by an
+    `edited_at` column and a "· edited" marker instead.
+  - `edited_at` is **stamped by a `BEFORE UPDATE` trigger and granted to nobody**.
+    The marker is a claim made to other readers, so the one party with a motive to
+    suppress it must not be able to write it. The same trigger refuses any browser
+    UPDATE touching a column other than `body` — a backstop against a future blanket
+    `GRANT`, not against a bad policy. It skips non-browser roles by `current_user`,
+    because `note_views_bump_counts()` legitimately writes the counters as the table
+    owner; without that skip every note read would 500.
+  - `note_counter_write_leaks()` asserts the whole property in CI, so a future
+    `GRANT ALL ON public.notes` fails the build rather than silently re-opening it.
 - `user_company_access` UPDATE/INSERT **are** column-scoped, to
   `(name, role, email, pin_hash)`. Without that, an admin flags everyone-but-one
   with `excluded_from_metrics`, watches whose reads still count, and has a full
@@ -173,6 +193,16 @@ to publishing any count. The design denies every amplifier — no per-job breakd
 no timestamps in the named list, no read timeline, no realtime stream. Jigged staff
 with prod access can read the table as `postgres`; the promise is "your boss cannot
 see this", not "nobody can".
+
+**Second residual, added with #628:** exposing Delete hands an author a crude version
+of the reset that editing deliberately refuses — delete the note, repost it, and the
+copy starts at `viewer_count` 0. That path is not new; RLS has always permitted an
+author to delete their own note, and only the UI was missing. It stays acceptable
+because it is **loud** where an edit-triggered reset would have been silent: the note
+visibly disappears and comes back, loses its reactions and its photos, and jumps to
+the top of the feed. Anyone using it as a polling oracle is doing so in full view of
+everyone reading the same feed. The distinction worth preserving is silence, not
+irreversibility.
 
 ### What comes back to the author
 

--- a/docs/modules/parts.md
+++ b/docs/modules/parts.md
@@ -174,6 +174,15 @@ An **editable, maturity-adaptive workspace** (`PartWorkspace`) — not a read-on
 - **Usage** — jobs and quotes that reference this part.
 - **Files** — engineering attachments (`?tab=files`, always visible).
 - **Activity** — the part Notes + transaction feed (its slug stays `history` for back-compat).
+  A `user` comment is **editable by its author and deletable by its author or a company admin**
+  ([#628](https://github.com/debola31/Jigged/issues/628)); an edited one renders "· edited". Edit is
+  author-only on purpose, asymmetric with delete: an admin who could reword somebody else's comment
+  would change what it says without changing whose name is on it. Auto-logged `pricing` entries are
+  neither editable nor deletable — they are the audit trail, and the RLS policies exclude them by
+  `note_type` rather than trusting the UI to hide the control. `part_comments` also carries a
+  column-scoped `UPDATE (body)` grant and a guard trigger, so an edit cannot reach `author_id` or
+  `note_type`; its legacy blanket `GRANT ALL` (which included `TRUNCATE`) was narrowed in the same
+  migration.
 
 A sticky header shows the part name and a completeness/priceability chip. Delete lives in the header; it **archives** the part (never disabled, never blocked — even when quotes/jobs/BOM parents reference it) and detaches it from other parts' BOMs so their costs recompute. See `docs/architecture.md` §16.
 

--- a/supabase/migrations/20260801012019_notes_editable_body.sql
+++ b/supabase/migrations/20260801012019_notes_editable_body.sql
@@ -1,0 +1,358 @@
+-- Notes become editable and deletable — issue #628.
+--
+-- Until now no note in Jigged could be corrected from the UI on any surface. That
+-- was deliberate: `20260728040701_notes_subjects_and_view_logging.sql:282-289`
+-- revoked UPDATE outright, because a writable viewer_count is a one-bit read
+-- oracle per note and the whole note_views privacy design rests on those counters
+-- being unwritable and monotonic. That same comment wrote down, in advance, what a
+-- safe body edit would need:
+--
+--   "If body editing is ever added it needs BOTH a permissive policy AND a
+--    column-scoped grant that excludes viewer_count, usage_count, company_id,
+--    author_id and every subject column."
+--
+-- This migration is that. It grants exactly one column.
+--
+-- WHAT WAS CONSIDERED AND REJECTED: resetting viewer_count on edit, so a note that
+-- changed would not carry reach earned by its old wording. Three reasons it is not
+-- here, and they are worth writing down because the idea is a natural one.
+--
+--   1. It would not stick. note_views_bump_counts() RECOUNTS rather than
+--      increments (GREATEST over count(DISTINCT viewer_id) across all note_views
+--      rows), so a reset to 0 is undone by the very next read. Making it stick
+--      needs the note_views rows purged, which breaks the ON CONFLICT dedupe — the
+--      same person re-reading then logs a fresh row — and destroys usage_count.
+--   2. A WORKING reset is precisely the oracle this subsystem refuses, assembled
+--      from parts already shipped. my_note_digest() gives an author their running
+--      total and NoteUsageBanner stores the last-acknowledged value client-side and
+--      renders the delta. An author-triggered reset closes the loop: edit at 9:00,
+--      glance at 9:15, and any increment says somebody read it in those fifteen
+--      minutes — then note_viewers() supplies the name. That function is
+--      name-ordered and deliberately carries NO timestamp; a reset would supply the
+--      missing one. Silent, repeatable, available to anyone who can make an account.
+--   3. Monotonicity was never protecting the counter from edits. It protects it
+--      from DIFFERENCING. Editing `body` under a column-scoped grant never goes
+--      near a counter, so the property is untouched.
+--
+-- The honesty cost of editing without a reset — "7 people read this" now refers to
+-- 7 people who read different words — is carried by edited_at and the "· edited"
+-- marker instead. A reset would not have undone the fact that 7 people read the old
+-- text; it would only have stopped reporting it.
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 1. THE MARKER
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Nullable, no default, no backfill. NULL means "never edited", which is the true
+-- state of every existing row — nothing is inconsistent at rest, so this is not the
+-- silent-fallback case CLAUDE.md forbids. A NOT NULL DEFAULT now() would make every
+-- historical note claim to have been edited the day this shipped.
+--
+-- NOT NAMED updated_at, and that is not bikeshedding. This column is a CLAIM MADE
+-- TO OTHER READERS — "this is not what was originally written" — rather than
+-- bookkeeping. Calling it updated_at invites some future generic touch trigger to
+-- set it on writes that are not edits, at which point the marker starts lying.
+
+ALTER TABLE public.notes         ADD COLUMN edited_at timestamptz;
+ALTER TABLE public.part_comments ADD COLUMN edited_at timestamptz;
+
+COMMENT ON COLUMN public.notes.edited_at IS
+  'When the body was last changed by its author. NULL = never edited. Stamped by notes_restrict_update_to_body() and granted to NO browser role: the marker is an integrity claim made to other readers, so the one person who benefits from suppressing it must not be able to write it.';
+COMMENT ON COLUMN public.part_comments.edited_at IS
+  'When the body was last changed by its author. NULL = never edited. Stamped by part_comments_restrict_update_to_body(); not writable by any browser role. See public.notes.edited_at.';
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 2. GRANTS
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Both ACLs are restated from scratch rather than amended, so the whole intended
+-- privilege set for these tables reads in one place. REVOKE must come first, or it
+-- takes the column-scoped UPDATE straight back off again.
+
+-- notes still carried TRUNCATE/REFERENCES/TRIGGER/MAINTAIN for the browser roles:
+-- the 2026-07 REVOKE took only UPDATE, and the 2026-07-16 default-privilege
+-- alignment left those four in the ON TABLES default. TRUNCATE bypasses RLS
+-- entirely. It is unreachable through PostgREST (which exposes no TRUNCATE verb),
+-- so this is not a live hole — but we are rewriting this table's ACL anyway.
+REVOKE ALL ON public.notes FROM anon, authenticated;
+
+-- anon gets nothing at all: RLS denies it every row, and no logged-out surface
+-- reads notes.
+GRANT SELECT, INSERT, DELETE ON public.notes TO authenticated;
+
+-- THE GRANT THE 2026-07 COMMENT ASKED FOR. It NAMES one column rather than
+-- EXCLUDING a list, which is the stronger form: the exclusion is satisfied by
+-- construction, so a column added to `notes` next year is non-updatable by default
+-- instead of needing someone to remember to add it to a denylist.
+--
+-- edited_at is deliberately absent — the trigger in section 4 stamps it.
+GRANT UPDATE (body) ON public.notes TO authenticated;
+
+-- part_comments predates the 2026-07-16 alignment and still carried a blanket
+-- GRANT ALL. That already included UPDATE — so this table's append-only-ness was
+-- UI convention and never enforcement — and TRUNCATE.
+--
+-- This IS the "REVOKE-down-from-ALL" idiom CLAUDE.md warns against, and the warning
+-- does not apply here: that rule addresses NEW tables under the current default,
+-- where nothing was granted in the first place and a REVOKE would be theatre. Here
+-- the privileges genuinely exist, and REVOKE is the only way to remove them.
+REVOKE ALL ON public.part_comments FROM anon, authenticated;
+
+GRANT SELECT, INSERT, DELETE ON public.part_comments TO authenticated;
+GRANT UPDATE (body)          ON public.part_comments TO authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 3. POLICIES
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- AUTHOR ONLY, with no admin branch — deliberately asymmetric with delete, which
+-- keeps its author-or-admin shape below.
+--
+-- An admin who could rewrite somebody else's note could change what it says without
+-- changing who it is attributed to. Deleting is visibly destructive and the author
+-- notices; silently editing under another person's name is neither. This mirrors
+-- notes_insert, which already refuses admin-on-behalf-of authoring for exactly the
+-- same reason (20260728040701:272-274).
+--
+-- note_type appears in BOTH clauses, and both are load-bearing: USING stops an
+-- auto-logged row being selected for edit, WITH CHECK stops note_type from being
+-- the thing you edit it into. (The trigger below refuses that too — defence in
+-- depth, since a policy and a trigger fail for different reasons.)
+
+CREATE POLICY notes_update_body ON public.notes
+    FOR UPDATE TO authenticated
+    USING (
+      company_id IN (SELECT public.get_user_company_ids())
+      AND note_type = 'user'
+      AND author_id = public.get_operator_access_id(company_id)
+    )
+    WITH CHECK (
+      company_id IN (SELECT public.get_user_company_ids())
+      AND note_type = 'user'
+      AND author_id = public.get_operator_access_id(company_id)
+    );
+
+CREATE POLICY part_comments_update_body ON public.part_comments
+    FOR UPDATE TO authenticated
+    USING (
+      company_id IN (SELECT public.get_user_company_ids())
+      AND note_type = 'user'
+      AND author_id = public.get_operator_access_id(company_id)
+    )
+    WITH CHECK (
+      company_id IN (SELECT public.get_user_company_ids())
+      AND note_type = 'user'
+      AND author_id = public.get_operator_access_id(company_id)
+    );
+
+-- DELETE keeps its author-or-admin shape and gains the auto-logged exclusion.
+--
+-- 'event' notes are the order-quantity-change audit trail; 'pricing' part comments
+-- are written automatically on a pricing save. Both stamp the ACTING member as
+-- author_id, so without this clause an author could already delete their own audit
+-- line — a privilege that has never been exercised, because until this PR neither
+-- delete path had a UI caller at all.
+DROP POLICY notes_delete ON public.notes;
+CREATE POLICY notes_delete ON public.notes
+    FOR DELETE TO authenticated
+    USING (
+      note_type = 'user'
+      AND (author_id = public.get_operator_access_id(company_id)
+           OR public.is_company_admin(company_id))
+    );
+
+DROP POLICY part_comments_delete ON public.part_comments;
+CREATE POLICY part_comments_delete ON public.part_comments
+    FOR DELETE TO authenticated
+    USING (
+      note_type = 'user'
+      AND (author_id = public.get_operator_access_id(company_id)
+           OR public.is_company_admin(company_id))
+    );
+
+-- The restrictive billing_gate_update policy already exists on both tables
+-- (apply_billing_write_gate, re-applied at 20260728040701:335-337). Restrictive
+-- policies AND with permissive ones, so a lapsed shop cannot edit and there is
+-- nothing to add here.
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 4. GUARD TRIGGERS
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- THE HAZARD THIS FUNCTION IS SHAPED AROUND, and the reason the role check is the
+-- first statement rather than a nicety:
+--
+--   note_views_bump_counts() (20260728040701:481) is an AFTER INSERT trigger on
+--   note_views that issues `UPDATE public.notes SET viewer_count = …`. A guard that
+--   raised on any viewer_count change would make EVERY NOTE READ throw.
+--
+-- It is SECURITY DEFINER owned by the table owner, so inside it current_user is the
+-- owner and not the PostgREST role — that is the discriminator below. Do not
+-- "simplify" this check away, and do not reason about it via a policy TO clause:
+-- in Supabase postgres is a member of authenticated, so role MEMBERSHIP is the
+-- wrong test. current_user is the right one.
+
+CREATE OR REPLACE FUNCTION public.notes_restrict_update_to_body()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $$
+BEGIN
+  -- ── THE STAMP: every role, no exceptions ────────────────────────────────────
+  -- Deliberately BEFORE the role check below, and that ordering is the whole
+  -- correctness of this function. An earlier draft returned early for non-browser
+  -- roles and stamped afterwards, which meant a body change made by anything other
+  -- than the browser — the backend, an RPC, a future admin tool, a data fix —
+  -- silently did NOT mark the note edited. A marker that is absent when the text
+  -- did change is worse than no marker at all: it is the column asserting "this is
+  -- the original" about text that is not.
+  --
+  -- The property is "a body change is an edit, whoever made it", which has nothing
+  -- to do with which role is trusted to change other columns. Those are two
+  -- separate concerns and they get two separate blocks.
+  --
+  -- SERVER-AUTHORED, overwriting whatever the client sent. The client cannot send
+  -- one today — there is no UPDATE grant on edited_at — but a future widened grant
+  -- must not silently make the marker forgeable by the one party with a motive to
+  -- suppress it.
+  --
+  -- Fires only on an ACTUAL change: re-saving identical text is not an edit, and a
+  -- marker that appears when nothing changed teaches readers to ignore it. This is
+  -- also what makes the stamp a no-op for note_views_bump_counts(), which changes
+  -- the counters and never the body.
+  NEW.edited_at := CASE
+    WHEN NEW.body IS DISTINCT FROM OLD.body THEN now()
+    ELSE OLD.edited_at
+  END;
+
+  -- ── THE COLUMN RESTRICTION: browser roles only ──────────────────────────────
+  -- Counter maintenance runs as the table owner and the FastAPI backend runs as
+  -- service_role; neither is the threat model, and blocking either breaks view
+  -- logging or the backend outright.
+  IF current_user IN ('anon', 'authenticated') THEN
+    -- DIVERGENCE FROM restrict_transaction_update_to_notes() (baseline.sql:1449),
+    -- which enumerates thirteen columns by name. An enumeration is correct only
+    -- until somebody adds a fourteenth — and `notes` has gained subject_kind,
+    -- captured_job_id, corrects_note_id, viewer_count, maintenance_kind and
+    -- resolves_note_id since it was created, so that is not hypothetical here. The
+    -- jsonb diff is complete by construction: a future column is immutable by
+    -- default, which is the direction a mistake should fail in.
+    --
+    -- edited_at is subtracted because we just set it ourselves a few lines up.
+    IF (to_jsonb(OLD) - 'body' - 'edited_at')
+       IS DISTINCT FROM
+       (to_jsonb(NEW) - 'body' - 'edited_at')
+    THEN
+      RAISE EXCEPTION 'Only a note''s body can be edited';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.notes_restrict_update_to_body() IS
+  'Backstop for the column-scoped UPDATE grant on public.notes: refuses any browser UPDATE that changes a column other than body, and stamps edited_at itself. Skips non-browser roles because note_views_bump_counts() legitimately writes viewer_count/usage_count as the table owner — without that skip, every note read throws.';
+
+CREATE TRIGGER notes_restrict_update_to_body_trg
+  BEFORE UPDATE ON public.notes
+  FOR EACH ROW EXECUTE FUNCTION public.notes_restrict_update_to_body();
+
+-- part_comments has no counters and no SECURITY DEFINER writer — nothing legitimate
+-- updates this table from any role — so this one is UNCONDITIONAL. The asymmetry
+-- with notes above is deliberate and load-bearing; do not "make them consistent".
+CREATE OR REPLACE FUNCTION public.part_comments_restrict_update_to_body()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $$
+BEGIN
+  IF (to_jsonb(OLD) - 'body' - 'edited_at')
+     IS DISTINCT FROM
+     (to_jsonb(NEW) - 'body' - 'edited_at')
+  THEN
+    RAISE EXCEPTION 'Only a comment''s body can be edited';
+  END IF;
+
+  NEW.edited_at := CASE
+    WHEN NEW.body IS DISTINCT FROM OLD.body THEN now()
+    ELSE OLD.edited_at
+  END;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.part_comments_restrict_update_to_body() IS
+  'Backstop for the column-scoped UPDATE grant on public.part_comments: refuses any UPDATE that changes a column other than body, and stamps edited_at itself. Unconditional, unlike the notes equivalent — no SECURITY DEFINER writer touches this table.';
+
+CREATE TRIGGER part_comments_restrict_update_to_body_trg
+  BEFORE UPDATE ON public.part_comments
+  FOR EACH ROW EXECUTE FUNCTION public.part_comments_restrict_update_to_body();
+
+-- ── Trigger inventory, checked rather than assumed ────────────────────────────
+-- The jsonb diff above is only safe if nothing else writes these rows on UPDATE.
+-- At the time of writing: `notes` has exactly ONE other trigger,
+-- notes_validate_subject_trg, and `part_comments` has none. Neither table has an
+-- updated_at column, so there is no moddatetime-style touch trigger to collide
+-- with.
+--
+-- THE FORWARD INVARIANT, because this is not obvious: same-level BEFORE ROW
+-- triggers fire in ALPHABETICAL ORDER BY TRIGGER NAME. A touch trigger sorting
+-- before this guard would modify NEW and make the guard reject every legitimate
+-- edit; one sorting after would drift unchecked. Which you got would be a name
+-- collation accident. So: ADDING A TOUCH TRIGGER OR AN updated_at COLUMN TO EITHER
+-- TABLE REQUIRES UPDATING THE EXCLUSION LIST ABOVE. The failure mode is loud (every
+-- edit rejected), not silent, which is the acceptable direction.
+--
+-- notes_validate_subject_trg itself does not interact: it fires only on
+-- UPDATE OF company_id, job_id, part_id, routing_operation_id, work_center_id,
+-- resolves_note_id, maintenance_kind (20260730015344:159-163), and we name only
+-- `body`. Do NOT add `body` to its column list — the guard above already refuses
+-- every column in it.
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 5. THE CI GUARD FOR THE PRIVILEGE THAT MATTERS
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- no_client_access_grant_leaks() (20260728040701:949) covers whole tables that must
+-- be invisible. This is the COLUMN-level sibling, and it is the assertion the entire
+-- design above rests on: a browser role must never be able to write a counter.
+--
+-- has_column_privilege() rather than information_schema.column_privileges, because
+-- it answers for column-level AND table-level grants together — so a future blanket
+-- `GRANT ALL ON public.notes TO authenticated` is caught, not just a careless
+-- column grant. That is the regression this is actually guarding against: blanket
+-- grants are the thing this repo has historically got wrong.
+
+CREATE OR REPLACE FUNCTION public.note_counter_write_leaks()
+RETURNS TABLE(role_name text, column_name text)
+LANGUAGE sql
+STABLE
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT r.rolname::text, c.col::text
+  FROM (VALUES ('anon'), ('authenticated')) AS r(rolname)
+  CROSS JOIN LATERAL (
+    SELECT a.attname AS col
+    FROM pg_attribute a
+    WHERE a.attrelid = 'public.notes'::regclass
+      AND a.attnum > 0
+      AND NOT a.attisdropped
+      -- `body` is the ONE column an author may edit. Everything else — counters,
+      -- tenancy, authorship, every subject column, and edited_at itself — must be
+      -- unwritable. Derived from the catalog rather than listed, so a column added
+      -- later is covered without anyone remembering to add it here.
+      AND a.attname <> 'body'
+  ) AS c
+  WHERE has_column_privilege(r.rolname, 'public.notes'::regclass, c.col, 'UPDATE')
+  ORDER BY 1, 2;
+$$;
+
+COMMENT ON FUNCTION public.note_counter_write_leaks() IS
+  'Lists any browser-role UPDATE privilege on a public.notes column other than `body`. Must always be empty. viewer_count and usage_count are the load-bearing entries: a writable counter is a one-bit read oracle per note (see 20260728040701:282-289 and docs/modules/operator-view.md). A CI test asserts this returns no rows, so a future blanket GRANT fails the build instead of silently reopening the oracle.';
+
+-- FROM PUBLIC, anon, authenticated — not just PUBLIC, which is the idiom used
+-- elsewhere in this schema and does NOT work. The public schema still carries
+-- `ALTER DEFAULT PRIVILEGES ... GRANT ALL ON FUNCTIONS TO anon/authenticated` (the
+-- 2026-07-16 alignment revoked the ON TABLES defaults only), so a new function is
+-- created with an EXPLICIT grant to both browser roles, and REVOKE ... FROM PUBLIC
+-- does not remove an explicit role grant. Tracked as issue #640.
+REVOKE EXECUTE ON FUNCTION public.note_counter_write_leaks()
+  FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.note_counter_write_leaks() TO service_role;

--- a/supabase/migrations/20260801012258_playbook_notes_expose_edited_at.sql
+++ b/supabase/migrations/20260801012258_playbook_notes_expose_edited_at.sql
@@ -1,0 +1,279 @@
+-- part_playbook_notes(): return edited_at, so the Playbook can render "· edited".
+--
+-- Companion to 20260801012019_notes_editable_body.sql (issue #628). The Playbook
+-- sheet is the one note surface that reads through an RPC rather than a PostgREST
+-- select, so the new column has to be threaded through by hand.
+--
+-- WHY THIS IS A DROP AND NOT A CREATE OR REPLACE: the RETURNS TABLE shape changes,
+-- and Postgres will not replace a function whose OUT parameters differ. Same reason
+-- 20260729133520 had to drop it.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- READ THIS BEFORE THE NEXT TIME SOMEBODY DROPS THIS FUNCTION
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- A DROP destroys the function's ACL and its COMMENT along with the body, and
+-- neither comes back with "copy the definition". That already went wrong here:
+--
+--   20260728041800:167-168  set the intended ACL —
+--                             REVOKE EXECUTE ... FROM PUBLIC;
+--                             GRANT  EXECUTE ... TO authenticated;
+--   20260729133520:14       DROPped the function to widen RETURNS TABLE, recreated
+--                           it, and never re-issued either. The ACL reverted to the
+--                           default, and the COMMENT was lost.
+--   20260729161455          used CREATE OR REPLACE, so it inherited that state
+--                           rather than fixing it.
+--
+-- Confirmed on a migration-replayed database: part_playbook_notes' ACL carries the
+-- `=X/postgres` PUBLIC entry that its sibling functions lack. It has been callable
+-- by anon since 2026-07-29.
+--
+-- That is harmless TODAY — the function is SECURITY INVOKER, and anon is a member
+-- of no company, so get_user_company_ids() returns empty and the query yields no
+-- rows. It stops being harmless the moment anyone makes this SECURITY DEFINER.
+--
+-- So this migration re-issues the ACL and the COMMENT below. If you drop this
+-- function again: bring all four of body, attributes, ACL and COMMENT with you.
+
+DROP FUNCTION IF EXISTS public.part_playbook_notes(uuid, uuid, text, uuid, integer);
+
+CREATE OR REPLACE FUNCTION public.part_playbook_notes(
+  p_part_id              uuid,
+  -- The step, when scoping to one. NULL returns everything known about the part.
+  p_routing_operation_id uuid    DEFAULT NULL,
+  -- Legacy step-name fallback, for prior-run job notes whose job_operation has no
+  -- routing_operation_id (an ad-hoc step added to a job). Mirrors the fallback that
+  -- matchingStepOperationIds() used.
+  p_operation_name       text    DEFAULT NULL,
+  -- The current job: its own notes are already in the job feed, so they are not
+  -- "previous" notes.
+  p_exclude_job_id       uuid    DEFAULT NULL,
+  -- Bounds branch 2 only. Branch 1 needs no cap — it is one indexed lookup.
+  p_max_runs             integer DEFAULT 10
+)
+RETURNS TABLE (
+  id                   uuid,
+  body                 text,
+  created_at           timestamptz,
+  -- NEW: NULL unless the author has corrected the wording. The sheet renders a
+  -- quiet "· edited" beside the timestamp, because a reader deciding whether to
+  -- trust a note is entitled to know the text is not the original. No time is
+  -- shown with it — see NoteEditedMark for why.
+  edited_at            timestamptz,
+  note_type            text,
+  subject_kind         text,
+  routing_operation_id uuid,
+  corrects_note_id     uuid,
+  viewer_count         integer,
+  usage_count          integer,
+  -- The reaction UI must not offer a thumbs-up on your own note — RLS forbids it,
+  -- so the button would be a guaranteed 42501. Only an id can decide that; matching
+  -- on author_name breaks the moment a shop has two Daves. Now also decides whether
+  -- to offer Edit and Delete.
+  author_id            uuid,
+  author_name          text,
+  job_number           text,
+  operation_label      text,
+  media                jsonb,
+  reactions            jsonb
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  WITH durable AS (
+    -- BRANCH 1 — the durable subject. One index hit on idx_notes_part_step. No prior
+    -- runs, no step-name heuristic, no cap. This is every note written after the
+    -- subject migration, and it is what makes the read-back loop possible at all.
+    SELECT
+      n.id, n.body, n.created_at, n.edited_at, n.note_type, n.subject_kind,
+      n.routing_operation_id,
+      n.corrects_note_id, n.viewer_count, n.usage_count, n.author_id,
+      cj.job_number AS src_job_number,
+      CASE
+        WHEN ro.id IS NULL THEN NULL
+        ELSE 'Op ' || ro.sequence::text ||
+             COALESCE(' · ' || wc.name, '')
+      END AS src_operation_label
+    FROM public.notes n
+    LEFT JOIN public.jobs cj              ON cj.id = n.captured_job_id
+    LEFT JOIN public.routing_operations ro ON ro.id = n.routing_operation_id
+    LEFT JOIN public.work_centers wc       ON wc.id = ro.work_center_id
+    WHERE n.subject_kind = 'part'
+      AND n.part_id = p_part_id
+      AND (p_routing_operation_id IS NULL
+           OR n.routing_operation_id = p_routing_operation_id)
+      -- Captured on the job the operator is standing in front of: already visible in
+      -- that job's feed, so showing it again as "previous" is noise.
+      AND (p_exclude_job_id IS NULL
+           OR n.captured_job_id IS DISTINCT FROM p_exclude_job_id)
+  ),
+  runs AS (
+    -- BRANCH 2 scaffolding — the most recent completed runs of this part.
+    SELECT jp.job_id, j.job_number
+    FROM public.job_parts jp
+    JOIN public.jobs j ON j.id = jp.job_id
+    WHERE jp.part_id = p_part_id
+      AND jp.production_status = 'completed'
+      AND (p_exclude_job_id IS NULL OR jp.job_id <> p_exclude_job_id)
+    ORDER BY jp.completed_at DESC NULLS LAST
+    LIMIT p_max_runs
+  ),
+  legacy AS (
+    -- BRANCH 2 — pre-migration notes, which are all subject_kind = 'job'. Step match
+    -- by routing_operation_id, falling back to operation_name when the job's step has
+    -- no routing link. Delete this branch once the old corpus stops mattering.
+    SELECT
+      n.id, n.body, n.created_at, n.edited_at, n.note_type, n.subject_kind,
+      n.routing_operation_id,
+      n.corrects_note_id, n.viewer_count, n.usage_count, n.author_id,
+      r.job_number AS src_job_number,
+      CASE
+        WHEN jo.id IS NULL THEN NULL
+        WHEN jo.sequence IS NULL THEN jo.operation_name
+        ELSE 'Op ' || jo.sequence::text || ' · ' || jo.operation_name
+      END AS src_operation_label
+    FROM runs r
+    JOIN public.notes n ON n.job_id = r.job_id AND n.subject_kind = 'job'
+    LEFT JOIN public.job_operations jo ON jo.id = n.job_operation_id
+    WHERE p_routing_operation_id IS NULL
+       OR jo.routing_operation_id = p_routing_operation_id
+       OR (jo.routing_operation_id IS NULL
+           AND p_operation_name IS NOT NULL
+           AND jo.operation_name = p_operation_name)
+  ),
+  combined AS (
+    SELECT * FROM durable
+    UNION ALL
+    SELECT * FROM legacy
+  )
+  SELECT
+    c.id, c.body, c.created_at, c.edited_at, c.note_type, c.subject_kind,
+    c.routing_operation_id,
+    c.corrects_note_id, c.viewer_count, c.usage_count,
+    c.author_id,
+    a.name AS author_name,
+    c.src_job_number,
+    c.src_operation_label,
+    COALESCE(m.media, '[]'::jsonb),
+    COALESCE(rx.reactions, '[]'::jsonb)
+  FROM combined c
+  LEFT JOIN public.user_company_access a ON a.id = c.author_id
+  LEFT JOIN LATERAL (
+    SELECT jsonb_agg(jsonb_build_object(
+             'id', md.id,
+             'storage_path', md.storage_path,
+             'thumbnail_path', md.thumbnail_path,
+             'kind', md.kind,
+             'mime_type', md.mime_type,
+             'width', md.width,
+             'height', md.height
+           ) ORDER BY md.created_at) AS media
+    FROM public.note_media md
+    WHERE md.note_id = c.id
+  ) m ON true
+  LEFT JOIN LATERAL (
+    -- Reactions embed here because they are PUBLIC within the shop — the deliberate
+    -- opposite of note_views, which has no read path at any level. Names and counts
+    -- both derive from this one array client-side, so the number and the names can
+    -- never disagree; that is why there is no denormalized reaction counter.
+    SELECT jsonb_agg(jsonb_build_object(
+             'kind', x.kind,
+             -- WITHOUT THIS the reader can never be found in the array, so the
+             -- thumbs-up renders un-pressed on a note they have already marked
+             -- helpful, and tapping it again just re-inserts a duplicate. The
+             -- reaction was persisting the whole time; it simply could not be
+             -- recognised as theirs. Costs nothing extra: the join is already here.
+             'reactor_id', x.reactor_id,
+             'name', u.name,
+             'created_at', x.created_at
+           )) AS reactions,
+           count(*) FILTER (WHERE x.kind = 'helpful') AS helpful_count
+    FROM public.note_reactions x
+    JOIN public.user_company_access u ON u.id = x.reactor_id
+    WHERE x.note_id = c.id
+  ) rx ON true
+  -- RANKING: the load-bearing note first, EXCEPT that nothing recent gets buried.
+  --
+  -- Newest-first was safe but wrong on a part with several notes: the one that has
+  -- actually been consulted on eleven jobs could sit fourth, below three that were
+  -- read once out of curiosity. Ranking by usefulness fixes that.
+  --
+  -- The recency guard is not a nicety. Pure usefulness ranking sinks a note written
+  -- this morning about a changed fixture below an old note with a long history —
+  -- and on a shop floor the fresh correction is the one that must be seen. The
+  -- original plan solved this with a 'confirmed' reaction and visual decay of stale
+  -- entries; both were dropped, so the guard carries that weight alone.
+  --
+  -- 14 days is a judgement, not a finding: long enough to cover a part that runs
+  -- monthly, short enough that the pinned group stays small. Worth revisiting with
+  -- real data.
+  --
+  -- DELIBERATELY ORDERS ON created_at, NEVER edited_at. Now that notes are editable
+  -- (#628), ordering on edited_at would let a one-character typo fix bump a note
+  -- back into the recent group ahead of genuinely new knowledge — a free way to
+  -- re-pin your own note to the top of everyone's Playbook. "Recent" here means
+  -- recently WRITTEN, which is the claim the guard is actually making.
+  ORDER BY
+    (c.created_at >= now() - interval '14 days') DESC,
+    -- Within the recent group, newest first. NULL for older notes, which the first
+    -- key has already partitioned below, so they tie here and fall through.
+    CASE WHEN c.created_at >= now() - interval '14 days' THEN c.created_at END DESC,
+    -- Distinct JOBS it was consulted on: behavioural, and the strongest signal we
+    -- have. It beats helpful because it records someone reaching for the note while
+    -- doing the work, not an opinion offered afterwards.
+    c.usage_count DESC,
+    COALESCE(rx.helpful_count, 0) DESC,
+    c.created_at DESC;
+$$;
+
+COMMENT ON FUNCTION public.part_playbook_notes(uuid, uuid, text, uuid, integer) IS
+  'Everything known about running this part (optionally scoped to one routing step), ranked by usefulness with a 14-day recency guard, in one round trip. Unions durable part-subject notes (a single index hit) with legacy job-scoped notes from recent completed runs. Returns author_id as well as author_name so the UI can suppress the thumbs-up on the reader''s own notes (RLS forbids self-reaction) and offer Edit/Delete only on them, and edited_at so a corrected note renders "· edited". Orders on created_at and never edited_at, so a typo fix cannot re-pin a note to the top. SECURITY INVOKER so notes/jobs/job_parts RLS still enforces tenancy.';
+
+-- RESTORING the ACL that 20260728041800 intended and the 2026-07-29 DROP destroyed.
+--
+-- `FROM PUBLIC, anon` rather than `FROM PUBLIC` alone: the schema still carries
+-- ALTER DEFAULT PRIVILEGES ... GRANT ALL ON FUNCTIONS TO anon/authenticated, so the
+-- CREATE above lands with an EXPLICIT anon grant that a REVOKE FROM PUBLIC would
+-- leave in place. The original migration had that same gap, which is why the goal
+-- here is the ACL that migration INTENDED rather than the one it produced. The
+-- general fix is tracked as issue #640.
+REVOKE EXECUTE ON FUNCTION public.part_playbook_notes(uuid, uuid, text, uuid, integer)
+  FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.part_playbook_notes(uuid, uuid, text, uuid, integer)
+  TO authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- THE DURABLE HALF: a CI guard, because the repair above only fixes TODAY
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Restoring the ACL is worth little on its own — the last DROP destroyed it
+-- silently and nothing noticed for three days, because an OVER-granted function
+-- breaks nothing you would ever see. Only a test catches that class of mistake.
+--
+-- Same idiom as no_client_access_grant_leaks() and note_counter_write_leaks():
+-- returns rows only when something is wrong, and a pytest asserts it is empty.
+
+CREATE OR REPLACE FUNCTION public.playbook_rpc_execute_leaks()
+RETURNS TABLE(role_name text)
+LANGUAGE sql
+STABLE
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  -- `authenticated` is SUPPOSED to hold EXECUTE and is deliberately not listed.
+  -- anon is the one that must never: the function is SECURITY INVOKER today, so
+  -- anon getting nothing back is a property of RLS rather than of the ACL, and
+  -- the ACL is the layer that would still hold if that ever changed.
+  SELECT r.rolname::text
+  FROM (VALUES ('anon')) AS r(rolname)
+  WHERE has_function_privilege(
+          r.rolname,
+          'public.part_playbook_notes(uuid, uuid, text, uuid, integer)',
+          'EXECUTE');
+$$;
+
+COMMENT ON FUNCTION public.playbook_rpc_execute_leaks() IS
+  'Lists browser roles that hold EXECUTE on part_playbook_notes but should not (anon). Must always be empty. Exists because a DROP FUNCTION destroys a function''s ACL, which already happened once (20260729133520) and shipped the Playbook RPC anon-executable for three days without any visible symptom. See issue #640 for the wider case: the ON FUNCTIONS default privileges were never revoked, so REVOKE ... FROM PUBLIC alone does not close a function.';
+
+REVOKE EXECUTE ON FUNCTION public.playbook_rpc_execute_leaks()
+  FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.playbook_rpc_execute_leaks() TO service_role;

--- a/types/database.ts
+++ b/types/database.ts
@@ -1489,6 +1489,7 @@ export type Database = {
           company_id: string
           corrects_note_id: string | null
           created_at: string
+          edited_at: string | null
           id: string
           job_id: string | null
           job_operation_id: string | null
@@ -1511,6 +1512,7 @@ export type Database = {
           company_id: string
           corrects_note_id?: string | null
           created_at?: string
+          edited_at?: string | null
           id?: string
           job_id?: string | null
           job_operation_id?: string | null
@@ -1533,6 +1535,7 @@ export type Database = {
           company_id?: string
           corrects_note_id?: string | null
           created_at?: string
+          edited_at?: string | null
           id?: string
           job_id?: string | null
           job_operation_id?: string | null
@@ -1743,6 +1746,7 @@ export type Database = {
           body: string
           company_id: string
           created_at: string
+          edited_at: string | null
           id: string
           note_type: string
           part_id: string
@@ -1752,6 +1756,7 @@ export type Database = {
           body: string
           company_id: string
           created_at?: string
+          edited_at?: string | null
           id?: string
           note_type?: string
           part_id: string
@@ -1761,6 +1766,7 @@ export type Database = {
           body?: string
           company_id?: string
           created_at?: string
+          edited_at?: string | null
           id?: string
           note_type?: string
           part_id?: string
@@ -3592,6 +3598,13 @@ export type Database = {
           stored_viewers: number
         }[]
       }
+      note_counter_write_leaks: {
+        Args: never
+        Returns: {
+          column_name: string
+          role_name: string
+        }[]
+      }
       note_viewers: {
         Args: { p_note_id: string }
         Returns: {
@@ -3613,6 +3626,7 @@ export type Database = {
           body: string
           corrects_note_id: string
           created_at: string
+          edited_at: string
           id: string
           job_number: string
           media: Json

--- a/types/database.ts
+++ b/types/database.ts
@@ -3647,6 +3647,12 @@ export type Database = {
           quotes_count: number
         }[]
       }
+      playbook_rpc_execute_leaks: {
+        Args: never
+        Returns: {
+          role_name: string
+        }[]
+      }
       reset_demo_company: {
         Args: { p_source_company_id: string; p_user_id: string }
         Returns: undefined

--- a/types/machineMaintenance.ts
+++ b/types/machineMaintenance.ts
@@ -47,10 +47,20 @@ export interface MachineNote {
   /** Set when this entry is the fix for an earlier 'noticed' one on this machine. */
   resolves_note_id: string | null;
   created_at: string;
+  /**
+   * When the author last changed the body; null means never edited (#628).
+   *
+   * Only the BODY is editable — `maintenance_kind` and `resolves_note_id` are
+   * immutable under the guard trigger, so an author can fix the wording of what
+   * they noticed but can never un-notice it or re-point a fix at a different item.
+   * That is what keeps the derived-open list (§4.4) trustworthy.
+   */
+  edited_at: string | null;
   author_name: string | null;
   /**
    * Author's user_company_access id. Needed because reacting to your own note is
    * refused by RLS, so the control has to be hidden there rather than fail on tap.
+   * Also decides whether Edit (author only) and Delete (author or admin) show.
    */
   author_id: string | null;
   /**

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -261,6 +261,15 @@ export interface JobNote {
    */
   note_type: 'user' | 'event';
   created_at: string;
+  /**
+   * When the author last changed the body; null means never edited (#628).
+   *
+   * NEVER written by the client — `notes.edited_at` carries no UPDATE grant, and
+   * the database stamps it in a BEFORE UPDATE trigger. It is a claim made to other
+   * readers that the text is not the original, so the one party with a motive to
+   * suppress it must not be able to.
+   */
+  edited_at: string | null;
   /** Author display name (from user_company_access.name); null if unknown. */
   author_name: string | null;
   /**
@@ -268,6 +277,9 @@ export interface JobNote {
    * forbids reacting to your OWN note, so the thumbs-up must be hidden there —
    * otherwise the tap is a guaranteed 42501 that reads as a broken button.
    * Matching on author_name instead breaks on two people with the same name.
+   *
+   * Also decides whether Edit and Delete are offered: edit is author-only, delete
+   * is author-or-admin (#628).
    */
   author_id: string | null;
   /**
@@ -353,6 +365,11 @@ export interface MyNote {
   id: string;
   body: string | null;
   created_at: string;
+  /**
+   * When the author last changed the body; null means never edited (#628).
+   * Server-stamped, never client-written. See JobNote.edited_at.
+   */
+  edited_at: string | null;
   /** "Op 20 · Mill" when the note carries a step, else null. */
   operation_label: string | null;
   /** Part the note is durably attached to, when it has one. */

--- a/types/part.ts
+++ b/types/part.ts
@@ -62,6 +62,13 @@ export interface PartNote {
   part_id: string;
   body: string;
   created_at: string;
+  /**
+   * When the author last changed the body; null means never edited (#628).
+   * Server-stamped by a BEFORE UPDATE trigger, never client-written — the column
+   * carries no UPDATE grant. Only `note_type: 'user'` comments are editable;
+   * 'pricing' entries are an audit trail.
+   */
+  edited_at: string | null;
   author_id: string | null;
   author_name: string | null;
   note_type: PartNoteType;

--- a/utils/machineMaintenanceAccess.ts
+++ b/utils/machineMaintenanceAccess.ts
@@ -31,7 +31,7 @@ import type {
 // is a stronger guarantee than remembering not to render it.
 const MACHINE_NOTE_SELECT =
   'id, work_center_id, body, maintenance_kind, resolves_note_id, ' +
-  'created_at, viewer_count, author_id, ' +
+  'created_at, edited_at, viewer_count, author_id, ' +
   'author:user_company_access(name), ' +
   'reactions:note_reactions(kind, reactor_id, reactor:user_company_access(name)), ' +
   'media:note_media(id, note_id, storage_path, thumbnail_path, kind, mime_type, width, height)';
@@ -45,6 +45,7 @@ type MachineNoteRow = {
   maintenance_kind: string | null;
   resolves_note_id: string | null;
   created_at: string;
+  edited_at: string | null;
   viewer_count: number;
   author_id: string | null;
   author: { name: string | null } | { name: string | null }[] | null;
@@ -87,6 +88,7 @@ function rowToNote(row: MachineNoteRow): MachineNote {
     maintenance_kind: narrowKind(row.maintenance_kind),
     resolves_note_id: row.resolves_note_id,
     created_at: row.created_at,
+    edited_at: row.edited_at,
     author_name: author?.name ?? null,
     author_id: row.author_id,
     viewer_count: row.viewer_count,

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -55,6 +55,13 @@ export async function getCurrentMember(companyId: string): Promise<{
   id: string;
   name: string | null;
   user_id: string;
+  /**
+   * The caller's role in THIS company. Selected here rather than through a second
+   * query because every note surface already calls this to resolve `id`, and
+   * delete gating needs author-or-admin (#628). `useUserRole` would issue a second
+   * round trip for a value that is on the row we are already fetching.
+   */
+  role: string | null;
 } | null> {
   const supabase = getSupabase();
 
@@ -63,7 +70,7 @@ export async function getCurrentMember(companyId: string): Promise<{
 
   const { data: member } = await supabase
     .from('user_company_access')
-    .select('id, name, user_id')
+    .select('id, name, user_id, role')
     .eq('user_id', session.user.id)
     .eq('company_id', companyId)
     .single();
@@ -1298,7 +1305,7 @@ export async function getJobPartsOverview(
 const JOB_NOTE_SELECT =
   'id, subject_kind, job_id, job_operation_id, captured_job_id, ' +
   'captured_job_operation_id, part_id, routing_operation_id, ' +
-  'viewer_count, usage_count, body, note_type, created_at, ' +
+  'viewer_count, usage_count, body, note_type, created_at, edited_at, ' +
   'author_id, author:user_company_access(name), ' +
   // Reactions embed because they are PUBLIC within the shop — the deliberate
   // opposite of note_views, which has no client read path at any level. Count and
@@ -1351,6 +1358,7 @@ type JobNoteRow = {
   body: string | null;
   note_type: string | null;
   created_at: string;
+  edited_at: string | null;
   author_id: string | null;
   author: { name: string | null } | { name: string | null }[] | null;
   reactions: ReactionRel[] | null;
@@ -1402,6 +1410,7 @@ function mapJobNoteRow(n: JobNoteRow): JobNote {
     body: n.body,
     note_type: n.note_type === 'event' ? 'event' : 'user',
     created_at: n.created_at,
+    edited_at: n.edited_at,
     author_name: author?.name ?? null,
     subject_kind: n.subject_kind === 'part' || n.subject_kind === 'work_center'
       ? n.subject_kind
@@ -1558,6 +1567,60 @@ export async function addJobNote(
   return mapJobNoteRow(data as unknown as JobNoteRow);
 }
 
+/**
+ * Edit the body of a note you wrote (#628).
+ *
+ * ONE function for every `notes` surface. The job feed, the Playbook sheet, My work
+ * and the machine logbook are four READ shapes over one table; a second update
+ * function would be a second place for the blank-body rule to drift out of step.
+ *
+ * WHAT THIS CANNOT DO, and it is structural rather than a convention here: the
+ * browser holds `GRANT UPDATE (body)` and nothing else, so `viewer_count`,
+ * `usage_count`, `author_id`, `note_type`, `maintenance_kind`, `resolves_note_id`
+ * and every subject column are unwritable — not merely "not written by this
+ * function". Editing therefore NEVER resets a note's reach. That is deliberate:
+ * a resettable counter would hand an author a timed read-oracle on their own notes
+ * (see the migration header and docs/modules/operator-view.md). The honesty cost of
+ * keeping the count is carried by `edited_at` and the "· edited" marker instead.
+ *
+ * `edited_at` is likewise absent from the payload — the database stamps it in a
+ * BEFORE UPDATE trigger, and only when the body actually changed, so a no-op
+ * re-save leaves the note unmarked.
+ *
+ * `body` may be null for a media-only note (the `notes_body_blank_or_null` CHECK
+ * permits NULL but not blank), so blank normalises to null here. Callers must
+ * refuse an empty body on a note with no media — an empty note is a delete, and
+ * the UI offers that instead.
+ *
+ * Returns only the two columns that can have changed. Every caller already holds
+ * the note it is editing, so patching `{ body, edited_at }` into it is cheaper and
+ * less error-prone than re-selecting one of four different embed shapes here.
+ */
+export async function updateNoteBody(
+  noteId: string,
+  body: string | null,
+): Promise<{ body: string | null; edited_at: string | null }> {
+  const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from('notes')
+    .update({ body: body?.trim() || null })
+    .eq('id', noteId)
+    .select('body, edited_at')
+    .single();
+
+  if (error) {
+    throw new Error(
+      friendlyErrorMessage(error, {
+        entity: 'note',
+        fallback: 'Could not save that change.',
+      }),
+    );
+  }
+
+  return data as { body: string | null; edited_at: string | null };
+}
+
 /** Resolve a step's identity for the RPC's legacy step-name fallback. */
 async function getStepIdentity(
   jobOperationId: string,
@@ -1575,6 +1638,7 @@ type PlaybookRow = {
   id: string;
   body: string | null;
   created_at: string;
+  edited_at: string | null;
   note_type: string | null;
   subject_kind: string;
   routing_operation_id: string | null;
@@ -1679,6 +1743,7 @@ export async function getPartPreviousNotes(
     body: r.body,
     note_type: r.note_type === 'event' ? 'event' : 'user',
     created_at: r.created_at,
+    edited_at: r.edited_at,
     author_name: r.author_name,
     author_id: r.author_id,
     reactions: mapReactions(r.reactions),
@@ -1728,7 +1793,7 @@ export async function getMyContribution(companyId: string): Promise<MyContributi
   const { data, error } = await supabase
     .from('notes')
     .select(
-      'id, body, created_at, viewer_count, usage_count, ' +
+      'id, body, created_at, edited_at, viewer_count, usage_count, ' +
         'operation:job_operations!notes_job_operation_fk(operation_name, sequence), ' +
         'captured_operation:job_operations!notes_captured_job_operation_fk(operation_name, sequence), ' +
         'part:parts(part_name), ' +
@@ -1754,6 +1819,7 @@ export async function getMyContribution(companyId: string): Promise<MyContributi
     id: string;
     body: string | null;
     created_at: string;
+    edited_at: string | null;
     viewer_count: number;
     usage_count: number;
     operation: StepRel;
@@ -1775,6 +1841,7 @@ export async function getMyContribution(companyId: string): Promise<MyContributi
       id: r.id,
       body: r.body,
       created_at: r.created_at,
+      edited_at: r.edited_at,
       job_id: job?.id ?? null,
       job_number: job?.job_number ?? null,
       // A durable part-subject note has no step of its own; the step it was

--- a/utils/partsAccess.ts
+++ b/utils/partsAccess.ts
@@ -1717,6 +1717,38 @@ export async function getPartTransactions(
 // PART NOTES + ACTIVITY FEED
 // ============================================================
 
+// One read shape for every part_comments path (read, insert, update). Hoisted when
+// editing arrived and made it a third copy — mirrors JOB_NOTE_SELECT in
+// operatorAccess and MACHINE_NOTE_SELECT in machineMaintenanceAccess.
+const PART_COMMENT_SELECT =
+  'id, part_id, body, created_at, edited_at, author_id, note_type, ' +
+  'author:user_company_access(name)';
+
+type PartCommentRow = {
+  id: string;
+  part_id: string;
+  body: string;
+  created_at: string;
+  edited_at: string | null;
+  author_id: string | null;
+  note_type: string;
+  author: { name: string | null } | { name: string | null }[] | null;
+};
+
+function mapPartCommentRow(n: PartCommentRow): PartNote {
+  const author = Array.isArray(n.author) ? n.author[0] : n.author;
+  return {
+    id: n.id,
+    part_id: n.part_id,
+    body: n.body,
+    created_at: n.created_at,
+    edited_at: n.edited_at,
+    author_id: n.author_id,
+    author_name: author?.name ?? null,
+    note_type: (n.note_type as PartNoteType) ?? 'user',
+  };
+}
+
 /**
  * Notes on a part, newest-first. Mirrors getJobNotes (operatorAccess).
  */
@@ -1725,7 +1757,7 @@ export async function getPartNotes(partId: string, companyId: string): Promise<P
 
   const { data, error } = await supabase
     .from('part_comments')
-    .select('id, part_id, body, created_at, author_id, note_type, author:user_company_access(name)')
+    .select(PART_COMMENT_SELECT)
     .eq('part_id', partId)
     .eq('company_id', companyId)
     .order('created_at', { ascending: false });
@@ -1735,28 +1767,7 @@ export async function getPartNotes(partId: string, companyId: string): Promise<P
     throw error;
   }
 
-  type NoteRow = {
-    id: string;
-    part_id: string;
-    body: string;
-    created_at: string;
-    author_id: string | null;
-    note_type: string;
-    author: { name: string | null } | { name: string | null }[] | null;
-  };
-
-  return ((data ?? []) as NoteRow[]).map((n) => {
-    const author = Array.isArray(n.author) ? n.author[0] : n.author;
-    return {
-      id: n.id,
-      part_id: n.part_id,
-      body: n.body,
-      created_at: n.created_at,
-      author_id: n.author_id,
-      author_name: author?.name ?? null,
-      note_type: (n.note_type as PartNoteType) ?? 'user',
-    };
-  });
+  return ((data ?? []) as unknown as PartCommentRow[]).map(mapPartCommentRow);
 }
 
 /**
@@ -1786,7 +1797,7 @@ export async function addPartNote(
       body: trimmed,
       note_type: noteType,
     })
-    .select('id, part_id, body, created_at, author_id, note_type, author:user_company_access(name)')
+    .select(PART_COMMENT_SELECT)
     .single();
 
   if (error) {
@@ -1794,26 +1805,40 @@ export async function addPartNote(
     throw error;
   }
 
-  type NoteRow = {
-    id: string;
-    part_id: string;
-    body: string;
-    created_at: string;
-    author_id: string | null;
-    note_type: string;
-    author: { name: string | null } | { name: string | null }[] | null;
-  };
-  const n = data as NoteRow;
-  const author = Array.isArray(n.author) ? n.author[0] : n.author;
-  return {
-    id: n.id,
-    part_id: n.part_id,
-    body: n.body,
-    created_at: n.created_at,
-    author_id: n.author_id,
-    author_name: author?.name ?? null,
-    note_type: (n.note_type as PartNoteType) ?? 'user',
-  };
+  return mapPartCommentRow(data as unknown as PartCommentRow);
+}
+
+/**
+ * Edit the body of a part comment you wrote (#628).
+ *
+ * RLS restricts this to the author and to `note_type = 'user'`; the column-scoped
+ * grant restricts it to `body`, and a BEFORE UPDATE trigger stamps `edited_at`.
+ * So an auto-logged 'pricing' entry is not editable, and nothing here can change
+ * authorship or type — the audit trail stays an audit trail.
+ *
+ * Blank is refused before the round trip. Unlike a job/machine note, a part comment
+ * has no media, so an empty one has nothing left to be: `part_comments_body_not_blank`
+ * requires a non-blank NOT NULL body unconditionally.
+ */
+export async function updatePartNote(noteId: string, body: string): Promise<PartNote> {
+  const supabase = getSupabase();
+
+  const trimmed = body.trim();
+  if (!trimmed) throw new Error('Comment cannot be empty.');
+
+  const { data, error } = await supabase
+    .from('part_comments')
+    .update({ body: trimmed })
+    .eq('id', noteId)
+    .select(PART_COMMENT_SELECT)
+    .single();
+
+  if (error) {
+    console.error('Error updating part note:', error);
+    throw error;
+  }
+
+  return mapPartCommentRow(data as unknown as PartCommentRow);
 }
 
 /**


### PR DESCRIPTION
Closes #628.

No note in Jigged could be edited, corrected or deleted from the UI on any surface — job notes, the operator traveler, the part Playbook, the machine log or the office part Activity tab. The complaint arrived against the machine maintenance log but the gap was product-wide.

**Author-only edit, unrestricted in time. Author-or-admin delete. All five surfaces in one PR**, because shipping one module would have made those notes the only editable ones in the product — worse than either consistent state.

## The design question, and how it resolved

The proposal was unrestricted editing **plus resetting `viewer_count` on edit**, so a reworded note would not carry reach earned by its old text. The editing half is safe; the reset is the half that breaks the design:

1. **It would not stick.** `note_views_bump_counts()` recounts rather than increments (`GREATEST` over `count(DISTINCT viewer_id)`), so the next read restores the true total. Making it stick would mean purging `note_views` rows, which breaks the `ON CONFLICT` dedupe — the same person re-reading then logs a fresh row — and destroys `usage_count`.
2. **A working reset is the exact oracle this subsystem refuses**, assembled from parts already shipped. `my_note_digest()` gives an author a running total and `NoteUsageBanner` renders the client-side delta. Edit at 9:00, glance at 9:15, and any increment says somebody read it in those fifteen minutes — then `note_viewers()` supplies the name, defeating its deliberate no-timestamps rule. Silent, repeatable, available to anyone who can create an account.
3. **Monotonicity was never protecting the counter from edits** — it protects it from *differencing*. Editing `body` under a column-scoped grant never goes near a counter.

The honesty cost — "7 people read this" now refers to 7 people who read different words — is carried by `edited_at` and a quiet "· edited" instead. A reset would not have undone the fact that 7 people read the old text; it would only have stopped reporting it.

I also went looking for a second written argument against editing and there isn't one. `NoteReactions`' *"corrected, never publicly judged"* is about the absent thumbs-down, not about edits.

## Enforcement — three layers, each independently asserted

- **`GRANT UPDATE (body)`** — *names* the one editable column rather than *excluding* a list, so a column added next year is immutable by default. Column privileges are checked by the executor before RLS, which puts this outside the failure mode the original migration named: a future careless permissive policy cannot make a counter writable.
- **Author-only permissive policy**, excluding auto-logged `note_type` in both `USING` and `WITH CHECK`. No admin branch — deliberately asymmetric with delete, because an admin who could reword someone else's note would change what it says without changing whose name is on it.
- **A `BEFORE UPDATE` guard trigger** that refuses any other column and stamps `edited_at` itself. Uses a `to_jsonb` diff rather than the thirteen-column enumeration in `restrict_transaction_update_to_notes()`, because an enumeration is correct only until somebody adds a fourteenth — and `notes` has gained six since it was created.

### The trap this migration is shaped around

`note_views_bump_counts()` UPDATEs `notes.viewer_count` from an `AFTER INSERT` trigger on `note_views`, running `SECURITY DEFINER` as the table owner. A guard that raised on any counter change would make **every note read 500** — a total outage of the read path, from a trigger that looks like it only concerns editing. The guard early-returns on `current_user`, and `test_view_logging_still_works_with_the_guard_trigger_installed` exists so a future "simplification" fails the build.

An earlier draft of that function returned early *before* stamping `edited_at`, which meant any non-browser edit path would silently fail to mark the note. Caught by running it; the stamp now applies to every role and only the column restriction is browser-scoped.

## Two pre-existing defects fixed in passing

Both were found while verifying this work, and both live in objects this PR already rewrites.

- **`part_playbook_notes` has been `anon`-executable since 2026-07-29.** `20260728041800` set `REVOKE … FROM PUBLIC` / `GRANT … TO authenticated`; `20260729133520` then `DROP FUNCTION`ed it to widen `RETURNS TABLE` and never re-issued either — a dropped function's ACL is destroyed. Harmless (`SECURITY INVOKER`, and `anon` is a member of nothing) but *invisible*, because over-granting breaks nothing you would ever notice. Restored, and `playbook_rpc_execute_leaks()` now asserts it so the next `DROP` fails the build instead of shipping quietly.
- **`notes` and `part_comments` still granted `TRUNCATE`** to browser roles, which bypasses RLS. Unreachable through PostgREST, narrowed anyway since both ACLs are being rewritten.

## Filed separately: #640

The `ON FUNCTIONS` default privileges were never revoked, so every function a migration creates lands with an **explicit** `EXECUTE` grant to `anon`/`authenticated` — meaning `REVOKE … FROM PUBLIC` does not close a function, and eight migrations assume it does. I verified each affected function and **none currently leaks anything**, so it is a latent hazard rather than a live breach and did not belong in this PR. Every `REVOKE` written here names roles explicitly.

## Interaction design

- **Operator surfaces** (job feed, Playbook, machine log) get one 48px kebab → Edit / Delete. Those headers already carry author + step chip + timestamp and already wrap at 375px; two more 48px targets push every note's header onto a third line. MUI `MenuItem`s clear 48px, so the touch floor is met at the point of *choice*.
- **Office surface** (part Activity) keeps the trash icon **at rest** per `docs/interaction-standards.md`, with an edit icon beside it and delete rightmost. Burying delete in a kebab would have regressed an explicitly-argued rule.
- **"· edited" carries no timestamp and no tooltip.** A tooltip is invisible on a phone, and "when exactly did they change it" is a per-person audit question this product declines elsewhere.
- **Delete gets a confirmation dialog** on every surface — these are hard deletes with no `deleted_at` and no restore. The part Activity tab previously deleted a comment on a single click with **no confirmation at all**; that pre-existing gap is closed here.
- **Photo removal is deferred to Save**, marked with an Undo, never applied on tap — otherwise Cancel is a lie for photos and a mis-tap irreversibly destroys a storage object. Adding photos stays out of scope: uploads are the part that dies mid-flight on cellular and needs progress, retry and orphan cleanup.
- Machine log: deleting a resolver returns its item to **Needs attention** (open is *derived*, not stored), and the dialog says so before the fact.

## Verification

- `tsc --noEmit` clean; `pnpm lint` 0 errors and **no new warnings** (17 → 16; the one my dialog introduced was fixed by keying the mount).
- **Vitest: 125 files, 1555 tests passing**, including a new `NoteEditDialog` suite and gating tests asserting no controls on someone else's note, none on `note_type: 'event'`, none in read-only, and Delete-but-not-Edit for an admin.
- The security assertion — `expect(Object.keys(payload)).toEqual(['body'])` — was **proven able to fail**: sabotaging `updateNoteBody` to send `viewer_count` produced `expected [ 'body', 'viewer_count' ] to deeply equal [ 'body' ]`.
- **Migrations validated against a real database**, in rolled-back transactions so the shared local stack was never mutated: `body` is the only browser-updatable column, `anon` is off both tables, TRUNCATE is gone, `part_playbook_notes` comes back `{postgres, authenticated, service_role}` with no PUBLIC entry, and both leak-guards return zero rows.
- **RLS validated by impersonating each actor's JWT** (`SET ROLE authenticated` + `request.jwt.claims`): author edits, colleague refused, admin refused on edit but permitted on delete, auto-logged rows immutable and undeletable.
- `types/database.ts` regenerated from a **clean replay of all 77 migrations** into a throwaway database — not from the shared stack, which turned out to hold the primary checkout's unmerged `feature/inventory-phase-2` migrations and would have polluted the diff. The `graphql_public` block was spliced back per the CLAUDE.md caveat; the final diff contains only `edited_at` ×6, `note_counter_write_leaks`, and `edited_at` in the RPC's `Returns`.

**Not run locally: the ~18 new pytest integration tests.** They need PostgREST in front of a database carrying these migrations, which from a worktree would mean mutating the machine-wide shared stack. They collect cleanly (70 tests) and the properties they assert were each validated directly via psql as described above, but CI on this PR is their first real execution. Backend unit suite: 217 passing.

E2E deliberately skipped — no spec covers these surfaces, and a new one would need `e2e/global-setup.ts` extended to seed a note with a known author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
