### PR TITLE
fix(db): make REVOKE EXECUTE ... FROM PUBLIC actually close a function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,29 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON public.your_table TO service_role;
 
 **Symptom of a missing grant:** PostgREST returns `42501 permission denied`, and its error hint names the grant to add. Because local now matches prod, this fails in dev rather than only in production.
 
+### Function EXECUTE grants (new functions in `public`)
+
+**A new function is browser-callable unless you revoke it.** Postgres grants `EXECUTE` to `PUBLIC` on every function it creates, and `authenticated` is a member of `PUBLIC`. So a `SECURITY DEFINER` helper you intend as backend-only is reachable from the browser the moment it exists — and because that function bypasses RLS by definition, the grant is the *only* thing between a caller and the data.
+
+To make one service-role-only, **name the roles**:
+
+```sql
+REVOKE EXECUTE ON FUNCTION public.your_function(uuid) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.your_function(uuid) TO service_role;
+```
+
+**Why the roles are named explicitly**, when `FROM PUBLIC` looks sufficient: until [`20260801024552`](supabase/migrations/20260801024552_revoke_function_execute_from_browser_roles.sql) the schema also carried `ALTER DEFAULT PRIVILEGES ... GRANT ALL ON FUNCTIONS TO anon, authenticated`, so every new function landed with **explicit** browser grants on top of PUBLIC's. `REVOKE ... FROM PUBLIC` removed only PUBLIC's and left the rest, which meant eight migrations claimed "service-role only" in their comments and none of them were ([#640](https://github.com/debola31/Jigged/issues/640)). That default is now revoked, so `FROM PUBLIC` alone *is* enough today — the explicit form is kept because it is correct under either state and costs nothing.
+
+Three cases need **no** grant at all, and revoking from them is free:
+
+- **Trigger functions** — permission is checked when the trigger is created, not each time it fires.
+- **Event-trigger functions** — same.
+- **Helpers called only from `SECURITY DEFINER` parents** — the parent body runs as the function owner, so the caller's privileges are irrelevant.
+
+Both non-obvious claims above are asserted behaviourally in [`test_function_execute_grants.py`](api/tests/integration/test_function_execute_grants.py), because getting them wrong breaks writes in production rather than failing loudly.
+
+**Enforced in CI:** `function_execute_leaks()` lists any `SECURITY DEFINER` function in `public` a browser role can execute that is not on its reviewed allowlist, and a test asserts it is empty. Adding a function to that allowlist should come with a sentence in the PR saying why the browser needs to call it. **This guard exists because over-granting is silent** — it produces no error, no broken page, no symptom; `part_playbook_notes` was left `anon`-executable by a `DROP FUNCTION` for three days and nothing noticed. A `DROP FUNCTION` destroys a function's ACL *and* its `COMMENT`, so any migration that drops and recreates one must re-issue both.
+
 ### Billing write-gate (new tenant tables)
 
 Entitlement is enforced at the DB layer: every browser-writable tenant table carries `billing_gate_*` restrictive RLS policies that call `company_can_write(company_id)`, so a lapsed/unsubscribed shop can't write (reads stay open). RLS is per-table — **a new `company_id` table without the gate silently bypasses billing.** When you add a tenant table:

--- a/api/tests/integration/test_function_execute_grants.py
+++ b/api/tests/integration/test_function_execute_grants.py
@@ -1,0 +1,248 @@
+"""Who can EXECUTE the SECURITY DEFINER functions in `public` — issue #640.
+
+THE BUG THESE GUARD AGAINST. Two things granted EXECUTE on every newly created
+function: Postgres' own `PUBLIC` default, and this schema's
+`ALTER DEFAULT PRIVILEGES ... GRANT ALL ON FUNCTIONS TO anon, authenticated`.
+`REVOKE EXECUTE ... FROM PUBLIC` removes only the first, so the idiom used by
+eight migrations — and the comments above them promising "service-role only" —
+did not close anything.
+
+WHY THIS NEEDS A TEST AT ALL, rather than careful review: over-granting is
+completely silent. It raises no error, breaks no page, and shows no symptom of
+any kind. `part_playbook_notes` sat anon-executable for three days after a
+DROP FUNCTION destroyed its ACL and nothing anywhere noticed. The only way this
+class of defect is ever caught is by asserting it.
+
+Two of these tests are behavioural rather than privilege assertions, and they are
+the ones that make the revokes SAFE rather than merely tidy: they prove that a
+trigger function and a SECURITY-DEFINER-called helper keep working once the
+browser can no longer execute them. If either assumption were wrong, the migration
+would have broken note capture and inventory writes in production.
+
+Requires a local Supabase with all migrations applied. Skipped without it.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from supabase import create_client
+
+pytestmark = pytest.mark.integration
+
+
+def _publishable_key() -> str:
+    return os.environ.get("TEST_SUPABASE_PUBLISHABLE_KEY") or os.environ["TEST_SUPABASE_ANON_KEY"]
+
+
+@pytest.fixture
+def shop(supabase_admin):
+    """A demo company with one signed-in operator, and a job to hang a note on."""
+    admin = supabase_admin
+    company_id = (
+        admin.table("companies")
+        .insert({"name": f"fx-{os.urandom(3).hex()}"})
+        .execute()
+        .data[0]["id"]
+    )
+    # Demo => company_can_write() is true without a billing row, so the billing
+    # gate cannot mask a result we are trying to assert.
+    admin.table("companies").update({"is_demo": True}).eq("id", company_id).execute()
+
+    email = f"fx-{os.urandom(4).hex()}@test.jigged.local"
+    password = "test-password-function-grants"
+    created = admin.auth.admin.create_user(
+        {"email": email, "password": password, "email_confirm": True}
+    )
+    access_id = (
+        admin.table("user_company_access")
+        .insert(
+            {
+                "user_id": created.user.id,
+                "company_id": company_id,
+                "role": "operator",
+                "name": "Fx",
+            }
+        )
+        .execute()
+        .data[0]["id"]
+    )
+    client = create_client(os.environ["TEST_SUPABASE_URL"], _publishable_key())
+    client.auth.sign_in_with_password({"email": email, "password": password})
+
+    job_id = (
+        admin.table("jobs")
+        .insert(
+            {
+                "company_id": company_id,
+                "job_number": f"J-FX-{os.urandom(2).hex()}",
+                "production_status": "not_started",
+                "fulfillment_status": "unshipped",
+            }
+        )
+        .execute()
+        .data[0]["id"]
+    )
+
+    yield {
+        "admin": admin,
+        "client": client,
+        "company_id": company_id,
+        "access_id": access_id,
+        "job_id": job_id,
+        "user_id": created.user.id,
+    }
+
+    for table in ("notes", "jobs"):
+        try:
+            admin.table(table).delete().eq("company_id", company_id).execute()
+        except Exception:
+            pass
+    admin.table("companies").delete().eq("id", company_id).execute()
+    try:
+        admin.auth.admin.delete_user(created.user.id)
+    except Exception:
+        pass
+
+
+def test_no_security_definer_function_is_browser_executable_off_allowlist(supabase_admin):
+    """The whole point of #640, and the durable half of the fix.
+
+    Every SECURITY DEFINER function a browser role can execute must be on the
+    reviewed allowlist inside function_execute_leaks(). A new one arriving
+    un-revoked fails here rather than shipping silently — which is exactly how the
+    original eight got in.
+    """
+    leaks = supabase_admin.rpc("function_execute_leaks", {}).execute().data
+    assert leaks == [], f"SECURITY DEFINER functions reachable by a browser role: {leaks}"
+
+
+def test_the_probe_the_notes_design_forbids_is_finally_closed(shop):
+    """viewer_excluded_from_metrics is the function this issue was found through.
+
+    Its comment has claimed since 20260728040701 that it is not granted to
+    authenticated, because a per-member "is this account excluded from metrics"
+    probe is the shape of thing the note_views privacy design refuses. The claim
+    was false for three months. Assert the specific function, not just the
+    aggregate above, so the reason survives even if the allowlist is refactored.
+    """
+    with pytest.raises(Exception) as exc:
+        shop["client"].rpc(
+            "viewer_excluded_from_metrics", {"p_access_id": shop["access_id"]}
+        ).execute()
+    assert "permission denied" in str(exc.value).lower() or "42501" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "fn,args",
+    [
+        ("seed_demo_data", {"p_company_id": "00000000-0000-0000-0000-000000000000",
+                            "p_user_id": "00000000-0000-0000-0000-000000000000",
+                            "p_template_name": "x"}),
+        ("inv_get_or_create_unassigned", {"p_company_id": "00000000-0000-0000-0000-000000000000"}),
+        ("inv_location_path_label", {"p_location_id": "00000000-0000-0000-0000-000000000000"}),
+    ],
+)
+def test_internal_helpers_are_not_callable_from_the_browser(shop, fn, args):
+    """These are reachable only through SECURITY DEFINER parents, which run as the
+    function owner — so the browser never needed EXECUTE on them. seed_demo_data in
+    particular writes a whole company's worth of rows."""
+    with pytest.raises(Exception):
+        shop["client"].rpc(fn, args).execute()
+
+
+# ── the behavioural half: the revokes must not have broken anything ──────────
+
+
+def test_a_trigger_function_still_fires_after_its_execute_was_revoked(shop):
+    """ASSUMPTION A, tested rather than asserted.
+
+    Inserting a note fires notes_validate_subject (BEFORE INSERT), whose EXECUTE
+    the browser no longer holds. Postgres checks permission when a trigger is
+    CREATED, not when it fires — but that is exactly the kind of belief that should
+    not be load-bearing without a test, because if it were wrong the symptom is
+    "operators cannot write notes at all".
+    """
+    row = (
+        shop["client"]
+        .table("notes")
+        .insert(
+            {
+                "company_id": shop["company_id"],
+                "subject_kind": "job",
+                "job_id": shop["job_id"],
+                "author_id": shop["access_id"],
+                "body": "written while the trigger function is un-executable",
+                "note_type": "user",
+            }
+        )
+        .execute()
+        .data
+    )
+    assert len(row) == 1
+
+
+def test_a_definer_parent_still_calls_its_revoked_callee(shop):
+    """ASSUMPTION B, tested rather than asserted.
+
+    log_note_views (granted, SECURITY DEFINER) calls viewer_excluded_from_metrics
+    (now revoked) in its body. The parent runs as the owner, so the caller's lost
+    privilege is irrelevant. If that were wrong, view logging would throw on every
+    note read — and the counters would silently stop moving.
+    """
+    admin = shop["admin"]
+    note_id = (
+        admin.table("notes")
+        .insert(
+            {
+                "company_id": shop["company_id"],
+                "subject_kind": "job",
+                "job_id": shop["job_id"],
+                # Authored by nobody, so the caller is not the author and the view
+                # actually counts.
+                "author_id": None,
+                "body": "read me",
+                "note_type": "user",
+            }
+        )
+        .execute()
+        .data[0]["id"]
+    )
+
+    shop["client"].rpc(
+        "log_note_views", {"p_note_ids": [note_id], "p_job_id": shop["job_id"]}
+    ).execute()
+
+    counts = (
+        admin.table("notes")
+        .select("viewer_count")
+        .eq("id", note_id)
+        .single()
+        .execute()
+        .data
+    )
+    assert counts["viewer_count"] == 1
+
+
+def test_the_functions_the_app_actually_calls_are_still_reachable(shop):
+    """The other half of safety: a revoke that went too far would break a feature.
+
+    Spot-checks one granted SECURITY DEFINER RPC end to end. The aggregate
+    allowlist test above says what is REACHABLE; this says something still WORKS.
+    """
+    shop["client"].rpc(
+        "log_operator_event",
+        {"p_company_id": shop["company_id"], "p_kind": "app_opened", "p_context": {}},
+    ).execute()
+
+    # Written through a SECURITY DEFINER function into a table with no client read
+    # path, so it is verified with the service role.
+    events = (
+        shop["admin"]
+        .table("operator_events")
+        .select("kind")
+        .eq("company_id", shop["company_id"])
+        .execute()
+        .data
+    )
+    assert any(e["kind"] == "app_opened" for e in events)

--- a/supabase/migrations/20260801024552_revoke_function_execute_from_browser_roles.sql
+++ b/supabase/migrations/20260801024552_revoke_function_execute_from_browser_roles.sql
@@ -1,0 +1,193 @@
+-- Make `REVOKE EXECUTE ... FROM PUBLIC` mean what eight migrations already think
+-- it means. Issue #640.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- THE BUG
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Two independent things grant EXECUTE on a newly created function:
+--
+--   1. Postgres' own built-in default — every function is executable by PUBLIC.
+--   2. THIS schema's default privileges, which still say
+--        ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+--          GRANT ALL ON FUNCTIONS TO anon;
+--          ... TO authenticated;
+--      so every new function ALSO lands with an EXPLICIT grant to both browser
+--      roles.
+--
+-- `REVOKE EXECUTE ... FROM PUBLIC` removes (1) and leaves (2) completely intact.
+-- It is the ACL equivalent of striking somebody off the all-staff mailing list
+-- while they still hold a personal invitation.
+--
+-- Eight migrations use exactly that idiom and state in their comments that the
+-- function is service-role-only. None of them is. The clearest example is
+-- viewer_excluded_from_metrics, whose own comment reads "Not granted to
+-- authenticated: ... Granting it would hand the browser a per-member probe."
+-- It was granted to authenticated the whole time.
+--
+-- 20260716025048 fixed precisely this for TABLES (it is why `notes` still carried
+-- a browser TRUNCATE until 20260801012019). It never touched FUNCTIONS.
+--
+-- NOTHING LEAKS TODAY — every affected function was checked, and each is either
+-- SECURITY INVOKER (so RLS still contains it), already deliberately granted to
+-- authenticated, or returns nothing an anonymous caller could use. This migration
+-- is about the NEXT function: SECURITY DEFINER is precisely where the sensitive
+-- logic lives, because that is why those functions bypass RLS, and the grant is
+-- then the only thing between the browser and the data.
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 1. STOP THE BLEEDING: the default itself
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- ALTER DEFAULT PRIVILEGES IS NOT RETROACTIVE (20260716025048 says the same about
+-- its own change). So this line changes NOTHING about the 130 functions that
+-- already exist — it only stops the next one being auto-granted. That is what
+-- makes it the safe half of this migration, and it is also what makes section 2
+-- necessary rather than redundant.
+--
+-- After this, a new function in public is reachable only by PUBLIC's built-in
+-- default, so the familiar `REVOKE ... FROM PUBLIC` finally does close it — and a
+-- function that genuinely needs the browser must say so with an explicit GRANT.
+-- Same discipline #406 introduced for tables.
+--
+-- The ACLs, measured, are the clearest way to see what changes:
+--
+--   before   {=X/postgres, postgres=X, anon=X, authenticated=X, service_role=X}
+--   after    {=X/postgres, postgres=X,                          service_role=X}
+--
+-- Only the leading `=X` (PUBLIC) is left, and that is the entry the standard
+-- idiom removes. NOTE that `has_function_privilege('authenticated', ...)` still
+-- returns true on a fresh function afterwards — authenticated is a MEMBER of
+-- PUBLIC — so the guard in section 3 will flag any new SECURITY DEFINER function
+-- until its author either revokes from PUBLIC or allowlists it deliberately.
+-- That is the intended outcome, not noise: both are a decision someone has to
+-- make on purpose and defend in review.
+--
+-- FOR ROLE postgres only, matching 20260716025048's scope. Objects created by
+-- supabase_admin (the platform's own migrations, not ours) carry a separate
+-- default that we neither own nor should fight; ours all run as postgres.
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  REVOKE EXECUTE ON FUNCTIONS FROM anon, authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 2. CLOSE THE EXISTING ONES THAT NEVER NEEDED BROWSER ACCESS
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 36 SECURITY DEFINER functions in public are currently browser-executable. Each
+-- was classified by EVIDENCE, not by taste — is it named in an RLS policy, called
+-- from application code, or called by a browser-callable SECURITY INVOKER
+-- function? 21 had at least one such reason and are deliberately left alone. The
+-- 15 below had none.
+--
+-- TWO ASSUMPTIONS UNDERPIN THIS, AND BOTH WERE TESTED RATHER THAN ASSUMED
+-- (see api/tests/integration/test_function_execute_grants.py):
+--
+--   A. A TRIGGER function needs no EXECUTE from the writing role. Permission is
+--      checked when the trigger is CREATED, not each time it fires. Verified by
+--      revoking notes_validate_subject and then INSERTing a note as
+--      `authenticated` — the insert succeeded.
+--   B. A function called only from SECURITY DEFINER parents needs no EXECUTE from
+--      the browser, because the parent body runs as the function owner. Verified
+--      by revoking viewer_excluded_from_metrics and then calling log_note_views
+--      as `authenticated` — it still ran and still moved the counter.
+--
+-- REVOKE names the roles explicitly rather than relying on FROM PUBLIC. That is
+-- the entire point of this migration; do not "tidy" these back to FROM PUBLIC.
+
+-- ── 2a. Trigger functions (9) — invoked by the trigger machinery, never called ──
+REVOKE EXECUTE ON FUNCTION public.auto_track_stocked_part()
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.enforce_tracked_part_quantity()
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.note_views_bump_counts()
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.notes_validate_subject()
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.recompute_part_quantity_from_locations()
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.snapshot_document_party()
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.snapshot_shipment_party()
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.snapshot_transaction_location_name()
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.user_company_access_fill_email()
+  FROM PUBLIC, anon, authenticated;
+
+-- ── 2b. Event-trigger function ────────────────────────────────────────────────
+REVOKE EXECUTE ON FUNCTION public.rls_auto_enable()
+  FROM PUBLIC, anon, authenticated;
+
+-- ── 2c. Internal helpers, reachable only through SECURITY DEFINER parents ─────
+-- inv_* are called by add/adjust/deplete/transfer_stock and enable_location_tracking;
+-- seed_demo_data by create_demo_company and reset_demo_company; and
+-- viewer_excluded_from_metrics only from inside log_note_views. Every one of those
+-- parents is SECURITY DEFINER and stays granted, so the call chains are unaffected.
+REVOKE EXECUTE ON FUNCTION public.inv_assert_location_in_company(p_location_id uuid, p_company_id uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.inv_get_or_create_unassigned(p_company_id uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.inv_location_path_label(p_location_id uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.seed_demo_data(p_company_id uuid, p_user_id uuid, p_template_name text)
+  FROM PUBLIC, anon, authenticated;
+
+-- THE ONE THIS ISSUE WAS FOUND THROUGH. Its comment has claimed since
+-- 20260728040701 that it is not granted to authenticated, because a per-member
+-- "is this account excluded from metrics" probe is exactly the shape of thing the
+-- note_views design refuses. The claim is finally true.
+REVOKE EXECUTE ON FUNCTION public.viewer_excluded_from_metrics(p_access_id uuid)
+  FROM PUBLIC, anon, authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- 3. THE DURABLE HALF
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Sections 1 and 2 fix today. This is what stops it coming back, and it is the
+-- part that actually matters: over-granting is SILENT. It produces no error, no
+-- broken page, no symptom of any kind — you find it only by looking, and nobody
+-- looks. part_playbook_notes sat anon-executable for three days after a
+-- DROP FUNCTION destroyed its ACL and would have sat there indefinitely.
+--
+-- Same idiom as tenant_tables_missing_write_gate() and no_client_access_grant_leaks():
+-- rows mean something is wrong, and a CI test asserts there are none. The
+-- allowlist is the reviewable record of a deliberate decision — adding a function
+-- to it should require saying why in the PR.
+
+CREATE OR REPLACE FUNCTION public.function_execute_leaks()
+RETURNS TABLE(function_name text, role_name text)
+LANGUAGE sql
+STABLE
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT p.proname::text, r.rolname::text
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  CROSS JOIN (VALUES ('anon'), ('authenticated')) AS r(rolname)
+  WHERE n.nspname = 'public'
+    -- SECURITY DEFINER only. An INVOKER function runs as the caller, so RLS and
+    -- table grants still contain it and a browser grant is not a hole; scoping
+    -- the guard this way keeps the allowlist to the set that actually matters
+    -- instead of every helper in the schema.
+    AND p.prosecdef
+    AND has_function_privilege(r.rolname, p.oid, 'EXECUTE')
+    AND p.proname NOT IN (
+      -- Named in an RLS policy: the browser cannot query the table without it.
+      'company_can_write', 'get_operator_access_id', 'get_user_company_ids',
+      'is_company_admin', 'is_system_admin',
+      -- Called directly from application code (utils/*Access.ts, app/, hooks/).
+      'accept_invitation', 'add_stock_at_location', 'adjust_stock_at_location',
+      'create_demo_company', 'create_shipment_with_line_items', 'delete_location',
+      'deplete_stock_at_location', 'disable_location_tracking',
+      'enable_location_tracking', 'log_note_views', 'log_operator_event',
+      'note_viewers', 'reset_demo_company', 'sync_demo_access', 'transfer_stock',
+      -- Called BY a browser-callable SECURITY INVOKER function, which runs as the
+      -- caller — so the caller genuinely needs EXECUTE on this one.
+      -- (generate_quote_number / generate_direct_job_number -> next_order_number)
+      'next_order_number'
+    )
+  ORDER BY 1, 2;
+$$;
+
+COMMENT ON FUNCTION public.function_execute_leaks() IS
+  'Lists SECURITY DEFINER functions in public that a browser role can execute and that are not on the reviewed allowlist. Must always be empty. Exists because the ON FUNCTIONS default privileges auto-granted every new function to anon/authenticated, making the REVOKE ... FROM PUBLIC idiom used across this schema ineffective (issue #640) — and because over-granting is silent, so only a test finds it. To add a function here, say in the PR why the browser needs to call it.';
+
+REVOKE EXECUTE ON FUNCTION public.function_execute_leaks()
+  FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.function_execute_leaks() TO service_role;

--- a/types/database.ts
+++ b/types/database.ts
@@ -3498,6 +3498,13 @@ export type Database = {
         Args: { p_company_id: string }
         Returns: Json
       }
+      function_execute_leaks: {
+        Args: never
+        Returns: {
+          function_name: string
+          role_name: string
+        }[]
+      }
       generate_direct_job_number: {
         Args: { company_uuid: string }
         Returns: string


### PR DESCRIPTION
Closes #640.

## The bug

Two independent things grant `EXECUTE` on every newly created function:

1. **Postgres' own default** — every function is executable by `PUBLIC`.
2. **This schema's default privileges**, which still said `ALTER DEFAULT PRIVILEGES ... GRANT ALL ON FUNCTIONS TO anon, authenticated` — so every new function *also* landed with an **explicit** grant to both browser roles.

`REVOKE EXECUTE … FROM PUBLIC` removes (1) and leaves (2) completely intact. It's the ACL equivalent of striking someone off the all-staff mailing list while they still hold a personal invitation.

Eight migrations use exactly that idiom and state in their comments that the function is service-role-only. **None of them was.** The clearest case is `viewer_excluded_from_metrics`, whose own comment reads *"Not granted to authenticated: … Granting it would hand the browser a per-member probe."* It was granted to `authenticated` the whole time.

`20260716025048` fixed precisely this for **tables** — it's why `notes` still carried a browser `TRUNCATE` until #641 — but never touched **functions**.

## Nothing leaked

I checked all 36 browser-executable `SECURITY DEFINER` functions. Each is either `SECURITY INVOKER` (so RLS still contains it), deliberately granted to `authenticated`, or returns nothing an anonymous caller can use. **This PR is about the next one**: `SECURITY DEFINER` is where the sensitive logic lives — that's *why* those functions bypass RLS — and the grant is then the only thing between the browser and the data.

## Three parts

**1 — Revoke the `ON FUNCTIONS` default.** `ALTER DEFAULT PRIVILEGES` is **not retroactive**, so this changes nothing about the 130 existing functions. It only stops the next one being auto-granted, and makes the familiar idiom finally work. Measured on a real database:

```
before   {=X/postgres, postgres=X, anon=X, authenticated=X, service_role=X}
after    {=X/postgres, postgres=X,                          service_role=X}
```

Only PUBLIC's leading `=X` remains — the entry `FROM PUBLIC` actually removes.

**2 — Revoke `EXECUTE` on 15 existing functions** that never needed browser access.

**3 — `function_execute_leaks()` + a CI test.** This is the part that matters, because **over-granting is silent**: no error, no broken page, no symptom of any kind. `part_playbook_notes` sat `anon`-executable for three days after a `DROP FUNCTION` destroyed its ACL and nothing anywhere noticed. Only a test catches this class of defect.

## How the 36 were classified — evidence, not taste

| Verdict | Count | Evidence |
|---|---|---|
| **Keep** | 5 | Named in an RLS policy (`get_user_company_ids`, `is_company_admin`, `company_can_write`, `get_operator_access_id`, `is_system_admin`) — the browser can't query the table without them |
| **Keep** | 15 | Called directly from app code (`utils/*Access.ts`, `app/`, `hooks/`) |
| **Keep** | 1 | Called *by* a browser-callable `SECURITY INVOKER` function, which runs as the caller (`generate_quote_number` → `next_order_number`) |
| **Revoke** | 9 | Trigger functions |
| **Revoke** | 1 | Event-trigger function (`rls_auto_enable`) |
| **Revoke** | 5 | Internal helpers reachable only through `SECURITY DEFINER` parents |

## The two assumptions were tested, not assumed

Both break writes in production if wrong, so neither is left as a belief:

- **A — a trigger function needs no `EXECUTE` from the writing role.** Verified by revoking `notes_validate_subject` and then `INSERT`ing a note as `authenticated`; the insert succeeded. Had this been wrong, operators could not write notes at all.
- **B — a helper called only from `SECURITY DEFINER` parents needs no `EXECUTE` from the browser**, since the parent runs as owner. Verified by revoking `viewer_excluded_from_metrics` and then calling `log_note_views` as `authenticated`; it ran and still moved the counter.

Both are now regression tests in `test_function_execute_grants.py`, not one-off checks.

## One near miss, recorded because it's the failure mode to watch

`create_shipment_with_line_items` looked uncalled under a `.rpc('name'` grep, because `utils/shipmentsAccess.ts` passes the name on its own line:

```ts
  'create_shipment_with_line_items',
```

Revoking it would have broken shipment creation in production. The caller search was widened to any quoted occurrence of the name and the function is on the keep list. It's the reason the classification table above leans on multiple independent signals rather than one grep.

## Verification

All against a database built from a **clean replay of all 78 migrations**, in rolled-back transactions — the shared local stack was never mutated (it holds unmerged `feature/inventory-phase-2` work, which is also why the function list was derived from a clean replay rather than from it):

- `function_execute_leaks()` → 0 rows
- the 15 revoked → 0 still reachable by either browser role
- **the 21 kept → all 21 still executable** (a false revoke is the real risk here)
- end-to-end as `authenticated` with the revokes live: note INSERT (fires a revoked trigger fn) works, `log_note_views` (calls a revoked helper) works and moves the counter, RLS-gated SELECT resolves
- a new `SECURITY DEFINER` function that *is* granted correctly **trips the guard** — the test can fail
- `types/database.ts` regenerated from the same clean replay; diff is exactly `function_execute_leaks` and nothing else
- Vitest 1555 passing, backend unit 217 passing, `tsc` clean

The 8 new integration tests collect cleanly; as with #641 they need PostgREST over a database carrying this migration, so CI is their first real execution.

## Also

`CLAUDE.md` gains a **Function EXECUTE grants** section next to the existing table-grants rule — the durable fix for the actual root cause, which was that the codebase taught the wrong idiom and every new function copied it. It documents the three no-grant-needed cases, the `DROP FUNCTION` destroys-ACL-and-COMMENT trap, and the CI guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
