### PR TITLE
fix(operator): make Me a tab root, and stop it stalling on the way in

### DIFF
--- a/__tests__/app/operator/MyWorkPage.test.tsx
+++ b/__tests__/app/operator/MyWorkPage.test.tsx
@@ -3,14 +3,23 @@ import { render, screen, within, routerMocks } from '@/__tests__/test-utils';
 import userEvent from '@testing-library/user-event';
 
 import MyWorkPage from '@/app/operator/[companyId]/my-work/page';
-import { getMyContribution, getNoteViewers } from '@/utils/operatorAccess';
-import type { MyContribution, MyNote } from '@/types/operator';
+import {
+  getMyContributionTotals,
+  getMyNotesPage,
+  getNoteViewers,
+  MY_NOTES_PAGE_SIZE,
+} from '@/utils/operatorAccess';
+import type { MyContributionTotals, MyNote } from '@/types/operator';
 
 vi.mock('@/utils/operatorAccess', () => ({
-  getMyContribution: vi.fn(),
+  getMyContributionTotals: vi.fn(),
+  getMyNotesPage: vi.fn(),
   getNoteViewers: vi.fn(),
   // The "Me" tab resolves the operator's display name through this.
   getCurrentMember: vi.fn(async () => ({ id: 'm1', name: 'Ada Lovelace', role: 'operator' })),
+  // Log out drops the cached member along with the session.
+  clearCurrentMemberCache: vi.fn(),
+  MY_NOTES_PAGE_SIZE: 10,
 }));
 
 // This page became the "Me" tab, so it now reaches identity + Log out — which pull in
@@ -39,7 +48,8 @@ vi.mock('@/lib/supabase', () => {
   return { getSupabase: stub, getTypedSupabase: stub, supabase: null };
 });
 
-const mockGetMyContribution = vi.mocked(getMyContribution);
+const mockGetTotals = vi.mocked(getMyContributionTotals);
+const mockGetNotesPage = vi.mocked(getMyNotesPage);
 const mockGetNoteViewers = vi.mocked(getNoteViewers);
 
 function note(over: Partial<MyNote> = {}): MyNote {
@@ -47,6 +57,7 @@ function note(over: Partial<MyNote> = {}): MyNote {
     id: 'n1',
     body: 'Clamp on the boss, not the flange — it walks.',
     created_at: '2026-07-20T14:00:00Z',
+    edited_at: null,
     operation_label: 'Op 20 · Mill',
     part_name: 'BRKT-1042',
     job_id: 'job-1',
@@ -59,27 +70,40 @@ function note(over: Partial<MyNote> = {}): MyNote {
   };
 }
 
-function contribution(over: Partial<MyContribution> = {}): MyContribution {
-  const notes = over.notes ?? [note()];
-  return {
+/**
+ * Stage the two loads the page makes. `totals` covers every note the operator has ever
+ * written; `notes` is only the first page. They are deliberately separate arguments here
+ * because the whole point of the split is that they CAN disagree — see the paging tests.
+ */
+function stage({
+  notes = [note()],
+  totals = {},
+  hasMore = false,
+}: {
+  notes?: MyNote[];
+  totals?: Partial<MyContributionTotals>;
+  hasMore?: boolean;
+} = {}) {
+  mockGetTotals.mockResolvedValue({
     noteCount: notes.length,
     photoCount: 0,
     peopleReached: 0,
-    ...over,
-    notes,
-  };
+    ...totals,
+  });
+  mockGetNotesPage.mockResolvedValue({ notes, hasMore });
 }
 
 beforeEach(() => {
   routerMocks.push.mockClear();
-  mockGetMyContribution.mockReset();
+  mockGetTotals.mockReset();
+  mockGetNotesPage.mockReset();
   mockGetNoteViewers.mockReset();
   mockGetNoteViewers.mockResolvedValue([]);
 });
 
 describe('My Work', () => {
   it('shows what the operator wrote', async () => {
-    mockGetMyContribution.mockResolvedValue(contribution({ photoCount: 2 }));
+    stage({ totals: { photoCount: 2 } });
     render(<MyWorkPage />);
 
     expect(await screen.findByText(/Clamp on the boss/)).toBeInTheDocument();
@@ -94,7 +118,7 @@ describe('My Work', () => {
     // looking at when they wrote it, let alone go and check. The link lives in
     // the expanded state so the row itself stays one compact tap target.
     const user = userEvent.setup();
-    mockGetMyContribution.mockResolvedValue(contribution());
+    stage();
     render(<MyWorkPage />);
 
     await user.click(await screen.findByText(/Clamp on the boss/));
@@ -110,7 +134,7 @@ describe('My Work', () => {
     // author is most likely to be checking up on — no viewers AND no way back to
     // the job. There is always something behind the tap now.
     const user = userEvent.setup();
-    mockGetMyContribution.mockResolvedValue(contribution());
+    stage();
     render(<MyWorkPage />);
 
     await user.click(await screen.findByText(/Clamp on the boss/));
@@ -124,9 +148,7 @@ describe('My Work', () => {
   it('survives a note whose job has been deleted', async () => {
     // Provenance is ON DELETE SET NULL: the knowledge outlives its origin, so a
     // missing job must cost the link, never the note.
-    mockGetMyContribution.mockResolvedValue(
-      contribution({ notes: [note({ job_id: null, job_number: null })] }),
-    );
+    stage({ notes: [note({ job_id: null, job_number: null })] });
     render(<MyWorkPage />);
 
     expect(await screen.findByText(/Clamp on the boss/)).toBeInTheDocument();
@@ -138,7 +160,7 @@ describe('My Work', () => {
     // three of your notes contributes three. Labelling that "people" overstates
     // it; a distinct-people figure would need the note_views rows, which no
     // browser role can read by design.
-    mockGetMyContribution.mockResolvedValue(contribution({ peopleReached: 5 }));
+    stage({ totals: { peopleReached: 5 } });
     render(<MyWorkPage />);
 
     expect(await screen.findByText('views')).toBeInTheDocument();
@@ -149,9 +171,7 @@ describe('My Work', () => {
     // Once both numbers are honestly labelled "viewed", a second one earns
     // nothing — it reads as a puzzle rather than a signal. usage_count stays on
     // the row for the Playbook to rank by; it is not the operator's business here.
-    mockGetMyContribution.mockResolvedValue(
-      contribution({ notes: [note({ viewer_count: 4, usage_count: 11 })] }),
-    );
+    stage({ notes: [note({ viewer_count: 4, usage_count: 11 })] });
     render(<MyWorkPage />);
 
     await screen.findByText(/Clamp on the boss/);
@@ -164,7 +184,7 @@ describe('My Work', () => {
     // An earlier pass rendered "Not used yet" under every note; seven of those
     // down a real screen is a column of apologies. A count reads the same at
     // zero as at four — it just hasn't moved yet.
-    mockGetMyContribution.mockResolvedValue(contribution());
+    stage();
     render(<MyWorkPage />);
 
     await screen.findByText(/Clamp on the boss/);
@@ -177,9 +197,7 @@ describe('My Work', () => {
     // note_viewers() is the single window through which a reader's name is ever
     // exposed. It must never fire as part of a list render.
     const user = userEvent.setup();
-    mockGetMyContribution.mockResolvedValue(
-      contribution({ notes: [note({ viewer_count: 2, usage_count: 1 })] }),
-    );
+    stage({ notes: [note({ viewer_count: 2, usage_count: 1 })] });
     mockGetNoteViewers.mockResolvedValue([
       { viewer_name: 'Diego', job_number: 'J-0004' },
       { viewer_name: 'Priya', job_number: 'J-0006' },
@@ -202,13 +220,10 @@ describe('My Work', () => {
     // screen is exactly where a leaderboard wants to grow. Nothing here may
     // reflect an operator's pace or standing back at them, or rank them against
     // anyone else.
-    mockGetMyContribution.mockResolvedValue(
-      contribution({
-        photoCount: 3,
-        peopleReached: 5,
-        notes: [note({ viewer_count: 5, usage_count: 9 })],
-      }),
-    );
+    stage({
+      notes: [note({ viewer_count: 5, usage_count: 9 })],
+      totals: { photoCount: 3, peopleReached: 5 },
+    });
     const { container } = render(<MyWorkPage />);
 
     await screen.findByText(/Clamp on the boss/);
@@ -229,7 +244,7 @@ describe('My Work', () => {
   });
 
   it('invites a first note rather than showing an empty scoreboard', async () => {
-    mockGetMyContribution.mockResolvedValue(contribution({ notes: [] }));
+    stage({ notes: [] });
     render(<MyWorkPage />);
 
     expect(await screen.findByText('Nothing written yet')).toBeInTheDocument();
@@ -238,7 +253,8 @@ describe('My Work', () => {
   });
 
   it('does not put a backend failure in front of an operator as a blank page', async () => {
-    mockGetMyContribution.mockRejectedValue(new Error('denied'));
+    mockGetTotals.mockRejectedValue(new Error('denied'));
+    mockGetNotesPage.mockRejectedValue(new Error('denied'));
     render(<MyWorkPage />);
 
     expect(await screen.findByText(/Could not load your work/)).toBeInTheDocument();
@@ -246,17 +262,127 @@ describe('My Work', () => {
 });
 
 /**
+ * Paging, and the trap it sets.
+ *
+ * The list is a page at a time, but the summary card is about everything the operator has
+ * ever written. Those totals used to be reduced out of the fetched rows, which was only
+ * correct while "the fetched rows" meant "all of them". Deriving them from a page would turn
+ * the operator's note count into a count of what happens to be rendered — a number that
+ * climbs as they tap Show more, wearing the label of a number about their work.
+ */
+describe('My Work — paging', () => {
+  it('reports every note in the summary, not just the page on screen', async () => {
+    stage({ notes: [note()], totals: { noteCount: 37, photoCount: 12, peopleReached: 9 }, hasMore: true });
+    render(<MyWorkPage />);
+
+    await screen.findByText(/Clamp on the boss/);
+    // One note rendered, thirty-seven written.
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByText('37')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('9')).toBeInTheDocument();
+  });
+
+  it('asks for the first page only, and asks by page size', async () => {
+    stage();
+    render(<MyWorkPage />);
+
+    await screen.findByText(/Clamp on the boss/);
+    expect(mockGetNotesPage).toHaveBeenCalledTimes(1);
+    expect(mockGetNotesPage).toHaveBeenCalledWith('test-company-id');
+    expect(MY_NOTES_PAGE_SIZE).toBe(10);
+  });
+
+  it('appends the next page on Show more rather than replacing what is there', async () => {
+    const user = userEvent.setup();
+    stage({ notes: [note({ id: 'n1', body: 'First note' })], hasMore: true });
+    render(<MyWorkPage />);
+
+    await screen.findByText('First note');
+    mockGetNotesPage.mockResolvedValue({
+      notes: [note({ id: 'n2', body: 'Second note' })],
+      hasMore: false,
+    });
+
+    await user.click(screen.getByRole('button', { name: /show more/i }));
+
+    // Both pages on screen — the first must not be discarded.
+    expect(await screen.findByText('Second note')).toBeInTheDocument();
+    expect(screen.getByText('First note')).toBeInTheDocument();
+    // Offset is where the loaded list ends, not a page counter that can drift.
+    expect(mockGetNotesPage).toHaveBeenLastCalledWith('test-company-id', { offset: 1 });
+  });
+
+  it('stops offering Show more once the last page comes back', async () => {
+    const user = userEvent.setup();
+    stage({ notes: [note({ id: 'n1', body: 'First note' })], hasMore: true });
+    render(<MyWorkPage />);
+
+    await screen.findByText('First note');
+    mockGetNotesPage.mockResolvedValue({
+      notes: [note({ id: 'n2', body: 'Second note' })],
+      hasMore: false,
+    });
+    await user.click(screen.getByRole('button', { name: /show more/i }));
+    await screen.findByText('Second note');
+
+    expect(screen.queryByRole('button', { name: /show more/i })).not.toBeInTheDocument();
+  });
+
+  it('offers no Show more when the first page is the whole list', async () => {
+    stage({ hasMore: false });
+    render(<MyWorkPage />);
+
+    await screen.findByText(/Clamp on the boss/);
+    expect(screen.queryByRole('button', { name: /show more/i })).not.toBeInTheDocument();
+  });
+
+  it('keeps the loaded pages when one extra page fails', async () => {
+    // A failed Show more must cost the tap, not the notes already on screen.
+    const user = userEvent.setup();
+    stage({ notes: [note({ id: 'n1', body: 'First note' })], hasMore: true });
+    render(<MyWorkPage />);
+
+    await screen.findByText('First note');
+    mockGetNotesPage.mockRejectedValue(new Error('offline'));
+
+    await user.click(screen.getByRole('button', { name: /show more/i }));
+
+    expect(await screen.findByText(/Could not load more notes/)).toBeInTheDocument();
+    expect(screen.getByText('First note')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /show more/i })).toBeInTheDocument();
+  });
+});
+
+/**
  * This page is the "Me" tab: the operator's work, with identity and account actions folded in
- * beneath it now that Profile is no longer a bottom tab.
+ * around it now that Profile is no longer a bottom tab.
  */
 describe('My Work — the "Me" tab', () => {
   it('shows the work itself, not an account screen you have to leave', async () => {
-    mockGetMyContribution.mockResolvedValue(contribution());
+    stage();
     render(<MyWorkPage />);
 
     // The note is present on first paint — no second tap to reach your own work.
     expect(await screen.findByText(/Clamp on the boss/)).toBeInTheDocument();
     expect(await screen.findByText('Ada Lovelace')).toBeInTheDocument();
+  });
+
+  it('puts the email in the identity row, not in a caption further down', async () => {
+    // It used to read "Signed in as …" near the bottom of the page. That was a second,
+    // worse home for a fact that is plainly identity — and it was behind the whole note
+    // list, so the one time it matters (reading your address out to support) it was the
+    // hardest thing on the screen to reach.
+    stage();
+    render(<MyWorkPage />);
+
+    const email = await screen.findByText('ada@shop.test');
+    expect(email).toBeInTheDocument();
+    expect(screen.queryByText(/signed in as/i)).not.toBeInTheDocument();
+
+    // Above the work, not below it.
+    const firstNote = screen.getAllByRole('listitem')[0];
+    expect(email.compareDocumentPosition(firstNote) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   /**
@@ -266,7 +392,7 @@ describe('My Work — the "Me" tab', () => {
    * out button anywhere in the app, because Profile had just stopped being a tab.
    */
   it('can still log out with nothing written yet', async () => {
-    mockGetMyContribution.mockResolvedValue(contribution({ notes: [] }));
+    stage({ notes: [] });
     render(<MyWorkPage />);
 
     expect(await screen.findByText('Nothing written yet')).toBeInTheDocument();
@@ -275,7 +401,8 @@ describe('My Work — the "Me" tab', () => {
   });
 
   it('can still log out when the work fails to load', async () => {
-    mockGetMyContribution.mockRejectedValue(new Error('denied'));
+    mockGetTotals.mockRejectedValue(new Error('denied'));
+    mockGetNotesPage.mockRejectedValue(new Error('denied'));
     render(<MyWorkPage />);
 
     expect(await screen.findByText(/Could not load your work/)).toBeInTheDocument();
@@ -283,17 +410,34 @@ describe('My Work — the "Me" tab', () => {
   });
 
   /**
-   * Log out is last and set apart, per NN/g's guidance on keeping a consequential option away
-   * from benign ones — operators repeating the same taps every shift slip into automaticity, and
-   * a mis-tap there is a slip that no clearer label fixes. Asserting document order keeps a
-   * future tidy-up from moving it back up next to Give feedback, which is where it used to be.
+   * Log out moved from "last on the page, set apart" to "an isolated icon in the identity row",
+   * and the safety argument moved with it — from DISTANCE to ISOLATION.
+   *
+   * The old placement put it below the operator's entire note list, which is unbounded. Once
+   * the list pages, distance stops meaning "slightly slower to reach" and starts meaning "past
+   * however many Show mores it takes", which is not a safety property, it is a broken control.
+   *
+   * The slip NN/g's proximity guidance protects against is a mis-tap onto a consequential
+   * action from a benign one BESIDE it. So what this asserts is the replacement invariant:
+   * Log out is the only thing you can tap in that row. Nothing adjacent means nothing to slip
+   * from — which is the same reasoning the operator layout uses to forbid a second icon button
+   * in the header, applied rather than contradicted.
    */
-  it('puts Log out after Give feedback, not beside it', async () => {
-    mockGetMyContribution.mockResolvedValue(contribution());
+  it('leaves Log out with no neighbouring tap target to slip from', async () => {
+    stage();
     render(<MyWorkPage />);
 
-    const feedback = await screen.findByRole('button', { name: /give feedback/i });
-    const logout = screen.getByRole('button', { name: /log out/i });
-    expect(feedback.compareDocumentPosition(logout) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    const logout = await screen.findByRole('button', { name: /log out/i });
+    const row = logout.parentElement!;
+
+    // Sole interactive element in its row.
+    expect(within(row).getAllByRole('button')).toHaveLength(1);
+    expect(within(row).queryAllByRole('link')).toHaveLength(0);
+
+    // And reachable before the work rather than after it — the point of the move.
+    const firstNote = screen.getAllByRole('listitem')[0];
+    expect(
+      logout.compareDocumentPosition(firstNote) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });

--- a/__tests__/app/operator/MyWorkPage.test.tsx
+++ b/__tests__/app/operator/MyWorkPage.test.tsx
@@ -56,7 +56,6 @@ function note(over: Partial<MyNote> = {}): MyNote {
     body: 'Clamp on the boss, not the flange — it walks.',
     created_at: '2026-07-20T14:00:00Z',
     edited_at: null,
-    operation_label: 'Op 20 · Mill',
     part_name: 'BRKT-1042',
     machine_name: null,
     maintenance_kind: null,
@@ -84,7 +83,6 @@ function machineNote(over: Partial<MyNote> = {}): MyNote {
     id: 'm1',
     body: 'Blade guard rattling at speed.',
     part_name: null,
-    operation_label: null,
     job_id: null,
     job_number: null,
     machine_name: 'Bandsaw',
@@ -130,10 +128,12 @@ describe('My Work', () => {
     render(<MyWorkPage />);
 
     expect(await screen.findByText(/Clamp on the boss/)).toBeInTheDocument();
-    expect(screen.getByText('BRKT-1042')).toBeInTheDocument();
-    expect(screen.getByText('Op 20 · Mill')).toBeInTheDocument();
-    // Where it came from, beside the date — visible without expanding anything.
+    // ONE quiet reference beside the date, and nothing leading the row. The subject
+    // used to lead in bold with the step as a chip, which made a list of what the
+    // operator wrote read as a list of stations.
     expect(screen.getByText(/J-0042 · Jul 20, 2026/)).toBeInTheDocument();
+    expect(screen.queryByText('BRKT-1042')).not.toBeInTheDocument();
+    expect(screen.queryByText('Op 20 · Mill')).not.toBeInTheDocument();
   });
 
   it('leads back to the job the note was written on', async () => {
@@ -460,35 +460,41 @@ describe('My Work — the "Me" tab', () => {
    * announced a part or a job. It was indistinguishable from a note whose context had been
    * lost.
    */
-  it('names the machine on a maintenance entry, which has no other subject', async () => {
+  it('names the machine where a job note names its job', async () => {
+    // A machine entry has no job, so the work center takes the same quiet slot beside
+    // the date rather than a bold heading of its own.
     stage({ notes: [machineNote()] });
     render(<MyWorkPage />);
 
     const row = (await screen.findAllByRole('listitem'))[0];
-    expect(within(row).getByText('Bandsaw')).toBeInTheDocument();
-    expect(within(row).getByText('noticed')).toBeInTheDocument();
+    expect(within(row).getByText(/Bandsaw · noticed · /)).toBeInTheDocument();
     // Nothing invented: a machine entry has no job to point at.
     expect(within(row).queryByText(/J-\d+/)).not.toBeInTheDocument();
   });
 
-  it('leaves an unclassified maintenance entry without a kind chip', async () => {
+  it('leaves an unclassified maintenance entry with just the machine', async () => {
     // Classifying is optional and null is a common, legal state — so absence must render
     // as absence, not as a placeholder.
     stage({ notes: [machineNote({ maintenance_kind: null })] });
     render(<MyWorkPage />);
 
     const row = (await screen.findAllByRole('listitem'))[0];
-    expect(within(row).getByText('Bandsaw')).toBeInTheDocument();
+    expect(within(row).getByText(/^Bandsaw · /)).toBeInTheDocument();
     expect(within(row).queryByText(/noticed|cleaned|repaired|adjusted|replaced/)).not.toBeInTheDocument();
   });
 
-  it('keeps the part name for a part note, unchanged', async () => {
-    stage({ notes: [note()] });
+  /**
+   * A durable part note outlives the job it was captured on — provenance is
+   * ON DELETE SET NULL, so the knowledge survives losing its origin. Once that job is
+   * gone the part is the only reference left, so it becomes the fallback rather than
+   * leaving the row with no context at all.
+   */
+  it('falls back to the part once the capturing job is gone', async () => {
+    stage({ notes: [note({ job_id: null, job_number: null })] });
     render(<MyWorkPage />);
 
     const row = (await screen.findAllByRole('listitem'))[0];
-    expect(within(row).getByText('BRKT-1042')).toBeInTheDocument();
-    expect(within(row).getByText('Op 20 · Mill')).toBeInTheDocument();
+    expect(within(row).getByText(/^BRKT-1042 · /)).toBeInTheDocument();
   });
 
   /**

--- a/__tests__/app/operator/MyWorkPage.test.tsx
+++ b/__tests__/app/operator/MyWorkPage.test.tsx
@@ -58,6 +58,8 @@ function note(over: Partial<MyNote> = {}): MyNote {
     edited_at: null,
     operation_label: 'Op 20 · Mill',
     part_name: 'BRKT-1042',
+    machine_name: null,
+    maintenance_kind: null,
     job_id: 'job-1',
     job_number: 'J-0042',
     photo_count: 0,
@@ -66,6 +68,29 @@ function note(over: Partial<MyNote> = {}): MyNote {
     usage_count: 0,
     ...over,
   };
+}
+
+/**
+ * A maintenance entry, as it really arrives here.
+ *
+ * Maintenance is not a separate store: an entry is a `notes` row with
+ * subject_kind='work_center', so it lands in the operator's own list beside their part and
+ * job notes. The DB CHECK constraint permits exactly one subject, so a machine entry has NO
+ * part, NO operation and NO job — which is why it needs the machine name to say anything at
+ * all about what it concerns.
+ */
+function machineNote(over: Partial<MyNote> = {}): MyNote {
+  return note({
+    id: 'm1',
+    body: 'Blade guard rattling at speed.',
+    part_name: null,
+    operation_label: null,
+    job_id: null,
+    job_number: null,
+    machine_name: 'Bandsaw',
+    maintenance_kind: 'noticed',
+    ...over,
+  });
 }
 
 /**
@@ -393,6 +418,62 @@ describe('My Work — the "Me" tab', () => {
     // The note is present on first paint — no second tap to reach your own work.
     expect(await screen.findByText(/Clamp on the boss/)).toBeInTheDocument();
     expect(await screen.findByText('Ada Lovelace')).toBeInTheDocument();
+  });
+
+  /**
+   * A maintenance entry has no part, no operation and no job — the CHECK constraint on
+   * `notes` allows exactly one subject and a machine entry's is the work center. Before the
+   * machine name was selected, such an entry rendered as a bare sentence with nothing
+   * anywhere on the row saying what it was about, sitting in a list where every other row
+   * announced a part or a job. It was indistinguishable from a note whose context had been
+   * lost.
+   */
+  it('names the machine on a maintenance entry, which has no other subject', async () => {
+    stage({ notes: [machineNote()] });
+    render(<MyWorkPage />);
+
+    const row = (await screen.findAllByRole('listitem'))[0];
+    expect(within(row).getByText('Bandsaw')).toBeInTheDocument();
+    expect(within(row).getByText('noticed')).toBeInTheDocument();
+    // Nothing invented: a machine entry has no job to point at.
+    expect(within(row).queryByText(/J-\d+/)).not.toBeInTheDocument();
+  });
+
+  it('leaves an unclassified maintenance entry without a kind chip', async () => {
+    // Classifying is optional and null is a common, legal state — so absence must render
+    // as absence, not as a placeholder.
+    stage({ notes: [machineNote({ maintenance_kind: null })] });
+    render(<MyWorkPage />);
+
+    const row = (await screen.findAllByRole('listitem'))[0];
+    expect(within(row).getByText('Bandsaw')).toBeInTheDocument();
+    expect(within(row).queryByText(/noticed|cleaned|repaired|adjusted|replaced/)).not.toBeInTheDocument();
+  });
+
+  it('keeps the part name for a part note, unchanged', async () => {
+    stage({ notes: [note()] });
+    render(<MyWorkPage />);
+
+    const row = (await screen.findAllByRole('listitem'))[0];
+    expect(within(row).getByText('BRKT-1042')).toBeInTheDocument();
+    expect(within(row).getByText('Op 20 · Mill')).toBeInTheDocument();
+  });
+
+  /**
+   * Give feedback moved above the work. It used to sit under the operator's entire note
+   * list, which is the one place a pilot's feedback channel must not be: once the list
+   * pages, reaching it means ten notes and a Show more, and the operators most likely to
+   * have something to say are the ones who never scrolled that far.
+   */
+  it('puts Give feedback above the work, not after it', async () => {
+    stage();
+    render(<MyWorkPage />);
+
+    const feedback = await screen.findByRole('button', { name: /give feedback/i });
+    const firstNote = screen.getAllByRole('listitem')[0];
+    expect(
+      feedback.compareDocumentPosition(firstNote) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it('puts the email in the identity row, not in a caption further down', async () => {

--- a/__tests__/app/operator/MyWorkPage.test.tsx
+++ b/__tests__/app/operator/MyWorkPage.test.tsx
@@ -138,34 +138,66 @@ describe('My Work', () => {
 
   it('leads back to the job the note was written on', async () => {
     // A note with no context is an orphan: the author cannot tell what they were
-    // looking at when they wrote it, let alone go and check. The link lives in
-    // the expanded state so the row itself stays one compact tap target.
+    // looking at when they wrote it, let alone go and check. The route back lives
+    // in the overflow menu, first and furthest from Delete.
     const user = userEvent.setup();
     stage();
     render(<MyWorkPage />);
 
-    await user.click(await screen.findByText(/Clamp on the boss/));
-    await user.click(await screen.findByRole('button', { name: /Open J-0042/ }));
+    await user.click(await screen.findByRole('button', { name: /actions for this note/i }));
+    await user.click(await screen.findByRole('menuitem', { name: /Open J-0042/ }));
 
     expect(routerMocks.push).toHaveBeenCalledWith(
       '/operator/test-company-id/jobs/job-1',
     );
   });
 
-  it('opens on a note nobody has read, so its job is still reachable', async () => {
-    // The card used to be inert at zero views. That stranded exactly the notes an
+  it('reaches the job of a note nobody has read', async () => {
+    // The row used to be inert at zero views, which stranded exactly the notes an
     // author is most likely to be checking up on — no viewers AND no way back to
-    // the job. There is always something behind the tap now.
+    // the job. The menu does not depend on the view count, so the route survives.
     const user = userEvent.setup();
     stage();
     render(<MyWorkPage />);
 
-    await user.click(await screen.findByText(/Clamp on the boss/));
+    await user.click(await screen.findByRole('button', { name: /actions for this note/i }));
 
-    expect(await screen.findByRole('button', { name: /Open J-0042/ })).toBeInTheDocument();
+    expect(await screen.findByRole('menuitem', { name: /Open J-0042/ })).toBeInTheDocument();
     // Still no pointless RPC: there are no names to fetch.
     expect(mockGetNoteViewers).not.toHaveBeenCalled();
     expect(screen.queryByText('Viewed by')).not.toBeInTheDocument();
+  });
+
+  /**
+   * The row body does nothing, and that is the design.
+   *
+   * NN/g measured across 136 participants and 11 mobile prototypes that when a row body
+   * and a trailing control do different things, people tap them about equally. A row that
+   * both expands on body-tap AND carries a menu is therefore a coin flip on every tap —
+   * which is unacceptable when one of the outcomes is a delete menu. So the readers open
+   * from the eye on the far left and the actions from the overflow on the far right, with
+   * nothing tappable in between.
+   */
+  it('does nothing when the note body is tapped', async () => {
+    const user = userEvent.setup();
+    stage({ notes: [note({ viewer_count: 2 })] });
+    render(<MyWorkPage />);
+
+    await user.click(await screen.findByText(/Clamp on the boss/));
+
+    expect(mockGetNoteViewers).not.toHaveBeenCalled();
+    expect(screen.queryByText('Viewed by')).not.toBeInTheDocument();
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('offers no reader disclosure at all when nobody has read it', async () => {
+    // One tap target on an unread row, not two: there are no names to ask for, so the
+    // count is a number rather than a control.
+    stage({ notes: [note({ viewer_count: 0 })] });
+    render(<MyWorkPage />);
+
+    await screen.findByText(/Clamp on the boss/);
+    expect(screen.queryByRole('button', { name: /who read this/i })).not.toBeInTheDocument();
   });
 
   it('survives a note whose job has been deleted', async () => {
@@ -230,7 +262,7 @@ describe('My Work', () => {
     await screen.findByText(/Clamp on the boss/);
     expect(mockGetNoteViewers).not.toHaveBeenCalled();
 
-    await user.click(screen.getByText(/Clamp on the boss/));
+    await user.click(screen.getByRole('button', { name: /who read this/i }));
 
     expect(await screen.findByText('Diego · J-0004')).toBeInTheDocument();
     expect(screen.getByText('Priya · J-0006')).toBeInTheDocument();

--- a/__tests__/app/operator/MyWorkPage.test.tsx
+++ b/__tests__/app/operator/MyWorkPage.test.tsx
@@ -218,8 +218,31 @@ describe('My Work', () => {
     stage({ totals: { peopleReached: 5 } });
     render(<MyWorkPage />);
 
-    expect(await screen.findByText('views')).toBeInTheDocument();
+    expect(await screen.findByText('times viewed')).toBeInTheDocument();
     expect(screen.queryByText(/people have (used|viewed)/i)).not.toBeInTheDocument();
+    // "viewed", never "used" — all that was recorded is that somebody opened the note.
+    expect(screen.queryByText(/used/i)).not.toBeInTheDocument();
+  });
+
+  /**
+   * The summary has no heading, and that is deliberate rather than an oversight.
+   *
+   * It used to read "What you've added", which was true of the notes and the photos and
+   * false of the views — those are not something the operator added, they are what came
+   * back. No one heading is true of both categories, and two headings over three figures
+   * is more structure than three numbers can carry, so each caption states its own kind
+   * instead: the contributions are past-tense verbs the operator performed, the reception
+   * one is passive.
+   */
+  it('states each figure kind in its own caption, with no heading claiming all three', async () => {
+    stage({ totals: { noteCount: 17, photoCount: 2, peopleReached: 9 } });
+    render(<MyWorkPage />);
+
+    expect(await screen.findByText('notes written')).toBeInTheDocument();
+    expect(screen.getByText('photos added')).toBeInTheDocument();
+    expect(screen.getByText('times viewed')).toBeInTheDocument();
+    // The heading claimed authorship of a number the operator did not author.
+    expect(screen.queryByText(/what you.?ve added/i)).not.toBeInTheDocument();
   });
 
   it('shows the view count alone, never a second job figure beside it', async () => {

--- a/__tests__/app/operator/MyWorkPage.test.tsx
+++ b/__tests__/app/operator/MyWorkPage.test.tsx
@@ -218,31 +218,52 @@ describe('My Work', () => {
     stage({ totals: { peopleReached: 5 } });
     render(<MyWorkPage />);
 
-    expect(await screen.findByText('times viewed')).toBeInTheDocument();
+    expect(await screen.findByText('Times viewed')).toBeInTheDocument();
     expect(screen.queryByText(/people have (used|viewed)/i)).not.toBeInTheDocument();
     // "viewed", never "used" — all that was recorded is that somebody opened the note.
     expect(screen.queryByText(/used/i)).not.toBeInTheDocument();
   });
 
   /**
-   * The summary has no heading, and that is deliberate rather than an oversight.
+   * The summary heading predicates THE NOTES, not the operator.
    *
    * It used to read "What you've added", which was true of the notes and the photos and
-   * false of the views — those are not something the operator added, they are what came
-   * back. No one heading is true of both categories, and two headings over three figures
-   * is more structure than three numbers can carry, so each caption states its own kind
-   * instead: the contributions are past-tense verbs the operator performed, the reception
-   * one is passive.
+   * false of the views — a view is not something the operator added, it is what came back.
+   * Moving the grammatical subject to the notes makes every figure a true predicate of it:
+   * the notes number 17, and they have been opened 9 times.
+   *
+   * "so far" is load-bearing and must stay unbounded. A windowed heading ("this month",
+   * "last 30 days") turns a tally into a rate, and a rate is pace — which the surveillance
+   * guardrail in docs/modules/operator-view.md forbids outright.
    */
-  it('states each figure kind in its own caption, with no heading claiming all three', async () => {
+  it('heads the summary with a claim that is true of every figure under it', async () => {
     stage({ totals: { noteCount: 17, photoCount: 2, peopleReached: 9 } });
     render(<MyWorkPage />);
 
-    expect(await screen.findByText('notes written')).toBeInTheDocument();
-    expect(screen.getByText('photos added')).toBeInTheDocument();
-    expect(screen.getByText('times viewed')).toBeInTheDocument();
-    // The heading claimed authorship of a number the operator did not author.
+    expect(await screen.findByRole('heading', { name: /your notes so far/i })).toBeInTheDocument();
+    // Never a claim the operator authored the views.
     expect(screen.queryByText(/what you.?ve added/i)).not.toBeInTheDocument();
+    // Never a bounded window, which would make it a rate.
+    expect(screen.queryByText(/this (week|month)|last \d+ days/i)).not.toBeInTheDocument();
+  });
+
+  /**
+   * The figures are data, not section titles. They rendered as `variant="h4"` — literal
+   * `<h4>` elements — so a screen reader's heading rotor listed "17", "0" and "9" as three
+   * headings with no antecedent, and nothing tied a figure to its caption. A `dt`/`dd` pair
+   * is the documented semantic for a big-number-plus-caption tile.
+   */
+  it('does not announce the figures as headings', async () => {
+    stage({ totals: { noteCount: 17, photoCount: 2, peopleReached: 9 } });
+    render(<MyWorkPage />);
+
+    await screen.findByRole('heading', { name: /your notes so far/i });
+    for (const figure of ['17', '2', '9']) {
+      expect(screen.queryByRole('heading', { name: figure })).not.toBeInTheDocument();
+    }
+    expect(screen.getByText('Notes')).toBeInTheDocument();
+    expect(screen.getByText('Photos')).toBeInTheDocument();
+    expect(screen.getByText('Times viewed')).toBeInTheDocument();
   });
 
   it('shows the view count alone, never a second job figure beside it', async () => {

--- a/__tests__/app/operator/MyWorkPage.test.tsx
+++ b/__tests__/app/operator/MyWorkPage.test.tsx
@@ -508,7 +508,10 @@ describe('My Work — the "Me" tab', () => {
     render(<MyWorkPage />);
 
     const feedback = await screen.findByRole('button', { name: /give feedback/i });
-    const firstNote = screen.getAllByRole('listitem')[0];
+    // findAllByRole, not getAllByRole: the identity block renders immediately but the notes
+    // arrive on their own load, so a synchronous query here races the list and fails on a
+    // slower machine. CI caught exactly this.
+    const firstNote = (await screen.findAllByRole('listitem'))[0];
     expect(
       feedback.compareDocumentPosition(firstNote) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
@@ -526,8 +529,8 @@ describe('My Work — the "Me" tab', () => {
     expect(email).toBeInTheDocument();
     expect(screen.queryByText(/signed in as/i)).not.toBeInTheDocument();
 
-    // Above the work, not below it.
-    const firstNote = screen.getAllByRole('listitem')[0];
+    // Above the work, not below it. Awaited — the notes load after the identity block.
+    const firstNote = (await screen.findAllByRole('listitem'))[0];
     expect(email.compareDocumentPosition(firstNote) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
@@ -581,7 +584,8 @@ describe('My Work — the "Me" tab', () => {
     expect(within(row).queryAllByRole('link')).toHaveLength(0);
 
     // And reachable before the work rather than after it — the point of the move.
-    const firstNote = screen.getAllByRole('listitem')[0];
+    // Awaited: the notes load after the identity block this test opened on.
+    const firstNote = (await screen.findAllByRole('listitem'))[0];
     expect(
       logout.compareDocumentPosition(firstNote) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();

--- a/__tests__/app/operator/MyWorkPage.test.tsx
+++ b/__tests__/app/operator/MyWorkPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, within, routerMocks } from '@/__tests__/test-utils';
+import { render, screen, within, waitFor, routerMocks } from '@/__tests__/test-utils';
 import userEvent from '@testing-library/user-event';
 
 import MyWorkPage from '@/app/operator/[companyId]/my-work/page';
@@ -17,8 +17,6 @@ vi.mock('@/utils/operatorAccess', () => ({
   getNoteViewers: vi.fn(),
   // The "Me" tab resolves the operator's display name through this.
   getCurrentMember: vi.fn(async () => ({ id: 'm1', name: 'Ada Lovelace', role: 'operator' })),
-  // Log out drops the cached member along with the session.
-  clearCurrentMemberCache: vi.fn(),
   MY_NOTES_PAGE_SIZE: 10,
 }));
 
@@ -351,6 +349,35 @@ describe('My Work — paging', () => {
     expect(await screen.findByText(/Could not load more notes/)).toBeInTheDocument();
     expect(screen.getByText('First note')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /show more/i })).toBeInTheDocument();
+  });
+
+  /**
+   * The retry above only works because `getMyNotesPage` REJECTS on a query failure.
+   *
+   * It used to swallow the error and resolve `{notes: [], hasMore: false}`, which took the
+   * success path here: nothing appended, `hasMore` false, Show more removed from the DOM,
+   * no error shown. One dropped request on a shop connection therefore made every
+   * remaining note look deleted, on a screen that otherwise read as settled. The guard is
+   * in the access layer (a rejected promise), so this asserts the component's half: an
+   * empty page that is genuinely the end must retire the button, and only a rejection may
+   * surface the retry — the two must not be conflated.
+   */
+  it('treats a genuinely empty last page as the end, not as a failure', async () => {
+    const user = userEvent.setup();
+    stage({ notes: [note({ id: 'n1', body: 'First note' })], hasMore: true });
+    render(<MyWorkPage />);
+
+    await screen.findByText('First note');
+    mockGetNotesPage.mockResolvedValue({ notes: [], hasMore: false });
+
+    await user.click(screen.getByRole('button', { name: /show more/i }));
+
+    // Button retires, and NO error is claimed — nothing actually went wrong.
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /show more/i })).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/Could not load more notes/)).not.toBeInTheDocument();
+    expect(screen.getByText('First note')).toBeInTheDocument();
   });
 });
 

--- a/__tests__/components/notes/NoteEditDialogStability.test.tsx
+++ b/__tests__/components/notes/NoteEditDialogStability.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Profiler } from 'react';
+import { render, screen } from '@/__tests__/test-utils';
+
+import NoteEditDialog from '@/components/notes/NoteEditDialog';
+
+vi.mock('@/utils/jobNoteMediaAccess', () => ({
+  getJobNoteMediaUrl: vi.fn(async () => 'https://example.test/photo.jpg'),
+}));
+
+/**
+ * This component must reach a resting state and stay there.
+ *
+ * The bug this guards against had no symptom anywhere you would normally look. `media = []`
+ * was a DEFAULT PARAMETER, so it produced a new array identity on every render; that array
+ * was `useLoad`'s dependency, so the loader re-ran every render and every resolution
+ * setState'd a fresh object, which rendered again. React never complained, because the
+ * setState came from a promise callback rather than synchronously during render, so the
+ * "Maximum update depth exceeded" guard never fired. With `open={false}` the dialog rendered
+ * null, so there were no DOM mutations to notice. The loader mapped over an empty array, so
+ * there were no network requests to notice. Every iteration was sub-millisecond, so a
+ * longtask observer reported zero.
+ *
+ * The only observable was a CPU core pinned for as long as the component stayed mounted —
+ * and the operator "Me" tab mounted one of these PER NOTE ROW, closed, so a screen of ten
+ * notes ran ten of them and every subsequent tap competed with a saturated core. That is
+ * what "the app stalls after going to the Me page" was.
+ *
+ * Counting commits is the assertion because it is the only thing that distinguishes the two
+ * states from outside. Rendered output is identical either way.
+ */
+async function countCommits(ui: React.ReactElement, ms: number): Promise<number> {
+  let commits = 0;
+  render(<Profiler id="probe" onRender={() => { commits += 1; }}>{ui}</Profiler>);
+  await new Promise((r) => setTimeout(r, ms));
+  return commits;
+}
+
+describe('NoteEditDialog render stability', () => {
+  const noop = () => {};
+
+  it('settles when no media prop is passed (the surface that spun a core)', async () => {
+    const commits = await countCommits(
+      <NoteEditDialog open={false} initialBody="Clamp on the boss." onSave={noop} onClose={noop} />,
+      300,
+    );
+
+    // Settled means a handful of commits, not thousands. Before the fix this was ~1000+
+    // in the same window and still climbing.
+    expect(commits).toBeLessThan(15);
+  });
+
+  it('settles for many closed instances, which is how the Me tab rendered them', async () => {
+    const many = (
+      <>
+        {Array.from({ length: 10 }, (_, i) => (
+          <NoteEditDialog
+            key={i}
+            open={false}
+            initialBody={`note ${i}`}
+            onSave={noop}
+            onClose={noop}
+          />
+        ))}
+      </>
+    );
+
+    const commits = await countCommits(many, 300);
+    expect(commits).toBeLessThan(40);
+  });
+
+  it('still settles when media IS passed with a stable identity', async () => {
+    const media = [
+      { id: 'm1', storage_path: 'a/b.jpg', thumbnail_path: null },
+    ] as never;
+
+    const commits = await countCommits(
+      <NoteEditDialog
+        open
+        initialBody="With a photo."
+        media={media}
+        onSave={noop}
+        onClose={noop}
+      />,
+      300,
+    );
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(commits).toBeLessThan(15);
+  });
+});

--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -48,6 +48,7 @@ import {
   markOperationReceived,
   revertOperationCompletion,
   getOutsideOpsForCompany,
+  clearCurrentMemberCache,
 } from '@/utils/operatorAccess';
 import { createOperationCompletion } from '@/utils/operationCompletionsAccess';
 
@@ -73,6 +74,11 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockQueryBuilder.data = null;
   mockQueryBuilder.error = null;
+  // `getCurrentMember` dedupes per company for the lifetime of a session, and a module
+  // lives longer than a test. Without this, the first test to resolve a member for a
+  // company pins that answer for every later one — which is exactly how the
+  // "not a member" case started passing a member.
+  clearCurrentMemberCache();
 });
 
 describe('getAllStationsOperatorJobs', () => {

--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -48,7 +48,7 @@ import {
   markOperationReceived,
   revertOperationCompletion,
   getOutsideOpsForCompany,
-  clearCurrentMemberCache,
+  getCurrentMember,
 } from '@/utils/operatorAccess';
 import { createOperationCompletion } from '@/utils/operationCompletionsAccess';
 
@@ -74,11 +74,6 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockQueryBuilder.data = null;
   mockQueryBuilder.error = null;
-  // `getCurrentMember` dedupes per company for the lifetime of a session, and a module
-  // lives longer than a test. Without this, the first test to resolve a member for a
-  // company pins that answer for every later one — which is exactly how the
-  // "not a member" case started passing a member.
-  clearCurrentMemberCache();
 });
 
 describe('getAllStationsOperatorJobs', () => {
@@ -549,6 +544,58 @@ describe('getOutsideOpsForCompany', () => {
   });
 });
 
+
+/**
+ * `getCurrentMember` shares one request between simultaneous callers, and keeps nothing
+ * afterwards.
+ *
+ * Both halves matter and they pull against each other. The sharing is the point: every
+ * call opens with `auth.getSession()`, which supabase-js serialises behind a
+ * `navigator.locks` acquisition, so the three callers the "Me" tab fires in one commit
+ * used to queue against each other on the lock that gates every other request on the page.
+ *
+ * Not retaining it is equally the point. A session-length cache of this row is a
+ * cross-user leak on a shared office computer: sign-out is `router.replace` and sign-in is
+ * `router.push`, so module state survives the whole cycle, and this row is what pins
+ * `uploaded_by` / `author_id` on writes whose RLS requires them to match the caller.
+ */
+describe('getCurrentMember request sharing', () => {
+  it('collapses simultaneous callers into ONE round trip', async () => {
+    mockQueryBuilder.data = { id: 'acc-me', name: 'Diego', user_id: 'auth-user-1', role: 'operator' };
+
+    const [a, b, c] = await Promise.all([
+      getCurrentMember('c1'),
+      getCurrentMember('c1'),
+      getCurrentMember('c1'),
+    ]);
+
+    expect(a).toEqual(b);
+    expect(b).toEqual(c);
+    // One session read and one table read, not three of each.
+    expect(mockSupabase.auth.getSession).toHaveBeenCalledTimes(1);
+    expect(mockSupabase.from).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps nothing once the request settles, so the next caller re-reads', async () => {
+    mockQueryBuilder.data = { id: 'acc-me', name: 'Diego', user_id: 'auth-user-1', role: 'operator' };
+    await getCurrentMember('c1');
+
+    // A different person is signed in now. Nothing may be inherited from the last one.
+    mockQueryBuilder.data = { id: 'acc-you', name: 'Priya', user_id: 'auth-user-2', role: 'admin' };
+    const second = await getCurrentMember('c1');
+
+    expect(second?.id).toBe('acc-you');
+    expect(mockSupabase.auth.getSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not pin a failure — a later call can still succeed', async () => {
+    mockQueryBuilder.data = null;
+    expect(await getCurrentMember('c1')).toBeNull();
+
+    mockQueryBuilder.data = { id: 'acc-me', name: 'Diego', user_id: 'auth-user-1', role: 'operator' };
+    expect((await getCurrentMember('c1'))?.id).toBe('acc-me');
+  });
+});
 
 describe('reactions', () => {
   // getCurrentMember resolves via a single() on user_company_access.

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useParams, useRouter, usePathname } from 'next/navigation';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Box from '@mui/material/Box';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
@@ -31,6 +31,7 @@ import { OperatorStationProvider, useStationContext } from '@/components/operato
 import { OperatorChromeProvider, useOperatorChrome, useOperatorNav } from '@/components/operator/OperatorChromeContext';
 import JiggedIcon from '@/components/branding/JiggedIcon';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
+import { clearCurrentMemberCache } from '@/utils/operatorAccess';
 import type { AuthChangeEvent } from '@supabase/supabase-js';
 
 /**
@@ -61,14 +62,42 @@ export default function OperatorLayout({
 
   const supabase = getSupabase();
 
-  // Check authentication on mount
+  // Whether we're on the login screen. Derived to a BOOLEAN on purpose: the auth effect
+  // below keys off this rather than off `pathname`, so it re-runs only when you cross the
+  // login boundary — not on every tap of the bottom bar. See the note on the effect.
+  const isAuthPage = Boolean(pathname?.includes('/login'));
+
+  // The companyId we have already validated in this mount. Guards against a re-run
+  // repeating the network work (React's development double-invoke, or a bounce out to
+  // login and back). Cleared on sign-out and when we land on login, so a NEW session
+  // always re-validates.
+  const validatedFor = useRef<string | null>(null);
+
+  /**
+   * Validate the session once per company, NOT once per navigation.
+   *
+   * `pathname` used to be in this dependency list, so every in-app navigation re-ran the
+   * whole check: another `auth.getSession()`, another `user_company_access` round trip,
+   * another `app_opened`. That mattered because `supabase-js` serialises `getSession()`
+   * behind a `navigator.locks` acquisition and can refresh the token inside that lock —
+   * so on a page that already fans out several session reads (Me was the worst: four),
+   * navigating added one more contender to a queue that was already the slowest thing on
+   * screen. Operators saw it as the Me tab hanging.
+   *
+   * It also fixes `app_opened`, which is documented below as top-of-funnel — one per
+   * session. Counting a tab tap as an app open inflated every ratio measured against it.
+   */
   useEffect(() => {
     const checkAuth = async () => {
-      // Skip auth check on login page
-      if (pathname?.includes('/login')) {
+      // Skip auth check on login page. Clearing the guard here is what makes a fresh
+      // sign-in re-validate rather than inherit the previous user's answer.
+      if (isAuthPage) {
+        validatedFor.current = null;
         setIsLoading(false);
         return;
       }
+
+      if (validatedFor.current === companyId) return;
 
       // 1. Get Supabase session
       const { data: { session } } = await supabase.auth.getSession();
@@ -94,12 +123,15 @@ export default function OperatorLayout({
         return;
       }
 
+      validatedFor.current = companyId;
       setUserRole(operatorAccess.role || 'operator');
 
       // Top of the funnel. Everything else is measured against this: if
       // app_opened is near zero, no downstream number is interpretable and the
       // problem is deployment, not the product. Fired after membership is
-      // confirmed so a bounced sign-in is not counted as a session.
+      // confirmed so a bounced sign-in is not counted as a session — and, since
+      // this effect no longer re-runs per navigation, once per session rather
+      // than once per screen.
       logOperatorEvent(companyId, 'app_opened');
 
       setIsLoading(false);
@@ -110,6 +142,10 @@ export default function OperatorLayout({
     // Listen for auth state changes
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event: AuthChangeEvent) => {
       if (event === 'SIGNED_OUT') {
+        // Drop the cached member with the validation guard — both are answers about a
+        // user who is no longer signed in.
+        validatedFor.current = null;
+        clearCurrentMemberCache();
         router.push(`/operator/${companyId}/login`);
       }
     });
@@ -117,7 +153,7 @@ export default function OperatorLayout({
     return () => {
       subscription.unsubscribe();
     };
-  }, [companyId, router, pathname, supabase]);
+  }, [companyId, router, isAuthPage, supabase]);
 
   // Update nav value based on current path.
   //
@@ -177,9 +213,7 @@ export default function OperatorLayout({
     router.push(scanDestination(companyId, { kind: 'traveler', jobId, jobPartId, operationId }));
   };
 
-  // Don't show header/nav on login page
-  const isAuthPage = pathname?.includes('/login');
-
+  // Don't show header/nav on login page — same `isAuthPage` the auth effect keys off.
   if (isAuthPage) {
     return (
       <Box
@@ -344,7 +378,17 @@ function OperatorShell({
         }}
       >
         <Toolbar sx={{ minHeight: '48px !important', px: 1 }}>
-          {/* Left: back on detail pages, JIG logo on back-less roots. */}
+          {/* Left: back on detail pages, JIG logo on back-less roots — which is every
+              tab the bottom bar owns. A tab root has no "back": the nav bar already IS
+              the way between them, so an arrow there just re-enters a sibling tab and
+              reads as though the operator has gone somewhere they need to leave.
+
+              32px, not the 20px this started at. It alternates in the same slot as the
+              `size="small"` back IconButton (~34px including its ripple), so anything
+              much smaller made the header visibly lurch as you moved between a traveler
+              and a tab root — and at 20px the mark was too small to read as branding at
+              arm's length on a shop floor. 32 clears the 48px Toolbar by 8px either side.
+              `ml` matches the IconButton's own padding so the left edge doesn't shift. */}
           {chrome.back ? (
             <IconButton
               color="inherit"
@@ -355,7 +399,9 @@ function OperatorShell({
               <ArrowBackIcon fontSize="small" />
             </IconButton>
           ) : (
-            <JiggedIcon size={20} />
+            <Box sx={{ display: 'flex', alignItems: 'center', ml: 0.5 }}>
+              <JiggedIcon size={32} />
+            </Box>
           )}
 
           {/* Center: station name + dropdown, centered between the clusters (the
@@ -451,18 +497,37 @@ function OperatorShell({
         </Menu>
       </AppBar>
 
-      {/* Main Content */}
+      {/*
+        Main content. THE DOCUMENT SCROLLS — this box must not.
+
+        It used to be `flex: 1` + `overflow: 'auto'`, which made it a private scroll
+        container: every sibling here is `position: fixed`, so it was the only in-flow
+        item, its flex basis resolved to 0, and it settled at exactly
+        `100vh - 48px - (56px + inset)` with its own scrollbar. Two bugs came out of that,
+        and both read to an operator as "the page is stuck":
+
+          1. `scrollTop` survived tab switches. This layout never unmounts on a client
+             navigation and Next's scroll restoration only touches `window`, so tapping Me
+             from a scrolled jobs list dropped you into the middle of the new page.
+
+          2. The end of the page was unreachable on a phone. `100vh` is the LARGE viewport
+             (browser chrome hidden) while the fixed bottom bar tracks the SMALL one, so at
+             maximum scroll the last chunk of content sat below the fold with no way to
+             reach it. On the Me tab that chunk was Give feedback and Log out.
+
+        Letting the document scroll fixes both for free: native scroll restoration works,
+        and `100vh` stops being load-bearing for anything you have to be able to reach.
+      */}
       <Box
         component="main"
         sx={{
           position: 'relative',
           zIndex: 1, // above the fixed ambient backdrop
-          flex: 1,
+          flexGrow: 1, // fill the viewport so the background reaches the bottom on short pages
           mt: '48px', // Single-row AppBar height
           // BottomNavigation height plus whatever the device reserves at the bottom (the iOS home
           // indicator). `viewportFit: 'cover'` in the root layout is what makes the inset non-zero.
           mb: navVisible ? 'calc(56px + env(safe-area-inset-bottom))' : 0,
-          overflow: 'auto',
           p: 2,
         }}
       >

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -31,7 +31,6 @@ import { OperatorStationProvider, useStationContext } from '@/components/operato
 import { OperatorChromeProvider, useOperatorChrome, useOperatorNav } from '@/components/operator/OperatorChromeContext';
 import JiggedIcon from '@/components/branding/JiggedIcon';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
-import { clearCurrentMemberCache } from '@/utils/operatorAccess';
 import type { AuthChangeEvent } from '@supabase/supabase-js';
 
 /**
@@ -142,10 +141,10 @@ export default function OperatorLayout({
     // Listen for auth state changes
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event: AuthChangeEvent) => {
       if (event === 'SIGNED_OUT') {
-        // Drop the cached member with the validation guard — both are answers about a
-        // user who is no longer signed in.
+        // Drop the validation answer — it was about a user who is no longer signed in.
+        // (`getCurrentMember` needs no equivalent: it only ever caches a request that is
+        // still in flight, so it has nothing that can outlive a session.)
         validatedFor.current = null;
-        clearCurrentMemberCache();
         router.push(`/operator/${companyId}/login`);
       }
     });

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -125,7 +125,23 @@ function ReachRow({
   );
 }
 
-/** One figure in the "what you've added" row: the number, then what it counts. */
+/**
+ * One figure in the summary: the number, and what it counts.
+ *
+ * A `dt`/`dd` pair, which is the documented semantic for a big-number-plus-caption tile —
+ * it is what programmatically ties "9" to "Times viewed". These were previously
+ * `variant="h4"`, which renders a literal `<h4>`, so a screen reader's heading rotor listed
+ * "17", "0" and "9" as three headings with no antecedent and no link to their captions.
+ *
+ * `column-reverse` puts the number on top while leaving `dt` before `dd` in the DOM, which
+ * HTML requires. Reading "Notes, 17" rather than "17, Notes" is also the better of the two
+ * announcements — the caption frames the number instead of the listener holding a bare
+ * figure in memory until the label arrives.
+ *
+ * Deliberately NOT `tabular-nums`: equal-width digits make a large standalone value look
+ * loose. Column positions are already fixed by the grid, so the row cannot shift as a count
+ * rolls over.
+ */
 function Stat({
   value,
   label,
@@ -136,12 +152,15 @@ function Stat({
   align: 'left' | 'center' | 'right';
 }) {
   return (
-    <Box sx={{ textAlign: align }}>
-      <Typography variant="h4" fontWeight={700}>
-        {value}
-      </Typography>
-      <Typography variant="caption" color="text.secondary">
+    <Box sx={{ display: 'flex', flexDirection: 'column-reverse', textAlign: align }}>
+      <Typography component="dt" sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
         {label}
+      </Typography>
+      <Typography
+        component="dd"
+        sx={{ m: 0, fontSize: '1.75rem', fontWeight: 700, lineHeight: 1.2 }}
+      >
+        {value}
       </Typography>
     </Box>
   );
@@ -295,7 +314,11 @@ function NoteRow({
               {/* Explicitly labelled: the job beside a viewer's name is the job
                   THEY consulted it on, not the job in the header where the note
                   was written. Same format, different meaning — so say which. */}
-              <Typography variant="overline" color="text.secondary" sx={{ display: 'block' }}>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ display: 'block', fontWeight: 600, mb: 0.5 }}
+              >
                 Viewed by
               </Typography>
               {loading ? (
@@ -535,58 +558,63 @@ function MyContribution({ companyId }: { companyId: string }) {
           the point is that writing things down is the work, not a score. */}
       <Card elevation={2} sx={{ ...cardSx, mb: 3 }}>
         <CardContent>
-          {/* NO HEADER, deliberately. "What you've added" was true of the notes and the
-              photos and false of the views — those are not something the operator added,
-              they are what came back. No single heading is true of both categories, and
-              two headings over three figures is more structure than three numbers can
-              carry, so the captions say what each figure is instead. */}
-          {/* Three equal columns, and each one aligned to the edge it sits nearest:
-              first hard left, middle centred, last hard right. Equal columns alone were
-              not enough — with every column's content left-aligned, the last number
-              landed a third of the way in from the right and the middle one sat left of
-              the card's true centre, so the row still read as clustered.
+          {/* A HEADING, and it predicates THE NOTES rather than the operator.
+              "What you've added" was false of the third figure — a view is not something
+              the operator added. Moving the grammatical subject to the notes makes every
+              figure a true predicate of it: the notes number 17, and they have been opened
+              9 times. Google Maps solves the identical card the same way, attaching the
+              possessive to the posts rather than to the views ("total review views … of
+              your posts").
 
-              CAPPED at 420px rather than stretched to the card. Nothing constrains the
-              operator column's width on this branch, so edge-to-edge on a laptop would
-              put "notes" and "views" a thousand pixels apart. A phone has ~340px of
-              usable width here, so the cap never binds on the device this is for. */}
+              "so far" and never "this month": a bounded window turns a tally into a rate,
+              and a rate is pace — which the surveillance guardrail forbids outright.
+
+              Sentence case, not the `overline` variant used elsewhere on this screen.
+              Overline stacks 12px + uppercase + letter-spacing, and readers over 55 were
+              measured 29% more likely to misread text set in capitals (Arbel & Toler 2020),
+              with reading speed down 10–20% (Tinker 1955). This is the exact demographic
+              the app is for. A real `h2` because it is a section title, and because it is
+              what lets the captions below stay short enough to fit three across at 14px —
+              they inherit "your notes" from it instead of each repeating it. */}
+          <Typography
+            component="h2"
+            sx={{ fontSize: '1rem', fontWeight: 600, textTransform: 'none', mb: 1.5 }}
+          >
+            Your notes so far
+          </Typography>
+
+          {/* Three equal columns, each aligned to the edge it sits nearest: first hard
+              left, middle centred, last hard right. Capped at 420px — nothing constrains
+              the operator column's width on this branch, so aligning to the card's own
+              edges would put the first and last figures a thousand pixels apart on a
+              laptop. A phone has ~340px of usable width, so the cap never binds there. */}
           <Box
+            component="dl"
             sx={{
+              m: 0,
               display: 'grid',
               gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
               gap: 2,
               maxWidth: 420,
-              mt: 0.5,
             }}
           >
-            <Stat
-              value={c.noteCount}
-              label={c.noteCount === 1 ? 'note written' : 'notes written'}
-              align="left"
-            />
+            <Stat value={c.noteCount} label={c.noteCount === 1 ? 'Note' : 'Notes'} align="left" />
             <Stat
               value={c.photoCount}
-              label={c.photoCount === 1 ? 'photo added' : 'photos added'}
+              label={c.photoCount === 1 ? 'Photo' : 'Photos'}
               align="center"
             />
-            {/* "views", not "people". This sums each note's viewer_count, so one colleague
-                who read three of your notes contributes three — a view total, not a
-                headcount. A distinct-people figure would need the note_views rows, which no
-                browser role can read by design. The per-note numbers below are exact.
+            {/* "Times viewed", not "Views": a passive phrasing is what marks this figure as
+                reception rather than contribution now that it sits under a heading covering
+                all three. Still "viewed" and never "used" — all that was recorded is that
+                somebody opened the note and stayed on it.
 
-                NOT GREEN, unlike the per-note count. Green is semantic in this theme — a
-                state, not a decoration — and a lifetime total has no state to report. It was
-                also the only one of three sibling metrics that was coloured, which made the
-                least actionable number the loudest thing in the card. On a note row the same
-                green earns its place: there it is binary and comparative, marking which
-                notes have landed as you scan a column. Here there is nothing to compare. */}
-            {/* "times viewed", not "views": a passive phrasing is what marks this one out
-                as reception rather than contribution, now that no heading does it. Still
-                "viewed" and never "used" — all that was recorded is that somebody opened
-                the note and stayed on it. */}
+                A sum, not a headcount: one colleague reading three of these notes counts
+                three. A distinct-people figure would need the note_views rows, which no
+                browser role can read by design. */}
             <Stat
               value={c.peopleReached}
-              label={c.peopleReached === 1 ? 'time viewed' : 'times viewed'}
+              label={c.peopleReached === 1 ? 'Time viewed' : 'Times viewed'}
               align="right"
             />
           </Box>
@@ -594,7 +622,13 @@ function MyContribution({ companyId }: { companyId: string }) {
         </CardContent>
       </Card>
 
-      <Typography variant="overline" color="text.secondary" sx={{ px: 0.5 }}>
+      {/* Sentence case and a real heading, matching the summary above it. Uppercase is
+          measurably worse for readers over 55 — see the note on the card's heading — and
+          `overline` applies it along with a 12px size and extra letter-spacing. */}
+      <Typography
+        component="h2"
+        sx={{ fontSize: '1rem', fontWeight: 600, color: 'text.secondary', px: 0.5, mb: 0.5 }}
+      >
         Your notes
       </Typography>
       {/* A real list: it is one semantically, screen readers announce the count,

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -15,6 +15,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import Collapse from '@mui/material/Collapse';
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
+import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
 import LaunchIcon from '@mui/icons-material/Launch';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
@@ -30,10 +31,7 @@ import NoteEditDialog from '@/components/notes/NoteEditDialog';
 import NoteEditedMark from '@/components/notes/NoteEditedMark';
 import NoteDeleteDialog from '@/components/notes/NoteDeleteDialog';
 import { useOperatorIdentity } from '@/hooks/useOperatorIdentity';
-import {
-  OperatorIdentityRow,
-  OperatorAccountActions,
-} from '@/components/operator/OperatorAccountBlock';
+import { OperatorIdentityRow } from '@/components/operator/OperatorAccountBlock';
 import NoteReactions from '@/components/operator/NoteReactions';
 import type { MyNote, NoteViewer } from '@/types/operator';
 
@@ -124,13 +122,35 @@ function NoteRow({
                 stable column to scan down, present whether or not the note
                 carries a part. */}
             <ReachRow note={note} />
-            {note.part_name && (
+            {/* THE SUBJECT, in one stable slot. A `notes` row has exactly one subject —
+                a part, a job, or a machine — and this list mixes all three, because all
+                three are things the operator wrote.
+
+                Machine entries used to render nothing here. They carry no part and no
+                operation, and unlike a job note they carry no job number either (the
+                CHECK constraint forbids it), so a maintenance entry appeared as a bare
+                sentence with nothing anywhere on the row saying it was about a machine.
+                Job notes are deliberately left bare: their subject is the job, and the
+                job reference already sits quietly beside the date — see the note there
+                for why it stays quiet rather than becoming a heading. */}
+            {(note.part_name || note.machine_name) && (
               <Typography variant="subtitle2" fontWeight={700} noWrap>
-                {note.part_name}
+                {note.part_name ?? note.machine_name}
               </Typography>
             )}
             {note.operation_label && (
               <Chip size="small" label={note.operation_label} variant="outlined" />
+            )}
+            {/* What they did to the machine, when they said. Optional by design, so a
+                classified entry gets a chip and an unclassified one simply doesn't. */}
+            {note.maintenance_kind && (
+              <Chip
+                size="small"
+                variant="outlined"
+                icon={<BuildOutlinedIcon />}
+                label={note.maintenance_kind}
+                sx={{ textTransform: 'capitalize' }}
+              />
             )}
             {note.photo_count > 0 && (
               <Chip
@@ -349,22 +369,25 @@ export default function MyWorkPage() {
   const { data: identity } = useOperatorIdentity(companyId);
 
   /**
-   * This is the "Me" tab: identity, then the work, then account actions.
+   * This is the "Me" tab: who you are and the two account actions, then the work.
    *
-   * The work is sandwiched rather than replaced — see `OperatorAccountBlock` for why the work
-   * has to lead, and why Log out now rides in the identity row instead of at the very bottom.
+   * Both account actions sit ABOVE the work now. They used to sandwich it — Log out last,
+   * Give feedback just before it — on the reasoning that the work must lead and a
+   * consequential action should be slightly slow to reach. The work still leads visually
+   * (a name, an email and a small link are not what the eye lands on), but "below the
+   * list" stopped being a place at all once the list could page: a pilot's feedback
+   * channel that only appears after ten notes and a Show more is a channel nobody uses,
+   * and a Log out you cannot reach is not a safe Log out.
    *
-   * The three loading/error/empty states are INSIDE `MyContribution` on purpose. They used to
-   * be early returns from this component, and leaving them there once Profile stopped being a
-   * tab would have meant a brand-new operator — the case with zero notes, i.e. the common one —
-   * had no Log out button anywhere in the app. That still holds: Log out lives above the work
-   * now, but Give feedback below it depends on the same thing.
+   * This also means neither action depends on the work loading. `MyContribution` owns its
+   * own loading/error/empty states rather than early-returning from here, which is what
+   * kept a brand-new operator — zero notes, the common case — from losing Log out
+   * entirely; now the ordering makes that structural rather than merely careful.
    */
   return (
     <Box sx={{ pb: 4 }}>
       <OperatorIdentityRow companyId={companyId} identity={identity} />
       <MyContribution companyId={companyId} />
-      <OperatorAccountActions identity={identity} />
     </Box>
   );
 }

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
@@ -19,12 +19,16 @@ import LaunchIcon from '@mui/icons-material/Launch';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
-import { getMyContribution, getNoteViewers, updateNoteBody } from '@/utils/operatorAccess';
+import {
+  getMyContributionTotals,
+  getMyNotesPage,
+  getNoteViewers,
+  updateNoteBody,
+} from '@/utils/operatorAccess';
 import { deleteJobNote } from '@/utils/jobNoteMediaAccess';
 import NoteEditDialog from '@/components/notes/NoteEditDialog';
 import NoteEditedMark from '@/components/notes/NoteEditedMark';
 import NoteDeleteDialog from '@/components/notes/NoteDeleteDialog';
-import { useSetOperatorChrome } from '@/components/operator/OperatorChromeContext';
 import { useOperatorIdentity } from '@/hooks/useOperatorIdentity';
 import {
   OperatorIdentityRow,
@@ -316,10 +320,19 @@ export default function MyWorkPage() {
   const params = useParams();
   const companyId = params.companyId as string;
 
-  useSetOperatorChrome(
-    { back: { href: `/operator/${companyId}/jobs`, label: 'Back to jobs' } },
-    [companyId],
-  );
+  /*
+   * NO `useSetOperatorChrome({ back })` HERE, deliberately.
+   *
+   * Me is a tab root, and a tab root has no "back". The bottom bar already is the way
+   * between tabs, so an arrow up here pointed at Jobs — a destination one tap away in
+   * the nav — and made a top-level destination read like a page you had wandered into.
+   * Declaring no chrome makes the header fall through to the Jigged mark, which is what
+   * Jobs, Inventory and Maintenance have always shown; Me was the only tab opting out.
+   *
+   * The other entry point, NoteUsageBanner on the jobs page, uses a plain `router.push`
+   * rather than `useOperatorNav().push`, so it doesn't bump the chrome depth counter
+   * either — that route lands on the same back-less root, with no special case.
+   */
 
   const { data: identity } = useOperatorIdentity(companyId);
 
@@ -327,28 +340,81 @@ export default function MyWorkPage() {
    * This is the "Me" tab: identity, then the work, then account actions.
    *
    * The work is sandwiched rather than replaced — see `OperatorAccountBlock` for why the work
-   * has to lead and why Log out sits at the very bottom.
+   * has to lead, and why Log out now rides in the identity row instead of at the very bottom.
    *
    * The three loading/error/empty states are INSIDE `MyContribution` on purpose. They used to
    * be early returns from this component, and leaving them there once Profile stopped being a
    * tab would have meant a brand-new operator — the case with zero notes, i.e. the common one —
-   * had no Log out button anywhere in the app.
+   * had no Log out button anywhere in the app. That still holds: Log out lives above the work
+   * now, but Give feedback below it depends on the same thing.
    */
   return (
     <Box sx={{ pb: 4 }}>
-      <OperatorIdentityRow identity={identity} />
+      <OperatorIdentityRow companyId={companyId} identity={identity} />
       <MyContribution companyId={companyId} />
-      <OperatorAccountActions companyId={companyId} identity={identity} />
+      <OperatorAccountActions identity={identity} />
     </Box>
   );
 }
 
-/** The operator's own notes and their reception. Owns its own loading/error/empty states. */
+/**
+ * The operator's own notes and their reception. Owns its own loading/error/empty states.
+ *
+ * Two loads, not one: the summary totals cover EVERY note the operator has written, while
+ * the list below is a page at a time. Reducing the totals out of the loaded rows would make
+ * "5 notes" mean "5 notes currently rendered" and climb on every Show more.
+ */
 function MyContribution({ companyId }: { companyId: string }) {
-  const { data, loading, error, reload } = useLoad(
-    () => getMyContribution(companyId),
-    [companyId],
+  const {
+    data: totals,
+    loading,
+    error,
+    reload: reloadTotals,
+  } = useLoad(() => getMyContributionTotals(companyId), [companyId]);
+
+  const {
+    data: firstPage,
+    error: pageError,
+    reload: reloadFirstPage,
+  } = useLoad(() => getMyNotesPage(companyId), [companyId]);
+
+  // Pages 2..n, appended. `useLoad` has no append semantics — it replaces — so the extra
+  // pages accumulate here and the first page stays owned by the hook, which keeps
+  // `reload()` after an edit or delete meaning "go back to one fresh page".
+  const [extraPages, setExtraPages] = useState<MyNote[]>([]);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [moreError, setMoreError] = useState(false);
+  const [exhausted, setExhausted] = useState(false);
+
+  const notes = useMemo(
+    () => [...(firstPage?.notes ?? []), ...extraPages],
+    [firstPage, extraPages],
   );
+  const hasMore = !exhausted && Boolean(firstPage?.hasMore);
+
+  /** Re-read from scratch after an edit or a delete, so the totals and the list agree. */
+  const refresh = useCallback(async () => {
+    setExtraPages([]);
+    setExhausted(false);
+    setMoreError(false);
+    await Promise.all([reloadTotals(), reloadFirstPage()]);
+  }, [reloadTotals, reloadFirstPage]);
+
+  const loadMore = useCallback(async () => {
+    setLoadingMore(true);
+    setMoreError(false);
+    try {
+      const next = await getMyNotesPage(companyId, { offset: notes.length });
+      setExtraPages((prev) => [...prev, ...next.notes]);
+      if (!next.hasMore) setExhausted(true);
+    } catch {
+      // Keep what is already on screen and offer the tap again — a failed extra page
+      // must not discard the pages that loaded.
+      setMoreError(true);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [companyId, notes.length]);
 
   if (loading) {
     return (
@@ -358,7 +424,7 @@ function MyContribution({ companyId }: { companyId: string }) {
     );
   }
 
-  if (error) {
+  if (error || pageError) {
     return (
       <Box sx={{ p: 1 }}>
         <Alert severity="error">Could not load your work. Try again.</Alert>
@@ -366,7 +432,7 @@ function MyContribution({ companyId }: { companyId: string }) {
     );
   }
 
-  const c = data ?? { noteCount: 0, photoCount: 0, peopleReached: 0, jobsReached: 0, notes: [] };
+  const c = totals ?? { noteCount: 0, photoCount: 0, peopleReached: 0 };
 
   if (c.noteCount === 0) {
     return (
@@ -435,10 +501,30 @@ function MyContribution({ companyId }: { companyId: string }) {
       {/* A real list: it is one semantically, screen readers announce the count,
           and each card becomes an addressable item rather than an anonymous div. */}
       <Box component="ul" sx={{ mt: 0.5, listStyle: 'none', p: 0, m: 0 }}>
-        {c.notes.map((n) => (
-          <NoteRow key={n.id} note={n} companyId={companyId} onChanged={reload} />
+        {notes.map((n) => (
+          <NoteRow key={n.id} note={n} companyId={companyId} onChanged={refresh} />
         ))}
       </Box>
+
+      {/*
+        Show more, not infinite scroll. Everything below this list — Give feedback — moves
+        further away with each page, so growing the list has to be something the operator
+        asks for. Auto-loading on scroll would make the bottom of the page unreachable by
+        design, which is the exact complaint paging was meant to answer.
+      */}
+      {hasMore && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 1 }}>
+          <Button onClick={loadMore} disabled={loadingMore} sx={{ minHeight: 48 }}>
+            {loadingMore ? <CircularProgress size={20} /> : 'Show more'}
+          </Button>
+        </Box>
+      )}
+
+      {moreError && (
+        <Alert severity="error" sx={{ mt: 1 }}>
+          Could not load more notes. Try again.
+        </Alert>
+      )}
     </Box>
   );
 }

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -250,8 +250,17 @@ function NoteRow({
           remove that you cannot see — so no media is passed and the dialog is
           text-only here. Removing individual photos lives on the three surfaces
           that actually show them. */}
+      {/* MOUNTED ONLY WHILE OPEN, like every other call site (JobFeed, PartNotesSheet,
+          MachineLogPanel all render `{editingNote && <NoteEditDialog open .../>}`).
+          This screen was the exception: it kept one edit dialog and one delete dialog
+          mounted per note row at open={false}, so a list of ten notes carried twenty
+          idle dialog subtrees. They rendered null, which is why nobody noticed — and
+          which is also why the render loop inside NoteEditDialog was invisible while it
+          held a core down. The loop is fixed at its source, but a dialog nobody has
+          opened should not be mounted at all. */}
+      {editing && (
       <NoteEditDialog
-        open={editing}
+        open
         initialBody={note.body}
         saving={busy}
         error={actionError}
@@ -273,9 +282,11 @@ function NoteRow({
           }
         }}
       />
+      )}
 
+      {confirmingDelete && (
       <NoteDeleteDialog
-        open={confirmingDelete}
+        open
         deleting={busy}
         error={actionError}
         onClose={() => {
@@ -299,6 +310,7 @@ function NoteRow({
           }
         }}
       />
+      )}
     </Card>
   );
 }

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -5,20 +5,17 @@ import { useParams, useRouter } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
+import ButtonBase from '@mui/material/ButtonBase';
+import Tooltip from '@mui/material/Tooltip';
 import CardContent from '@mui/material/CardContent';
-import CardActionArea from '@mui/material/CardActionArea';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
-import Divider from '@mui/material/Divider';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import Collapse from '@mui/material/Collapse';
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
 import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
-import LaunchIcon from '@mui/icons-material/Launch';
-import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import {
   getMyContributionTotals,
@@ -30,6 +27,7 @@ import { deleteJobNote } from '@/utils/jobNoteMediaAccess';
 import NoteEditDialog from '@/components/notes/NoteEditDialog';
 import NoteEditedMark from '@/components/notes/NoteEditedMark';
 import NoteDeleteDialog from '@/components/notes/NoteDeleteDialog';
+import NoteActionsMenu from '@/components/notes/NoteActionsMenu';
 import { useOperatorIdentity } from '@/hooks/useOperatorIdentity';
 import { OperatorIdentityRow } from '@/components/operator/OperatorAccountBlock';
 import NoteReactions from '@/components/operator/NoteReactions';
@@ -61,17 +59,64 @@ function formatDate(value: string): string {
  * quality signal the Playbook ranks by; it is just not the operator's business
  * on this screen.
  */
-function ReachRow({ note }: { note: MyNote }) {
+function ReachRow({
+  note,
+  expanded,
+  onToggle,
+}: {
+  note: MyNote;
+  expanded: boolean;
+  /** Omitted when nobody has read it — there are no names to ask for. */
+  onToggle?: () => void;
+}) {
   const read = note.viewer_count > 0;
-  return (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-      <VisibilityOutlinedIcon
-        sx={{ fontSize: 16, color: read ? 'success.light' : 'text.secondary' }}
-      />
-      <Typography variant="caption" sx={{ color: read ? 'success.light' : 'text.secondary' }}>
+  const color = read ? 'success.light' : 'text.secondary';
+
+  const face = (
+    <>
+      <VisibilityOutlinedIcon sx={{ fontSize: 18, color }} />
+      <Typography variant="caption" sx={{ color, fontWeight: 600 }}>
         {note.viewer_count}
       </Typography>
-    </Box>
+    </>
+  );
+
+  // Nobody has read it yet: a number, not a control. This is also what keeps an
+  // unread row down to ONE tap target instead of two.
+  if (!onToggle) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, width: 48, height: 48, justifyContent: 'center', flexShrink: 0 }}>
+        {face}
+      </Box>
+    );
+  }
+
+  /* THE DISCLOSURE FOR "WHO READ THIS", and deliberately not the whole row.
+     NN/g measured (136 participants, 11 mobile prototypes) that when a row body
+     and a trailing control do different things, people tap them about equally —
+     a coin flip. So the row body stays inert and the two controls sit at opposite
+     ends: readers here on the left, actions in the overflow on the right.
+     The count is the label, which is what keeps a bare icon honest. */
+  return (
+    <Tooltip title={expanded ? 'Hide readers' : 'Who read this'}>
+      <ButtonBase
+        onClick={onToggle}
+        aria-label={`Who read this note — ${note.viewer_count} so far`}
+        aria-expanded={expanded}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.5,
+          width: 48,
+          height: 48,
+          flexShrink: 0,
+          borderRadius: 1,
+          '&:hover': { bgcolor: 'rgba(255,255,255,0.06)' },
+        }}
+      >
+        {face}
+      </ButtonBase>
+    </Tooltip>
   );
 }
 
@@ -110,18 +155,30 @@ function NoteRow({
   };
 
   return (
-    <Card component="li" elevation={2} sx={{ ...cardSx, mb: 1.5 }}>
-      {/* The whole row expands. Navigation lives inside the expanded state
-          instead of on the card, so the list stays compact and there is only one
-          tap target per row — a chip up here both bloated the card and stole the
-          row's tap, because a button cannot nest inside a button. */}
-      <CardActionArea onClick={toggle} sx={{ p: 0 }}>
-        <CardContent sx={{ py: 1.5 }}>
+    /*
+     * A FLAT ROW WITH TWO CONTROLS AT OPPOSITE ENDS, and an inert body between them.
+     *
+     * This used to be a card that was one big CardActionArea: tap anywhere to expand,
+     * with Edit / Delete / Open-job as full-width buttons inside. Two things were wrong
+     * with that. The card chrome cost three notes per phone screen for no information —
+     * NN/g puts ~74% of viewing time in the first two screenfuls, and this screen's job
+     * is reading. And the per-card `backdrop-filter` was one blurred compositing layer
+     * per row, on the one screen that renders an unbounded list of them.
+     *
+     * The controls are split left and right ON PURPOSE. NN/g measured (136 participants,
+     * 11 mobile prototypes) that when a row body and a trailing control do different
+     * things, people tap them roughly equally — a coin flip. So the body does nothing at
+     * all: readers open from the eye on the left, actions from the overflow on the right,
+     * as far apart as the row allows. That also brings this surface into line with the
+     * job feed, the Playbook sheet and the machine logbook, which all use the same
+     * `NoteActionsMenu` — this screen was the only operator note surface rolling its own.
+     */
+    <Box component="li" sx={{ borderBottom: '1px solid', borderColor: 'divider', py: 0.5 }}>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
+        <ReachRow note={note} expanded={open} onToggle={note.viewer_count > 0 ? toggle : undefined} />
+
+        <Box sx={{ flex: 1, minWidth: 0, py: 1 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 0.5 }}>
-            {/* Leads the row so every card has a number in the same place — a
-                stable column to scan down, present whether or not the note
-                carries a part. */}
-            <ReachRow note={note} />
             {/* THE SUBJECT, in one stable slot. A `notes` row has exactly one subject —
                 a part, a job, or a machine — and this list mixes all three, because all
                 three are things the operator wrote.
@@ -162,7 +219,7 @@ function NoteRow({
             )}
             <Box sx={{ flex: 1 }} />
             {/* Where it came from, sat quietly beside the date — an indication,
-                not an action. The action is one tap away, inside the card. */}
+                not an action. Opening the job is in the overflow menu. */}
             <Typography variant="caption" color="text.secondary">
               {note.job_number ? `${note.job_number} · ` : ''}
               {formatDate(note.created_at)}
@@ -178,7 +235,13 @@ function NoteRow({
 
           {/* Read-only by necessity, not omission: RLS forbids reacting to your
               own note, so here endorsements are RECEPTION — the same category as
-              the view count above, and the other half of what came back. */}
+              the view count above, and the other half of what came back.
+
+              STAYS INLINE, and is not folded in behind the eye with the readers.
+              A view is involuntary and private, which is why the names sit behind a
+              deliberate tap; a reaction is a voluntary public claim and attribution
+              is the whole point of it. The list already caps at three names then
+              "+N", so it holds at shop scale. */}
           <NoteReactions
             companyId={companyId}
             noteId={note.id}
@@ -187,13 +250,29 @@ function NoteRow({
             memberId={null}
             readOnly
           />
-        </CardContent>
-      </CardActionArea>
+        </Box>
 
+        {/* THE ONLY OTHER CONTROL, hard right. Every note here is unconditionally the
+            caller's own — getMyNotesPage filters to author_id = me AND note_type =
+            'user' — so there is no permission test to run. */}
+        <NoteActionsMenu
+          canEdit
+          canDelete
+          onEdit={() => setEditing(true)}
+          onDelete={() => setConfirmingDelete(true)}
+          onOpen={
+            note.job_id && note.job_number
+              ? () => router.push(`/operator/${companyId}/jobs/${note.job_id}`)
+              : undefined
+          }
+          openLabel={note.job_number ? `Open ${note.job_number}` : undefined}
+        />
+      </Box>
+
+      {/* Readers only. The actions left this disclosure when they moved to the menu,
+          so what remains is content rather than a second action surface. */}
       <Collapse in={open} unmountOnExit>
-        <Box sx={{ px: 2, pb: 2 }}>
-          <Divider sx={{ mb: 1 }} />
-
+        <Box sx={{ pl: 6.5, pr: 2, pb: 1.5 }}>
           {note.viewer_count > 0 && (
             <>
               {/* Explicitly labelled: the job beside a viewer's name is the job
@@ -213,55 +292,6 @@ function NoteRow({
                 ))
               )}
             </>
-          )}
-
-          {/* THE PRIMARY HOME FOR EDIT AND DELETE (#628), and the one surface that
-              needs no permission test at all: getMyContribution already filters to
-              author_id = me AND note_type = 'user', so every note on this screen is
-              unconditionally the caller's own editable note.
-
-              Full-width buttons rather than the kebab used in the feeds, because
-              the card is one big CardActionArea and a button cannot nest inside a
-              button — the same constraint that put navigation down here in the
-              first place. */}
-          <Box
-            sx={{
-              display: 'flex',
-              gap: 1,
-              mt: note.viewer_count > 0 ? 1.5 : 0,
-            }}
-          >
-            <Button
-              variant="outlined"
-              fullWidth
-              startIcon={<EditOutlinedIcon />}
-              onClick={() => setEditing(true)}
-              sx={{ minHeight: 48 }}
-            >
-              Edit
-            </Button>
-            <Button
-              variant="outlined"
-              color="error"
-              fullWidth
-              startIcon={<DeleteOutlineIcon />}
-              onClick={() => setConfirmingDelete(true)}
-              sx={{ minHeight: 48 }}
-            >
-              Delete
-            </Button>
-          </Box>
-
-          {note.job_id && note.job_number && (
-            <Button
-              variant="outlined"
-              fullWidth
-              startIcon={<LaunchIcon />}
-              onClick={() => router.push(`/operator/${companyId}/jobs/${note.job_id}`)}
-              sx={{ minHeight: 48, mt: 1.5 }}
-            >
-              Open {note.job_number}
-            </Button>
           )}
         </Box>
       </Collapse>
@@ -331,7 +361,7 @@ function NoteRow({
         }}
       />
       )}
-    </Card>
+    </Box>
   );
 }
 

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -535,9 +535,11 @@ function MyContribution({ companyId }: { companyId: string }) {
           the point is that writing things down is the work, not a score. */}
       <Card elevation={2} sx={{ ...cardSx, mb: 3 }}>
         <CardContent>
-          <Typography variant="overline" color="text.secondary">
-            What you&apos;ve added
-          </Typography>
+          {/* NO HEADER, deliberately. "What you've added" was true of the notes and the
+              photos and false of the views — those are not something the operator added,
+              they are what came back. No single heading is true of both categories, and
+              two headings over three figures is more structure than three numbers can
+              carry, so the captions say what each figure is instead. */}
           {/* Three equal columns, and each one aligned to the edge it sits nearest:
               first hard left, middle centred, last hard right. Equal columns alone were
               not enough — with every column's content left-aligned, the last number
@@ -557,10 +559,14 @@ function MyContribution({ companyId }: { companyId: string }) {
               mt: 0.5,
             }}
           >
-            <Stat value={c.noteCount} label={c.noteCount === 1 ? 'note' : 'notes'} align="left" />
+            <Stat
+              value={c.noteCount}
+              label={c.noteCount === 1 ? 'note written' : 'notes written'}
+              align="left"
+            />
             <Stat
               value={c.photoCount}
-              label={c.photoCount === 1 ? 'photo' : 'photos'}
+              label={c.photoCount === 1 ? 'photo added' : 'photos added'}
               align="center"
             />
             {/* "views", not "people". This sums each note's viewer_count, so one colleague
@@ -574,9 +580,13 @@ function MyContribution({ companyId }: { companyId: string }) {
                 least actionable number the loudest thing in the card. On a note row the same
                 green earns its place: there it is binary and comparative, marking which
                 notes have landed as you scan a column. Here there is nothing to compare. */}
+            {/* "times viewed", not "views": a passive phrasing is what marks this one out
+                as reception rather than contribution, now that no heading does it. Still
+                "viewed" and never "used" — all that was recorded is that somebody opened
+                the note and stayed on it. */}
             <Stat
               value={c.peopleReached}
-              label={c.peopleReached === 1 ? 'view' : 'views'}
+              label={c.peopleReached === 1 ? 'time viewed' : 'times viewed'}
               align="right"
             />
           </Box>

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -516,7 +516,23 @@ function MyContribution({ companyId }: { companyId: string }) {
           <Typography variant="overline" color="text.secondary">
             What you&apos;ve added
           </Typography>
-          <Box sx={{ display: 'flex', gap: 4, flexWrap: 'wrap', mt: 0.5 }}>
+          {/* Three equal columns rather than three items pushed against the left edge.
+              A stat row reads as a set, and an even rhythm is what makes it one — clustered
+              left, the numbers looked like the start of a sentence that ran out.
+
+              CAPPED, not stretched to the card. Nothing constrains the operator column's
+              width on this branch, so `space-between` on a laptop would strand "views"
+              several hundred pixels from "notes". At 420px the row fills a phone (~340px of
+              usable width) and stays a group everywhere wider. */}
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+              gap: 2,
+              maxWidth: 420,
+              mt: 0.5,
+            }}
+          >
             <Box>
               <Typography variant="h4" fontWeight={700}>
                 {c.noteCount}
@@ -538,12 +554,15 @@ function MyContribution({ companyId }: { companyId: string }) {
                 is a view total, not a headcount. A distinct-people figure would
                 need the note_views rows, which no browser role can read by
                 design. The per-note numbers below are exact. */}
+            {/* NOT GREEN, unlike the per-note count below.
+                Green is semantic in this theme — success.main is a state, not a decoration —
+                and a lifetime view total has no state to report. It is also the only one of
+                three sibling metrics that was coloured, which made the least actionable
+                number the loudest thing in the card. On a note row the same green earns its
+                place, because there it is binary and comparative: it marks which notes have
+                landed as you scan a column of them. Here there is nothing to compare it to. */}
             <Box>
-              <Typography
-                variant="h4"
-                fontWeight={700}
-                sx={{ color: c.peopleReached > 0 ? 'success.light' : 'text.primary' }}
-              >
+              <Typography variant="h4" fontWeight={700}>
                 {c.peopleReached}
               </Typography>
               <Typography variant="caption" color="text.secondary">

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -15,7 +15,6 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import Collapse from '@mui/material/Collapse';
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
-import BuildOutlinedIcon from '@mui/icons-material/BuildOutlined';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import {
   getMyContributionTotals,
@@ -179,36 +178,6 @@ function NoteRow({
 
         <Box sx={{ flex: 1, minWidth: 0, py: 1 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 0.5 }}>
-            {/* THE SUBJECT, in one stable slot. A `notes` row has exactly one subject —
-                a part, a job, or a machine — and this list mixes all three, because all
-                three are things the operator wrote.
-
-                Machine entries used to render nothing here. They carry no part and no
-                operation, and unlike a job note they carry no job number either (the
-                CHECK constraint forbids it), so a maintenance entry appeared as a bare
-                sentence with nothing anywhere on the row saying it was about a machine.
-                Job notes are deliberately left bare: their subject is the job, and the
-                job reference already sits quietly beside the date — see the note there
-                for why it stays quiet rather than becoming a heading. */}
-            {(note.part_name || note.machine_name) && (
-              <Typography variant="subtitle2" fontWeight={700} noWrap>
-                {note.part_name ?? note.machine_name}
-              </Typography>
-            )}
-            {note.operation_label && (
-              <Chip size="small" label={note.operation_label} variant="outlined" />
-            )}
-            {/* What they did to the machine, when they said. Optional by design, so a
-                classified entry gets a chip and an unclassified one simply doesn't. */}
-            {note.maintenance_kind && (
-              <Chip
-                size="small"
-                variant="outlined"
-                icon={<BuildOutlinedIcon />}
-                label={note.maintenance_kind}
-                sx={{ textTransform: 'capitalize' }}
-              />
-            )}
             {note.photo_count > 0 && (
               <Chip
                 size="small"
@@ -218,10 +187,27 @@ function NoteRow({
               />
             )}
             <Box sx={{ flex: 1 }} />
-            {/* Where it came from, sat quietly beside the date — an indication,
-                not an action. Opening the job is in the overflow menu. */}
-            <Typography variant="caption" color="text.secondary">
-              {note.job_number ? `${note.job_number} · ` : ''}
+            {/* WHERE IT CAME FROM — one quiet reference, always in the same place.
+                The job number for a job or part note, the machine for a maintenance
+                entry; they are mutually exclusive, because a `notes` row has exactly
+                one subject under the CHECK constraint.
+
+                It sits here rather than leading the row because the NOTE is the point
+                of this screen. An earlier pass put the subject first in bold with the
+                step as a chip beside it, and the effect was that a list of what the
+                operator had written read as a list of stations — the reference
+                out-shouted the sentence it was supposed to annotate. Same reason the
+                maintenance kind is plain text here rather than an icon chip: "Noticed"
+                is worth knowing and not worth a wrench.
+
+                `part_name` is the last fallback, not a normal case: a durable part note
+                outlives the job it was captured on (provenance is ON DELETE SET NULL),
+                so once that job is deleted the part is the only reference left. */}
+            <Typography variant="caption" color="text.secondary" noWrap>
+              {[note.machine_name ?? note.job_number ?? note.part_name, note.maintenance_kind]
+                .filter(Boolean)
+                .map((s) => `${s} · `)
+                .join('')}
               {formatDate(note.created_at)}
               <NoteEditedMark editedAt={note.edited_at} />
             </Typography>

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -125,6 +125,28 @@ function ReachRow({
   );
 }
 
+/** One figure in the "what you've added" row: the number, then what it counts. */
+function Stat({
+  value,
+  label,
+  align,
+}: {
+  value: number;
+  label: string;
+  align: 'left' | 'center' | 'right';
+}) {
+  return (
+    <Box sx={{ textAlign: align }}>
+      <Typography variant="h4" fontWeight={700}>
+        {value}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
 function NoteRow({
   note,
   companyId,
@@ -516,14 +538,16 @@ function MyContribution({ companyId }: { companyId: string }) {
           <Typography variant="overline" color="text.secondary">
             What you&apos;ve added
           </Typography>
-          {/* Three equal columns rather than three items pushed against the left edge.
-              A stat row reads as a set, and an even rhythm is what makes it one — clustered
-              left, the numbers looked like the start of a sentence that ran out.
+          {/* Three equal columns, and each one aligned to the edge it sits nearest:
+              first hard left, middle centred, last hard right. Equal columns alone were
+              not enough — with every column's content left-aligned, the last number
+              landed a third of the way in from the right and the middle one sat left of
+              the card's true centre, so the row still read as clustered.
 
-              CAPPED, not stretched to the card. Nothing constrains the operator column's
-              width on this branch, so `space-between` on a laptop would strand "views"
-              several hundred pixels from "notes". At 420px the row fills a phone (~340px of
-              usable width) and stays a group everywhere wider. */}
+              CAPPED at 420px rather than stretched to the card. Nothing constrains the
+              operator column's width on this branch, so edge-to-edge on a laptop would
+              put "notes" and "views" a thousand pixels apart. A phone has ~340px of
+              usable width here, so the cap never binds on the device this is for. */}
           <Box
             sx={{
               display: 'grid',
@@ -533,42 +557,28 @@ function MyContribution({ companyId }: { companyId: string }) {
               mt: 0.5,
             }}
           >
-            <Box>
-              <Typography variant="h4" fontWeight={700}>
-                {c.noteCount}
-              </Typography>
-              <Typography variant="caption" color="text.secondary">
-                {c.noteCount === 1 ? 'note' : 'notes'}
-              </Typography>
-            </Box>
-            <Box>
-              <Typography variant="h4" fontWeight={700}>
-                {c.photoCount}
-              </Typography>
-              <Typography variant="caption" color="text.secondary">
-                {c.photoCount === 1 ? 'photo' : 'photos'}
-              </Typography>
-            </Box>
-            {/* "views", not "people". This sums each note's viewer_count, so one
-                colleague who read three of your notes contributes three — which
-                is a view total, not a headcount. A distinct-people figure would
-                need the note_views rows, which no browser role can read by
-                design. The per-note numbers below are exact. */}
-            {/* NOT GREEN, unlike the per-note count below.
-                Green is semantic in this theme — success.main is a state, not a decoration —
-                and a lifetime view total has no state to report. It is also the only one of
-                three sibling metrics that was coloured, which made the least actionable
-                number the loudest thing in the card. On a note row the same green earns its
-                place, because there it is binary and comparative: it marks which notes have
-                landed as you scan a column of them. Here there is nothing to compare it to. */}
-            <Box>
-              <Typography variant="h4" fontWeight={700}>
-                {c.peopleReached}
-              </Typography>
-              <Typography variant="caption" color="text.secondary">
-                {c.peopleReached === 1 ? 'view' : 'views'}
-              </Typography>
-            </Box>
+            <Stat value={c.noteCount} label={c.noteCount === 1 ? 'note' : 'notes'} align="left" />
+            <Stat
+              value={c.photoCount}
+              label={c.photoCount === 1 ? 'photo' : 'photos'}
+              align="center"
+            />
+            {/* "views", not "people". This sums each note's viewer_count, so one colleague
+                who read three of your notes contributes three — a view total, not a
+                headcount. A distinct-people figure would need the note_views rows, which no
+                browser role can read by design. The per-note numbers below are exact.
+
+                NOT GREEN, unlike the per-note count. Green is semantic in this theme — a
+                state, not a decoration — and a lifetime total has no state to report. It was
+                also the only one of three sibling metrics that was coloured, which made the
+                least actionable number the loudest thing in the card. On a note row the same
+                green earns its place: there it is binary and comparative, marking which
+                notes have landed as you scan a column. Here there is nothing to compare. */}
+            <Stat
+              value={c.peopleReached}
+              label={c.peopleReached === 1 ? 'view' : 'views'}
+              align="right"
+            />
           </Box>
 
         </CardContent>

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -10,11 +10,9 @@ import Tooltip from '@mui/material/Tooltip';
 import CardContent from '@mui/material/CardContent';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
-import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import Collapse from '@mui/material/Collapse';
-import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import {
   getMyContributionTotals,
@@ -84,7 +82,7 @@ function ReachRow({
   // unread row down to ONE tap target instead of two.
   if (!onToggle) {
     return (
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, width: 48, height: 48, justifyContent: 'center', flexShrink: 0 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minHeight: 40, pr: 0.5, flexShrink: 0 }}>
         {face}
       </Box>
     );
@@ -93,9 +91,16 @@ function ReachRow({
   /* THE DISCLOSURE FOR "WHO READ THIS", and deliberately not the whole row.
      NN/g measured (136 participants, 11 mobile prototypes) that when a row body
      and a trailing control do different things, people tap them about equally —
-     a coin flip. So the row body stays inert and the two controls sit at opposite
-     ends: readers here on the left, actions in the overflow on the right.
-     The count is the label, which is what keeps a bare icon honest. */
+     a coin flip. So the note text stays inert; this opens the readers and the
+     overflow opens the actions, and the two sit DIAGONALLY opposite — this at the
+     bottom-left of the row, the menu at the top-right — so neither is a plausible
+     mis-tap for the other. The count is the label, which is what keeps a bare icon
+     honest.
+
+     Sized to the metadata line rather than to a 48px gutter. The gutter was what
+     stranded it level with the reference instead of the sentence it belongs to, and
+     it cost the note 48px of width on a 375px screen for no reason. 40px tall plus
+     the icon-and-count width clears WCAG 2.5.8's 24px floor with room to spare. */
   return (
     <Tooltip title={expanded ? 'Hide readers' : 'Who read this'}>
       <ButtonBase
@@ -106,8 +111,9 @@ function ReachRow({
           display: 'flex',
           alignItems: 'center',
           gap: 0.5,
-          width: 48,
-          height: 48,
+          minHeight: 40,
+          px: 0.75,
+          ml: -0.75, // absorb the padding so the glyph keeps the note's left edge
           flexShrink: 0,
           borderRadius: 1,
           '&:hover': { bgcolor: 'rgba(255,255,255,0.06)' },
@@ -174,45 +180,12 @@ function NoteRow({
      */
     <Box component="li" sx={{ borderBottom: '1px solid', borderColor: 'divider', py: 0.5 }}>
       <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
-        <ReachRow note={note} expanded={open} onToggle={note.viewer_count > 0 ? toggle : undefined} />
-
-        <Box sx={{ flex: 1, minWidth: 0, py: 1 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 0.5 }}>
-            {note.photo_count > 0 && (
-              <Chip
-                size="small"
-                variant="outlined"
-                icon={<PhotoCameraIcon />}
-                label={note.photo_count}
-              />
-            )}
-            <Box sx={{ flex: 1 }} />
-            {/* WHERE IT CAME FROM — one quiet reference, always in the same place.
-                The job number for a job or part note, the machine for a maintenance
-                entry; they are mutually exclusive, because a `notes` row has exactly
-                one subject under the CHECK constraint.
-
-                It sits here rather than leading the row because the NOTE is the point
-                of this screen. An earlier pass put the subject first in bold with the
-                step as a chip beside it, and the effect was that a list of what the
-                operator had written read as a list of stations — the reference
-                out-shouted the sentence it was supposed to annotate. Same reason the
-                maintenance kind is plain text here rather than an icon chip: "Noticed"
-                is worth knowing and not worth a wrench.
-
-                `part_name` is the last fallback, not a normal case: a durable part note
-                outlives the job it was captured on (provenance is ON DELETE SET NULL),
-                so once that job is deleted the part is the only reference left. */}
-            <Typography variant="caption" color="text.secondary" noWrap>
-              {[note.machine_name ?? note.job_number ?? note.part_name, note.maintenance_kind]
-                .filter(Boolean)
-                .map((s) => `${s} · `)
-                .join('')}
-              {formatDate(note.created_at)}
-              <NoteEditedMark editedAt={note.edited_at} />
-            </Typography>
-          </Box>
-
+        <Box sx={{ flex: 1, minWidth: 0, pt: 1, pb: 0.25, pl: 0.5 }}>
+          {/* THE NOTE ITSELF, first and full width. It used to sit on the second line,
+              under a meta row that held the reference — which left the sentence
+              starting below and to the right of the eye that belonged to it, and gave
+              the row three different left edges. Everything in this column now shares
+              one. */}
           {note.body && (
             <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
               {note.body}
@@ -236,6 +209,42 @@ function NoteRow({
             memberId={null}
             readOnly
           />
+
+          {/* ONE METADATA LINE, under the note it describes.
+              How far it travelled, where it came from, and when — all the same weight,
+              because none of them is the point of the row. The reference is the job
+              number for a job or part note and the machine for a maintenance entry;
+              they are mutually exclusive, since a `notes` row has exactly one subject
+              under the CHECK constraint. `part_name` is the last fallback rather than a
+              normal case: a durable part note outlives the job it was captured on
+              (provenance is ON DELETE SET NULL), so once that job is gone the part is
+              the only reference left.
+
+              The reader count leads it because it IS metadata — it was previously
+              stranded in a 48px gutter of its own, level with the reference rather than
+              with the sentence, which is what made the row look broken. Sitting here it
+              needs no gutter, so the note gets the full width back. */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap', minHeight: 40 }}>
+            <ReachRow
+              note={note}
+              expanded={open}
+              onToggle={note.viewer_count > 0 ? toggle : undefined}
+            />
+            <Typography variant="caption" color="text.secondary" sx={{ minWidth: 0 }}>
+              {[
+                note.machine_name ?? note.job_number ?? note.part_name,
+                note.maintenance_kind,
+                note.photo_count > 0
+                  ? `${note.photo_count} photo${note.photo_count === 1 ? '' : 's'}`
+                  : null,
+              ]
+                .filter(Boolean)
+                .map((s) => `${s} · `)
+                .join('')}
+              {formatDate(note.created_at)}
+              <NoteEditedMark editedAt={note.edited_at} />
+            </Typography>
+          </Box>
         </Box>
 
         {/* THE ONLY OTHER CONTROL, hard right. Every note here is unconditionally the

--- a/components/notes/NoteActionsMenu.tsx
+++ b/components/notes/NoteActionsMenu.tsx
@@ -9,6 +9,7 @@ import ListItemText from '@mui/material/ListItemText';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import LaunchIcon from '@mui/icons-material/Launch';
 
 /**
  * Edit / Delete for one note on the OPERATOR surfaces — the job feed, the Playbook
@@ -39,16 +40,29 @@ export default function NoteActionsMenu({
   onDelete,
   /** Distinguishes "note" from "comment" in the labels and aria text. */
   noun = 'note',
+  onOpen,
+  openLabel,
 }: {
   canEdit: boolean;
   canDelete: boolean;
   onEdit: () => void;
   onDelete: () => void;
   noun?: string;
+  /**
+   * Optional navigation away from the note — "Open J-0042" on the operator's own
+   * work list, where the note is the only route back to the job it was written on.
+   * Omitted everywhere else, because the other surfaces ARE the job.
+   *
+   * Listed FIRST, with delete last: docs/interaction-standards.md requires the
+   * destructive option to sit at the end, away from the benign ones, so it is
+   * predictably located rather than crowded next to something routine.
+   */
+  onOpen?: () => void;
+  openLabel?: string;
 }) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
-  if (!canEdit && !canDelete) return null;
+  if (!canEdit && !canDelete && !onOpen) return null;
 
   const close = () => setAnchorEl(null);
 
@@ -70,6 +84,20 @@ export default function NoteActionsMenu({
         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       >
+        {onOpen && (
+          <MenuItem
+            onClick={() => {
+              close();
+              onOpen();
+            }}
+            sx={{ minHeight: 48 }}
+          >
+            <ListItemIcon>
+              <LaunchIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>{openLabel ?? 'Open job'}</ListItemText>
+          </MenuItem>
+        )}
         {canEdit && (
           <MenuItem
             onClick={() => {

--- a/components/notes/NoteEditDialog.tsx
+++ b/components/notes/NoteEditDialog.tsx
@@ -62,10 +62,30 @@ export interface NoteEditResult {
  * orphan cleanup for a file that reached storage without its row. A delete is one
  * fast statement with none of that.
  */
+/**
+ * Stable empty default for `media`. MUST be module-level, not a `= []` default parameter.
+ *
+ * A default parameter is re-evaluated on every render, so it produced a NEW array identity
+ * each time. That array is the dependency of the `useLoad` below, and `useLoad` memoises its
+ * loader with `useCallback(fn, deps)` and re-runs on the loader's identity — so a fresh `[]`
+ * per render re-ran the loader per render, and each resolution called setState with a fresh
+ * object (no Object.is bailout), which rendered again, which built another `[]`. An infinite
+ * loop that React never reports, because the setState happens in a promise callback rather
+ * than synchronously in render, so the "Maximum update depth exceeded" guard never fires.
+ *
+ * It was invisible from outside: with `open={false}` the Dialog renders null, so the loop
+ * made no DOM mutations and no network requests, and every task in it was sub-millisecond,
+ * so a longtask observer reported nothing. It simply held a CPU core down for as long as the
+ * page was mounted. The operator "Me" tab was the one surface that mounted this dialog
+ * unconditionally — one per note row — so a screen showing ten notes ran ten of these at
+ * once and everything the operator tapped afterwards competed with a pegged core.
+ */
+const NO_MEDIA: JobNoteMedia[] = [];
+
 export default function NoteEditDialog({
   open,
   initialBody,
-  media = [],
+  media = NO_MEDIA,
   saving = false,
   error = null,
   noun = 'note',

--- a/components/operator/OperatorAccountBlock.tsx
+++ b/components/operator/OperatorAccountBlock.tsx
@@ -5,9 +5,9 @@
  *
  * Two exports, meant to sandwich the operator's own work:
  *
- *   <OperatorIdentityRow />      one compact row — who you are
+ *   <OperatorIdentityRow />      one row — who you are, and the way out
  *   … the operator's notes …     the reason the tab exists
- *   <OperatorAccountActions />   feedback, then Log out last
+ *   <OperatorAccountActions />   feedback
  *
  * ## Why identity is one row and not a card
  *
@@ -24,17 +24,35 @@
  * direct answer to "this treats My work as spare real estate" — the merge is what gave the
  * work surface its reason to own a tab.
  *
- * ## Why Log out is last, and why there is no confirm dialog
+ * The row carries the email as its third line. It used to sit near the bottom as "Signed in as
+ * …", on the reasoning that it is the least useful thing here to an operator who already knows
+ * who they are. True, but it is still identity, and identity belongs in the identity row — the
+ * caption was a second, worse place for the same fact, parked behind a scroll.
  *
- * Log out sits at the very end, in its own visually distinct block, separated from the benign
- * action above it. NN/g's proximity guidance explicitly endorses using distance to make a
- * consequential action slightly slower to reach, because operators repeating the same taps
- * every shift slip into automaticity — and a mis-tap here is a *slip*, not a mistake, so no
- * amount of clearer labelling fixes it. Only layout does.
+ * ## Why Log out is an isolated icon at the top, and why there is no confirm dialog
  *
- * It is deliberately NOT behind a confirmation dialog: logging out is recoverable by logging
- * back in, and a dialog on a recoverable action is the confirmation-fatigue trap that strips
- * the dialogs that matter of their force.
+ * It used to be a full-width button at the very end of the page, deliberately set apart: NN/g's
+ * proximity guidance endorses using distance to make a consequential action slower to reach,
+ * because operators repeating the same taps every shift slip into automaticity, and a mis-tap
+ * here is a *slip* rather than a mistake — no amount of clearer labelling fixes a slip, only
+ * layout does.
+ *
+ * That argument is now served by ISOLATION instead of distance, because distance stopped being
+ * affordable. Log out sat below the operator's entire note list, which is unbounded, so the only
+ * way to reach it was to scroll past everything they had ever written. An action you cannot
+ * reach is not a safe action, it is a broken one.
+ *
+ * The slip risk the old placement guarded against came specifically from Log out sitting
+ * ADJACENT to a benign button an operator taps often. At the end of a row whose only other
+ * content is static text, there is nothing to slip from: it is the sole tap target in its row,
+ * ≥48px, and the nearest other control is the header's dashboard shortcut roughly 64px above —
+ * past both WCAG 2.5.8's 24px centre-to-centre floor and Material's 8dp clearance. That is the
+ * same reasoning `app/operator/[companyId]/layout.tsx` uses to forbid a second icon button in
+ * the header, applied rather than contradicted.
+ *
+ * It is deliberately NOT behind a confirmation dialog, and moving it up does not change that:
+ * logging out is recoverable by logging back in, and a dialog on a recoverable action is the
+ * confirmation-fatigue trap that strips the dialogs that matter of their force.
  */
 
 import { useState } from 'react';
@@ -44,7 +62,9 @@ import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
 import Snackbar from '@mui/material/Snackbar';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import FeedbackIcon from '@mui/icons-material/Feedback';
 import LogoutIcon from '@mui/icons-material/Logout';
@@ -54,6 +74,7 @@ import FeedbackDialog from '@/components/feedback/FeedbackDialog';
 // `auth.signOut` is used here, which is schema-independent.
 import { getTypedSupabase } from '@/lib/supabase';
 import { clearStoredStation } from '@/components/operator/OperatorStationContext';
+import { clearCurrentMemberCache } from '@/utils/operatorAccess';
 
 export interface OperatorIdentity {
   name: string;
@@ -72,7 +93,30 @@ function initials(name: string): string {
     .join('');
 }
 
-export function OperatorIdentityRow({ identity }: { identity: OperatorIdentity | null }) {
+export function OperatorIdentityRow({
+  companyId,
+  identity,
+}: {
+  companyId: string;
+  identity: OperatorIdentity | null;
+}) {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    // Clears the persisted station (localStorage) on explicit logout — same store
+    // OperatorStationContext uses.
+    clearStoredStation();
+    // And the in-memory member lookup, which answers "who is acting" and must not
+    // outlive the session that made it true.
+    clearCurrentMemberCache();
+    const supabase = getTypedSupabase();
+    // Local scope — sign out ONLY this device. An operator logging out here must not revoke
+    // their session on their other devices (which surfaced as a forced re-login when marking
+    // a job complete).
+    await supabase.auth.signOut({ scope: 'local' });
+    router.push(`/operator/${companyId}/login`);
+  };
+
   return (
     <Box
       sx={{
@@ -83,10 +127,12 @@ export function OperatorIdentityRow({ identity }: { identity: OperatorIdentity |
         minHeight: 48,
       }}
     >
-      <Avatar sx={{ bgcolor: 'primary.main', width: 40, height: 40 }}>
+      <Avatar sx={{ bgcolor: 'primary.main', width: 40, height: 40, flexShrink: 0 }}>
         {initials(identity?.name ?? '')}
       </Avatar>
-      <Box sx={{ minWidth: 0 }}>
+      {/* minWidth: 0 is what lets the three noWrap lines actually truncate instead of
+          forcing the row wider and pushing Log out off a 375px screen. */}
+      <Box sx={{ minWidth: 0, flex: 1 }}>
         <Typography sx={{ fontWeight: 600 }} noWrap>
           {identity?.name || 'You'}
         </Typography>
@@ -95,33 +141,37 @@ export function OperatorIdentityRow({ identity }: { identity: OperatorIdentity |
             {identity.companyName}
           </Typography>
         )}
+        {identity?.email && (
+          <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
+            {identity.email}
+          </Typography>
+        )}
       </Box>
+
+      {/* The only tap target in this row — see the note at the top of this file for why
+          that isolation is what replaced the old "put it last" distance argument. */}
+      <Tooltip title="Log out">
+        <IconButton
+          onClick={handleLogout}
+          aria-label="Log out"
+          sx={{
+            flexShrink: 0,
+            width: 48,
+            height: 48,
+            color: 'text.secondary',
+            '&:hover': { bgcolor: 'rgba(239, 68, 68, 0.1)', color: 'error.main' },
+          }}
+        >
+          <LogoutIcon />
+        </IconButton>
+      </Tooltip>
     </Box>
   );
 }
 
-export function OperatorAccountActions({
-  companyId,
-  identity,
-}: {
-  companyId: string;
-  identity: OperatorIdentity | null;
-}) {
-  const router = useRouter();
+export function OperatorAccountActions({ identity }: { identity: OperatorIdentity | null }) {
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [feedbackSuccess, setFeedbackSuccess] = useState(false);
-
-  const handleLogout = async () => {
-    // Clears the persisted station (localStorage) on explicit logout — same store
-    // OperatorStationContext uses.
-    clearStoredStation();
-    const supabase = getTypedSupabase();
-    // Local scope — sign out ONLY this device. An operator logging out here must not revoke
-    // their session on their other devices (which surfaced as a forced re-login when marking
-    // a job complete).
-    await supabase.auth.signOut({ scope: 'local' });
-    router.push(`/operator/${companyId}/login`);
-  };
 
   return (
     <Box sx={{ mt: 4 }}>
@@ -136,35 +186,6 @@ export function OperatorAccountActions({
       >
         Give feedback
       </Button>
-
-      {/* The email lives down here rather than in the identity row: it is the least useful
-          thing on the page to an operator who already knows who they are, and it is the thing
-          a support conversation occasionally needs. */}
-      {identity?.email && (
-        <Typography
-          variant="caption"
-          color="text.secondary"
-          sx={{ display: 'block', mt: 2, textAlign: 'center' }}
-        >
-          Signed in as {identity.email}
-        </Typography>
-      )}
-
-      {/* Log out, last and set apart — see the note at the top of this file. The gap above is
-          the point, not spacing for its own sake. */}
-      <Box sx={{ mt: 3 }}>
-        <Divider sx={{ mb: 2 }} />
-        <Button
-          variant="outlined"
-          color="error"
-          startIcon={<LogoutIcon />}
-          onClick={handleLogout}
-          fullWidth
-          sx={{ minHeight: 48 }}
-        >
-          Log out
-        </Button>
-      </Box>
 
       <FeedbackDialog
         open={feedbackOpen}

--- a/components/operator/OperatorAccountBlock.tsx
+++ b/components/operator/OperatorAccountBlock.tsx
@@ -3,11 +3,15 @@
 /**
  * The identity and account half of the operator's "Me" tab.
  *
- * Two exports, meant to sandwich the operator's own work:
+ * One export, above the operator's own work:
  *
- *   <OperatorIdentityRow />      one row — who you are, and the way out
+ *   <OperatorIdentityRow />      who you are, the way out, and the way to reach us
  *   … the operator's notes …     the reason the tab exists
- *   <OperatorAccountActions />   feedback
+ *
+ * It used to be two, sandwiching the work, with Give feedback and then Log out below the
+ * note list. That stopped being tenable once the list paged: an action below an unbounded
+ * (and now paged) list is not "slightly slower to reach", it is unreachable, and a pilot's
+ * feedback channel that only appears after a Show more is a channel nobody uses.
  *
  * ## Why identity is one row and not a card
  *
@@ -45,10 +49,16 @@
  * The slip risk the old placement guarded against came specifically from Log out sitting
  * ADJACENT to a benign button an operator taps often. At the end of a row whose only other
  * content is static text, there is nothing to slip from: it is the sole tap target in its row,
- * ≥48px, and the nearest other control is the header's dashboard shortcut roughly 64px above —
- * past both WCAG 2.5.8's 24px centre-to-centre floor and Material's 8dp clearance. That is the
- * same reasoning `app/operator/[companyId]/layout.tsx` uses to forbid a second icon button in
- * the header, applied rather than contradicted.
+ * ≥48px, and its neighbours are the header's dashboard shortcut roughly 64px above and the
+ * Give feedback link below and hard left — diagonally opposite, never beside. Both clear WCAG
+ * 2.5.8's 24px centre-to-centre floor and Material's 8dp by a wide margin. That is the same
+ * reasoning `app/operator/[companyId]/layout.tsx` uses to forbid a second icon button in the
+ * header, applied rather than contradicted.
+ *
+ * This is a real constraint on future edits, not decoration: Give feedback is deliberately a
+ * SIBLING of the identity row rather than a child of it. Moving it inside — to sit next to the
+ * icon, which is the obvious tidy-up — reintroduces exactly the adjacency this is avoiding.
+ * The test `leaves Log out with no neighbouring tap target to slip from` fails if you do.
  *
  * It is deliberately NOT behind a confirmation dialog, and moving it up does not change that:
  * logging out is recoverable by logging back in, and a dialog on a recoverable action is the
@@ -61,7 +71,6 @@ import Alert from '@mui/material/Alert';
 import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import Snackbar from '@mui/material/Snackbar';
 import Tooltip from '@mui/material/Tooltip';
@@ -100,6 +109,8 @@ export function OperatorIdentityRow({
   identity: OperatorIdentity | null;
 }) {
   const router = useRouter();
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const [feedbackSuccess, setFeedbackSuccess] = useState(false);
 
   const handleLogout = async () => {
     // Clears the persisted station (localStorage) on explicit logout — same store
@@ -114,12 +125,12 @@ export function OperatorIdentityRow({
   };
 
   return (
+    <>
     <Box
       sx={{
         display: 'flex',
         alignItems: 'center',
         gap: 1.5,
-        mb: 2,
         minHeight: 48,
       }}
     >
@@ -162,46 +173,60 @@ export function OperatorIdentityRow({
         </IconButton>
       </Tooltip>
     </Box>
-  );
-}
 
-export function OperatorAccountActions({ identity }: { identity: OperatorIdentity | null }) {
-  const [feedbackOpen, setFeedbackOpen] = useState(false);
-  const [feedbackSuccess, setFeedbackSuccess] = useState(false);
+    {/*
+      Give feedback, at the top and always on screen.
 
-  return (
-    <Box sx={{ mt: 4 }}>
-      <Divider sx={{ mb: 2 }} />
+      It used to be a full-width button at the very bottom of the tab, under the
+      operator's whole note list, which is the one place a pilot's feedback channel
+      must not be: the people most likely to have something to say are the ones who
+      never scrolled that far. Being small is the trade for being permanent — this is
+      a secondary action that must be FINDABLE, not prominent, and a full-width button
+      up here would outrank the operator's own work, which the tab exists for.
 
+      A SIBLING of the identity row, not a child of it. Log out has to stay the only
+      tap target in that row — that isolation is what replaced the old "put it last"
+      distance argument (see the note at the top of this file), and a link sitting
+      beside it would give a habituated thumb something to slip from. Here it is below
+      and hard left, diagonally opposite the icon.
+    */}
+    <Box sx={{ mb: 2, pl: 7 }}>
       <Button
-        variant="outlined"
-        startIcon={<FeedbackIcon />}
         onClick={() => setFeedbackOpen(true)}
-        fullWidth
-        sx={{ minHeight: 48 }}
+        startIcon={<FeedbackIcon fontSize="small" />}
+        size="small"
+        sx={{
+          minHeight: 40,
+          px: 0.5,
+          textTransform: 'none',
+          color: 'text.secondary',
+          '&:hover': { bgcolor: 'transparent', color: 'primary.light' },
+        }}
       >
         Give feedback
       </Button>
-
-      <FeedbackDialog
-        open={feedbackOpen}
-        onClose={() => setFeedbackOpen(false)}
-        onSuccess={() => {
-          setFeedbackOpen(false);
-          setFeedbackSuccess(true);
-        }}
-        userId={identity?.userId}
-      />
-      <Snackbar
-        open={feedbackSuccess}
-        autoHideDuration={4000}
-        onClose={() => setFeedbackSuccess(false)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert severity="success" onClose={() => setFeedbackSuccess(false)}>
-          Thanks for your feedback!
-        </Alert>
-      </Snackbar>
     </Box>
+
+    <FeedbackDialog
+      open={feedbackOpen}
+      onClose={() => setFeedbackOpen(false)}
+      onSuccess={() => {
+        setFeedbackOpen(false);
+        setFeedbackSuccess(true);
+      }}
+      userId={identity?.userId}
+    />
+    <Snackbar
+      open={feedbackSuccess}
+      autoHideDuration={4000}
+      onClose={() => setFeedbackSuccess(false)}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+    >
+      <Alert severity="success" onClose={() => setFeedbackSuccess(false)}>
+        Thanks for your feedback!
+      </Alert>
+    </Snackbar>
+    </>
   );
 }
+

--- a/components/operator/OperatorAccountBlock.tsx
+++ b/components/operator/OperatorAccountBlock.tsx
@@ -74,7 +74,6 @@ import FeedbackDialog from '@/components/feedback/FeedbackDialog';
 // `auth.signOut` is used here, which is schema-independent.
 import { getTypedSupabase } from '@/lib/supabase';
 import { clearStoredStation } from '@/components/operator/OperatorStationContext';
-import { clearCurrentMemberCache } from '@/utils/operatorAccess';
 
 export interface OperatorIdentity {
   name: string;
@@ -106,9 +105,6 @@ export function OperatorIdentityRow({
     // Clears the persisted station (localStorage) on explicit logout — same store
     // OperatorStationContext uses.
     clearStoredStation();
-    // And the in-memory member lookup, which answers "who is acting" and must not
-    // outlive the session that made it true.
-    clearCurrentMemberCache();
     const supabase = getTypedSupabase();
     // Local scope — sign out ONLY this device. An operator logging out here must not revoke
     // their session on their other devices (which surfaced as a forced re-login when marking

--- a/docs/interaction-standards.md
+++ b/docs/interaction-standards.md
@@ -107,6 +107,25 @@ the generic "low-stakes ⇒ no dialog" advice.
     rightmost. Burying delete in a kebab there would regress the red-at-rest and
     delete-sits-last rules above; desktop has the width and the hover, so the phone
     constraint does not apply.
+  - *The operator's own work list* (`/operator/[companyId]/my-work`) uses the same
+    kebab, **plus one extra rule the other operator surfaces don't need: the row body
+    must stay inert.** This is the only note surface whose row also has to disclose
+    something — the "Viewed by" reader list, which is content and therefore cannot
+    live in a menu ([NN/g — contextual menus reveal *actions*](https://www.nngroup.com/articles/contextual-menus-guidelines/)).
+    The naive shape (tap the row to expand, kebab for actions) is a **split-button
+    row**, and NN/g measured across 136 participants and 11 mobile prototypes that
+    users "tap fairly equally on both the accordion icon and the accordion label"
+    ([NN/g — accordion icons](https://www.nngroup.com/articles/accordion-icons/)) —
+    i.e. roughly a coin flip on every tap, with a delete menu as one of the outcomes.
+    So the two disclosures sit at **opposite ends** of the row (readers on the eye at
+    far left, actions in the overflow at far right) and nothing between them is
+    tappable. `NoteActionsMenu` also carries an optional third item, "Open J-0042",
+    listed first so delete still sits last; this list is the only place a note is the
+    only route back to its job.
+
+> **If you are adding a note surface:** the kebab is the rule. Only add a second
+> disclosure if that surface has *content* to reveal as well as actions — and if it
+> does, make the row body inert rather than letting it compete with the menu.
 - 🔄 **Superseded:** the earlier target of "drop the BOM dialog + add Undo
   snackbars to BOM/tier/operation" is reversed after UX research (the audience
   floor above). We keep dialogs on destructive row deletes; ephemeral Undo is not

--- a/docs/modules/machine-maintenance.md
+++ b/docs/modules/machine-maintenance.md
@@ -32,6 +32,14 @@
 the only entrance to this module, and the one live defect in it named in
 [§6](#6-phases-and-gates).
 
+> **An entry is a `notes` row**, `subject_kind='work_center'` with `note_type='user'` — not a
+> separate store. So maintenance entries are part of the author's contribution and appear on
+> **My work** beside their job and part notes, where the row names the machine in the slot a job
+> note uses for its job number. The CHECK constraint on `notes` permits exactly one subject, so a
+> maintenance entry carries no part, no operation and no job; before the machine name was
+> selected there, those rows rendered as a bare sentence with nothing saying what they concerned.
+> Anything that changes what an entry carries has to be checked on that surface too.
+
 ---
 
 ## 1. Problem

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -239,9 +239,15 @@ irreversibility.
   recover *when* a note was read, which combined with `note_viewers()` naming the
   reader reconstructs "Kurtis had to look this up on Tuesday". A count is a number
   the server already told us, so subtracting on the client leaks nothing.
-- **My work** (`/operator/{companyId}/my-work`) — notes / photos / views, then each
-  note with its view count, the job it was written on beside the date, and on tap
-  the named viewers plus an **Open J-NNNN** link back to the source.
+- **My work** (`/operator/{companyId}/my-work`) — notes / photos / views, then the
+  operator's notes ten at a time behind **Show more**. Each row is the note itself,
+  with one quiet metadata line beneath it: the view count, one reference, and the
+  date. The reference is the job number for a job or part note and the **work
+  center** for a maintenance entry — a `notes` row has exactly one subject under the
+  CHECK constraint, so they are mutually exclusive; `part_name` appears only as a
+  fallback once a durable part note's capturing job has been deleted. Tapping the
+  view count reveals the named viewers; the overflow menu carries **Open J-NNNN**,
+  Edit and Delete.
 
 **The word is "views", never "uses".** All that is recorded is that someone opened
 a note and stayed on it. Whether they acted on it is not measured, and claiming it
@@ -518,7 +524,7 @@ to protect.
 | Job parts hub | `/operator/{companyId}/jobs/{jobId}` | For multi-part jobs, lists the job's parts with progress; single-part jobs redirect straight to the traveler. |
 | Part traveler | `…/jobs/{jobId}/parts/{jobPartId}` | All steps for one part (read-only), with a back-link to the parts hub on multi-part jobs. |
 | Operation action | `…/parts/{jobPartId}/operations/{jobOperationId}` | Internal step: **Mark Complete** / **Undo**. Outside step: an "Outside process" banner (+ vendor) and **Mark Sent Out** / **Mark Received** (station-mismatch guard suppressed — outside steps have no operator station). Both: notes + photos, "last time we ran this part" guidance. |
-| My work | `/operator/{companyId}/my-work` | The author's own contribution and its reception: notes / photos / views, each note's view count, the job it was written on, and on tap the named viewers + a link back to that job. Bottom-nav tab; also the login banner's tap-through. **No completion count, streak or average — see the guardrail above.** |
+| My work | `/operator/{companyId}/my-work` | The author's own contribution and its reception: identity + Log out + Give feedback, the notes / photos / views totals, then the notes ten at a time behind Show more. Each row is the note, with view count / reference / date beneath it; the reference is the job number, or the work center for a maintenance entry. Tapping the view count names the viewers; the overflow menu carries Open J-NNNN, Edit and Delete. Bottom-nav tab; also the login banner's tap-through. **No completion count, streak or average — see the guardrail above.** |
 | Inventory (optional) | `/operator/{companyId}/inventory[/locations/{id}]` | Feature-gated bin browse + add/remove/adjust stock. |
 | Profile | `/operator/{companyId}/profile` | Operator name, email, company name, **Logout**, and **Give Feedback**. (The current station lives in the header selector, not on this page.) |
 
@@ -623,7 +629,10 @@ Each bullet is a Given/When/Then scenario carrying a verification clause — a p
 - [ ] **Given** a new reader, **when** the digest is called again, **then** the running total has climbed — it is a total, not a window, which is what makes a client-side subtraction correct — *verified by `api/tests/integration/test_note_views_rls.py > test_digest_is_a_running_total_not_a_window`*.
 - [ ] **Given** a non-zero banner, **when** the operator taps it, **then** it navigates to My work AND banks the whole total; **when** they tap its close button, **then** it dismisses **without** navigating — *verified by `__tests__/components/operator/NoteUsageBanner.test.tsx`*.
 - [ ] **Given** My work, **when** it renders with any data, **then** no completion count, streak, average, pace or rank appears anywhere on the page — *verified by `__tests__/app/operator/MyWorkPage.test.tsx > 'shows no completion count, streak, average or pace'`*.
-- [ ] **Given** a note whose job has been deleted, **when** My work renders it, **then** the note survives and only the job link is absent — *verified by `__tests__/app/operator/MyWorkPage.test.tsx`*.
+- [ ] **Given** a note whose job has been deleted, **when** My work renders it, **then** the note survives, the Open-job item leaves the overflow menu, and the reference falls back to the part it is anchored to — *verified by `__tests__/app/operator/MyWorkPage.test.tsx > 'falls back to the part once the capturing job is gone'`*.
+- [ ] **Given** a maintenance entry the operator wrote, **when** My work renders it, **then** the row names the **work center** where a job note names its job — maintenance entries are `notes` rows with `subject_kind='work_center'` and land in this list like anything else the operator wrote — *verified by `__tests__/app/operator/MyWorkPage.test.tsx > 'names the machine where a job note names its job'`*.
+- [ ] **Given** My work, **when** the operator taps a note's text, **then** nothing happens: the row body is inert, the view count opens the readers and the overflow opens the actions, so no tap is ambiguous between reading and deleting — *verified by `__tests__/app/operator/MyWorkPage.test.tsx > 'does nothing when the note body is tapped'`; rationale in [interaction-standards.md §1](../interaction-standards.md)*.
+- [ ] **Given** an operator with more than ten notes, **when** My work renders, **then** ten load and the totals still count every note they have written, not the ten on screen — *verified by `__tests__/app/operator/MyWorkPage.test.tsx > 'reports every note in the summary, not just the page on screen'`*.
 
 **Playbook ordering**
 

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -239,7 +239,9 @@ irreversibility.
   recover *when* a note was read, which combined with `note_viewers()` naming the
   reader reconstructs "Kurtis had to look this up on Tuesday". A count is a number
   the server already told us, so subtracting on the client leaks nothing.
-- **My work** (`/operator/{companyId}/my-work`) — notes / photos / views, then the
+- **My work** (`/operator/{companyId}/my-work`) — a heading-less summary of notes
+  written / photos added / times viewed (no one heading is true of both a
+  contribution and a reception figure, so each caption states its own kind), then the
   operator's notes ten at a time behind **Show more**. Each row is the note itself,
   with one quiet metadata line beneath it: the view count, one reference, and the
   date. The reference is the job number for a job or part note and the **work

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -239,9 +239,11 @@ irreversibility.
   recover *when* a note was read, which combined with `note_viewers()` naming the
   reader reconstructs "Kurtis had to look this up on Tuesday". A count is a number
   the server already told us, so subtracting on the client leaks nothing.
-- **My work** (`/operator/{companyId}/my-work`) — a heading-less summary of notes
-  written / photos added / times viewed (no one heading is true of both a
-  contribution and a reception figure, so each caption states its own kind), then the
+- **My work** (`/operator/{companyId}/my-work`) — a summary headed **"Your notes so
+  far"** (the heading predicates the NOTES, not the operator: a view is not something
+  they added, but the notes *were* viewed, so every figure under it is a true predicate.
+  "so far" stays unbounded — a window would turn a tally into a rate, and a rate is
+  pace) over notes / photos / times viewed, then the
   operator's notes ten at a time behind **Show more**. Each row is the note itself,
   with one quiet metadata line beneath it: the view count, one reference, and the
   date. The reference is the job number for a job or part note and the **work

--- a/hooks/useCompanyFeatures.ts
+++ b/hooks/useCompanyFeatures.ts
@@ -23,25 +23,35 @@ import { useLoad } from '@/hooks/useLoad';
  * safer than the alternative of leaking gated UI to a tenant that hasn't
  * opted in. The no-companyId guard lives inside the loader (not a synchronous
  * setState in the effect body) so it doesn't trip set-state-in-effect.
+ *
+ * `companyName` rides along because `getCompany` already returns it. A separate
+ * `useCompany()` would re-fetch the identical row for anything that needs both —
+ * which is exactly what the operator "Me" tab was doing, requesting one companies
+ * row twice per mount on the page whose problem was concurrent request volume.
  */
 export function useCompanyFeatures() {
   const params = useParams();
   const companyId = params.companyId as string | undefined;
 
   const { data, loading } = useLoad(
-    async () => {
-      if (!companyId) return EMPTY_FEATURES;
+    async (): Promise<{ features: Record<KnownFeatureKey, boolean>; name: string | null }> => {
+      if (!companyId) return EMPTY_RESULT;
       try {
-        return readCompanyFeatures(await getCompany(companyId));
+        const company = await getCompany(companyId);
+        return { features: readCompanyFeatures(company), name: company?.name ?? null };
       } catch (err) {
         console.warn('useCompanyFeatures: failed to load company:', err);
-        return EMPTY_FEATURES;
+        return EMPTY_RESULT;
       }
     },
     [companyId],
   );
 
-  return { features: data ?? EMPTY_FEATURES, loading };
+  return {
+    features: data?.features ?? EMPTY_FEATURES,
+    companyName: data?.name ?? null,
+    loading,
+  };
 }
 
 function emptyFeatures(): Record<KnownFeatureKey, boolean> {
@@ -53,3 +63,4 @@ function emptyFeatures(): Record<KnownFeatureKey, boolean> {
 // Stable "all flags false" map — computed once, shared as the loading/fallback
 // value so consumers don't see a new object identity each render.
 const EMPTY_FEATURES: Record<KnownFeatureKey, boolean> = emptyFeatures();
+const EMPTY_RESULT = { features: EMPTY_FEATURES, name: null } as const;

--- a/hooks/useLoad.ts
+++ b/hooks/useLoad.ts
@@ -56,6 +56,36 @@ export function useLoad<T>(
   // responses (deps changed, or reload() fired, while a fetch was in flight).
   const runId = useRef(0);
 
+  /**
+   * PASS PRIMITIVE DEPS (ids, hrefs, counts). An object or array literal rebuilt each
+   * render is a new identity each render, which re-memoises `load`, which re-runs the
+   * effect, which resolves and setStates a fresh object (no Object.is bailout), which
+   * renders again — an infinite loop.
+   *
+   * It is worth a runtime warning rather than a comment because the failure is silent in
+   * every channel you would normally check. The setState happens in a promise callback,
+   * not synchronously in render, so React's "Maximum update depth exceeded" guard never
+   * fires. If the loader short-circuits (an empty array to map over) there is no network
+   * traffic. And every iteration is sub-millisecond, so a longtask observer sees nothing.
+   * The only symptom is a pegged CPU core — which is exactly how NoteEditDialog's
+   * `media = []` default parameter went unnoticed while it made the operator "Me" tab
+   * feel frozen. Same caller-owned-deps contract as `useSetOperatorChrome`, which carries
+   * the same warning in prose.
+   */
+  if (process.env.NODE_ENV !== 'production') {
+    for (const dep of deps) {
+      if (dep !== null && typeof dep === 'object') {
+        console.error(
+          'useLoad: received a non-primitive dependency (%o). If it is rebuilt each ' +
+            'render this is an infinite render loop. Pass a primitive (id/href), or ' +
+            'memoise the value with a stable identity.',
+          dep,
+        );
+        break;
+      }
+    }
+  }
+
   // Hold the latest onError in a ref so `load` need not depend on a possibly
   // inline callback. Updated AFTER render (the react-hooks/refs rule forbids
   // ref writes in the render body), never during it.

--- a/hooks/useOperatorIdentity.ts
+++ b/hooks/useOperatorIdentity.ts
@@ -5,16 +5,23 @@
  *
  * Lifted verbatim out of the old `/profile` page when Profile stopped being a tab. The email
  * comes from the auth session, the display name from `user_company_access` via
- * `getCurrentMember`, and the company name from `getCompany`.
+ * `getCurrentMember`, and the company name from `useCompanyFeatures`.
  *
  * Deliberately never throws and never blocks: the "Me" tab's reason to exist is the operator's
  * own work, and identity failing to resolve must not take the work — or the Log out button —
  * down with it. A null return renders as "You" with no company line.
+ *
+ * THE COMPANY NAME IS NOT FETCHED HERE. It comes from `useCompanyFeatures`, which the operator
+ * shell already mounts on every screen and which returns `companyName` off the same `getCompany`
+ * row it needs for the feature flags — exactly the reuse that hook's own docstring describes.
+ * Fetching it again here meant the Me tab asked for one `companies` row twice on every mount,
+ * on the page whose problem was already too many concurrent requests. `useLoad` dedupes nothing,
+ * so two callers really were two round trips.
  */
 
 import { useLoad } from '@/hooks/useLoad';
+import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 import { getCurrentMember } from '@/utils/operatorAccess';
-import { getCompany } from '@/utils/companyAccess';
 // `getTypedSupabase`, not `getSupabase` — new code uses the typed client (issue #573). Only
 // `auth.getSession()` is used here, which is schema-independent, so the two behave identically;
 // the typed one is simply what new files are required to reach for.
@@ -22,26 +29,38 @@ import { getTypedSupabase } from '@/lib/supabase';
 import type { OperatorIdentity } from '@/components/operator/OperatorAccountBlock';
 
 export function useOperatorIdentity(companyId: string) {
-  return useLoad<OperatorIdentity>(async () => {
-    // Every one of the three reads is guarded independently. The docstring above promises this
-    // never blocks the work or the Log out button, and an unguarded `getSession()` quietly broke
-    // that promise — one throw took the whole identity down, name included, rather than degrading
-    // to a missing email.
-    const session = await getTypedSupabase()
-      .auth.getSession()
-      .then((r) => r.data.session)
-      .catch(() => null);
+  const { companyName } = useCompanyFeatures();
 
-    const [member, company] = await Promise.all([
-      getCurrentMember(companyId).catch(() => null),
-      getCompany(companyId).catch(() => null),
-    ]);
+  const { data, loading, error, reload } = useLoad<Omit<OperatorIdentity, 'companyName'>>(
+    async () => {
+      // Both reads are guarded independently. The docstring above promises this never blocks
+      // the work or the Log out button, and an unguarded `getSession()` quietly broke that
+      // promise — one throw took the whole identity down, name included, rather than degrading
+      // to a missing email.
+      const [session, member] = await Promise.all([
+        getTypedSupabase()
+          .auth.getSession()
+          .then((r) => r.data.session)
+          .catch(() => null),
+        getCurrentMember(companyId).catch(() => null),
+      ]);
 
-    return {
-      name: member?.name || 'Operator',
-      email: session?.user?.email ?? '',
-      companyName: company?.name ?? '',
-      userId: session?.user?.id ?? '',
-    };
-  }, [companyId]);
+      return {
+        name: member?.name || 'Operator',
+        email: session?.user?.email ?? '',
+        userId: session?.user?.id ?? '',
+      };
+    },
+    [companyId],
+  );
+
+  // The company name arrives on its own schedule (the shell's load, not ours), so it is
+  // merged at read time rather than awaited — the name and email must not wait on a flag
+  // fetch to render.
+  return {
+    data: data ? { ...data, companyName: companyName ?? '' } : null,
+    loading,
+    error,
+    reload,
+  };
 }

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -404,8 +404,14 @@ export interface MyNote {
  * Deliberately carries no completion count, streak, average or anything
  * comparable against another person — see the surveillance guardrail in
  * docs. This screen is where a leaderboard would want to grow, and it must not.
+ *
+ * SEPARATE FROM THE NOTE LIST ON PURPOSE. These totals used to be reduced from
+ * the fetched rows, which was only correct while the list was every row the
+ * operator had ever written. Now that the list is paged, deriving them from what
+ * happens to be loaded would quietly turn "notes you have written" into "notes
+ * currently on screen" — a number that grows as you tap Show more.
  */
-export interface MyContribution {
+export interface MyContributionTotals {
   noteCount: number;
   photoCount: number;
   /**
@@ -415,7 +421,13 @@ export interface MyContribution {
    * can read by design.
    */
   peopleReached: number;
+}
+
+/** One page of the operator's own notes, newest first. */
+export interface MyNotesPage {
   notes: MyNote[];
+  /** Whether another page exists after this one. */
+  hasMore: boolean;
 }
 
 /** A named reader of one of your own notes. Authors only — see note_viewers(). */

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -370,8 +370,6 @@ export interface MyNote {
    * Server-stamped, never client-written. See JobNote.edited_at.
    */
   edited_at: string | null;
-  /** "Op 20 · Mill" when the note carries a step, else null. */
-  operation_label: string | null;
   /** Part the note is durably attached to, when it has one. */
   part_name: string | null;
   /**

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -375,6 +375,23 @@ export interface MyNote {
   /** Part the note is durably attached to, when it has one. */
   part_name: string | null;
   /**
+   * Machine this was logged against, for maintenance entries.
+   *
+   * Maintenance is not a separate store — an entry is a `notes` row with
+   * subject_kind='work_center', so it lands in the operator's own list beside their
+   * part and job notes. But that subject carries no part, no operation and no job, so
+   * without the machine name the row rendered as a bare sentence with nothing anywhere
+   * on it saying what it was about. Mutually exclusive with `part_name` and with
+   * `job_number` — the CHECK constraint on `notes` allows exactly one subject.
+   */
+  machine_name: string | null;
+  /**
+   * How the author classified a maintenance entry ('cleaned', 'repaired', 'replaced',
+   * 'adjusted', 'noticed'). Null is legal and common — classifying is optional, and
+   * the DB constraint only permits a value at all on a work_center note.
+   */
+  maintenance_kind: string | null;
+  /**
    * The job this note was written on — job_id for a job-subject note,
    * captured_job_id for a durable part-subject one. Null once that job is
    * deleted (provenance is ON DELETE SET NULL: the knowledge outlives its

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -1917,8 +1917,6 @@ export async function getMyNotesPage(
     .from('notes')
     .select(
       'id, body, created_at, edited_at, viewer_count, usage_count, maintenance_kind, ' +
-        'operation:job_operations!notes_job_operation_fk(operation_name, sequence), ' +
-        'captured_operation:job_operations!notes_captured_job_operation_fk(operation_name, sequence), ' +
         'part:parts(part_name), ' +
         // The machine, for maintenance entries. Those are `notes` rows too
         // (subject_kind='work_center'), so they land in this list like anything else the
@@ -1969,8 +1967,6 @@ export async function getMyNotesPage(
     viewer_count: number;
     usage_count: number;
     maintenance_kind: string | null;
-    operation: StepRel;
-    captured_operation: StepRel;
     part: { part_name: string | null } | { part_name: string | null }[] | null;
     work_center: { name: string | null } | { name: string | null }[] | null;
     reactions: ReactionRel[] | null;
@@ -1993,9 +1989,6 @@ export async function getMyNotesPage(
       edited_at: r.edited_at,
       job_id: job?.id ?? null,
       job_number: job?.job_number ?? null,
-      // A durable part-subject note has no step of its own; the step it was
-      // captured at is the readable label.
-      operation_label: stepLabel(r.operation) ?? stepLabel(r.captured_operation),
       part_name: part?.part_name ?? null,
       machine_name: workCenter?.name ?? null,
       maintenance_kind: r.maintenance_kind,

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -34,7 +34,8 @@ import type {
   JobNote,
   JobNoteMedia,
   PartPreviousNote,
-  MyContribution,
+  MyContributionTotals,
+  MyNotesPage,
   MyNote,
   NoteViewer,
   NoteReaction,
@@ -44,14 +45,7 @@ import type {
 // CURRENT USER (the signed-in company member — ANY role)
 // ============================================================================
 
-/**
- * The signed-in user's user_company_access row for this company — used wherever
- * we need the acting member's account id (job-note author, operation completer,
- * activity attribution). Intentionally NOT role-filtered: operators, users, and
- * admins are all company members, and every one of them can act in the operator
- * view. (There is no separate "operators" table — that legacy table is gone.)
- */
-export async function getCurrentMember(companyId: string): Promise<{
+export interface CurrentMember {
   id: string;
   name: string | null;
   user_id: string;
@@ -62,7 +56,65 @@ export async function getCurrentMember(companyId: string): Promise<{
    * round trip for a value that is on the row we are already fetching.
    */
   role: string | null;
-} | null> {
+}
+
+/**
+ * In-flight and resolved member lookups, keyed by company.
+ *
+ * This is a REQUEST cache, not a data cache — it exists because the answer is stable
+ * for the lifetime of a session and because several components resolve it at once.
+ * Mounting the "Me" tab used to call this twice concurrently (the identity hook and the
+ * contribution loader), and each call opens with `auth.getSession()`, which `supabase-js`
+ * serialises behind a `navigator.locks` acquisition and may refresh the token inside.
+ * Duplicate callers therefore didn't just cost a round trip, they queued behind each
+ * other on the one lock that gates every other request on the page.
+ *
+ * The promise is cached, not the value, so simultaneous callers share ONE flight rather
+ * than racing to populate it. A rejected or null-resolving lookup is evicted so a
+ * transient failure can't pin "not a member" for the rest of the session.
+ */
+const memberCache = new Map<string, Promise<CurrentMember | null>>();
+
+/**
+ * Forget every cached member. Call on sign-out: the cache answers "who is acting", and
+ * after a sign-out the honest answer is "nobody yet" — a stale entry would otherwise let
+ * the next user inherit the previous one's membership row.
+ */
+export function clearCurrentMemberCache(): void {
+  memberCache.clear();
+}
+
+/**
+ * The signed-in user's user_company_access row for this company — used wherever
+ * we need the acting member's account id (job-note author, operation completer,
+ * activity attribution). Intentionally NOT role-filtered: operators, users, and
+ * admins are all company members, and every one of them can act in the operator
+ * view. (There is no separate "operators" table — that legacy table is gone.)
+ *
+ * Deduplicated per company for the session — see `memberCache`.
+ */
+export function getCurrentMember(companyId: string): Promise<CurrentMember | null> {
+  const cached = memberCache.get(companyId);
+  if (cached) return cached;
+
+  const flight = fetchCurrentMember(companyId).then(
+    (member) => {
+      // Don't cache a negative. "No session yet" is a normal state during startup, and
+      // pinning it would leave every later caller in this session acting as a non-member.
+      if (!member) memberCache.delete(companyId);
+      return member;
+    },
+    (err) => {
+      memberCache.delete(companyId);
+      throw err;
+    },
+  );
+
+  memberCache.set(companyId, flight);
+  return flight;
+}
+
+async function fetchCurrentMember(companyId: string): Promise<CurrentMember | null> {
   const supabase = getSupabase();
 
   const { data: { session } } = await supabase.auth.getSession();
@@ -1763,7 +1815,68 @@ export async function getPartPreviousNotes(
 // ============================================================================
 
 /**
- * What the caller has written, and how far it has travelled.
+ * How many of the caller's own notes load at a time on the "Me" tab.
+ *
+ * Ten, where the completed-jobs list above uses fifty, because the two caps are
+ * solving different problems. That one is bounding a query; this one is bounding
+ * a SCROLL — "Give feedback" sits under this list, and the whole point of paging
+ * it is that the end of the page stays about a screen away on a phone. Fifty
+ * blurred cards would page the query and still bury the button.
+ */
+export const MY_NOTES_PAGE_SIZE = 10;
+
+/**
+ * The totals on the "Me" tab's summary card.
+ *
+ * A SEPARATE QUERY FROM THE LIST, deliberately. These used to be reduced from the
+ * fetched note rows, which was only honest while the list was unbounded. Once the
+ * list pages, deriving them from the loaded rows would mean the operator's note
+ * count climbed every time they tapped Show more — a number about the UI wearing
+ * the label of a number about their work.
+ *
+ * Two columns and one embed, against the seven relations the list select needs:
+ * this exists to be cheap enough to run alongside the first page. `photoCount`
+ * needs the media rows counted per note, and `peopleReached` needs each row's
+ * viewer_count summed; neither is expressible as a PostgREST `count`.
+ */
+export async function getMyContributionTotals(
+  companyId: string,
+): Promise<MyContributionTotals> {
+  const supabase = getSupabase();
+
+  const empty: MyContributionTotals = { noteCount: 0, photoCount: 0, peopleReached: 0 };
+
+  const member = await getCurrentMember(companyId);
+  if (!member) return empty;
+
+  const { data, error } = await supabase
+    .from('notes')
+    .select('viewer_count, media:note_media(id)')
+    .eq('company_id', companyId)
+    .eq('author_id', member.id)
+    // Auto-logged entries are not somebody's contribution.
+    .eq('note_type', 'user');
+
+  if (error || !data) return empty;
+
+  const rows = data as unknown as Array<{
+    viewer_count: number;
+    media: Array<{ id: string }> | null;
+  }>;
+
+  return {
+    noteCount: rows.length,
+    photoCount: rows.reduce((n, r) => n + (r.media ?? []).length, 0),
+    // Summed rather than distinct, and labelled "views" in the UI for exactly
+    // that reason: the per-note numbers it adds up are visible right below it.
+    // Distinct people across all notes would need the view rows, which are
+    // deliberately unreadable by any browser role.
+    peopleReached: rows.reduce((n, r) => n + r.viewer_count, 0),
+  };
+}
+
+/**
+ * What the caller has written, and how far it has travelled — one page of it.
  *
  * This is the return half of the loop: an operator writes something down and,
  * without this, nothing ever comes back. The login banner says "3 people used
@@ -1775,19 +1888,23 @@ export async function getPartPreviousNotes(
  * that no operator-facing surface ever reflects their pace or standing back at
  * them. Their own output and its reception, nothing else.
  *
- * viewer_count and usage_count are columns on the row, so the whole screen is
- * one round trip — no per-note count queries.
+ * viewer_count and usage_count are columns on the row, so a page is one round
+ * trip — no per-note count queries.
+ *
+ * PAGED SINCE #6xx. This used to fetch every note the operator had ever written,
+ * with all seven embeds, and render the lot. It was the only operator screen
+ * putting a `backdrop-filter` card inside an uncapped `.map()`, so the cost grew
+ * without bound in both the query and the compositor. `hasMore` is derived from a
+ * full page coming back rather than from a count, matching the activity feed.
  */
-export async function getMyContribution(companyId: string): Promise<MyContribution> {
+export async function getMyNotesPage(
+  companyId: string,
+  { offset = 0, limit = MY_NOTES_PAGE_SIZE }: { offset?: number; limit?: number } = {},
+): Promise<MyNotesPage> {
   const supabase = getSupabase();
 
   const member = await getCurrentMember(companyId);
-  const empty: MyContribution = {
-    noteCount: 0,
-    photoCount: 0,
-    peopleReached: 0,
-    notes: [],
-  };
+  const empty: MyNotesPage = { notes: [], hasMore: false };
   if (!member) return empty;
 
   const { data, error } = await supabase
@@ -1811,7 +1928,11 @@ export async function getMyContribution(companyId: string): Promise<MyContributi
     .eq('author_id', member.id)
     // Auto-logged entries are not somebody's contribution.
     .eq('note_type', 'user')
-    .order('created_at', { ascending: false });
+    // `id` breaks ties: two notes saved in the same millisecond would otherwise
+    // sort unstably between pages, which is how a row goes missing or repeats.
+    .order('created_at', { ascending: false })
+    .order('id', { ascending: false })
+    .range(offset, offset + limit - 1);
 
   if (error || !data) return empty;
 
@@ -1855,16 +1976,11 @@ export async function getMyContribution(companyId: string): Promise<MyContributi
     };
   });
 
-  return {
-    noteCount: notes.length,
-    photoCount: notes.reduce((n, x) => n + x.photo_count, 0),
-    // Summed rather than distinct, and labelled "views" in the UI for exactly
-    // that reason: the per-note numbers it adds up are visible right below it.
-    // Distinct people across all notes would need the view rows, which are
-    // deliberately unreadable by any browser role.
-    peopleReached: notes.reduce((n, x) => n + x.viewer_count, 0),
-    notes,
-  };
+  // A full page means there is probably another one; a short page means there
+  // certainly isn't. Same rule the activity feed uses. It can show Show more once
+  // on an exact multiple of the page size, which costs one empty fetch and is
+  // preferable to paying for an exact count on every page.
+  return { notes, hasMore: notes.length === limit };
 }
 
 /**

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -59,30 +59,34 @@ export interface CurrentMember {
 }
 
 /**
- * In-flight and resolved member lookups, keyed by company.
+ * IN-FLIGHT lookups only, keyed by company. Entries are dropped the moment they settle.
  *
- * This is a REQUEST cache, not a data cache — it exists because the answer is stable
- * for the lifetime of a session and because several components resolve it at once.
- * Mounting the "Me" tab used to call this twice concurrently (the identity hook and the
- * contribution loader), and each call opens with `auth.getSession()`, which `supabase-js`
+ * WHY THIS EXISTS. Every call opens with `auth.getSession()`, which `supabase-js`
  * serialises behind a `navigator.locks` acquisition and may refresh the token inside.
- * Duplicate callers therefore didn't just cost a round trip, they queued behind each
- * other on the one lock that gates every other request on the page.
+ * Mounting the "Me" tab fires three of these in one commit (the identity hook, the totals
+ * loader, the first-page loader), so duplicate callers didn't just cost a round trip —
+ * they queued against each other on the single lock that gates every other request on the
+ * page, which is what the tab's stall actually was. Sharing one flight collapses that to
+ * one lock acquisition.
  *
- * The promise is cached, not the value, so simultaneous callers share ONE flight rather
- * than racing to populate it. A rejected or null-resolving lookup is evicted so a
- * transient failure can't pin "not a member" for the rest of the session.
+ * WHY IT DOES NOT OUTLIVE THE FLIGHT. A session-length cache of this row is a cross-user
+ * data leak waiting to happen, and the app's shape makes it near-certain rather than
+ * theoretical: sign-out on the admin surface is `await signOut(); router.replace('/')`
+ * (components/layout/Header.tsx) and sign-in is `router.push` — every step a client
+ * navigation, so module state survives the whole sign-out/sign-in cycle. A retained entry
+ * would hand the next person the previous person's `user_company_access` row on a shared
+ * office computer, and this function is what pins `uploaded_by` / `author_id` on writes
+ * whose RLS policies require them to match the caller (utils/partAttachmentsAccess.ts,
+ * utils/workCenterAttachmentsAccess.ts) and what drives the admin-only delete affordances
+ * in FilesTab and JobFeed. Rather than maintain a list of every sign-out path that must
+ * remember to invalidate — one forgotten call site is a silent leak — the entry simply
+ * never outlives the request it was deduplicating. There is nothing to invalidate.
+ *
+ * The cost is one lookup per navigation instead of one per session, which is what the
+ * code did before the cache existed. The stall was never sequential calls; it was three
+ * concurrent ones.
  */
-const memberCache = new Map<string, Promise<CurrentMember | null>>();
-
-/**
- * Forget every cached member. Call on sign-out: the cache answers "who is acting", and
- * after a sign-out the honest answer is "nobody yet" — a stale entry would otherwise let
- * the next user inherit the previous one's membership row.
- */
-export function clearCurrentMemberCache(): void {
-  memberCache.clear();
-}
+const memberFlights = new Map<string, Promise<CurrentMember | null>>();
 
 /**
  * The signed-in user's user_company_access row for this company — used wherever
@@ -91,26 +95,17 @@ export function clearCurrentMemberCache(): void {
  * admins are all company members, and every one of them can act in the operator
  * view. (There is no separate "operators" table — that legacy table is gone.)
  *
- * Deduplicated per company for the session — see `memberCache`.
+ * Concurrent callers share one request — see `memberFlights`.
  */
 export function getCurrentMember(companyId: string): Promise<CurrentMember | null> {
-  const cached = memberCache.get(companyId);
-  if (cached) return cached;
+  const inFlight = memberFlights.get(companyId);
+  if (inFlight) return inFlight;
 
-  const flight = fetchCurrentMember(companyId).then(
-    (member) => {
-      // Don't cache a negative. "No session yet" is a normal state during startup, and
-      // pinning it would leave every later caller in this session acting as a non-member.
-      if (!member) memberCache.delete(companyId);
-      return member;
-    },
-    (err) => {
-      memberCache.delete(companyId);
-      throw err;
-    },
-  );
+  const flight = fetchCurrentMember(companyId).finally(() => {
+    memberFlights.delete(companyId);
+  });
 
-  memberCache.set(companyId, flight);
+  memberFlights.set(companyId, flight);
   return flight;
 }
 
@@ -1857,7 +1852,18 @@ export async function getMyContributionTotals(
     // Auto-logged entries are not somebody's contribution.
     .eq('note_type', 'user');
 
-  if (error || !data) return empty;
+  // THROW, don't return zeroes. A failed count and a genuine zero are different
+  // facts, and rendering the first as the second tells an operator their notes are
+  // gone. The caller has an error state; give it something to show.
+  if (error) {
+    throw new Error(
+      friendlyErrorMessage(error, {
+        entity: 'note',
+        fallback: 'Could not load your work.',
+      }),
+    );
+  }
+  if (!data) return empty;
 
   const rows = data as unknown as Array<{
     viewer_count: number;
@@ -1934,7 +1940,21 @@ export async function getMyNotesPage(
     .order('id', { ascending: false })
     .range(offset, offset + limit - 1);
 
-  if (error || !data) return empty;
+  // THROW rather than resolving to an empty page. Swallowing this is worse here than
+  // anywhere else in the file: an empty page reads as `hasMore: false`, which retires
+  // the Show more button, so a single dropped request on a flaky shop connection made
+  // every remaining note look deleted — with no error and no way back short of leaving
+  // the tab. The caller's catch is what shows the retry, and it can only fire if this
+  // rejects.
+  if (error) {
+    throw new Error(
+      friendlyErrorMessage(error, {
+        entity: 'note',
+        fallback: 'Could not load your notes.',
+      }),
+    );
+  }
+  if (!data) return empty;
 
   type Row = {
     id: string;

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -1916,10 +1916,15 @@ export async function getMyNotesPage(
   const { data, error } = await supabase
     .from('notes')
     .select(
-      'id, body, created_at, edited_at, viewer_count, usage_count, ' +
+      'id, body, created_at, edited_at, viewer_count, usage_count, maintenance_kind, ' +
         'operation:job_operations!notes_job_operation_fk(operation_name, sequence), ' +
         'captured_operation:job_operations!notes_captured_job_operation_fk(operation_name, sequence), ' +
         'part:parts(part_name), ' +
+        // The machine, for maintenance entries. Those are `notes` rows too
+        // (subject_kind='work_center'), so they land in this list like anything else the
+        // operator wrote — but they carry no part, no operation and no job, so without
+        // this they rendered as a bare sentence with nothing saying what it was about.
+        'work_center:work_centers!notes_work_center_fk(name), ' +
         // Read-only here: RLS forbids reacting to your own note, so on My work
         // these are reception rather than an available action.
         'reactions:note_reactions(kind, reactor_id, reactor:user_company_access(name)), ' +
@@ -1963,9 +1968,11 @@ export async function getMyNotesPage(
     edited_at: string | null;
     viewer_count: number;
     usage_count: number;
+    maintenance_kind: string | null;
     operation: StepRel;
     captured_operation: StepRel;
     part: { part_name: string | null } | { part_name: string | null }[] | null;
+    work_center: { name: string | null } | { name: string | null }[] | null;
     reactions: ReactionRel[] | null;
     job: JobRel;
     captured_job: JobRel;
@@ -1977,6 +1984,7 @@ export async function getMyNotesPage(
 
   const notes: MyNote[] = (data as unknown as Row[]).map((r) => {
     const part = Array.isArray(r.part) ? r.part[0] : r.part;
+    const workCenter = Array.isArray(r.work_center) ? r.work_center[0] : r.work_center;
     const job = oneJob(r.job) ?? oneJob(r.captured_job);
     return {
       id: r.id,
@@ -1989,6 +1997,8 @@ export async function getMyNotesPage(
       // captured at is the readable label.
       operation_label: stepLabel(r.operation) ?? stepLabel(r.captured_operation),
       part_name: part?.part_name ?? null,
+      machine_name: workCenter?.name ?? null,
+      maintenance_kind: r.maintenance_kind,
       photo_count: (r.media ?? []).length,
       reactions: mapReactions(r.reactions),
       viewer_count: r.viewer_count,


### PR DESCRIPTION
Seven fixes to the operator **Me** tab (`/operator/[companyId]/my-work`). The headline one — the stall — was found only after a first attempt at it failed on the preview.

---

## 1. THE STALL — `NoteEditDialog` was spinning a CPU core

`NoteEditDialog` declared `media = []` as a **default parameter**, so it built a new array identity on every render. That array is a `useLoad` dependency, and `useLoad` memoises its loader with `useCallback(fn, deps)` and re-runs on the loader's identity. So: render → new `[]` → new loader → effect re-runs → resolves → `setState` with a fresh object (no `Object.is` bailout) → render. **~4,000 renders per second, per instance.**

It survived because it is silent in every channel anyone checks:

- **React never reports it** — the `setState` is in a promise callback, not synchronous render, so the "Maximum update depth exceeded" guard never fires.
- **No DOM churn** — at `open={false}` the dialog renders null.
- **No network** — the loader maps over an empty array.
- **No long tasks** — every iteration is sub-millisecond, so a `longtask` PerformanceObserver reports **0**.

The only observable is a pegged core. Instrumenting the live page found 5 requests on arrival, 0 while idle, 0 long tasks — and a screen that still felt frozen.

The Me tab was the one surface mounting this dialog **unconditionally, one per note row, closed**. `JobFeed`, `PartNotesSheet` and `MachineLogPanel` all render `{editingNote && <NoteEditDialog open …/>}` *and* pass `media`, so none of them hit it.

Fixes: a module-level `NO_MEDIA` constant replaces the default parameter; the Me tab mounts dialogs only while open; and `useLoad` now warns in development on a non-primitive dependency — a contract documented on `useSetOperatorChrome` but not here. With that warning in place the full suite flagged **no other violator** among the 54 call sites.

**Measured:** the regression test counts render commits, since rendered output is identical either way. Old default: **1187 commits in 300 ms** from one closed dialog. Fixed: **under 15**. End to end with a driver that waits for page idle: **152s → 0s**.

## 2. The note list is now a flat row on the shared kebab

The Me tab was the only operator note surface rolling its own edit/delete affordance — a card that was one big `CardActionArea`, with Edit / Delete / Open-job as full-width buttons inside the expanded state. `JobFeed`, `PartNotesSheet` and `MachineEntry` all use `NoteActionsMenu`, which is what `docs/interaction-standards.md` requires for this device class.

It now uses that menu, and the card is gone.

**Why the row body is inert.** The obvious shape — tap the row to expand, kebab for actions — is a split-button row, and that is the one thing the research is unambiguous about: NN/g measured across 136 participants and 11 mobile prototypes that users ["tap fairly equally on both the accordion icon and the accordion label"](https://www.nngroup.com/articles/accordion-icons/). On a row whose trailing control opens a menu containing Delete, a coin flip is not an acceptable outcome — and this surface is used in gloves. So the two disclosures sit at opposite ends with nothing tappable between them:

```
👁 2   (far left)   → who read this
⋮      (far right)  → Open J-0006 / Edit / Delete
```

An unread note gets **no** reader disclosure at all — no names to ask for — so those rows carry one tap target rather than two.

**Why "Viewed by" could not just move into the menu**, which would have removed the second control entirely: NN/g's [contextual-menu guidance](https://www.nngroup.com/articles/contextual-menus-guidelines/) reserves kebabs for revealing *actions*, not content. The reader list is content. Reactions stay inline for the opposite reason — a view is involuntary and private, a reaction is a voluntary public claim and attribution is the point of it. That list already caps at three names then "+N", so it holds at shop scale.

**Card chrome removed.** It cost roughly three notes per phone screen for no information, on a screen whose job is reading. It also carried one `backdrop-filter` compositing layer per row, on the one screen that renders a long list of them.

`NoteActionsMenu` gains an optional `onOpen`/`openLabel`, listed first so delete still sits last. The other three call sites are untouched. `docs/interaction-standards.md` records the extra rule and why, so a reviewer who reads "operator surfaces use a kebab" doesn't reintroduce the row tap.

## 3. Maintenance entries had no subject at all

Maintenance is not a separate store — an entry is a `notes` row with `subject_kind='work_center'`. But the CHECK constraint permits exactly one subject, so a machine entry carries no part, no operation and — unlike a job note — **no job number either**. The query never selected the work center, so those rows rendered as a bare sentence and a date.

They now carry the machine name in the slot the part name uses, plus the maintenance kind as a chip when classified (optional by design, so unclassified gets no chip).

Job notes are deliberately unchanged: their subject *is* the job, and the job reference already sits quietly beside the date.

For the record, since the asymmetry causes confusion: `addJobNote` picks the subject with no operator input — a step **with** a routing link produces a durable `subject_kind='part'` note anchored to `(part_id, routing_operation_id)` with the job kept as provenance; without one it falls back to `'job'`. That is why some rows name a part. Admin-side **part comments** are a different table and are never read here. Bare rows with no subject at all are **seed-only** — `supabase/seed.sql`'s `add_note` inserts job notes with no `job_operation_id`, a shape no app path produces.

## 4. It showed a back arrow

Me is a bottom-nav tab root, so "back" pointed at Jobs — one tap away in the nav bar. Dropping its chrome declaration lets the header fall through to the Jigged mark that Jobs, Inventory and Maintenance already show. The mark also goes **20px → 32px**: it alternates in the same slot as the back IconButton, so being much smaller made the header lurch between screens.

## 5. Give feedback was in the basement

It sat under the operator's entire note list — the one place a pilot's feedback channel must not be. Once the list pages, reaching it means ten notes and a Show more. Now a small permanent link under the identity block, above the work. It is a **sibling** of the identity row, not a child: putting it beside the Log out icon would recreate the adjacency the isolation argument exists to avoid, and a test fails if a future edit does that. `OperatorAccountActions` had nothing left and is gone.

## 6. The shell scrolled an inner box, not the document

`main` was `flex: 1` + `overflow: auto` inside a `minHeight: 100vh` column with every sibling fixed, making it a private scroll container. Its `scrollTop` survived tab switches (the layout never unmounts; Next restores `window` only), and since `100vh` is the *large* viewport while the fixed bottom bar tracks the *small* one, the end of the page sat below the fold unreachable — on Me, that was Give feedback and Log out. The document scrolls now.

## 7. Identity, Log out, pagination — and two defects found reviewing them

Log out becomes an isolated 48px icon in the identity row; the email moves up beside the name (it was in a "Signed in as …" caption behind the whole list). The `OperatorAccountBlock` docstring **and** its guard test are rewritten rather than dropped: the safety argument moves from **distance** to **isolation**, because distance stopped meaning "slightly slower to reach" and started meaning "past however many Show mores it takes".

The note list had no pagination at all — every note ever written, with seven embeds, all rendered. Now **10 at a time behind "Show more"**. The summary card gets its own query: reducing totals from a page would turn "notes you have written" into "notes currently on screen". No migration; both queries are plain PostgREST.

An adversarial review of the first pass surfaced two more, both fixed:

- **The member cache could hand one user another user's identity.** Keyed by company and kept for the session, cleared only from the two operator sign-out paths — but `getCurrentMember` is also called from `FilesTab`, `HistoryTab`, `PartPricing`, `MachineLogPanel` and the attachment writers on the **admin** surface, which cleared nothing, and every step of a sign-out/sign-in cycle is a client navigation, so module state survives it. On a shared office computer the next person would have inherited the previous person's `user_company_access` row — the row that pins `uploaded_by`/`author_id` on writes whose RLS requires them to match the caller. The entry now never outlives the in-flight request it was deduplicating, so there is nothing to invalidate.
- **A failed "Show more" retired the button instead of offering the retry.** `getMyNotesPage` swallowed query errors and resolved an empty page, so `loadMore`'s catch was unreachable: `hasMore` went false, the button left the DOM, no error appeared, and the remaining notes looked deleted. Both new access functions now throw.

### ⚠️ `app_opened` changes meaning (not a regression)

The shell's auth check keyed off `pathname`, so it re-ran `getSession()` + a `user_company_access` round trip + `app_opened` on **every** in-app navigation. Now once per session. `app_opened` is documented as top-of-funnel — one per session — so it has been counting tab taps and inflating every ratio measured against it. **Expect the number to drop after merge.**

An earlier version of this description claimed concurrent `auth.getSession()` calls were the stall. They were not — see §1. Measurement also shows **zero** `/auth/v1/` requests, since `getSession()` reads local storage when the token is valid and only takes the lock.

---

## Verified on the preview (production build)

```
DENSITY     rows=10  aboveFold=8  blurredRows=0        (card chrome gone)
INERT BODY  tapped the note text -> menuOpen=false  viewedByShown=false
GEOMETRY    eye=48x48  kebab=48x48  interactivePerRow=2
GEOMETRY @375  eye=48  kebab=48  gap=247px  bodyScrollsSideways=false
UNREAD      zeroViewRows=8  withEyeButton=0           (one target on unread rows)
EYE         tap reveals "Viewed by"
MENU job-note      ["Open J-0006","Edit","Delete"]    (Open first, Delete last)
MENU machine-note  ["Edit","Delete"]                  (no job to open)
EDIT        round-tripped via the menu and persisted
PAGING      firstPageRows=10  Show more -> rows=11  summaryTotal=11 (corpus-wide)
SCROLL      mainOverflow=visible  documentScrolls=true
            giveFeedbackVisibleAtBottom=true  clearOfNav=true
            scrollY after Jobs->Me round trip = 0
DETAIL      traveler back arrow present=1
OPERATOR ROLE  headerButtons=0  dashboardShortcut=0  logo=1  back=0
MAINTENANCE    "0 | Bandsaw | Noticed | Aug 1, 2026 | Blade guard rattling…"
FEEDBACK       aboveNotes=true  visibleWithoutScrolling=true  interactiveInLogoutRow=1
STALL          152s -> 0s (same driver, same interaction)
```

1592 unit tests, `tsc` clean, lint unchanged from baseline (16 warnings, 0 errors).

**Known pre-existing, not from this branch:** a `406` on `GET /rest/v1/companies` during the post-login transition. `useCompanyFeatures` → `getCompany` is called by the operator shell as it mounts, before the session has fully settled, and `.single()` turns zero RLS-visible rows into a 406. The hook catches it and falls back to all-flags-false, which briefly hides the flag-gated tabs. Present on `origin/main`; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
