### PR TITLE
docs(customers): rewrite for the module that actually shipped

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -471,7 +471,7 @@ documents; apply the standard above when closing them.
 ### 16. Deletion & Archiving Policy
 
 **"Delete" = archive (soft-delete), universally.** Every user-facing entity — `parts`,
-`customers`, `vendors`, `work_centers`, `jobs`, `quotes` — carries a nullable
+`customers`, `customer_carrier_accounts`, `vendors`, `work_centers`, `jobs`, `quotes` — carries a nullable
 `deleted_at timestamptz`. The UI "Delete" action sets `deleted_at` instead of issuing a
 SQL `DELETE`, and it **never blocks**: the row survives, so every downstream reference
 (quote lines, job parts, shipments, invoices, BOM edges) keeps resolving and no foreign

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -397,8 +397,7 @@ import StatusChip from '@/components/common/StatusChip';
 
 **Exempt (intentionally custom, do not force onto `StatusChip`):** chips with a
 bespoke palette for a domain reason — stock level (`StockStatusChip`), part
-classification (`PartClassificationChips`), customer active state
-(`CustomerStatusChip`), work-center kind — and the `HOT` rush badge
+classification (`PartClassificationChips`), work-center kind — and the `HOT` rush badge
 (`JobHotBadge`), which deliberately mutes to outlined for historical jobs. These
 use custom hex/rgba, not the semantic palette, and are not on/off status badges.
 

--- a/docs/modules/customers.md
+++ b/docs/modules/customers.md
@@ -2,397 +2,458 @@
 
 ## Overview
 
-The Customers module manages the master list of companies that the shop does business with. Customers are required to create quotes and jobs.
+> **A shop CRM is not a sales pipeline. It is the customer's standing commercial contract, made machine-readable so it stops being retyped onto every document.**
 
-**Priority:** Must Have (Build First)
+`customers` was a 7-column identity stub until August 2026. It now carries the small set of facts that govern how every quote, job, packing slip and invoice for that customer must be produced: **what terms we agreed**, **whether they're clear to ship to**, and **who pays the freight, on whose account**.
 
-**Dependencies:** None - this is the foundational module
+The operating rule for all of it:
 
-**Database Table:** `customers`
+> Store only what cannot be derived. Resolve it **at document-create time**, freeze it into the document's own column, and **never read it back at render time**. Show which level a value came from.
+
+That last clause is the whole safety argument, and the reason this is not the `markup_rates` module deleted in July 2026 — that one resolved a shared named default at *read* time with nothing on screen to say where the number came from, so it silently rewrote finished documents.
+
+**Priority:** Must Have · **Dependencies:** none (foundational) · **Tables:** `customers`, `customer_contacts`, `customer_addresses`, `customer_carrier_accounts`
 
 ---
 
-## User Stories
+## Data model
 
-| As a... | I want to... | So that... |
+### `customers` — 12 columns
+
+| Column | Type | Notes |
 |---|---|---|
-| Owner/Admin | View a list of all customers | I can see who we do business with |
-| Owner/Admin | Search customers by name | I can quickly find a specific customer |
-| Owner/Admin | Create a new customer with contact details | I can start doing business with them |
-| Owner/Admin | Edit customer information | I can keep records up to date |
-| Owner/Admin | Delete a customer | I can remove customers we no longer do business with |
-| Owner/Admin | Bulk import customers from CSV | I can migrate from my legacy system |
+| `id` | uuid PK | `gen_random_uuid()` |
+| `company_id` | uuid NOT NULL | tenant key |
+| `name` | text NOT NULL | unique per company — **`customers_company_name_unique (company_id, name)`, FULL, no `WHERE`** |
+| `website` | text | |
+| `created_at` / `updated_at` | timestamptz | `updated_at` maintained by the `customers_updated_at` trigger (no column list — fires on every update) |
+| `deleted_at` | timestamptz | archive marker |
+| `default_payment_terms` | text | standing terms ↓ |
+| `default_lead_time_text` | text | |
+| `default_fob_point` | text | |
+| `credit_status` | text NOT NULL DEFAULT `'open'` | `CHECK (credit_status IN ('open','hold'))` |
+| `credit_hold_note` | text | |
 
----
+Everything unmarked is nullable. `customers_credit_status_check` is the **only** CHECK on the table. There is no `phone`, `email`, `notes`, `tax_status`, `customer_number`, or credit limit — see [Explicitly not built](#explicitly-not-built).
 
-## Data Model
+Contacts and addresses live in their own tables so a customer can have many of each.
 
-The `customers` row holds only **identity** — name + website. Contacts and addresses were split into their own tables (`customer_contacts`, `customer_addresses`), so a customer can have many of each. There is **no** `notes` column, no embedded `phone`/`email`, and no embedded single-contact/single-address columns.
+**`customer_contacts`** — `name` (req), `role` (`buyer` / `accounts_payable` / `engineering` / `quality` / `shipping_receiving` / `other`), `role_label` (required by CHECK when role is `other`), `email`, `phone`, `is_primary` (at most one per customer, `customer_contacts_one_primary` partial unique index).
 
-**`customers`**
+**`customer_addresses`** — `address_line1`/`2`, `city`, `state`, `postal_code`, `country` (default `USA`), `attention_to` (the "ATTN:" line printed above the address on packing slips), `default_billing`, `default_shipping`.
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| name | Text | Yes | Full company name (unique per company — `customers_company_name_unique`) |
-| website | Text | No | Company website |
+### `customer_carrier_accounts` — the customer's own UPS/FedEx account
 
-**`customer_contacts`** (one person at the customer; managed via `utils/customerContactsAccess.ts`)
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| name | Text | Yes | Contact person's name |
-| role | Enum | Yes | `buyer` / `accounts_payable` / `engineering` / `quality` / `shipping_receiving` / `other` |
-| role_label | Text | When `role='other'` | Free-text label (DB CHECK requires it for `other`) |
-| email | Text | No | Contact email |
-| phone | Text | No | Contact phone |
-| is_primary | Boolean | — | At most one primary per customer (`customer_contacts_one_primary` partial unique index) |
-
-**`customer_addresses`** (managed via `utils/customerAddressesAccess.ts`)
-
-| Field | Type | Required | Description |
-|---|---|---|---|
-| address_line1 / address_line2 | Text | No | Street / suite |
-| city / state / postal_code | Text | No | Locality (state/country picked from canonical lists) |
-| country | Text | No | Default `USA` |
-| attention_to | Text | No | "ATTN:" recipient line printed above the address on packing slips |
-| default_billing | Boolean | — | At most one default-billing address per customer (partial unique index) |
-| default_shipping | Boolean | — | At most one default-shipping address per customer (partial unique index) |
-
-> **Note:** A quote **snapshots** the chosen billing/shipping address and contact at creation time (via `pickBillingAddress` / `pickShippingAddress` / `pickPrimaryContact`), and the printed quote PDF renders that frozen snapshot in its customer block — it does not read the customer's current default. Keep contacts + addresses filled in for customers you send quotes to. Missing fields are skipped cleanly — no "null" placeholders.
-
----
-
-## UI Screens
-
-### 1. Customer List
-
-**Route:** `/dashboard/{companyId}/customers`
-
-**Features:**
-
-- AG Grid showing: Name, Contact (primary contact name), Email (primary contact email), Phone (primary contact phone), Location (default-billing city/state)
-
-- Search box (searches name, case-insensitive, debounced)
-
-- "New Customer" and "Import" buttons
-
-- Row checkboxes with a bulk **Delete** action (and Export CSV) shown when rows are selected
-
-- Click row (or Enter on a focused row) to open the customer detail page
-
-- Client-side pagination (25 per page, selector for 25 / 50 / 100)
-
-**Empty State:**
-
-"No customers yet. Create your first customer or import from CSV."
-
-### 2. Customer Create/Edit
-
-**Route:** `/dashboard/{companyId}/customers/new` or `/dashboard/{companyId}/customers/{id}/edit`
-
-**Form Sections:**
-
-▸ **Basic Information**
-
-- Company Name (required, unique per company)
-
-- Website
-
-▸ **Initial Contact (optional — create mode only)**
-
-An expandable accordion that captures one optional primary contact so a user can create the customer and its first contact in one step. Fields: Contact Name, Role, Email, Phone (Role label appears when Role = Other). Leaving all fields blank inserts no contact. In **edit mode this accordion is hidden** — contacts and addresses are managed on the customer detail page.
-
-There are **no** Address or Notes sections on this form. Additional contacts and all addresses are added/edited on the detail page.
-
-**Actions:**
-
-- Save → Create mode routes to the new customer's detail page; edit mode routes back to detail
-
-- Cancel → Returns without saving
-
-- Delete (edit mode only) → Confirmation dialog, then **archive** (soft-delete): sets `customers.deleted_at`, hiding the customer from lists/search/pickers. The row — and its contacts + addresses — are kept, so any quotes/jobs that reference it still resolve. Re-creating the same name later revives it.
-
-### 3. Customer Detail
-
-**Route:** `/dashboard/{companyId}/customers/{id}`
-
-The detail page is the hub for everything below the name:
-
-- Header card: name + website link + created/updated timestamps
-
-- **Contacts** card — list of contacts with a primary star, role chip, and email/phone links; add/edit via `CustomerContactModal`, "Set as primary" on non-primary rows, and per-row delete
-
-- **Addresses** card — list of addresses with Billing / Shipping / "Not assigned" chips; add/edit via the inline `CustomerAddressForm`, and per-row delete (deleting a default warns it will leave the customer without one)
-
-- **Related** card — live counts of the customer's Quotes and Jobs
-
-- **Edit** button (routes to the `/edit` form) and a **Delete** button. "Delete" **archives** the customer (soft-delete — sets `deleted_at`) after a confirmation; it is **never blocked** by references — a customer with related quotes or jobs archives fine, and those documents keep resolving the (now-hidden) row. The Related-card counts are impact information, not a block. See `docs/architecture.md` §16.
-
----
-
-## AI-Powered Bulk Import
-
-**Route:** `/dashboard/{companyId}/customers/import`
-
-Replaces manual CSV column mapping with an AI-powered backend that analyzes CSV data, suggests mappings with confidence scores, detects conflicts, and provides a guided import workflow.
-
-### Import Flow (5 Steps)
-
-```javascript
-1. UPLOAD CSV
-   Parse file, extract headers + first 5 rows
-       │
-       ▼
-2. AI ANALYSIS
-   Call /analyze endpoint, show loading spinner
-   AI suggests column mappings with confidence scores
-       │
-       ▼
-3. REVIEW MAPPINGS
-   Display mappings with confidence indicators (green/yellow/red)
-   User can override AI suggestions
-       │
-       ▼
-4. VALIDATE
-   Call /validate endpoint
-   Flag within-CSV duplicate names + validation errors
-       │
-       ▼
-5. EXECUTE
-   Call /execute endpoint (upsert on (company_id, name))
-   Show results: created, updated, skipped, errors
-```
-
-### Conflict Detection & idempotency
-
-- **A customer name that already exists in the company is NOT a conflict — it is an update.**
-  Execute upserts `ON CONFLICT (company_id, name)`, so re-importing the same list updates
-  those customers in place rather than skipping or duplicating them (idempotent). Only the
-  columns present in the CSV are written; a contact/address is attached only to a **new**
-  customer (re-attaching a primary contact to an existing one would duplicate it).
-
-- **Duplicate name *within the same CSV*** (`csv_duplicate_name`) → those rows are skipped.
-
-- User can choose to skip conflicts and import valid rows.
-
-### Confidence Scoring
-
-| Score | Color | Meaning |
+| Column | Type | Notes |
 |---|---|---|
-| >= 0.8 | Green | High confidence, auto-mapped |
-| 0.5 - 0.79 | Yellow | Medium confidence, review suggested |
-| < 0.5 | Red | Low confidence, manual selection needed |
+| `id` / `company_id` / `customer_id` | uuid NOT NULL | both FKs `ON DELETE CASCADE` |
+| `carrier` | text NOT NULL | **free text**, not an enum — an enum regresses the first time a shop uses a regional LTL carrier. UI offers UPS/FedEx/USPS + "Other" |
+| `bill_to_party` | text NOT NULL | `CHECK IN ('recipient','third_party')` |
+| `account_number` | text | **nullable on purpose** ↓ |
+| `account_postal_code` | text | the postal code **of the account**, not of any address on the shipment — UPS validates the pair and rejects a mismatch |
+| `account_country_code` | text NOT NULL | default `'US'` |
+| `notes` | text | |
+| `created_at` / `updated_at` / `deleted_at` | timestamptz | **no `updated_at` trigger** — the access layer sets it explicitly on update and archive |
 
-### API Endpoints
-
-**POST ****`/api/customers/import/analyze`**
-
-Send CSV headers + 5 sample rows, get AI mapping suggestions.
-
-```json
-// Request
-{
-  "company_id": "uuid",
-  "headers": ["Company", "Tel", "Email"],
-  "sample_rows": [["Acme Corp", "555-1234", "[info@acme.com](mailto:info@acme.com)"]]
-}
-
-// Response
-{
-  "mappings": [
-    {"csv_column": "Company", "db_field": "name", "confidence": 0.95, "needs_review": false},
-    {"csv_column": "Tel", "db_field": "phone", "confidence": 0.65, "needs_review": true}
-  ],
-  "unmapped_required": [],
-  "discarded_columns": ["Internal ID"],
-  "ai_provider": "claude"
-}
-```
-
-**POST ****`/api/customers/import/validate`**
-
-Check for conflicts before import.
-
-```json
-// Response
-{
-  "has_conflicts": true,
-  "conflicts": [
-    {"row_number": 3, "conflict_type": "duplicate_name", "csv_value": "ACM01"}
-  ],
-  "valid_rows_count": 47,
-  "conflict_rows_count": 3
-}
-```
-
-**POST ****`/api/customers/import/execute`**
-
-Perform the import.
-
-```json
-// Response
-{
-  "success": true,
-  "imported_count": 47,
-  "skipped_count": 3,
-  "errors": []
-}
-```
-
-### UI Components
-
-| Component | Purpose |
-|---|---|
-| `MappingReviewTable` | Show mappings with confidence chips, allow manual changes |
-| `ConflictDialog` | Display conflicts, option to skip and proceed |
-| `ConfidenceChip` | Visual indicator based on confidence score |
-
-### Mapping Review UI Sections
-
-1. **Mapped Columns** - CSV → DB field with confidence indicator
-
-2. **Discarded Columns** - CSV columns that won't be imported
-
-3. **Missing Required** - Alert if name unmapped
-
-### AI Provider Configuration
-
-Provider selection is per-company, stored in `ai_config` database table:
+Three CHECKs. The one worth reading:
 
 ```sql
-CREATE TABLE [public.ai](http://public.ai/)_config (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  company_id uuid NOT NULL REFERENCES companies(id),
-  feature text NOT NULL,  -- 'csv_mapping', 'chat', etc.
-  provider text NOT NULL DEFAULT 'anthropic',  -- 'anthropic', 'openai', 'gemini'
-  model text,
-  settings jsonb DEFAULT '{}',
-  UNIQUE (company_id, feature)
-);
+CONSTRAINT customer_carrier_accounts_account_required
+  CHECK (bill_to_party <> 'third_party'
+         OR (account_number IS NOT NULL AND length(btrim(account_number)) > 0))
 ```
 
-API keys remain in environment variables (secure). Default provider is Claude if no config exists.
+**A `recipient` row may legally have no account number** — null, empty, or whitespace. LTL bills the payer by name and address on the bill of lading, and FedEx Ground Collect needs no account at all. A blanket `NOT NULL` here is how the column gets poisoned with "N/A" in week one.
 
-### Error Handling
+`bill_to_party` is not cosmetic: UPS levies a third-party billing surcharge (~5% of base plus accessorials) that bill-receiver does not carry, so storing only "collect" would hide the cheaper legal option. `toBillToParty` falls back to **`recipient`** — the option *without* the surcharge — so an impossible value can never cost the customer money.
 
-- **AI failure** → Fall back to manual column mapping
+One index besides the PK: `idx_customer_carrier_accounts_customer ON (customer_id) WHERE deleted_at IS NULL`. **No unique constraint on `(customer_id, carrier)`** — a customer may hold several accounts with one carrier. No `customer_address_id` and no `scope` enum: the pilot shop had exactly one account, and both would be columns nobody fills. Adding either later is purely additive.
 
-- **Rate limit** → Show "Too many requests, please wait"
-
-- **Conflicts found** → Block import, show conflict resolution UI
-
-- **Validation errors** → Show per-row errors in results table
-
-### Backend Files (New)
-
-```javascript
-/api/
-├── routes/import_[routes.py](http://routes.py/)         # Import endpoints
-├── services/
-│   ├── ai/
-│   │   ├── base_[provider.py](http://provider.py/)        # Abstract AI provider
-│   │   ├── claude_[provider.py](http://provider.py/)      # Claude implementation
-│   │   ├── openai_[provider.py](http://provider.py/)      # OpenAI implementation
-│   │   ├── gemini_[provider.py](http://provider.py/)      # Gemini implementation
-│   │   └── [factory.py](http://factory.py/)              # Provider factory with DB lookup
-│   └── import_[service.py](http://service.py/)           # Import business logic
-├── models/import_[models.py](http://models.py/)         # Pydantic schemas
-└── utils/rate_[limiter.py](http://limiter.py/)           # Rate limiting
-```
-
-### Frontend Files (New)
-
-```javascript
-/components/customers/import/
-├── MappingReviewTable.tsx
-├── ConflictDialog.tsx
-└── ConfidenceChip.tsx
-
-/types/import.ts
-```
-
-### Validation Rules
-
-- name is required and must be unique per company
-
-- Simple 1:1 column mapping only (no concatenation)
+**Security posture.** RLS on, four company-scoped policies for `authenticated`, `GRANT SELECT/INSERT/UPDATE/DELETE` to `authenticated` + `service_role`, **no `anon` grant**, `SELECT public.apply_billing_write_gate(...)`, and an explicit `REVOKE ALL … FROM jigged_ai_readonly`. That REVOKE is load-bearing, not decorative: the baseline's `ALTER DEFAULT PRIVILEGES` grants `SELECT` on **every** new public table to the AI role.
 
 ---
 
-## Acceptance Criteria
+## Standing terms
 
-Each bullet is a Given/When/Then scenario carrying a verification clause — a pointer to the test that proves it, a manual procedure, or an explicit automation-pending tag. Every editable entity has at least one edit -> save -> reload -> persists bullet. Doc-vs-code disagreements this audit surfaced are recorded in the divergence report on issue #333.
+Three customer columns seed three quote columns. All optional; a shop that fills nothing sees byte-identical behaviour to before the feature existed.
 
-**List & search**
+| Customer column | Quote column | Levels |
+|---|---|---|
+| `default_payment_terms` | `quotes.payment_terms` | **two** — customer, then shop-wide |
+| `default_lead_time_text` | `quotes.lead_time_text` | one (customer only) |
+| `default_fob_point` | `quotes.fob_point` *(new)* | one (customer only) |
 
-- [ ] **Given** a company's customers, **when** the list page loads, **then** it renders an AG Grid of Name / Contact / Email / Phone / Location (primary contact + default-billing city/state joined per row) with client-side pagination at 25/page — *access-layer join verified by `__tests__/utils/customerAccess.test.ts > 'customerAccess utilities' > 'getAllCustomers' > 'returns customers for a company'`; grid rendering automation-pending (`CustomersPage`)*.
+**Why payment terms gets a second level and the others don't.** A shop typically has one house term with a handful of exceptions, so customer-only would mean retyping the house term onto nearly every customer. Lead time and FOB are on the discovery watch list — building a shop-wide default for a field we may delete would be spending the effort twice.
 
-- [ ] **Given** the search box, **when** the user types a name fragment, **then** the list filters to customers whose name matches (case-insensitive `name.ilike`, debounced) — *verified by `__tests__/utils/customerAccess.test.ts > 'customerAccess utilities' > 'getAllCustomers' > 'applies search filter correctly'`*.
+`default_fob_point` is **free text naming a place** ("FOB Cleveland, OH"), never an origin/destination enum. FOB governs where title and risk transfer; who *pays* is `freight_terms`, a separate axis on the job and shipment. Conflating them is the classic error in this domain, which is why the two never share a control.
 
-**Create**
+`default_lead_time_text` is, by its own migration comment, the weakest of the three: lead time is a function of shop load and the specific part, so a standing value can become a stale promise.
 
-- [ ] **Given** the New Customer form, **when** the user submits with a Company Name, **then** a customer row is inserted (name + website only) and the app routes to the new customer's detail page — *verified by `__tests__/components/customers/CustomerForm.test.tsx > 'CustomerForm' > 'Create mode' > 'creates customer and redirects on success'` AND write path by `__tests__/utils/customerAccess.test.ts > 'customerAccess utilities' > 'createCustomer' > 'inserts customer and returns data'`*.
+### Resolution chain
 
-- [ ] **Given** the create form's optional "Initial Contact" accordion, **when** the user fills a contact name and submits, **then** `createCustomer` receives that contact and inserts it as the customer's primary — *write path verified by `__tests__/utils/customerAccess.test.ts > 'customerAccess utilities' > 'createCustomer' > 'inserts customer and returns data'` (the 3rd-arg initial-contact plumbing is asserted undefined-by-default in `__tests__/components/customers/CustomerForm.test.tsx > 'CustomerForm' > 'Create mode' > 'creates customer and redirects on success'`); populated-contact E2E automation-pending (#367)*.
+> **customer's own terms → shop-wide default → leave empty**
 
-- [ ] **Given** the create form, **when** the user submits an empty Company Name, **then** an inline "Company name is required" error shows and no insert fires — *verified by `__tests__/components/customers/CustomerForm.test.tsx > 'CustomerForm' > 'Validation' > 'shows error when name is empty on submit'`*.
+The shop-wide default lives at **`companies.settings.default_payment_terms`** — a **jsonb key, not a column**. Its writer read-modify-writes the whole `settings` object; writing the key alone would silently drop every feature flag on the company. Blank stores `null`, never `''`, so "unset" has one representation.
 
-- [ ] **Given** a name already used in the company, **when** the user submits, **then** an inline "A customer with this name already exists" error shows (enforced by the `customers_company_name_unique` constraint) and no insert fires — *verified by `__tests__/components/customers/CustomerForm.test.tsx > 'CustomerForm' > 'Create mode' > 'shows error for duplicate customer name'` AND lookup by `__tests__/utils/customerAccess.test.ts > 'customerAccess utilities' > 'checkCustomerNameExists' > 'returns true when name exists'`*.
+It is deliberately **not** in `KNOWN_DEFAULTS` (`lib/companyDefaults.ts`): that registry is numeric to the floor (`coerceInt`, numeric `fallback`, `readCompanyDefault(): number`, a card rendering `type="number"`), so threading one string through it would need a discriminated union across five call sites. `custom_payment_terms` set the precedent for a string setting living beside the numeric block.
 
-- [ ] **Given** the New Customer dialog opened from the Quote form (`CustomerFormModal`), **when** it is closed and reopened, **then** the embedded form remounts empty (no stale Company Name) — *verified by `__tests__/components/customers/CustomerFormModal.test.tsx > 'CustomerFormModal — reopen remounts a fresh CustomerForm (formKey bump)' > 'clears a typed Company Name when the modal is closed and reopened (no stale value)'`*.
+Resolution happens **once**, in `QuoteForm.handleCustomerChange`, at customer-select time — never in the access-layer resolvers (`pickPaymentTerms` and friends each read one column, trim, and return `null`; none of them knows about a shop default). The value is copied into the quote's own column and never read from the customer again.
 
-**Edit (edit -> save -> reload -> persists)**
+### Provenance — the visible half
 
-- [ ] **Given** an existing customer, **when** the edit form loads, **then** it pre-fills Company Name + Website and hides the Initial Contact accordion (contacts/addresses are edited on the detail page) — *verified by `__tests__/components/customers/CustomerForm.test.tsx > 'CustomerForm' > 'Edit mode' > 'pre-fills form with existing customer data'`*.
+A prefilled field carries a helper line naming **which level** it came from:
 
-- [ ] **Given** an edited customer, **when** the user saves and the detail page reloads, **then** the new name/website persist — *write path verified by `__tests__/utils/customerAccess.test.ts > 'customerAccess utilities' > 'updateCustomer' > 'updates customer and returns data'`; reload-persistence E2E automation-pending (#367)*.
+- `From Acme Corp's standing terms — edit to override`
+- `From your shop default — edit to override`
 
-- [ ] **Given** a customer contact, **when** the user edits it in `CustomerContactModal` and saves, **then** reopening the modal on that contact shows the saved values (re-seeded on open, no stale carry-over) — *write path verified by `__tests__/utils/customerAccess.test.ts` is N/A (contact writes live in `customerContactsAccess`, `updateCustomerContact`, automation-pending); modal re-seed verified by `__tests__/components/customers/CustomerContactModal.test.tsx > 'CustomerContactModal — reopen shows fresh (re-seeded) state' > 're-seeds the Name field from a DIFFERENT existing contact on reopen (no stale carry-over)'`*.
+Two answers to "why does this say Net 30?" means the user must not have to go looking for which. Editing the field drops the line and hands ownership to the user permanently.
 
-- [ ] **Given** two contacts on a customer, **when** the user marks a different one primary, **then** the previous primary is cleared and only the new one carries the star (DB `customer_contacts_one_primary` partial unique index) — *automation-pending (`setPrimaryContact`)*.
+### Ownership on a customer switch
 
-- [ ] **Given** a customer address, **when** the user edits it in the inline `CustomerAddressForm` and saves with Default Billing/Shipping checked, **then** that flag is cleared on any other address and the saved row shows the Billing/Shipping chip on reload — *automation-pending (`updateCustomerAddress`)*.
+A field is **ours** (overwritable) when it is empty/whitespace **or** still recorded as prefilled. Anything the user typed or picked is theirs and survives a switch.
 
-**Delete**
+**A field we own follows the new customer all the way, including to empty.** Pick Acme (lead time "4 weeks"), realise it's the wrong customer, pick Beta (none) → the field **clears**. Clearing matters as much as filling: a stranded value would also lose its provenance marker, thereafter read as hand-typed, and no later switch would correct it.
 
-- [ ] **Given** any customer, **when** the user confirms delete, **then** the customer is **archived** (soft-delete, never a hard delete): `softDeleteCustomer` stamps `customers.deleted_at`, the row is hidden from the list/search/pickers, its contacts + addresses and any quote/job links are kept, and the app returns to the list — *write path verified by `__tests__/utils/customerAccess.test.ts > 'customerAccess utilities' > 'softDeleteCustomer' > 'archives customer by ID (stamps deleted_at)'`; reload E2E automation-pending (#367)*.
+Two deliberate asymmetries:
+- **Clearing the customer entirely** resets the contact and address FKs but does **not** touch the terms fields or their provenance — previously prefilled terms stay on screen.
+- **Edit mode never seeds provenance.** An existing quote owns its terms outright, so opening one for edit shows no "From …" lines even where the values originally came from the customer.
 
-- [ ] **Given** a customer referenced by quotes or jobs, **when** the user deletes it, **then** the delete is **never blocked** — the customer archives like any other and the referencing quotes/jobs keep resolving the retained (now-hidden) row (no FK can trap the user). The list/bulk delete confirms through `DeleteImpactDialog` (impact/warn, not a disable) and calls `softDeleteCustomer` / `bulkSoftDeleteCustomers`, both of which `UPDATE deleted_at` — *archive write path verified by `__tests__/utils/customerAccess.test.ts > 'customerAccess utilities' > 'softDeleteCustomer' > 'archives customer by ID (stamps deleted_at)'`; canonical policy in `docs/architecture.md` §16*.
+Inline customer creation from the quote form hands the new row **directly** to `handleCustomerChange` rather than reading it back from state, because the `setCustomersById` in the same event handler has not committed yet — reading the map there would miss the customer and quietly prefill the shop default over the terms just typed into the modal.
 
-- [ ] **Given** a previously-archived customer, **when** a customer with the same name is re-created or re-imported, **then** the archived row is **revived** (not duplicated): `createCustomer` catches the unique-name `23505` and calls `reviveArchivedCustomerByName` (clears `deleted_at`, applies the new values), and the CSV import upsert sets `deleted_at = NULL`; `checkCustomerNameExists` is scoped to live rows so an archived name never falsely blocks — *grounded in `utils/customerAccess.ts` (`createCustomer` → `reviveArchivedCustomerByName`, `checkCustomerNameExists`); dedicated revive test automation-pending*.
+### Drift — reported, never applied
 
-- [ ] **Given** a contact or address on the detail page, **when** the user deletes it, **then** a confirmation dialog appears (address dialog warns if a default is being removed) and the row is deleted independently of the customer — *automation-pending (`deleteCustomerContact` / `deleteCustomerAddress`)*.
+Computed **on the quote detail page only** (`QuoteForm`'s drift state is a separate, per-line *price* mechanism). Three pairs, each against the customer's **current** value:
 
-**AI-powered CSV import** (`/customers/import`, backed by FastAPI `/api/customers/import/{analyze,validate,execute}`)
+| Chip | Compares |
+|---|---|
+| `Payment terms differs from standing terms` | `quote.payment_terms` vs `customers.default_payment_terms` |
+| `Lead time differs from standing terms` | `quote.lead_time_text` vs `default_lead_time_text` |
+| `FOB differs from standing terms` | `quote.fob_point` vs `default_fob_point` |
 
-- [ ] **Given** a CSV, **when** the user uploads it and AI analysis returns mappings, **then** the review table shows one row per mapping with the CSV column and a needs-review alert when any mapping is low-confidence — *verified by `__tests__/components/import/MappingReviewTable.test.tsx > 'MappingReviewTable' > 'renders one row per mapping with csv_column + reasoning'` AND `> 'shows the needs-review alert with singular wording for one needs-review mapping'`*.
+`hasTermDrift` compares trimmed and case-insensitively (`net 30` ≡ `Net 30`), returns **false** when the customer has no standing value (nothing to drift from), and returns **true** when the customer has a value and the quote's field is empty.
 
-- [ ] **Given** the review table, **when** the user picks a different DB field (or "Skip") for a column, **then** the mapping change fires with the new field (or null) — *verified by `__tests__/components/import/MappingReviewTable.test.tsx > 'MappingReviewTable' > 'calls onMappingChange with the new db_field when the user changes the dropdown'` AND `> 'calls onMappingChange with null when "Skip" is selected'`*.
+**A change to the shop-wide default produces no chip anywhere, and must not.** Shop policy moving is not a per-customer promise changing; chipping every open quote the day a shop edits its house term would train people to ignore the chip. The guarantee is structural rather than conditional — `hasTermDrift` takes the customer's standing terms as its second argument and nothing else, so there is no parameter through which a shop default could reach it.
 
-- [ ] **Given** validation returns duplicate-name conflicts, **when** the conflict dialog opens, **then** it shows can-import / will-skip / total counts and lets the user proceed importing only the valid rows — *verified by `__tests__/components/import/ConflictDialog.test.tsx > 'ConflictDialog' > 'renders the headline counts (can-import / will-skip / total)'` AND `> 'enables the import button and labels it with the count'` AND `> 'calls onConfirm when the import button is clicked'`*.
+The chip has **no "update to current" action**, deliberately: re-agreeing terms is a conversation, not a button. (Contrast the price-drift banner directly below it, which does offer repricing.) Its tooltip reads: *This quote says "X". Acme Corp is now set to "Y". The quote keeps what it was issued with.*
 
-- [ ] **Given** zero importable rows, **when** the conflict dialog renders, **then** the import button is disabled — *verified by `__tests__/components/import/ConflictDialog.test.tsx > 'ConflictDialog' > 'disables the import button when validRowsCount is 0'`*.
+### The picker
 
-- [ ] **Given** an import row that maps contact/address columns (`contact_name`/`contact_phone`/`contact_email`/`address_line1`…/`country`), **when** execute runs, **then** the backend writes a `customers` row plus an optional `customer_contacts` row and `customer_addresses` row per customer — *manual: `api/routes/import_routes.py` execute handler splits each CSV row into customer + contact + address payloads (`CUSTOMER_FIELDS` in `types/import.ts` defines the mappable set)*.
+Options in priority order, deduped **case-insensitively with first-wins**:
 
-- [ ] **Given** the AI provider config, **when** no `ai_config` row exists for the company, **then** import defaults to Claude; a per-company row can select another provider — *automation-pending (provider factory in `api/services/ai/`)*.
+1. **In QuickBooks** — terms the shop already has (so `SalesTermRef` always resolves)
+2. **Your saved terms** — `companies.settings.custom_payment_terms`, each removable, capped at 15
+3. **Standard terms** — `Due on Receipt, Net 15, Net 30, Net 60, 2/10 Net 30, 50% Deposit / Balance Net 30, Prepay, Cash on Delivery`
+
+QuickBooks' spelling wins on a collision — it ships `Due on receipt` (lowercase r) against our `Due on Receipt`, and one term must not occupy two rows. The group names drive ordering and the remove-icon branch only; they are **not** rendered as headers. An "Add New" row is pinned last and survives typing.
+
+QuickBooks terms are fetched in their **own effect**, outside the form's main load, so the quote form never waits on Intuit. `listQuickBooksTerms` resolves to `{connected:false, terms:[]}` on any error, so a shop with no QuickBooks and a shop whose connection is momentarily down take the identical path — the local list. A term typed here is created in QuickBooks at push time, so an unlisted term is never a dead end.
 
 ---
 
-## Delete Behavior — archive (soft-delete), never blocks
+## Credit hold
 
-"Delete" is a universal **archive**. See `docs/architecture.md` §16 (Deletion & Archiving Policy) for the canonical, cross-entity policy; the customer-specific behavior is:
+`credit_status` (`'open'` | `'hold'`) + `credit_hold_note`. A human decision, typed by a human. **No balance, no automation, no QuickBooks sync, nothing computed.**
 
-- **Archive, not hard delete.** `customers` carries a nullable `deleted_at timestamptz`. `softDeleteCustomer` / `bulkSoftDeleteCustomers` `UPDATE customers SET deleted_at = now()` for the target rows — they do **not** issue a SQL `DELETE`. The customer row and its `customer_contacts` + `customer_addresses` are **kept**, just hidden.
+**It warns and never gates.** No code path may block on it — a held customer's quote, job and shipment all proceed.
 
-- **Never blocked by references.** A customer referenced by quotes, jobs, or shipments archives fine: the row survives, so every retained `customer_id` FK still resolves the (now-hidden) customer and the document stays readable. There is no "cannot delete — referenced" block and no foreign-key error to surface. Deletion is confirmed through `DeleteImpactDialog` (an impact/warning summary), never a disable.
+| Surface | Treatment |
+|---|---|
+| Customer detail | `Chip "On credit hold"` (warning) beside the name, note beneath in warning colour — placed there because it changes how you read everything else on the page |
+| Quote form | `Alert` below the customer picker: *"{name} is on credit hold."* + note |
+| Shipment form | Same alert |
+| Customer **list** | **Nothing** — a held customer is visually identical to any other row |
+| Quote **detail** | **Nothing** |
 
-- **Reads hide archived customers.** List / search / picker / count queries filter `deleted_at IS NULL` (`getAllCustomers`, `checkCustomerNameExists`, …). By-id reads (`getCustomer`) intentionally do **not** filter, so a direct link or a document's retained FK still resolves an archived customer.
+The guarantee is proved by comparing the submit button's disabled state between a `hold` render and an `open` render — not by asserting it is enabled, which would pass even if the hold did gate, because a blank form disables submit for unrelated reasons.
 
-- **History is retained.** Because the row persists, the customer's quotes/jobs history stays intact after archiving — nothing is destroyed.
+`credit_hold_note` is **deliberately not cleared when a hold is lifted**, so the next person to place one can see what happened last time. It renders only while `credit_status = 'hold'`, so a leftover note is invisible in the UI while surviving in the DB.
 
-- **Name is the natural identity — reuse revives.** `customers_company_name_unique` stays a full `(company_id, name)` constraint, so there is only ever one row per name. Re-creating or re-importing an archived customer's name **revives** the archived row instead of duplicating it: `createCustomer` catches the unique-name `23505` and calls `reviveArchivedCustomerByName` (clears `deleted_at`, applies the new form values); the CSV import upsert sets `deleted_at = NULL` on `DO UPDATE`. `checkCustomerNameExists` is scoped to live rows so an archived name never falsely blocks creation.
+Two states, not E2's three: the design partner could not explain the third, and a state nobody can define is a state nobody sets correctly.
 
-**Supersedes the earlier #333 / #550 decision.** The prior framing — "hard delete is the model, there is **no** archive, history is **not** retained, deletes are blocked when referenced, and snapshot + hard-delete is Planned (#550)" — is **no longer accurate**. Archive is the shipped model (PR #580) and history **is** retained (the row persists). Individually deleting a contact or address from the detail page is still a real delete — those are sub-entities, not archived.
+`NOT NULL DEFAULT 'open'` means every pre-existing row satisfied the invariant the moment the migration finished — no backfill, and no "if null, assume open" branch anywhere.
 
-**Deferred (not built):** a Trash / Restore UI and a permanent purge are intentionally out of v1 — v1 archives and retains, and reuse-by-name already brings an archived customer back.
+---
+
+## Freight — three grains
+
+> customer's carrier account → **job (set when the PO is read)** → shipment (frozen at pack time)
+
+The middle grain is the point. The freight instruction arrives *on the customer's PO* ("Ship UPS Ground, collect, acct 4A72W9"). Resolving only at shipment creation, days later, means the packer re-derives a customer-level default that may contradict the PO — the sticky note, moved later in the process.
+
+**There is no customer-level `freight_terms` column.** The customer grain is expressed entirely by the account's `bill_to_party`: a single live account resolves to `third_party` or, otherwise, `collect`. A shop cannot store a customer-level standing "prepaid".
+
+| Grain | Columns |
+|---|---|
+| `jobs` | `freight_terms`, `customer_carrier_account_id`, `ship_via`, `shipping_instructions` |
+| `shipments` | `freight_terms`, `customer_carrier_account_id`, `freight_account_snapshot` (jsonb) |
+
+Shipments get no `ship_via` — they already have `carrier`. `jobs.ship_via` holds *the PO's words* ("UPS Ground", "their truck"), which is not the same field.
+
+`FREIGHT_TERMS` is four values, constrained identically at both grains (NULL allowed at both — the job column is constrained deliberately so a bad value cannot flow through the resolver and fail at pack time):
+
+| Value | Label |
+|---|---|
+| `prepaid` | We pay (prepaid) |
+| `collect` | Freight collect (their account) |
+| `third_party` | Bill third party |
+| `customer_arranged` | They collect it |
+
+`prepaid_and_add` is **excluded**: it promises adding freight to the invoice, and there is no freight amount in the schema (`shipments.weight_lbs` was dropped June 2026). An enum value naming a mechanism the schema cannot execute is why the retired `default_shipping_arrangement` died of non-use. `customer_arranged` **is** included — "our truck will collect it" is a real answer.
+
+Shipments carry one extra constraint jobs do not: `shipments_freight_terms_method_check` permits non-null freight terms only when `shipping_method IN ('shipment','dropship')`. `FREIGHT_TERMS_METHODS` mirrors it client-side and the form nulls both freight columns on submit when freight doesn't apply, so the shipper never meets a raw constraint error. (Switching method does not clear the React state — the panel just stops rendering and the payload nulls them, so switching back restores the earlier choices.)
+
+### `resolveFreightLine`
+
+Three inputs — `{ jobFreightTerms, jobCarrierAccountId, customerAccounts }`. No shipment, no company, no shipping method. Returns `{ terms, account, requiresChoice, source }` with `source ∈ 'job' | 'customer' | 'none'`.
+
+| Case | Result |
+|---|---|
+| Job named an account | that account + the job's terms, `source: 'job'` |
+| Job has terms but no account, terms `prepaid`/`customer_arranged` | terms, account null, `source: 'job'` |
+| Job has terms but no account, terms `collect`/`third_party` | falls through to `pickCarrierAccount`, keeps `source: 'job'` |
+| Nothing on the job | `pickCarrierAccount`; terms **derived** from `bill_to_party`, `source: 'customer'` |
+| Otherwise | nulls, `source: 'none'` |
+
+**`pickCarrierAccount` refuses to guess: it resolves only at exactly one live account.** Zero → null. One → that account. Two or more → null, and the caller must ask. There is deliberately no `is_default` column to break the tie — it was considered and cut because the one shop with data has exactly one account. The failure mode this prevents: a customer with both a parcel account and an LTL arrangement gets whichever row sorts first, and the freight bills to the wrong one — invisible in test data, which has one account. If shops routinely carry two or more, the remedy is to **add `is_default`**, not to pick arbitrarily.
+
+Resolution happens at **form load**, not at submit, so the shipper sees and can override what will be recorded rather than discovering it on the printed slip.
+
+Job-level freight is written **only by `JobEditForm`**, through `updateJobAddressContact`. `JobBillingShippingCard` displays it read-only and writes none of it — the job page renders that card with `readOnly`, so an earlier version that put the editor there was write-dead and left all four columns NULL for every job.
+
+`convertQuoteToJob` deliberately leaves freight NULL (unlike addresses, contact and `payment_terms`, which are carried): prefilling would make the job assert something the PO may never have stated, and `resolveFreightLine` would then mis-report provenance as `'job'`.
+
+### The redaction boundary
+
+> **Redaction is a property of the printed document and the frozen snapshot — never of the packer-facing form.**
+
+| Surface | Shows |
+|---|---|
+| `ShipmentForm` account picker | **full number** — the packer is at the bench keying it into WorldShip; redacting here sends them back to the sticky note |
+| Customer detail, `JobEditForm` picker | **full number** — behind auth, and whoever ships must be able to read it |
+| **Printed packing slip** | `••••1576`; `<carrier> (account on file)` when the number was too short to reveal any of; carrier alone when there is no account; **row omitted entirely** when there's no freight at all |
+| `freight_account_snapshot` | `{ carrier, bill_to_party, has_account, account_last4 }` — **the full number is never stored** |
+| AI SQL layer | **unreachable** |
+
+`account_last4` is NULL when the trimmed number is ≤ 4 characters — showing 3 of 4 is not redaction. The snapshot deliberately does **not** duplicate the account id: `shipments.customer_carrier_account_id` is a real FK one column over, and a copy would diverge the moment the account is archived.
+
+The snapshot trigger fires `BEFORE INSERT OR UPDATE OF customer_id, shipping_address_id, customer_carrier_account_id`, so **editing the underlying account later does not rewrite an existing shipment** — Document Snapshot Standard.
+
+Four independent layers keep the AI out of `customer_carrier_accounts`: absent from `ALLOWED_TABLES`, present in `SENSITIVE_TABLES` (whole-word denylist), `REVOKE ALL FROM jigged_ai_readonly`, and no `ai_readonly_select` policy. `shipments` is not allowlisted either, so `freight_account_snapshot` is equally out of reach.
+
+### Carrier vs account
+
+The slip prints `Carrier:` and `Freight:` one above the other, so a mismatch reads as a contradiction to whoever opens the box. Two mechanisms, both keeping the packer in charge:
+
+- **Seed** — when an account resolves, the carrier select starts on that account's carrier (case-insensitive match, else "Other" with the name filled in). A visible default they can change, not a forced value. A trigger cannot distinguish "stale" from "the packer deliberately corrected it" and would stomp the correction on every save.
+- **Warn** — `carrierAccountMismatch` returns a *message*, never a verdict: *"Shipping FedEx but billing the UPS account — the packing slip will show both."* Shipping one carrier while billing another's account is legitimate.
+
+It is computed **outside** the validation memo, which makes it structurally impossible for freight to reach `canSubmit`.
+
+### Cross-customer freight is blocked in the DB
+
+`enforce_job_address_contact_customer` and `enforce_shipment_address_contact_customer` both now reject a `customer_carrier_account_id` belonging to a different customer, raising with `ERRCODE = 'foreign_key_violation'`. A UI-filtered dropdown does not prevent this; billing Customer B's account on Customer A's shipment is the worst bug the feature could produce.
+
+**The two triggers' `UPDATE OF` lists are asymmetric** — jobs watches five columns (`billing_address_id, shipping_address_id, contact_id, customer_id, customer_carrier_account_id`), shipments three (`shipping_address_id, customer_id, customer_carrier_account_id`). Missing the shipments list would mean an update changing *only* the carrier account never fires the guard, at precisely the grain where money moves. *(The migration's own "THE TRAP" comment says "four and two" — it predates the column it added and is stale. Trust the trigger definitions.)*
+
+`create_shipment_with_line_items` went from 9 to 11 parameters, the two new ones trailing with `DEFAULT NULL`. Both hazards are guarded: the `DROP` names the exact old signature (a mismatched `DROP FUNCTION IF EXISTS` **succeeds and does nothing**, leaving the old `SECURITY DEFINER` overload callable), and a trailing `DO` block fails the migration unless exactly one overload exists. All defaulted params must stay trailing — the access layer passes ten named args and omits `p_notes`, and PostgREST resolves RPCs by supplied argument names.
+
+---
+
+## QuickBooks
+
+The chain that carries a customer's terms to an invoice:
+
+```
+customers.default_payment_terms → quotes.payment_terms → jobs.payment_terms → SalesTermRef
+```
+
+`jobs.payment_terms` is frozen at quote→job conversion and backfilled from the originating quote in its own migration. **The push reads the job row, never the customer or the quote** — the quote may have been edited since.
+
+**The payload sends `SalesTermRef` and deliberately omits `DueDate`.** Verified in the sandbox: supplying both lets `DueDate` win while the term is still stored, so an invoice prints "Terms: Net 60" beside a date seven days out. Sending *neither* — what the code did before this increment — was worst of all: five real invoices came back with `SalesTermRef` null and a due date of exactly `TxnDate + 30`, from a QuickBooks company default nothing in Jigged chose or could see. (Intuit's docs claim the fallback is the transaction date; observed behaviour is +30.)
+
+`resolve_term_id` matches **case-insensitively** because QBO ships `Due on receipt` against our `Due on Receipt`, and creating a Term whose name already exists is rejected with HTTP 400 — a case-sensitive compare would fail the push on the most common term of all. Intuit documents a 31-character cap on `Term.Name`, so a longer term is created truncated and the lookup accepts **both** spellings; otherwise the truncated row we created would never match, we'd re-POST it, take the duplicate 400, and the first invoice on a job would carry a term while every later one silently carried none. It returns `None` rather than raising in every failure mode — a mis-typed term must not block an invoice.
+
+**The customer PO reaches the invoice in four places** (it is `jobs.customer_po_number`, not a customer field):
+
+| Placement | Prints? | Setup |
+|---|---|---|
+| Line `Description` suffix `(PO Number: X)` | yes | none — what the pilot shop's AP already pays from |
+| `CustomerMemo` → "Note to customer" | yes *(verified on a real PDF)* | none |
+| Sales `CustomField` | yes | **the shop must create the field by hand** |
+| `PrivateNote` | **no** — Intuit documents it as not appearing to the customer | none; internal search only |
+
+**Jigged cannot create the custom field**, verified on both paths: the legacy REST Preferences write returns HTTP 200 and silently changes nothing, and the GraphQL Custom Fields API answers 403 without a paid partner tier. Intuit's own matrix agrees — *"Create custom field names | UI: Yes | API: No."*
+
+So `discover_po_custom_field` **finds** the shop's field, matching on its **label** (`\bp\.?\s?o\.?\b|purchase\s*order`), never its slot position — Intuit states definitions "may not appear in numeric order". Writing to a guessed `DefinitionId` overwrites whatever the shop keeps there and cannot be reassigned, so with no match we send no `CustomField` at all.
+
+**Success-with-no-match and a failed read are different outcomes, deliberately.** No match returns `id: None` — the normal starting state. A failed Preferences read **raises**, and the route turns it into a 502 and writes nothing. "Couldn't check" is not "there is no field": the result is persisted, so swallowing the error would let one Intuit blip wipe a correctly discovered id and silently stop the PO reaching invoices.
+
+**Nothing about terms is cached.** A stored term map would be a second list drifting from QuickBooks' own — the exact problem this removes — to save a four-row query. The PO field *is* cached on `quickbooks_connections`, because it changes only when a human edits QuickBooks settings; refreshing it is an explicit admin button, never a mount or a push.
+
+---
+
+## UI surfaces
+
+### List — `/dashboard/{companyId}/customers`
+
+Six columns: **Name** (pinned), **Contact**, **Email**, **Phone** (all three derived from `primary_contact`, em-dash when absent), **Payment terms**, **Location** (derived from the default-billing address, `sortable: false`).
+
+Search is debounced 300 ms and matches **name only** — not website, contact or city. Sorting is server-side (the colId goes straight to `.order()`). Toolbar: Search · Import · New Customer, with Export CSV and Delete (n) appearing on selection. Empty state: *"No customers yet"* → *"Create your first customer or import from CSV."* (or *"No customers match your search."*).
+
+### Detail — `/dashboard/{companyId}/customers/{id}`
+
+Render order: **header** (name, credit chip + note, website, timestamps) → **Contacts** and **Addresses** side by side → **Terms** → **Shipping** → **Related**.
+
+- **Terms** — read-only here (edited on the form). Shows the three values, `—` when unset. Caption: *"Applied to new quotes for this customer. Quotes you've already sent keep the terms they were created with."* It shows only the customer's own values and never mentions the shop default.
+- **Shipping (n)** — carrier accounts. Named *Shipping*, not *Freight*: to a machinist "freight" means all shipping cost. Each row: carrier, bill-to chip, then `Account 4A72W9 · ZIP 97124` or *"No account number (billed on the BOL)"*, notes, Edit / Delete. Empty: *"No carrier accounts. Add one if this customer wants their shipments billed to their own UPS or FedEx account."* Delete **archives**: *"Shipments already billed to this account keep their record. It just stops being offered on new ones."*
+- **Related** — Quotes and Jobs head-counts.
+
+### Form — `/customers/new` · `/customers/{id}/edit`
+
+Four sections: **Basic Information** (Company Name, Website) · **Terms & Lead Time** · **Credit** · **Initial Contact** (accordion, create mode only). Addresses and carrier accounts are not editable here.
+
+Terms copy: *"Applied to new quotes for this customer. Changing them here never affects quotes you've already sent. Leave blank if you have no standing agreement."* All three are plain free-text fields — the preset picker lives on the quote form, not here.
+
+Credit copy: *"Putting a customer on hold shows a warning when someone quotes or ships to them. It never stops the work — the decision stays yours."* Selecting **On hold** reveals a Reason field.
+
+`CustomerFormModal` wraps the whole form for quick-create from the quote form, so a customer created there can carry standing terms, a credit hold and a first contact.
+
+`CarrierAccountModal` — Carrier (required) · Who pays · Account number (*"Their account with the carrier. Leave blank for LTL billed on the bill of lading, or FedEx Ground Collect."*) · Account ZIP (*"Carriers check this against the account."*) · Country · Notes.
+
+---
+
+## Archive, revive, and multi-tenancy
+
+Delete is **archive**, per [`docs/architecture.md` §16](../architecture.md). `softDeleteCustomer` stamps `deleted_at`; there is no hard `DELETE` and no reference check, so a customer used by quotes or jobs archives like any other and those documents keep resolving the retained row.
+
+| Query | Filters `deleted_at IS NULL`? |
+|---|---|
+| `getCustomers`, `getAllCustomers`, `checkCustomerNameExists`, `getCarrierAccountsForCustomer` | yes |
+| `getCustomer`, `getCustomerWithRelations` | **no** — by-id reads, so a detail page or a document's retained FK still resolves |
+
+**Name is the identity — reuse revives.** The unique constraint is FULL `(company_id, name)`, covering archived rows, so re-creating an archived name raises `23505`; `createCustomer` catches it and revives. A collision with a *live* row re-throws as a genuine duplicate. A partial (`WHERE deleted_at IS NULL`) constraint would break this.
+
+**A revive is not a fresh create wearing the same name.** It writes `name`, `deleted_at = null`, `updated_at`, and *only the non-blank* values of website and the three standing terms. The caller is always the create form, so a blank means "didn't say", never "deliberately cleared" — writing the whole column set would wipe the archived row's terms. It **never** writes `credit_status` or `credit_hold_note`: lifting a hold must be a deliberate act on the customer page, not a side effect of re-typing a name into a quick-create modal.
+
+Archiving a customer does **not** archive its carrier accounts (a soft delete fires no cascade), so they return intact on revive. An archived carrier account keeps resolving everywhere it matters — shipments and jobs keep the FK (archiving is an UPDATE, so `ON DELETE SET NULL` never fires), the slip prints from the frozen snapshot, and both pickers keep a currently-selected archived row so editing an old document never silently blanks its freight. It loses only its place in the picker for *new* documents.
+
+**RLS + billing gate.** `customers` carries four company-scoped browser policies plus `ai_readonly_select`; `customer_carrier_accounts` gets the write gate via its own `apply_billing_write_gate` call; contacts and addresses are parent-resolved children. A lapsed shop can still **read** every customer and carrier account but cannot create or edit one.
+
+**Permissions.** The shop-wide default payment terms is admin-only (Settings sits behind `AdminGuard`). A customer's own terms and credit hold have no such gate — any member who can edit a customer can set them.
+
+---
+
+## CSV import
+
+Two live paths, both hitting `/api/customers/import/execute`.
+
+**Mappable fields (14):** `name` (required), `website`, `contact_name`, `contact_phone`, `contact_email`, `address_line1`, `address_line2`, `city`, `state`, `postal_code`, `country`, **`default_payment_terms`**, **`default_lead_time_text`**, **`default_fob_point`**.
+
+**Not mappable:** credit status or note (so an import can never set or lift a hold), and no carrier-account field.
+
+The guided flow (`lib/dataImportSchema.ts`) exposes only `name` and `default_payment_terms` — a UI restriction, not a server limit.
+
+The AI column mapper matches source headers against the schema *descriptions*, which deliberately carry legacy-ERP vocabulary: `default_payment_terms` notes *"Often exported as 'Terms', 'Terms Code' or 'Payment Terms'"*, and `default_fob_point` explicitly says it is **not** the freight payment terms, "which describe who PAYS and are not imported here."
+
+Execute sets `deleted_at = None` on every row before upserting on `(company_id, name)`, so **a re-import revives an archived customer** rather than leaving it hidden. A blank cell omits the key entirely rather than writing null. Contacts and addresses attach only to a **new** customer — re-importing an existing one silently drops any contact/address columns in the CSV.
+
+---
+
+## Acceptance criteria
+
+Each bullet cites a real test. Gaps are named as gaps rather than implied to be covered.
+
+**Standing terms**
+- Resolvers return the customer value, treat blank/whitespace as no agreement, and trim — `__tests__/utils/customerAccess.test.ts > standing terms — resolution for a NEW quote` (3 its).
+- The chain prefers the customer, falls back to the shop default, and names the level — `__tests__/components/quotes/QuoteForm.test.tsx > QuoteForm — standing-terms resolution chain > 'falls back to the shop default and says so…'`, `'prefers the customer's own terms…'`, `'leaves the field empty when neither level has a value'`.
+- A switch clears a prefill, survives a second hop, and never touches a hand-typed value — same describe, `'clears a prefilled term when the next customer has none'`, `'still applies the next customer's terms after a clear'`, `'leaves a hand-typed term alone when the customer changes'`.
+- The shop default is read from `settings.default_payment_terms`, beside (not inside) the numeric block — `__tests__/lib/companyDefaults.test.ts > readCompanyDefaultPaymentTerms` (5 its, including the regression guard `'lives BESIDE the numeric defaults block, not inside it'`).
+
+**Drift**
+- Reported and never applied; no drift when the customer has no value; drift when the quote is empty and the customer now has terms — `__tests__/utils/customerAccess.test.ts > standing terms — drift is reported, never applied` (4 its).
+- **Customer-scoped, not shop-scoped** — `> standing terms — drift is customer-scoped, not shop-scoped` (2 its).
+
+**Credit hold**
+- Narrowing resolves anything unexpected to `open`, never `hold` — `> credit status — narrowing at the DB boundary` (2 its).
+- Warns on the quote form, silent for a customer in good standing, and **leaves the submit button exactly as it was** — `__tests__/components/quotes/QuoteForm.test.tsx` (3 its).
+
+**Carrier accounts & freight**
+- `pickCarrierAccount` resolves at exactly one and refuses to guess otherwise — `__tests__/utils/customerCarrierAccountsAccess.test.ts > pickCarrierAccount — refuses to guess` (3 its).
+- `toBillToParty` falls back to the option without the surcharge — `> toBillToParty — narrowing at the DB boundary` (2 its).
+- Masked for print, full for the bench — `> describeFreightAccount — masked for print, full for the bench` (3 its) and `> maskAccountNumber — for anything that leaves the building`.
+- Job wins over customer default, across all seven precedence cases — `> resolveFreightLine — the job wins over the customer default` (7 its).
+- Everything printed comes from the snapshot — `> describeShipmentFreight — everything printed comes from the snapshot` (5 its).
+- Carrier/account mismatch returns a message, never a verdict — `__tests__/components/shipments/shipmentFormHelpers.test.ts > carrierAccountMismatch` (4 its).
+- The table is billing-gated — `api/tests/integration/test_billing_enforcement.py::test_no_tenant_table_left_ungated`.
+
+**Archive / revive**
+- A revive never touches the credit hold, leaves unsupplied terms alone, and applies what was supplied — `__tests__/utils/customerAccess.test.ts > createCustomer > reviving an archived customer by name` (3 its).
+- `softDeleteCustomer > archives customer by ID (stamps deleted_at)`.
+
+**QuickBooks**
+- Sends `SalesTermRef`, never a `DueDate`; omits the key entirely with no term — `api/tests/unit/test_quickbooks_service.py::test_payload_sends_sales_term_and_never_a_due_date`, `::test_payload_without_a_term_sends_no_sales_term_ref`.
+- Term matching is case-insensitive and survives the 31-char cap — `::test_resolve_term_id_is_case_insensitive`, `::test_resolve_term_id_matches_the_truncated_name_it_created`, `::test_resolve_term_id_creates_within_the_name_cap`.
+- Discovery matches on label, raises rather than reporting a false negative — `::test_po_field_pattern_matches_real_shop_labels`, `::test_discover_po_custom_field_raises_when_it_cannot_ask`.
+
+### Coverage gaps — stated, not implied
+
+| Gap | Consequence |
+|---|---|
+| **No render test for `ShipmentForm`** | The freight controls, the seeded carrier default and the mismatch alert have no component-level coverage. This is why `carrierAccountMismatch` was extracted to `shipmentMath.ts`. |
+| **No test for the carrier-account authoring surface** | `CarrierAccountModal`, `DefaultPaymentTermsCard`, and the four Supabase-touching functions in `customerCarrierAccountsAccess.ts` are untested; only the pure `pickCarrierAccount` is. |
+| **`CustomerForm.test.tsx` was not extended** | Its four tests predate the Terms and Credit sections the form now renders. |
+| **No page-level test** for the customer list or detail page. |
+| **No E2E spec touches the customer CRM.** `quote-detail-drift.spec.ts` covers *price* drift only. |
+| **No backend freight test** — the `freight_account_snapshot` freeze is a DB trigger nothing exercises. |
+| **`getCompanyDefaultPaymentTerms` / `setCompanyDefaultPaymentTerms` untested** — only the pure reader is covered, so the read-modify-write that actually persists the shop default has no test. |
+| **No test for `packingSlipPdf.ts`** — the printed freight row is unverified in CI. |
+
+---
+
+## Known defects
+
+Found by auditing the shipped code. Recorded here rather than fixed silently.
+
+| # | Defect | Effect |
+|---|---|---|
+| 1 | The revive lookup is case-**sensitive** (`.eq('name', …)`) while the create pre-check is case-**insensitive** (`.ilike`) and the unique constraint is case-sensitive | Archive "Acme Corp", create "acme corp" → the pre-check passes, no `23505` fires, and a **second** customer row is inserted instead of reviving |
+| 2 | The importer decides `is_new` on a **lowercased** name but upserts on the case-sensitive constraint | "acme corp" against an existing "Acme Corp" is counted as an update, gets no contact/address — and still inserts a second row |
+| 3 | `defaultColDef` sets `sortable: true` and Contact/Email/Phone are not opted out | Clicking those headers sends non-existent columns (`primary_contact_name`, …) to PostgREST's `.order()` |
+| 4 | A failed quotes/jobs count is `console.error`'d and reported as `0` | The Related card renders "Quotes 0 / Jobs 0" — a definitive negative for a question never answered, against the [CLAUDE.md](../../CLAUDE.md) rule that "couldn't check" is never "denied" |
+| 5 | `hasTermDrift` returns true when the quote's field is empty and the customer has a value; `quotes.fob_point` is new, so every pre-existing quote has it NULL | The day a shop sets `default_fob_point`, every one of that customer's older quotes grows a "FOB differs" chip |
+| 6 | An archived customer's detail page renders normally — no banner, Edit and Delete still offered — and quote/job pages link straight to it | An archived customer is reachable by an ordinary click, not just a hand-typed URL |
+| 7 | `ShipmentForm` resolves freight **only in job mode**; the customer-mode query doesn't select `carrier_accounts` | A shipment created from the customer surface always saves NULL freight |
+| 8 | `bulkImportCustomers` has no callers, discards standing terms, and **blocks** on an existing name instead of reviving | Dead code with semantics opposite to the live importer |
+| 9 | Three stale comments | `customerAccess.ts`'s docblock still says rows hold "just identity"; `jobs.payment_terms` claims it is "editable on the job" (no UI writes it — only quote conversion does); the freight migration's "THE TRAP" comment says four/two columns where the triggers say five/three |
+| 10 | `getCustomers` (paginated, `{data,total}`) has no callers, and the `filter` argument on both list functions is dead (`_filter`) | `CustomerFilter`'s `active`/`inactive` values have no effect |
+
+---
+
+## Explicitly not built
+
+**Numeric credit limits** — QuickBooks Online has no `CreditLimit` field (Intuit marks it Desktop-only, and its official workaround is typing the number into a Notes field). A limit implies a balance to compare against, which implies the AR subledger this product refuses. The moment `credit_status` grows a threshold, it has become this.
+
+**Customer pricing tiers / group codes** — E2's own manual admits a group code grays out the customer's own values; that is `markup_rates` written down by the vendor.
+
+**An invoices table / AR subledger. Statements & dunning** — QuickBooks already ships three formats plus automated reminders; two engines means the AP clerk gets two past-due emails. **Sales tax calculation** — QBO Automated Sales Tax computes from the address and overwrites anything we send.
+
+**Lead/prospect/opportunity pipeline** — quote-to-book is ~98% on repeat part numbers and below 10% for new customers. Build retention, not acquisition.
+
+**Generic user-defined fields** — the highest-conviction trap, and the evidence is causal: JobBOSS's 69-vote, five-year-old "Add a Shipping tab to Customers" request exists *precisely because* JobBOSS has custom fields, so the UPS account went into one and nobody could report on it.
+
+**Customer code as a second identity key** — imports JobBOSS's own worst problem (JBCORE-I-2022 "Allow Customer ID change", still open). Here a rename is an `UPDATE`.
+
+**Merge/dedup tooling** — name is the identity and upsert-on-name already revives. **AI customer summaries** — banned by the no-AI-on-mount policy. **Trash/Restore UI and permanent purge** — archive plus reuse-by-name already brings a customer back.
+
+⚠️ **Flagged, not fixed:** the invoice push hard-codes `TaxCodeRef: NON` on every line. If the pilot shop has *any* taxable work this is a live under-collection with seller-side audit liability, and it jumps ahead of everything else here.
+
+---
+
+## Open questions
+
+| # | Question | Decides |
+|---|---|---|
+| 1 | Does any customer have more than one ship-to plant? | Whether address-level freight defaults (`fob_point`, `shipping_instructions`, `print_coc` per address) ever get built |
+| 2 | Do shops routinely carry 2+ carrier accounts? | Whether to add `is_default` — the recorded remedy, as opposed to picking arbitrarily |
+| 3 | Are `default_lead_time_text` and `default_fob_point` used after 60 days? | Both are on the watch list. Johnny on FOB: *"we sort of ignore that."* If both are still empty across every customer, remove the columns and their form fields together in one migration |
+| 4 | Does the shop charge sales tax on any work? | Moves the `TaxCodeRef` fix between P0 and P3 — the highest-consequence unanswered question here |

--- a/docs/testing/divergence/customers.md
+++ b/docs/testing/divergence/customers.md
@@ -1,5 +1,15 @@
 # Divergence report — Customers (#333)
 
+> **SUPERSEDED (2026-08-02).** This audited a version of `docs/modules/customers.md`
+> that no longer exists — that doc was rewritten from scratch after the customer-CRM
+> increment (PR #651) added standing terms, a shop-wide default, credit hold and
+> carrier accounts. Findings below are kept as a record of what #333 fixed; several
+> are now stale on their face (notably "`customers` holds only `name` + `website`",
+> the `CustomerStatusChip` removal — since done — and the import field list, which
+> now also carries the three standing-terms columns). For current behaviour and a
+> current list of known defects and coverage gaps, read
+> [`docs/modules/customers.md`](../../modules/customers.md).
+
 Method: compared `docs/modules/customers.md` against the real UI (`app/dashboard/[companyId]/customers/**`, `components/customers/**`), the access layer (`utils/customerAccess.ts`, `utils/customerContactsAccess.ts`, `utils/customerAddressesAccess.ts`), the CSV-import backend (`api/routes/import_routes.py`), the schema (`supabase/schema.prod.sql`), and the tests under `__tests__/utils/`, `__tests__/components/customers/`, and `__tests__/components/import/`.
 
 ## Fixed in this PR


### PR DESCRIPTION
The old spec described `customers` as a name-plus-website identity stub. It has been **twelve columns** since #651, and the module now owns standing terms, a shop-wide default, credit hold, and the customer's own carrier accounts feeding a three-grain freight flow.

Rewritten from scratch rather than patched, because roughly half of it had become **wrong** rather than merely incomplete — its delete section still argued against a #333/#550 framing nobody holds any more.

## How it was written

Seven readers went through the shipped code by area — schema, access layer, customer UI, the terms/drift flow, freight end-to-end, QuickBooks, and test coverage — each required to cite `file:line` for every fact, with a critic afterwards to spot-check the load-bearing claims and find gaps. Every claim in the doc came out of the code, not out of the plan. (The critic caught the readers' own miscount of the customers table, among other things.)

Written to the **#634 density standard**: decision plus a one-line why, superseded reasoning collapsed instead of left beside its replacement, prose turned into tables where the content is really rows. **3,359 → 6,499 words** for roughly triple the surface area, which puts it between `jobs.md` (6,016) and `quotes.md` (9,341).

## The facts worth having written down

Things that would otherwise cost real debugging time:

- The `account_required` CHECK deliberately **permits** a `recipient` row with no account number — LTL bills the payer on the bill of lading and FedEx Ground Collect needs no account. A blanket `NOT NULL` is how the column gets poisoned with "N/A" in week one.
- The two customer-match triggers watch **five** columns on `jobs` and **three** on `shipments`. The migration's own "THE TRAP" comment says four and two — it predates the column it added and is stale.
- `account_last4` is NULL at four characters or fewer, because showing three of four is not redaction.
- A shop-default change produces **no** drift chip and structurally cannot: `hasTermDrift` takes the customer's terms as its second argument and nothing else, so there is no parameter through which a shop default could reach it.
- `pickCarrierAccount` resolves only at **exactly one** live account. Two or more returns null and the caller must ask — with the recorded remedy being to add `is_default`, not to pick arbitrarily.

## Two sections the old doc had no equivalent of

**Known defects — ten of them**, found by auditing rather than by a bug report, and recorded rather than fixed silently. The two worth reading:

1. The revive lookup is case-**sensitive** while the create pre-check is case-**insensitive**, so archiving "Acme Corp" and creating "acme corp" passes the pre-check, never raises `23505`, and inserts a **second row** instead of reviving.
2. The importer has the same bug from the other direction — it decides `is_new` on a lowercased name while upserting on the case-sensitive constraint.

Also recorded: a failed quotes/jobs count is swallowed and rendered as "Quotes 0", which is a definitive-looking negative for a question that was never answered — against the CLAUDE.md rule that *"couldn't check" is never "denied"*.

**Coverage gaps — stated as gaps.** There is no render test for `ShipmentForm`, no test for the carrier-account authoring surface, no page-level test for either customer page, and no E2E spec that touches the CRM at all. A doc claiming coverage that does not exist is worse than one that admits the hole.

## Three siblings fixed

| File | Was |
|---|---|
| `docs/architecture.md` §16 | omitted `customer_carrier_accounts` from the archive-standard entity list |
| `docs/design-system.md` | still cited `CustomerStatusChip`, which #651 deleted |
| `docs/testing/divergence/customers.md` | audited a version of this doc that no longer exists — now carries a superseded banner rather than being patched claim by claim |

Docs only — no code, no migration. Per the CLAUDE.md smart-scope table, doc PRs skip pre-PR validation and CI is the gate.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)