### PR TITLE
feat(customers): contacts archive, the AP contact gets a name, two live bugs die

### DIFF
--- a/__tests__/utils/customerAccess.test.ts
+++ b/__tests__/utils/customerAccess.test.ts
@@ -135,7 +135,7 @@ describe('customerAccess utilities', () => {
       // Addresses + primary contact joined so the list page can render
       // both Location and Contact columns without per-row fetches.
       expect(mockQueryBuilder.select).toHaveBeenCalledWith(
-        '*, addresses:customer_addresses(*), customer_contacts(id, name, role, email, phone, is_primary)',
+        '*, addresses:customer_addresses(*), customer_contacts(id, name, role, email, phone, is_primary, is_billing_default, deleted_at)',
       );
       expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'company-1');
       // The result is mapped (primary_contact, addresses, etc) — at minimum the

--- a/__tests__/utils/customerContactsAccess.test.ts
+++ b/__tests__/utils/customerContactsAccess.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// A chainable builder: every method returns the builder, and awaiting it
+// destructures { data, error } straight off it. Mirrors the harness in
+// customerAccess.test.ts.
+const { mockQueryBuilder, mockSupabase, errorQueue } = vi.hoisted(() => {
+  // `update` writes go through more than one round trip (clear-then-set), so a
+  // single shared `error` cannot say WHICH one failed. The queue lets a test
+  // fail the second write while the first succeeds — which is the only case
+  // that can actually happen, since an UPDATE setting a flag to false cannot
+  // violate a unique index.
+  const queue: Array<{ code: string; message: string } | null> = [];
+  const builder: Record<string, unknown> = {};
+  for (const m of ['from', 'select', 'insert', 'eq', 'is', 'order', 'single']) {
+    builder[m] = vi.fn(() => builder);
+  }
+  builder.update = vi.fn(() => {
+    builder.error = queue.length ? queue.shift()! : null;
+    return builder;
+  });
+  builder.data = null;
+  builder.error = null;
+  return {
+    mockQueryBuilder: builder,
+    mockSupabase: { from: vi.fn(() => builder) },
+    errorQueue: queue,
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+  createClient: () => mockSupabase,
+  supabase: mockSupabase,
+}));
+
+import {
+  getContactsForCustomer,
+  archiveCustomerContact,
+  setBillingDefaultContact,
+} from '@/utils/customerContactsAccess';
+
+const update = () => mockQueryBuilder.update as ReturnType<typeof vi.fn>;
+const is = () => mockQueryBuilder.is as ReturnType<typeof vi.fn>;
+const eq = () => mockQueryBuilder.eq as ReturnType<typeof vi.fn>;
+
+describe('customer contacts — archive rather than destroy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    errorQueue.length = 0;
+    mockQueryBuilder.data = [];
+    mockQueryBuilder.error = null;
+  });
+
+  it('only offers live contacts', async () => {
+    // Someone who left the company must stop being offered on new work. A
+    // document that already names them resolves by id instead.
+    await getContactsForCustomer('cust-1');
+    expect(is()).toHaveBeenCalledWith('deleted_at', null);
+  });
+
+  it('stamps deleted_at instead of issuing a DELETE', async () => {
+    // A hard delete would take the row a quote's contact_id still points at.
+    await archiveCustomerContact('contact-1');
+
+    expect(mockQueryBuilder.delete).toBeUndefined();
+    const patch = update().mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(patch.deleted_at).toEqual(expect.any(String));
+  });
+
+  // The load-bearing half. Both "at most one per customer" indexes are scoped
+  // to live rows, so an archived contact that kept its flag would hold the slot
+  // forever and the customer could never name a replacement.
+  it('hands back both roles it held, so the slots are free again', async () => {
+    await archiveCustomerContact('contact-1');
+
+    const patch = update().mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(patch.is_primary).toBe(false);
+    expect(patch.is_billing_default).toBe(false);
+  });
+});
+
+describe('customer contacts — who invoices go to', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    errorQueue.length = 0;
+    mockQueryBuilder.data = [];
+    mockQueryBuilder.error = null;
+  });
+
+  it('clears the previous billing contact before naming the new one', async () => {
+    // The DB index is the real guarantee; clearing first is what stops the UI
+    // tripping it. Same shape as setPrimaryContact.
+    await setBillingDefaultContact('cust-1', 'contact-2');
+
+    const patches = update().mock.calls.map((c) => c[0] as Record<string, unknown>);
+    expect(patches[0]).toEqual({ is_billing_default: false });
+    expect(patches[1]).toMatchObject({ is_billing_default: true });
+    expect(eq()).toHaveBeenCalledWith('id', 'contact-2');
+  });
+
+  it('clears without naming a replacement when passed null', async () => {
+    // A customer is allowed to have no billing contact. Nothing falls back to
+    // the primary — inferring one would put invoices somewhere nobody chose.
+    await setBillingDefaultContact('cust-1', null);
+
+    const patches = update().mock.calls.map((c) => c[0] as Record<string, unknown>);
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toEqual({ is_billing_default: false });
+  });
+
+  it('surfaces a lost race as a retry rather than a raw 23505', async () => {
+    // Two people naming a billing contact at once: both clear, then one loses
+    // the insert to the partial unique index. The clear succeeds; the set 23505s.
+    errorQueue.push(null, { code: '23505', message: 'duplicate key' });
+    await expect(setBillingDefaultContact('cust-1', 'contact-2')).rejects.toThrow(
+      /just marked for billing/i,
+    );
+  });
+});

--- a/app/dashboard/[companyId]/customers/[customerId]/page.tsx
+++ b/app/dashboard/[companyId]/customers/[customerId]/page.tsx
@@ -27,6 +27,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import AddIcon from '@mui/icons-material/Add';
 import StarIcon from '@mui/icons-material/Star';
 import StarOutlineIcon from '@mui/icons-material/StarOutline';
+import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 
 import {
   getCustomerWithRelations,
@@ -34,8 +35,9 @@ import {
 } from '@/utils/customerAccess';
 import {
   getContactsForCustomer,
-  deleteCustomerContact,
+  archiveCustomerContact,
   setPrimaryContact,
+  setBillingDefaultContact,
 } from '@/utils/customerContactsAccess';
 import {
   getAddressesForCustomer,
@@ -191,11 +193,27 @@ export default function CustomerDetailPage() {
     if (!deleteContactId) return;
     setActionLoading(true);
     try {
-      await deleteCustomerContact(deleteContactId);
+      await archiveCustomerContact(deleteContactId);
       setDeleteContactId(null);
       await refreshContacts();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete contact');
+      setError(err instanceof Error ? err.message : 'Failed to remove contact');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+  /**
+   * Toggle who invoices go to. Clicking the current billing contact clears it —
+   * a customer is allowed to have none, and forcing one would make the office
+   * name a person they haven't agreed on.
+   */
+  const handleToggleBillingDefault = async (contactId: string, isCurrent: boolean) => {
+    setActionLoading(true);
+    try {
+      await setBillingDefaultContact(customerId, isCurrent ? null : contactId);
+      await refreshContacts();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to set billing contact');
     } finally {
       setActionLoading(false);
     }
@@ -452,6 +470,20 @@ export default function CustomerDetailPage() {
                               {contact.name}
                             </Typography>
                             <Chip size="small" label={roleDisplayLabel(contact)} variant="outlined" />
+                            {/* Named separately from the role chip: a contact's
+                                role is who they ARE at the customer, this is a
+                                job we've given them. The AP clerk is usually the
+                                billing contact, but not always — a buyer at a
+                                small shop often is too. */}
+                            {contact.is_billing_default && (
+                              <Chip
+                                size="small"
+                                color="primary"
+                                variant="outlined"
+                                icon={<ReceiptLongIcon />}
+                                label="Invoices"
+                              />
+                            )}
                           </Box>
                           <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap', mt: 0.5 }}>
                             {contact.email && (
@@ -485,6 +517,29 @@ export default function CustomerDetailPage() {
                               </span>
                             </Tooltip>
                           )}
+                          <Tooltip
+                            title={
+                              contact.is_billing_default
+                                ? 'Stop sending invoices here'
+                                : 'Send invoices to this contact'
+                            }
+                          >
+                            <span>
+                              <IconButton
+                                size="small"
+                                onClick={() =>
+                                  handleToggleBillingDefault(
+                                    contact.id,
+                                    contact.is_billing_default,
+                                  )
+                                }
+                                disabled={actionLoading}
+                                color={contact.is_billing_default ? 'primary' : 'default'}
+                              >
+                                <ReceiptLongIcon fontSize="small" />
+                              </IconButton>
+                            </span>
+                          </Tooltip>
                           <Tooltip title="Edit contact">
                             <span>
                               <IconButton
@@ -877,11 +932,12 @@ export default function CustomerDetailPage() {
         open={!!deleteContactId}
         onClose={() => !actionLoading && setDeleteContactId(null)}
       >
-        <DialogTitle>Delete contact?</DialogTitle>
+        <DialogTitle>Remove contact?</DialogTitle>
         <DialogContent>
           <Typography>
-            Delete <strong>{contactBeingDeleted?.name ?? 'this contact'}</strong>?
-            This can&apos;t be undone.
+            <strong>{contactBeingDeleted?.name ?? 'This contact'}</strong> will stop
+            being offered on new quotes and jobs. Quotes and jobs that already name
+            them keep working, and you can add them again with the same details.
           </Typography>
         </DialogContent>
         <DialogActions>
@@ -894,7 +950,7 @@ export default function CustomerDetailPage() {
             variant="contained"
             disabled={actionLoading}
           >
-            Delete
+            Remove
           </Button>
         </DialogActions>
       </Dialog>

--- a/components/jobs/JobBillingShippingCard.tsx
+++ b/components/jobs/JobBillingShippingCard.tsx
@@ -52,7 +52,10 @@ export default function JobBillingShippingCard({
 }) {
   const router = useRouter();
   const addresses: JobAddress[] = job.customers?.addresses ?? [];
-  const contacts: JobContact[] = job.customers?.customer_contacts ?? [];
+  // Archived contacts leave the picker, keeping one this job already names.
+  const contacts: JobContact[] = (job.customers?.customer_contacts ?? []).filter(
+    (c) => c.deleted_at === null || c.id === job.contact_id,
+  );
 
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);

--- a/components/jobs/JobEditForm.tsx
+++ b/components/jobs/JobEditForm.tsx
@@ -76,7 +76,12 @@ export default function JobEditForm({
 }: JobEditFormProps) {
   const router = useRouter();
   const addresses = job.customers?.addresses ?? [];
-  const contacts = job.customers?.customer_contacts ?? [];
+  // Archived contacts leave the picker, but one this job already names is
+  // kept — a person leaving the customer must not silently blank who the
+  // work was agreed with. Same rule as the carrier accounts below.
+  const contacts = (job.customers?.customer_contacts ?? []).filter(
+    (c) => c.deleted_at === null || c.id === job.contact_id,
+  );
   // Archived accounts stay out of the picker, but one this job already points
   // at is kept so editing an old job doesn't silently blank its freight.
   const carrierAccounts = (job.customers?.carrier_accounts ?? []).filter(

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -750,6 +750,8 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
         email: saved.email,
         phone: saved.phone,
         is_primary: saved.is_primary,
+        is_billing_default: saved.is_billing_default,
+        deleted_at: saved.deleted_at,
       };
       setCustomersById((prev) => {
         const existing = prev.get(formData.customer_id);
@@ -771,7 +773,11 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     ? customersById.get(formData.customer_id) ?? null
     : null;
   const customerAddresses: CustomerAddress[] = selectedCustomer?.addresses ?? [];
-  const customerContacts: CustomerListContact[] = selectedCustomer?.customer_contacts ?? [];
+  // Archived contacts leave the picker, keeping one this quote already names
+  // so editing an older quote never blanks the person it was agreed with.
+  const customerContacts: CustomerListContact[] = (
+    selectedCustomer?.customer_contacts ?? []
+  ).filter((c) => c.deleted_at === null || c.id === formData.contact_id);
 
   /**
    * Multi-line address display used in both the Select's renderValue

--- a/supabase/migrations/20260802013726_customer_contact_hygiene.sql
+++ b/supabase/migrations/20260802013726_customer_contact_hygiene.sql
@@ -1,0 +1,89 @@
+-- Customer contacts: archive instead of destroy, name the AP contact, and stop
+-- a delete from failing outright.
+--
+-- Three problems, one grain.
+--
+-- 1. DELETING A CONTACT USED ON A QUOTE FAILED. quotes_contact_id_fkey carries
+--    no ON DELETE clause at all, so it defaults to NO ACTION and the delete is
+--    refused. jobs_contact_id_fkey has had ON DELETE SET NULL since the baseline.
+--    Same relationship, two behaviours, and the stricter one is the accident:
+--    both documents freeze the contact into contact_snapshot via
+--    snapshot_document_party(), so the printed block survives either way and the
+--    FK is only a link back to the live row.
+--
+-- 2. A CONTACT WHO LEAVES HAD NOWHERE TO GO. The only options were to keep a
+--    stale person in every picker or destroy the row. customer_contacts had no
+--    deleted_at, which also made it the one customer-family table outside the
+--    archive standard (docs/architecture.md §16).
+--
+-- 3. THE AP CONTACT WAS UNNAMEABLE. is_primary answers "who do we call about
+--    the work", which is rarely the person who pays. A shop had to put the AP
+--    clerk in as primary and lose the buyer, or keep the buyer and have nowhere
+--    to record AP. A default AP contact is the highest-voted customer request in
+--    the JobBOSS ideas portal (102 votes, status Developed); contact
+--    active/inactive is second at 88. Both are one column away here.
+--
+-- NOT DOING: adding a 'planner_scheduler' role. The plan called for it, but it
+-- appears nowhere in this repo and no shop has asked for it — unlike the two
+-- above, which carry vote counts. An enum value nobody requested is the kind of
+-- speculative width this module refuses everywhere else.
+
+-- ---------------------------------------------------------------------------
+-- 1. Archive + the AP default.
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.customer_contacts
+    ADD COLUMN IF NOT EXISTS deleted_at timestamptz,
+    ADD COLUMN IF NOT EXISTS is_billing_default boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.customer_contacts.deleted_at IS
+    'Archive marker. "Delete" on a contact stamps this instead of destroying the row, so a quote or job that named this person keeps resolving them and the shop keeps the history of who they dealt with. Lists, pickers and counts filter deleted_at IS NULL; by-id reads and a document''s retained contact_id deliberately do not. Also the answer to "this person left the company" — the row stops being offered without anything being lost.';
+
+COMMENT ON COLUMN public.customer_contacts.is_billing_default IS
+    'The person invoices and statements go to. Deliberately SEPARATE from is_primary, which answers "who do we call about the work" — at most shops those are two different people, and collapsing them forces the shop to lose one. At most one live row per customer (customer_contacts_one_billing_default). Nothing is inferred when it is unset: a customer with no billing default simply has none, rather than silently falling back to the primary.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Both "at most one per customer" indexes become LIVE-SCOPED.
+-- ---------------------------------------------------------------------------
+-- The existing one-primary index has no deleted_at predicate, so an archived
+-- contact would keep occupying the primary slot forever and the customer could
+-- never name a new one. Archiving has to free the slot, which means the
+-- predicate has to know about deleted_at.
+DROP INDEX IF EXISTS public.customer_contacts_one_primary;
+CREATE UNIQUE INDEX customer_contacts_one_primary
+    ON public.customer_contacts (customer_id)
+    WHERE is_primary AND deleted_at IS NULL;
+
+CREATE UNIQUE INDEX customer_contacts_one_billing_default
+    ON public.customer_contacts (customer_id)
+    WHERE is_billing_default AND deleted_at IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- 3. Make the quote FK behave like the job FK.
+-- ---------------------------------------------------------------------------
+-- With archive in place this should never fire through the UI. It is fixed
+-- anyway: an asymmetric FK is a latent trap for a service-role script or a
+-- future bulk operation, and this repo has already been bitten once by two
+-- sibling objects disagreeing (the customer-match triggers' UPDATE OF lists).
+-- Losing the link costs nothing that matters — quotes.contact_snapshot holds the
+-- frozen name/email/phone the document was issued with.
+ALTER TABLE public.quotes DROP CONSTRAINT IF EXISTS quotes_contact_id_fkey;
+ALTER TABLE public.quotes
+    ADD CONSTRAINT quotes_contact_id_fkey
+    FOREIGN KEY (contact_id) REFERENCES public.customer_contacts(id) ON DELETE SET NULL;
+
+-- Fail the migration rather than ship a silently-unfixed FK: DROP CONSTRAINT
+-- IF EXISTS on a wrong name succeeds and does nothing, which is exactly how this
+-- asymmetry survived this long.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conname = 'quotes_contact_id_fkey'
+           AND conrelid = 'public.quotes'::regclass
+           AND confdeltype = 'n'          -- 'n' = SET NULL
+    ) THEN
+        RAISE EXCEPTION
+            'quotes_contact_id_fkey is not ON DELETE SET NULL after this migration';
+    END IF;
+END $$;

--- a/supabase/migrations/20260802013846_customer_address_default_uniqueness.sql
+++ b/supabase/migrations/20260802013846_customer_address_default_uniqueness.sql
@@ -1,0 +1,71 @@
+-- Make the one-default-address rule real.
+--
+-- customer_addresses.default_billing and .default_shipping have been documented
+-- as "at most one row per customer can be true (enforced by
+-- idx_customer_addresses_one_default_billing / _shipping)" since the baseline —
+-- in the column COMMENTs, in utils/customerAddressesAccess.ts, and in
+-- docs/modules/customers.md. Those two indexes have never existed. The rule was
+-- enforced only by app code that clears the other rows first, so anything that
+-- bypassed it — a concurrent save, an importer, a service-role script — could
+-- leave a customer with two default billing addresses and nothing would notice.
+--
+-- What a second default actually does: pickBillingAddress returns the first row
+-- matching default_billing, i.e. whichever PostgREST happened to return first,
+-- so a quote silently bills to an arbitrary one of the two and can pick
+-- differently on a later load. That is the failure mode this closes.
+--
+-- customer_addresses has no deleted_at (addresses are edited or removed, not
+-- archived — unlike contacts, which gain one in the migration alongside this),
+-- so the predicates need no liveness clause.
+
+-- ---------------------------------------------------------------------------
+-- 1. Backfill: keep the OLDEST default of each kind, clear the rest.
+-- ---------------------------------------------------------------------------
+-- Oldest wins because it is the one that has been in use longest and is
+-- therefore the one already frozen onto existing quotes and jobs — clearing it
+-- in favour of a newer row would make the live default disagree with what every
+-- historical document was issued with. Both statements are no-ops on clean data.
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER (
+               PARTITION BY customer_id
+               ORDER BY created_at, id
+           ) AS rn
+      FROM public.customer_addresses
+     WHERE default_billing
+)
+UPDATE public.customer_addresses a
+   SET default_billing = false,
+       updated_at = now()
+  FROM ranked r
+ WHERE a.id = r.id
+   AND r.rn > 1;
+
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER (
+               PARTITION BY customer_id
+               ORDER BY created_at, id
+           ) AS rn
+      FROM public.customer_addresses
+     WHERE default_shipping
+)
+UPDATE public.customer_addresses a
+   SET default_shipping = false,
+       updated_at = now()
+  FROM ranked r
+ WHERE a.id = r.id
+   AND r.rn > 1;
+
+-- ---------------------------------------------------------------------------
+-- 2. The indexes the comments have been promising.
+-- ---------------------------------------------------------------------------
+-- Names match the ones already cited in the column COMMENTs, so the
+-- documentation becomes true rather than needing a rewrite.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_customer_addresses_one_default_billing
+    ON public.customer_addresses (customer_id)
+    WHERE default_billing;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_customer_addresses_one_default_shipping
+    ON public.customer_addresses (customer_id)
+    WHERE default_shipping;

--- a/supabase/schema.prod.sql
+++ b/supabase/schema.prod.sql
@@ -187,6 +187,8 @@ CREATE TABLE IF NOT EXISTS "public"."customer_contacts"
     "email" text,
     "phone" text,
     "is_primary" boolean NOT NULL DEFAULT false,
+    "is_billing_default" boolean NOT NULL DEFAULT false,
+    "deleted_at" timestamp with time zone,
     "created_at" timestamp with time zone NOT NULL DEFAULT now(),
     "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
     CONSTRAINT "customer_contacts_pkey" PRIMARY KEY (id),
@@ -3847,7 +3849,7 @@ ALTER TABLE "public"."quotes"
     ADD CONSTRAINT "quotes_company_id_fkey" FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;
 
 ALTER TABLE "public"."quotes"
-    ADD CONSTRAINT "quotes_contact_id_fkey" FOREIGN KEY (contact_id) REFERENCES customer_contacts(id);
+    ADD CONSTRAINT "quotes_contact_id_fkey" FOREIGN KEY (contact_id) REFERENCES customer_contacts(id) ON DELETE SET NULL;
 
 ALTER TABLE "public"."quotes"
     ADD CONSTRAINT "quotes_created_by_fkey" FOREIGN KEY (created_by) REFERENCES auth.users(id);
@@ -3953,7 +3955,10 @@ CREATE INDEX IF NOT EXISTS idx_companies_is_demo ON public.companies USING btree
 CREATE INDEX IF NOT EXISTS idx_companies_name ON public.companies USING btree (name);
 CREATE INDEX IF NOT EXISTS idx_companies_slug ON public.companies USING btree (slug);
 CREATE INDEX IF NOT EXISTS idx_customer_addresses_customer ON public.customer_addresses USING btree (customer_id);
-CREATE UNIQUE INDEX IF NOT EXISTS customer_contacts_one_primary ON public.customer_contacts USING btree (customer_id) WHERE is_primary;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_customer_addresses_one_default_billing ON public.customer_addresses USING btree (customer_id) WHERE default_billing;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_customer_addresses_one_default_shipping ON public.customer_addresses USING btree (customer_id) WHERE default_shipping;
+CREATE UNIQUE INDEX IF NOT EXISTS customer_contacts_one_primary ON public.customer_contacts USING btree (customer_id) WHERE (is_primary AND (deleted_at IS NULL));
+CREATE UNIQUE INDEX IF NOT EXISTS customer_contacts_one_billing_default ON public.customer_contacts USING btree (customer_id) WHERE (is_billing_default AND (deleted_at IS NULL));
 CREATE INDEX IF NOT EXISTS idx_customer_carrier_accounts_customer ON public.customer_carrier_accounts USING btree (customer_id) WHERE (deleted_at IS NULL);
 
 CREATE INDEX IF NOT EXISTS idx_customer_contacts_customer ON public.customer_contacts USING btree (customer_id);

--- a/types/customer.ts
+++ b/types/customer.ts
@@ -152,6 +152,13 @@ export interface CustomerListContact {
   email: string | null;
   phone: string | null;
   is_primary: boolean;
+  is_billing_default: boolean;
+  /**
+   * Carried so a picker can drop archived people while keeping the one a
+   * document already names — blanking a job's contact because that person left
+   * would lose who the work was actually agreed with.
+   */
+  deleted_at: string | null;
 }
 
 export interface CustomerWithRelations extends Customer {

--- a/types/customerContact.ts
+++ b/types/customerContact.ts
@@ -45,7 +45,17 @@ export interface CustomerContact {
   role_label: string | null;
   email: string | null;
   phone: string | null;
+  /** Who we call about the work. */
   is_primary: boolean;
+  /**
+   * Who invoices go to. Separate from `is_primary` on purpose — at most shops
+   * the buyer and the AP clerk are two different people, and one flag forces
+   * the shop to lose one of them. Nothing falls back to the primary when this
+   * is unset; a customer is allowed to have no billing contact.
+   */
+  is_billing_default: boolean;
+  /** Archive marker. A contact who left the company stops being offered. */
+  deleted_at: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/types/database.ts
+++ b/types/database.ts
@@ -480,8 +480,10 @@ export type Database = {
         Row: {
           created_at: string
           customer_id: string
+          deleted_at: string | null
           email: string | null
           id: string
+          is_billing_default: boolean
           is_primary: boolean
           name: string
           phone: string | null
@@ -492,8 +494,10 @@ export type Database = {
         Insert: {
           created_at?: string
           customer_id: string
+          deleted_at?: string | null
           email?: string | null
           id?: string
+          is_billing_default?: boolean
           is_primary?: boolean
           name: string
           phone?: string | null
@@ -504,8 +508,10 @@ export type Database = {
         Update: {
           created_at?: string
           customer_id?: string
+          deleted_at?: string | null
           email?: string | null
           id?: string
+          is_billing_default?: boolean
           is_primary?: boolean
           name?: string
           phone?: string | null

--- a/types/job.ts
+++ b/types/job.ts
@@ -301,6 +301,10 @@ export interface JobWithRelations extends Job {
       email: string | null;
       phone: string | null;
       is_primary: boolean;
+      is_billing_default: boolean;
+      /** Carried so a picker can drop archived people while keeping the one
+       *  this job already names. */
+      deleted_at: string | null;
     }>;
     addresses?: Array<{
       id: string;

--- a/utils/customerAccess.ts
+++ b/utils/customerAccess.ts
@@ -44,13 +44,21 @@ type CustomerWithPrimaryContactRow = Customer & {
     email: string | null;
     phone: string | null;
     is_primary: boolean;
+    is_billing_default: boolean;
+    deleted_at: string | null;
   }> | null;
 };
 
 function extractPrimaryContact(
   row: CustomerWithPrimaryContactRow,
 ): CustomerWithRelations['primary_contact'] {
-  const primary = (row.customer_contacts ?? []).find((c) => c.is_primary);
+  // Archiving a contact clears is_primary in the same write, so an archived
+  // person cannot be picked here. The deleted_at check is belt-and-braces
+  // against a row that got archived some other way (a service-role script,
+  // a future bulk operation) and kept its flag.
+  const primary = (row.customer_contacts ?? []).find(
+    (c) => c.is_primary && c.deleted_at === null,
+  );
   if (!primary) return null;
   return {
     id: primary.id,
@@ -80,7 +88,7 @@ export async function getCustomers(
   let query = supabase
     .from('customers')
     .select(
-      '*, addresses:customer_addresses(*), customer_contacts(id, name, role, email, phone, is_primary)',
+      '*, addresses:customer_addresses(*), customer_contacts(id, name, role, email, phone, is_primary, is_billing_default, deleted_at)',
       { count: 'exact' },
     )
     .eq('company_id', companyId)
@@ -135,7 +143,7 @@ export async function getAllCustomers(
     let query = supabase
       .from('customers')
       .select(
-        '*, addresses:customer_addresses(*), customer_contacts(id, name, role, email, phone, is_primary)',
+        '*, addresses:customer_addresses(*), customer_contacts(id, name, role, email, phone, is_primary, is_billing_default, deleted_at)',
       )
       .eq('company_id', companyId)
       .is('deleted_at', null)
@@ -214,7 +222,7 @@ export async function getCustomerWithRelations(
   const { data: customer, error: customerError } = await supabase
     .from('customers')
     .select(
-      '*, addresses:customer_addresses(*), customer_contacts(id, name, role, email, phone, is_primary)',
+      '*, addresses:customer_addresses(*), customer_contacts(id, name, role, email, phone, is_primary, is_billing_default, deleted_at)',
     )
     .eq('id', customerId)
     .single();

--- a/utils/customerContactsAccess.ts
+++ b/utils/customerContactsAccess.ts
@@ -30,7 +30,7 @@ import type {
 type CustomerContactInsert = Database['public']['Tables']['customer_contacts']['Insert'];
 
 const CUSTOMER_CONTACT_COLUMNS =
-  'id, customer_id, name, role, role_label, email, phone, is_primary, created_at, updated_at';
+  'id, customer_id, name, role, role_label, email, phone, is_primary, is_billing_default, deleted_at, created_at, updated_at';
 
 function formDataToInsert(
   formData: CustomerContactFormData,
@@ -49,8 +49,15 @@ function formDataToInsert(
 }
 
 /**
- * Get all contacts for a customer.
+ * Get a customer's LIVE contacts.
  * Ordered: primary first (is_primary DESC), then by creation order.
+ *
+ * Filters archived rows: this feeds the Contacts card and every picker that
+ * offers a person to choose, and someone who left the company must stop being
+ * offered. A document that already names an archived contact resolves it by id
+ * instead — see the `deleted_at` selected in the embeds on quotesAccess /
+ * jobsAccess, which the pickers use to keep a currently-selected archived row
+ * visible rather than silently blanking it.
  */
 export async function getContactsForCustomer(
   customerId: string,
@@ -61,6 +68,7 @@ export async function getContactsForCustomer(
     .from('customer_contacts')
     .select(CUSTOMER_CONTACT_COLUMNS)
     .eq('customer_id', customerId)
+    .is('deleted_at', null)
     .order('is_primary', { ascending: false })
     .order('created_at', { ascending: true });
 
@@ -177,18 +185,37 @@ export async function updateCustomerContact(
   return data as CustomerContact;
 }
 
-export async function deleteCustomerContact(contactId: string): Promise<void> {
+/**
+ * Archive a contact. Stamps `deleted_at` — never a SQL DELETE.
+ *
+ * The row survives because a quote or job that named this person keeps a
+ * `contact_id` pointing at it, and because "who did we deal with on this job"
+ * is a question shops ask about work that finished years ago. Both documents
+ * also freeze a `contact_snapshot`, so the printed block was never at risk —
+ * what archiving preserves is the live link and the ability to un-archive.
+ *
+ * Also clears both default flags in the same write. An archived contact that
+ * kept `is_primary` would hold the slot against the live partial unique index
+ * and the customer could never name a new primary; the same for the billing
+ * default. Archiving a person has to hand back whatever roles they held.
+ */
+export async function archiveCustomerContact(contactId: string): Promise<void> {
   const supabase = getSupabase();
   const { error } = await supabase
     .from('customer_contacts')
-    .delete()
+    .update({
+      deleted_at: new Date().toISOString(),
+      is_primary: false,
+      is_billing_default: false,
+      updated_at: new Date().toISOString(),
+    })
     .eq('id', contactId);
   if (error) {
-    console.error('Error deleting customer contact:', error);
+    console.error('Error archiving customer contact:', error);
     throw new Error(
       friendlyErrorMessage(error, {
         entity: 'contact',
-        fallback: 'Failed to delete contact.',
+        fallback: 'Failed to remove contact.',
       }),
     );
   }
@@ -218,6 +245,48 @@ export async function setPrimaryContact(
       );
     }
     console.error('Error setting primary contact:', error);
+    throw error;
+  }
+}
+
+/**
+ * Clear is_billing_default across a customer's contacts, then flip the named one.
+ *
+ * Mirrors setPrimaryContact, including its race window (see the file header):
+ * the DB index is the real guarantee, the clear-first is what keeps the UI from
+ * tripping it. Passing `null` clears the billing default without naming a new
+ * one — a customer is allowed to have none, and nothing falls back to the
+ * primary in its absence.
+ */
+export async function setBillingDefaultContact(
+  customerId: string,
+  contactId: string | null,
+): Promise<void> {
+  const supabase = getSupabase();
+
+  const { error: clearError } = await supabase
+    .from('customer_contacts')
+    .update({ is_billing_default: false })
+    .eq('customer_id', customerId)
+    .eq('is_billing_default', true);
+  if (clearError) {
+    console.error('Error clearing billing-default contact:', clearError);
+    throw clearError;
+  }
+
+  if (!contactId) return;
+
+  const { error } = await supabase
+    .from('customer_contacts')
+    .update({ is_billing_default: true, updated_at: new Date().toISOString() })
+    .eq('id', contactId);
+  if (error) {
+    if (error.code === '23505') {
+      throw new Error(
+        'Another contact for this customer was just marked for billing. Refresh and try again.',
+      );
+    }
+    console.error('Error setting billing-default contact:', error);
     throw error;
   }
 }

--- a/utils/jobsAccess.ts
+++ b/utils/jobsAccess.ts
@@ -249,7 +249,7 @@ export async function getJobWithRelations(
       *,
       customers!left(
         id, name,
-        customer_contacts(id, name, role, email, phone, is_primary),
+        customer_contacts(id, name, role, email, phone, is_primary, is_billing_default, deleted_at),
         addresses:customer_addresses(
           id,
           address_line1, address_line2, city, state, postal_code, country,

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -126,7 +126,7 @@ const QUOTE_DETAIL_SELECT = `
   customers!left(
     id, name, website,
     default_payment_terms, default_lead_time_text, default_fob_point,
-    customer_contacts(id, name, role, email, phone, is_primary),
+    customer_contacts(id, name, role, email, phone, is_primary, is_billing_default, deleted_at),
     addresses:customer_addresses(
       id,
       address_line1, address_line2, city, state, postal_code, country,


### PR DESCRIPTION
Phase 3 of the customer CRM plan. **Two of these were real defects sitting in `main`**, not features.

## Deleting a contact used on a quote failed outright

`quotes_contact_id_fkey` carries **no `ON DELETE` clause at all**, so it defaults to `NO ACTION` and Postgres refuses the delete. `jobs_contact_id_fkey` has had `ON DELETE SET NULL` since the baseline — same relationship, two behaviours, and the stricter one is the accident.

It now matches, with a `DO` block that fails the migration if it somehow doesn't: `DROP CONSTRAINT IF EXISTS` on a wrong name **succeeds and does nothing**, which is plausibly how the asymmetry survived this long.

Losing the link costs nothing that matters — `quotes.contact_snapshot` holds the frozen name/email/phone the document was issued with.

## The one-default-address rule was fiction

Both column COMMENTs, `utils/customerAddressesAccess.ts` and the module doc have said *"at most one row per customer (enforced by `idx_customer_addresses_one_default_billing` / `_shipping`)"* since the baseline. **Neither index has ever existed.**

The rule lived only in app code that clears the other rows first, so anything bypassing it — a concurrent save, an importer, a service-role script — could leave a customer with two default billing addresses. `pickBillingAddress` then returns whichever row PostgREST happened to hand back first, so the quote bills to an arbitrary one of the two **and can pick differently on a later load**.

Backfilled **oldest-wins** — the oldest is the one already frozen onto existing quotes and jobs, so clearing it in favour of a newer row would make the live default disagree with every document ever issued. Then created both indexes under the names the comments already cite, so the documentation becomes true rather than needing a rewrite.

## Contacts now archive

`customer_contacts` was the last customer-family table outside the archive standard. "Delete" stamps `deleted_at`, so a quote or job that named someone keeps resolving them, and *"who did we deal with on this job"* survives for work that finished years ago.

Archiving also **clears both flags in the same write**, and that half is load-bearing rather than tidy: both "at most one per customer" indexes are now scoped to live rows, so an archived contact that kept `is_primary` would hold the slot forever and the customer could never name a replacement.

## The AP contact was unnameable

`is_primary` answers *"who do we call about the work"*, which is rarely the person who pays — so a shop had to put the AP clerk in as primary and lose the buyer, or keep the buyer and have nowhere to record AP.

`is_billing_default` is a separate flag with its own live-scoped index. **Nothing is inferred when it is unset** — a customer with no billing contact simply has none, rather than invoices quietly going to whoever happens to be primary. Clicking the current one clears it, because forcing a choice makes the office name a person they haven't agreed on.

This is the **highest-voted** customer request in the JobBOSS ideas portal (102 votes, status *Developed*); contact active/inactive — which the archive half answers — is second at 88.

## Not doing

The plan called for a `planner_scheduler` role. It appears **nowhere in this repo** and no shop has asked for it — unlike the two above, which carry vote counts. An enum value nobody requested is the speculative width this module refuses everywhere else.

## The archive sweep

Follows the pattern the carrier accounts already set: the embeds select `deleted_at`, and each picker drops archived rows **while keeping the one its document already names** — so editing an older job never silently blanks who the work was agreed with. `getContactsForCustomer` filters server-side, since it only ever offers a choice.

| Surface | Treatment |
|---|---|
| `getContactsForCustomer` | `deleted_at IS NULL` server-side |
| QuoteForm / JobEditForm / JobBillingShippingCard pickers | drop archived, keep the currently-named one |
| `extractPrimaryContact` | belt-and-braces `deleted_at === null` check |
| A document's retained `contact_id` | deliberately unfiltered |

## Verification

`types/database.ts` regenerated from a throwaway container — six lines, both new columns across Row/Insert/Update, no other drift. tsc clean · **1642** Vitest · lint at baseline. Six new tests cover the archive clearing both flags, the clear-then-set ordering, the null-clears case, and the lost-race message.

**Manual, on the preview branch** (the real gate for the two migrations):

- [ ] Delete a contact that a quote names → **succeeds** (this is the bug: on `main` it fails), the quote still shows the person from its snapshot.
- [ ] Archive the primary contact → the star is free, another contact can be made primary.
- [ ] Set a billing contact, then click it again → clears, and no invoice contact is inferred.
- [ ] Open a job whose contact was archived → the picker still shows them, not a blank.
- [ ] Both address indexes exist in `pg_indexes`; setting a second default billing address is rejected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)