### PR TITLE
fix(customers): close the ten defects the module audit found (#653)

### DIFF
--- a/__tests__/components/quotes/QuoteForm.test.tsx
+++ b/__tests__/components/quotes/QuoteForm.test.tsx
@@ -816,9 +816,19 @@ describe('QuoteForm — standing-terms resolution chain', () => {
   });
 
   /** Pick a customer from the "Customer" autocomplete by visible name. */
+  /**
+   * Pick a customer by visible name.
+   *
+   * findByRole, not getByRole, and that is not defensive padding. When another
+   * MUI popup has just closed — the payment-terms picker, in the hand-typed
+   * test below — the customer combobox is briefly out of the accessibility tree,
+   * because MUI aria-hidden's the rest of the app while a popup is mounted. A
+   * synchronous getByRole races that transition: it passed locally and failed on
+   * CI's slower box, which is the signature of exactly this.
+   */
   async function selectCustomer(name: string) {
     const user = userEvent.setup();
-    await user.click(screen.getByRole('combobox', { name: /customer/i }));
+    await user.click(await screen.findByRole('combobox', { name: /customer/i }));
     await user.click(await screen.findByRole('option', { name }));
   }
 

--- a/__tests__/utils/customerAccess.test.ts
+++ b/__tests__/utils/customerAccess.test.ts
@@ -17,6 +17,9 @@ const NO_STANDING_TERMS = {
   default_fob_point: null,
   credit_status: 'open',
   credit_hold_note: null,
+  // Live, not archived. Note tsconfig excludes __tests__, so a fixture that
+  // drifts from the Customer type will NOT fail `tsc` — keep it honest by hand.
+  deleted_at: null,
 } as const;
 
 // Use vi.hoisted to define mock variables before vi.mock is called
@@ -149,7 +152,7 @@ describe('customerAccess utilities', () => {
       mockQueryBuilder.data = [mockCustomers[0]];
       mockQueryBuilder.error = null;
 
-      const result = await getAllCustomers('company-1', 'all', 'Customer One');
+      const result = await getAllCustomers('company-1', 'Customer One');
 
       expect(mockQueryBuilder.or).toHaveBeenCalledWith(
         'name.ilike."%Customer One%"'
@@ -373,6 +376,25 @@ describe('customerAccess utilities', () => {
         expect(patch).not.toHaveProperty('default_fob_point');
       });
 
+      // #653 P1. This is the defect that produced two rows for one company:
+      // the lookup was .eq (case-sensitive) while the create pre-check was
+      // .ilike (case-insensitive) and the constraint was case-sensitive — so
+      // archiving "Acme Corp" and creating "acme corp" found nothing to revive
+      // and inserted a duplicate instead.
+      it('finds the archived row whatever case the name was typed in', async () => {
+        stageRevive();
+        await createCustomer('company-1', {
+          ...EMPTY_CUSTOMER_FORM,
+          name: 'acme corp',
+        });
+
+        const ilike = mockQueryBuilder.ilike as ReturnType<typeof vi.fn>;
+        expect(ilike).toHaveBeenCalledWith('name', 'acme corp');
+        // ...and NOT via a case-sensitive equality on the name.
+        const eq = mockQueryBuilder.eq as ReturnType<typeof vi.fn>;
+        expect(eq).not.toHaveBeenCalledWith('name', 'acme corp');
+      });
+
       it('does apply the values the form did supply', async () => {
         stageRevive();
         await createCustomer('company-1', {
@@ -539,10 +561,17 @@ describe('standing terms — drift is reported, never applied', () => {
     expect(hasTermDrift(null, null)).toBe(false);
   });
 
-  it('reports drift when the quote states nothing but the customer now has terms', () => {
-    // Worth surfacing: an older quote written before the standing terms existed.
-    expect(hasTermDrift(null, 'Net 30')).toBe(true);
-    expect(hasTermDrift('', 'Net 30')).toBe(true);
+  // REVERSED from the original decision, deliberately. This used to assert
+  // true — "worth surfacing: an older quote written before the standing terms
+  // existed". In practice it is a chip storm: quotes.fob_point is newer than
+  // the quotes themselves, so every pre-existing quote holds NULL, and the
+  // first time a shop fills in one customer's FOB point every open quote for
+  // that customer chips at once. A quote that states nothing never promised
+  // terms, so there is no disagreement to report.
+  it('reports no drift when the quote states nothing — silence is not a promise', () => {
+    expect(hasTermDrift(null, 'Net 30')).toBe(false);
+    expect(hasTermDrift('', 'Net 30')).toBe(false);
+    expect(hasTermDrift('   ', 'Net 30')).toBe(false);
   });
 });
 

--- a/api/routes/import_routes.py
+++ b/api/routes/import_routes.py
@@ -412,8 +412,20 @@ async def execute_import(
         # contact/address only to NEW customers — re-attaching a primary contact to an existing
         # customer would duplicate it and trip the one-primary index — and (b) the
         # created-vs-updated split in the summary.
+        # Keyed by the CASEFOLDED name, valued by the name EXACTLY as stored. The
+        # value is load-bearing: the upsert's on_conflict is the case-sensitive
+        # (company_id, name) constraint, so a CSV row spelled "acme corp" against
+        # a stored "Acme Corp" would not conflict — it would insert a SECOND
+        # customer while is_new (decided case-insensitively, just below) reported
+        # it as existing. Rewriting the payload to the stored spelling makes the
+        # upsert land on the row it was always meant to update.
+        #
+        # Consequence worth knowing: a re-import cannot RE-CASE a customer. That
+        # is the right trade — a silent duplicate of the entity every quote, job
+        # and invoice hangs off is far worse than a capitalisation fix the user
+        # can make on the customer page.
         existing_customer_names = {
-            c["name"].lower()
+            c["name"].strip().lower(): c["name"]
             for c in fetch_all_by_company(supabase, "customers", "name", request.company_id)
             if c.get("name")
         }
@@ -466,8 +478,13 @@ async def execute_import(
             if address_data and "country" not in address_data:
                 address_data["country"] = "USA"
 
-            name_lower = customer_data.get("name", "").lower()
-            is_new = name_lower not in existing_customer_names
+            name_lower = customer_data.get("name", "").strip().lower()
+            stored_name = existing_customer_names.get(name_lower)
+            is_new = stored_name is None
+            if stored_name is not None:
+                # Match the stored spelling so the upsert conflicts (and updates)
+                # instead of inserting a case-variant duplicate.
+                customer_data["name"] = stored_name
 
             # Attach a contact/address ONLY to a NEW customer — a re-imported (existing)
             # customer updates in place; re-inserting its primary contact/address would
@@ -516,7 +533,10 @@ async def execute_import(
                     )
                     for r in response.data or []:
                         if r.get("name") and r.get("id"):
-                            name_to_customer_id[r["name"].lower()] = r["id"]
+                            # Same normalisation as name_lower above, or the
+                            # lookup below misses and the row's contact/address
+                            # is silently dropped.
+                            name_to_customer_id[r["name"].strip().lower()] = r["id"]
 
                 contact_rows_to_insert = []
                 address_rows_to_insert = []

--- a/api/tests/integration/test_import_api.py
+++ b/api/tests/integration/test_import_api.py
@@ -467,6 +467,47 @@ class TestExecuteEndpoint:
         assert data["skipped_count"] == 0
 
     @pytest.mark.unit
+    async def test_execute_matches_an_existing_customer_regardless_of_case(self, test_client):
+        """A CSV row spelled differently is the SAME customer, not a second one.
+
+        Issue #653 P1. is_new was decided on a lowercased name while the upsert
+        ran on the case-sensitive (company_id, name) constraint — so "acme corp"
+        against a stored "Acme Corp" was counted as an update, denied its
+        contact and address, and still INSERTED a second customer row. The fix
+        rewrites the payload to the stored spelling so the upsert lands on the
+        row it was always meant to update.
+        """
+        existing_customers = [
+            {"id": "existing-1", "name": "Acme Corp"},
+        ]
+
+        request_data = {
+            "company_id": "test-company-id",
+            "mappings": {"Name": "name"},
+            "rows": [
+                {"Name": "  acme corp  "},  # same company: different case AND padding
+            ],
+            "skip_conflicts": True,
+        }
+
+        app.dependency_overrides[get_supabase] = create_mock_supabase_override(existing_customers)
+
+        response = await test_client.post(
+            "/api/customers/import/execute",
+            json=request_data,
+        )
+
+        app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        # The row IS the existing customer. Nothing is created.
+        assert data["imported_count"] == 0
+        assert data["updated_count"] == 1
+        assert data["skipped_count"] == 0
+
+    @pytest.mark.unit
     async def test_execute_returns_correct_counts(self, test_client):
         """Returns correct imported_count and skipped_count."""
         existing_customers = [

--- a/app/dashboard/[companyId]/customers/[customerId]/page.tsx
+++ b/app/dashboard/[companyId]/customers/[customerId]/page.tsx
@@ -28,6 +28,7 @@ import AddIcon from '@mui/icons-material/Add';
 import StarIcon from '@mui/icons-material/Star';
 import StarOutlineIcon from '@mui/icons-material/StarOutline';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
+import ArchiveOutlinedIcon from '@mui/icons-material/ArchiveOutlined';
 
 import {
   getCustomerWithRelations,
@@ -353,7 +354,27 @@ export default function CustomerDetailPage() {
                 {customer.credit_status === 'hold' && (
                   <Chip label="On credit hold" color="warning" size="small" />
                 )}
+                {/* This page is reachable for an ARCHIVED customer by an
+                    ordinary click, not just a hand-typed URL — every quote and
+                    job links straight here, and the by-id read deliberately
+                    doesn't filter deleted_at so those links keep resolving.
+                    Without this the page looks completely live, Edit and Delete
+                    included. */}
+                {customer.deleted_at && (
+                  <Chip
+                    label="Archived"
+                    size="small"
+                    variant="outlined"
+                    icon={<ArchiveOutlinedIcon />}
+                  />
+                )}
               </Box>
+              {customer.deleted_at && (
+                <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                  Removed from your lists. Quotes and jobs that reference it still
+                  work. Re-creating or re-importing the same name brings it back.
+                </Typography>
+              )}
               {customer.credit_status === 'hold' && customer.credit_hold_note && (
                 <Typography variant="body2" color="warning.main" sx={{ mt: 0.5 }}>
                   {customer.credit_hold_note}

--- a/app/dashboard/[companyId]/customers/page.tsx
+++ b/app/dashboard/[companyId]/customers/page.tsx
@@ -92,7 +92,7 @@ export default function CustomersPage() {
     loading,
     reload: fetchCustomers,
   } = useLoad(
-    () => getAllCustomers(companyId, 'all', searchDebounced, sortModel.field, sortModel.sort),
+    () => getAllCustomers(companyId, searchDebounced, sortModel.field, sortModel.sort),
     [companyId, searchDebounced, sortModel],
     {
       onError: (error) => {
@@ -210,10 +210,17 @@ export default function CustomersPage() {
       minWidth: 200,
       pinned: 'left' as const,
     },
+    // Contact / Email / Phone are read off the embedded primary contact — they
+    // are NOT columns on `customers`. Sorting is server-side (the colId goes
+    // straight into .order()), so leaving these sortable sent PostgREST a
+    // column name that does not exist and the request failed. Derived columns
+    // stay unsortable until there is something real to sort on, same as
+    // Location below.
     {
       colId: 'primary_contact_name',
       headerName: 'Contact',
       width: 250,
+      sortable: false,
       valueGetter: (params) => params.data?.primary_contact?.name ?? '—',
     },
     {
@@ -221,12 +228,14 @@ export default function CustomersPage() {
       headerName: 'Email',
       flex: 2,
       minWidth: 200,
+      sortable: false,
       valueGetter: (params) => params.data?.primary_contact?.email ?? '—',
     },
     {
       colId: 'primary_contact_phone',
       headerName: 'Phone',
       width: 180,
+      sortable: false,
       valueGetter: (params) => params.data?.primary_contact?.phone ?? '—',
     },
     {

--- a/components/shipments/ShipmentForm.tsx
+++ b/components/shipments/ShipmentForm.tsx
@@ -330,6 +330,11 @@ export default function ShipmentForm({
                addresses:customer_addresses (
                  id, customer_id, address_line1, address_line2, city, state,
                  postal_code, country, default_billing, default_shipping, attention_to
+               ),
+               carrier_accounts:customer_carrier_accounts (
+                 id, company_id, customer_id, carrier, bill_to_party, account_number,
+                 account_postal_code, account_country_code, notes,
+                 created_at, updated_at, deleted_at
                )`,
             )
             .eq('id', source.customerId)
@@ -338,6 +343,33 @@ export default function ShipmentForm({
             throw new Error(customerErr?.message ?? 'Customer not found.');
           }
           ctx = customerRow as unknown as CustomerContext;
+
+          // Customer mode has no job to name a freight instruction, so the
+          // customer's standing arrangement IS the answer — resolveFreightLine
+          // with no job inputs falls straight to pickCarrierAccount. Without
+          // this the panel never rendered here and every shipment created from
+          // the customer surface saved NULL freight, even for a customer whose
+          // whole point is that shipping bills to their own account.
+          const customerFreight = resolveFreightLine({
+            jobFreightTerms: null,
+            jobCarrierAccountId: null,
+            customerAccounts: (customerRow.carrier_accounts ??
+              []) as unknown as CustomerCarrierAccount[],
+          });
+          setResolvedFreight(customerFreight);
+          setFreightTerms(customerFreight.terms ?? '');
+          setFreightAccountId(customerFreight.account?.id ?? '');
+          if (customerFreight.account?.carrier) {
+            const match = CARRIER_OPTIONS.find(
+              (c) =>
+                c.toLowerCase() === customerFreight.account!.carrier.trim().toLowerCase(),
+            );
+            if (match) setCarrierChoice(match);
+            else {
+              setCarrierChoice('other');
+              setCarrierOther(customerFreight.account.carrier);
+            }
+          }
 
           const openParts = await getOpenJobPartsForCustomer(
             companyId,

--- a/docs/modules/customers.md
+++ b/docs/modules/customers.md
@@ -24,7 +24,7 @@ That last clause is the whole safety argument, and the reason this is not the `m
 |---|---|---|
 | `id` | uuid PK | `gen_random_uuid()` |
 | `company_id` | uuid NOT NULL | tenant key |
-| `name` | text NOT NULL | unique per company — **`customers_company_name_unique (company_id, name)`, FULL, no `WHERE`** |
+| `name` | text NOT NULL | **the identity, case- and space-insensitive** — `customers_company_name_ci_unique (company_id, lower(btrim(name)))`. FULL, no `WHERE`, so archived rows collide too: that collision is the signal to revive. The plain `customers_company_name_unique` survives beside it only as the CSV importer's `on_conflict` target |
 | `website` | text | |
 | `created_at` / `updated_at` | timestamptz | `updated_at` maintained by the `customers_updated_at` trigger (no column list — fires on every update) |
 | `deleted_at` | timestamptz | archive marker |
@@ -38,9 +38,14 @@ Everything unmarked is nullable. `customers_credit_status_check` is the **only**
 
 Contacts and addresses live in their own tables so a customer can have many of each.
 
-**`customer_contacts`** — `name` (req), `role` (`buyer` / `accounts_payable` / `engineering` / `quality` / `shipping_receiving` / `other`), `role_label` (required by CHECK when role is `other`), `email`, `phone`, `is_primary` (at most one per customer, `customer_contacts_one_primary` partial unique index).
+**`customer_contacts`** — `name` (req), `role` (`buyer` / `accounts_payable` / `engineering` / `quality` / `shipping_receiving` / `other`), `role_label` (required by CHECK when role is `other`), `email`, `phone`, `deleted_at`, and two independent flags:
 
-**`customer_addresses`** — `address_line1`/`2`, `city`, `state`, `postal_code`, `country` (default `USA`), `attention_to` (the "ATTN:" line printed above the address on packing slips), `default_billing`, `default_shipping`.
+- `is_primary` — who we call about the work.
+- `is_billing_default` — who invoices go to. **Separate on purpose**: at most shops the buyer and the AP clerk are two different people, and one flag forces the shop to lose one. Nothing falls back to the primary when it is unset.
+
+Both are "at most one per customer" via partial unique indexes **scoped to live rows**, which is why archiving a contact clears both flags in the same write — otherwise an archived person would hold the slot forever.
+
+**`customer_addresses`** — `address_line1`/`2`, `city`, `state`, `postal_code`, `country` (default `USA`), `attention_to` (the "ATTN:" line printed above the address on packing slips), `default_billing`, `default_shipping` — each **at most one per customer**, enforced by `idx_customer_addresses_one_default_billing` / `_shipping`. Those two indexes were documented from the baseline but did not exist until August 2026; until then a second default was possible and `pickBillingAddress` returned whichever row came back first.
 
 ### `customer_carrier_accounts` — the customer's own UPS/FedEx account
 
@@ -408,28 +413,31 @@ Each bullet cites a real test. Gaps are named as gaps rather than implied to be 
 | **`getCompanyDefaultPaymentTerms` / `setCompanyDefaultPaymentTerms` untested** — only the pure reader is covered, so the read-modify-write that actually persists the shop default has no test. |
 | **No test for `packingSlipPdf.ts`** — the printed freight row is unverified in CI. |
 
+Filled since: the contact-archive rules and the billing-default clear-then-set are covered by `__tests__/utils/customerContactsAccess.test.ts`, and the case-insensitive identity by `__tests__/utils/customerAccess.test.ts > 'finds the archived row whatever case the name was typed in'` plus `api/tests/integration/test_import_api.py::test_execute_matches_an_existing_customer_regardless_of_case`.
+
 ---
 
 ## Known defects
 
-Found by auditing the shipped code. Recorded here rather than fixed silently.
+**None outstanding.** The ten found by auditing this module ([#653](https://github.com/debola31/Jigged/issues/653)) are fixed. Two are worth remembering as a class, because the shape recurs:
 
-| # | Defect | Effect |
-|---|---|---|
-| 1 | The revive lookup is case-**sensitive** (`.eq('name', …)`) while the create pre-check is case-**insensitive** (`.ilike`) and the unique constraint is case-sensitive | Archive "Acme Corp", create "acme corp" → the pre-check passes, no `23505` fires, and a **second** customer row is inserted instead of reviving |
-| 2 | The importer decides `is_new` on a **lowercased** name but upserts on the case-sensitive constraint | "acme corp" against an existing "Acme Corp" is counted as an update, gets no contact/address — and still inserts a second row |
-| 3 | `defaultColDef` sets `sortable: true` and Contact/Email/Phone are not opted out | Clicking those headers sends non-existent columns (`primary_contact_name`, …) to PostgREST's `.order()` |
-| 4 | A failed quotes/jobs count is `console.error`'d and reported as `0` | The Related card renders "Quotes 0 / Jobs 0" — a definitive negative for a question never answered, against the [CLAUDE.md](../../CLAUDE.md) rule that "couldn't check" is never "denied" |
-| 5 | `hasTermDrift` returns true when the quote's field is empty and the customer has a value; `quotes.fob_point` is new, so every pre-existing quote has it NULL | The day a shop sets `default_fob_point`, every one of that customer's older quotes grows a "FOB differs" chip |
-| 6 | An archived customer's detail page renders normally — no banner, Edit and Delete still offered — and quote/job pages link straight to it | An archived customer is reachable by an ordinary click, not just a hand-typed URL |
-| 7 | `ShipmentForm` resolves freight **only in job mode**; the customer-mode query doesn't select `carrier_accounts` | A shipment created from the customer surface always saves NULL freight |
-| 8 | `bulkImportCustomers` has no callers, discards standing terms, and **blocks** on an existing name instead of reviving | Dead code with semantics opposite to the live importer |
-| 9 | Three stale comments | `customerAccess.ts`'s docblock still says rows hold "just identity"; `jobs.payment_terms` claims it is "editable on the job" (no UI writes it — only quote conversion does); the freight migration's "THE TRAP" comment says four/two columns where the triggers say five/three |
-| 10 | `getCustomers` (paginated, `{data,total}`) has no callers, and the `filter` argument on both list functions is dead (`_filter`) | `CustomerFilter`'s `active`/`inactive` values have no effect |
+**Name is the identity, and three layers disagreed about what that means.** The constraint was case-sensitive, the create pre-check was `.ilike`, and the revive lookup was `.eq` — so archiving "Acme Corp" and creating "acme corp" found nothing to revive and inserted a **second row for the same company**. The CSV importer reached the same end from the other side. Both lookups are now case-insensitive, and `customers_company_name_ci_unique` on `(company_id, lower(btrim(name)))` makes the DB the authority. The plain constraint survives beside it only because the importer upserts with `on_conflict="company_id,name"` and PostgREST cannot name an expression index.
+
+**A chip that fires on everything at once is a chip people learn to ignore.** `hasTermDrift` used to report drift when the quote stated nothing and the customer had a value. Because `quotes.fob_point` is newer than the quotes themselves, the first time a shop filled in one customer's FOB point every open quote for that customer chipped. A quote that states nothing never promised terms, so there is nothing to disagree with — drift now needs a value on both sides.
 
 ---
 
 ## Explicitly not built
+
+**Phases 4 and 5 of the CRM plan were dropped on 2026-08-02**, before being built, on the founder's call. Recorded here so they are a decision rather than a backlog item that quietly returns:
+
+| Dropped | Was | Why not |
+|---|---|---|
+| **Customer notes + activity feed** (`quote_note` / `shipping_note`, a `customer_comments` table, attachments, a merged timeline) | Phase 4 | The half that depends on someone choosing to type has **negative** evidence: E2's customer comments went entirely unused at the pilot shop. The attachments and merged-timeline halves have none at all. The one piece with a real question behind it — an auto-log answering *"who put them on credit hold, and when"* — is worth **asking** about before building |
+| **CustomerWorkspace** (tabbed shell replacing the card stack) | Phase 5 | Chrome. The page did pass the plan's own trigger (*"if four cards still feel comfortable, don't build the shell"* — it is at six), but a long page is a code-quality observation, not a reported problem. Nobody has said the page is hard to use |
+
+Both were dropped in favour of fixing [#653](https://github.com/debola31/Jigged/issues/653), whose P1 was silently duplicating the entity every quote, job and invoice hangs off. If either comes back, it should come back with a shop asking for it.
+
 
 **Numeric credit limits** — QuickBooks Online has no `CreditLimit` field (Intuit marks it Desktop-only, and its official workaround is typing the number into a Notes field). A limit implies a balance to compare against, which implies the AR subledger this product refuses. The moment `credit_status` grows a threshold, it has become this.
 

--- a/supabase/migrations/20260802022238_customer_name_case_insensitive_identity.sql
+++ b/supabase/migrations/20260802022238_customer_name_case_insensitive_identity.sql
@@ -1,0 +1,91 @@
+-- A customer's name is its identity, and identity is not case-sensitive.
+--
+-- Three layers disagreed about that, which is how you get two rows for one
+-- company (issue #653, P1):
+--
+--   * the constraint  customers_company_name_unique (company_id, name)  — case-SENSITIVE
+--   * the create pre-check  checkCustomerNameExists  .ilike             — case-INSENSITIVE
+--   * the revive lookup     reviveArchivedCustomerByName  .eq           — case-SENSITIVE
+--
+-- Archive "Acme Corp", then create "acme corp": the pre-check finds nothing
+-- (it only looks at LIVE rows), the insert does not collide (the constraint is
+-- case-sensitive), no 23505 fires, the revive path never runs, and a second
+-- customer row appears. The CSV importer reaches the same end from the other
+-- side — it decides is_new on a lowercased name but upserts on the
+-- case-sensitive constraint, so "acme corp" against an existing "Acme Corp" is
+-- counted as an update, is denied its contact and address, and still inserts.
+--
+-- The app fix (both lookups become case-insensitive) is in the same commit and
+-- is what actually stops it happening. This index is the guard that keeps the
+-- class closed: with it, anything that still tries turns a silent duplicate
+-- into a loud 23505.
+--
+-- WHY BOTH INDEXES SURVIVE. customers_company_name_unique stays exactly as it
+-- is, because the importer upserts with on_conflict="company_id,name" and
+-- PostgREST can only name plain columns — pointing it at an expression index is
+-- not possible. The case-sensitive constraint therefore remains the upsert
+-- target; the case-insensitive index sits behind it as the real rule. The
+-- former is implied by the latter, so keeping both costs one index and no
+-- correctness.
+--
+-- FULL, not partial: archived rows are covered, exactly as the existing
+-- constraint covers them. That is what makes reuse-revives work — a collision
+-- with an archived row is the signal to un-archive it rather than duplicate.
+
+-- ---------------------------------------------------------------------------
+-- 1. De-duplicate what the importer may already have created.
+-- ---------------------------------------------------------------------------
+-- Only the importer could produce a case-variant (the UI pre-check has always
+-- been .ilike), so this is a no-op for most companies.
+--
+-- These rows are NOT merged. Merging customers means re-pointing quotes, jobs,
+-- shipments, addresses and contacts, and choosing which history wins — the
+-- module refuses merge/dedup tooling on purpose (docs/modules/customers.md,
+-- "Explicitly not built"). Renaming keeps both rows and both histories intact
+-- and lets the shop decide.
+--
+-- Who keeps the name: a LIVE row beats an archived one (the live row is the one
+-- being used today), then the oldest wins (it is the one already frozen onto
+-- the most documents). Losers get their own id appended — deliberately ugly, so
+-- it reads as something that happened TO the data rather than as a name someone
+-- chose, and guaranteed not to collide with a second pass.
+WITH ranked AS (
+    SELECT id,
+           name,
+           row_number() OVER (
+               PARTITION BY company_id, lower(btrim(name))
+               ORDER BY (deleted_at IS NOT NULL), created_at, id
+           ) AS rn
+      FROM public.customers
+)
+UPDATE public.customers c
+   SET name = r.name || ' [' || left(c.id::text, 8) || ']',
+       updated_at = now()
+  FROM ranked r
+ WHERE c.id = r.id
+   AND r.rn > 1;
+
+-- ---------------------------------------------------------------------------
+-- 2. The rule itself.
+-- ---------------------------------------------------------------------------
+-- btrim as well as lower: " Acme Corp" and "Acme Corp" are the same company too,
+-- and every writer already trims before insert, so this only closes the path
+-- around them.
+CREATE UNIQUE INDEX IF NOT EXISTS customers_company_name_ci_unique
+    ON public.customers (company_id, lower(btrim(name)));
+
+COMMENT ON INDEX public.customers_company_name_ci_unique IS
+    'Name is the customer''s identity and identity ignores case and surrounding space, so "Acme Corp", "acme corp" and " Acme Corp " are one company. Covers archived rows (no WHERE clause) because a collision with an archived row is the signal to REVIVE it — see reviveArchivedCustomerByName. The plain customers_company_name_unique constraint is kept alongside this only because the CSV importer upserts with on_conflict="company_id,name" and PostgREST cannot name an expression index; this index is the rule, that constraint is the upsert target.';
+
+-- ---------------------------------------------------------------------------
+-- 3. Correct a column COMMENT that describes an intention, not the product.
+-- ---------------------------------------------------------------------------
+-- jobs.payment_terms was documented as "editable on the job". No job UI writes
+-- it — grep of components/jobs and app/dashboard/[companyId]/jobs finds nothing,
+-- and createJobFromPO omits the column entirely. Today the only writers are
+-- quote conversion and that migration's own backfill, which means a job created
+-- directly from a customer PO reaches QuickBooks with no SalesTermRef at all.
+-- Stating that plainly is worth more than a comment that sends the next reader
+-- looking for a control that does not exist.
+COMMENT ON COLUMN public.jobs.payment_terms IS
+    'Payment terms this order was sold on, copied from the originating quote at conversion. Pushed to QuickBooks as SalesTermRef when the invoice is created. Distinct from customers.default_payment_terms (the standing agreement, which only seeds a NEW quote) — a job keeps what it was converted with. NOT currently editable on the job: quote conversion is the only writer, so a job created directly from a customer PO carries NULL and its invoice gets no SalesTermRef (QuickBooks then applies its own company default).';

--- a/supabase/schema.prod.sql
+++ b/supabase/schema.prod.sql
@@ -3957,6 +3957,7 @@ CREATE INDEX IF NOT EXISTS idx_companies_slug ON public.companies USING btree (s
 CREATE INDEX IF NOT EXISTS idx_customer_addresses_customer ON public.customer_addresses USING btree (customer_id);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_customer_addresses_one_default_billing ON public.customer_addresses USING btree (customer_id) WHERE default_billing;
 CREATE UNIQUE INDEX IF NOT EXISTS idx_customer_addresses_one_default_shipping ON public.customer_addresses USING btree (customer_id) WHERE default_shipping;
+CREATE UNIQUE INDEX IF NOT EXISTS customers_company_name_ci_unique ON public.customers USING btree (company_id, lower(btrim(name)));
 CREATE UNIQUE INDEX IF NOT EXISTS customer_contacts_one_primary ON public.customer_contacts USING btree (customer_id) WHERE (is_primary AND (deleted_at IS NULL));
 CREATE UNIQUE INDEX IF NOT EXISTS customer_contacts_one_billing_default ON public.customer_contacts USING btree (customer_id) WHERE (is_billing_default AND (deleted_at IS NULL));
 CREATE INDEX IF NOT EXISTS idx_customer_carrier_accounts_customer ON public.customer_carrier_accounts USING btree (customer_id) WHERE (deleted_at IS NULL);

--- a/types/customer.ts
+++ b/types/customer.ts
@@ -60,6 +60,15 @@ export interface Customer {
   credit_status: CustomerCreditStatus;
   /** Why they're on hold. Kept after a hold is lifted, as history for next time. */
   credit_hold_note: string | null;
+  /**
+   * Archive marker. Set by "Delete"; the row survives so every quote, job and
+   * shipment that references it keeps resolving.
+   *
+   * Carried on the type because a BY-ID read deliberately does not filter it —
+   * a quote or job links straight to the customer page, so that page can be
+   * showing an archived customer and needs to say so.
+   */
+  deleted_at: string | null;
   // created_at / updated_at have DEFAULT now() but no NOT NULL constraint —
   // mirror the DB shape. Consumers (e.g. the customer detail page) already
   // handle null via formatDate(string | null).

--- a/utils/customerAccess.ts
+++ b/utils/customerAccess.ts
@@ -4,15 +4,12 @@
 // CLAUDE.md "Typed Supabase client (incremental adoption)".
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import {
-  EMPTY_CUSTOMER_FORM,
   toCreditStatus,
   type Customer,
   type CustomerAddress,
   type CustomerFormData,
-  type CustomerFilter,
   type CustomerWithRelations,
   type CustomerWithAddresses,
-  type ImportResult,
 } from '@/types/customer';
 import type {
   CustomerContact,
@@ -20,15 +17,21 @@ import type {
   CustomerContactRole,
 } from '@/types/customerContact';
 import { createCustomerContact } from '@/utils/customerContactsAccess';
-import { orIlikeValue } from '@/utils/searchFilter';
+import { orIlikeValue, escapeIlikePattern } from '@/utils/searchFilter';
+import { toError } from '@/lib/supabaseErrors';
 
 /**
  * Customer access layer.
  *
- * Customer rows hold just identity (name, website). Contacts live in
- * customer_contacts and are managed via utils/customerContactsAccess.ts.
- * Addresses live in customer_addresses and are managed via
- * utils/customerAddressesAccess.ts.
+ * A customer row holds identity (name, website) plus the shop's standing
+ * commercial position on that customer: three default_* terms copied onto a NEW
+ * quote at create time, and a manual credit_status. Contacts, addresses and
+ * carrier accounts each live in their own table with their own access module.
+ *
+ * NAME IS THE IDENTITY, and identity ignores case and surrounding space — the
+ * DB agrees via customers_company_name_ci_unique. Every name lookup here is
+ * case-insensitive for that reason; a mix of .eq and .ilike across the layers is
+ * what produced two rows for one company (#653).
  *
  * createCustomer() optionally takes one initial contact, which is inserted
  * as the primary after the parent row is created — mirrors VendorForm's
@@ -69,66 +72,10 @@ function extractPrimaryContact(
 }
 
 /**
- * Get paginated list of customers for a company.
- * Joins customer_contacts (primary only) + customer_addresses so the AG Grid
- * list can render Contact and Location columns without per-row fetches.
- */
-export async function getCustomers(
-  companyId: string,
-  _filter: CustomerFilter = 'all',
-  search: string = '',
-  page: number = 1,
-  limit: number = 25,
-  sortField: string = 'name',
-  sortDirection: 'asc' | 'desc' = 'asc'
-): Promise<{ data: CustomerWithRelations[]; total: number }> {
-  const supabase = getSupabase();
-  const offset = (page - 1) * limit;
-
-  let query = supabase
-    .from('customers')
-    .select(
-      '*, addresses:customer_addresses(*), customer_contacts(id, name, role, email, phone, is_primary, is_billing_default, deleted_at)',
-      { count: 'exact' },
-    )
-    .eq('company_id', companyId)
-    .is('deleted_at', null)
-    .order(sortField, { ascending: sortDirection === 'asc' })
-    .range(offset, offset + limit - 1);
-
-  if (search.trim()) {
-    query = query.or(`name.ilike.${orIlikeValue(search)}`);
-  }
-
-  const { data, error, count } = await query;
-
-  if (error) {
-    console.error('Error fetching customers:', error);
-    throw error;
-  }
-
-  const rows = ((data || []) as (CustomerWithPrimaryContactRow & { addresses: CustomerAddress[] })[]).map((r) => ({
-    ...r,
-    // Narrowed explicitly rather than left to the row cast above: credit_status
-    // is enum-via-CHECK, so the generated types widen it to `string` and the
-    // cast would assert the union without anything checking it.
-    credit_status: toCreditStatus(r.credit_status),
-    addresses: r.addresses ?? [],
-    customer_contacts: r.customer_contacts ?? [],
-    primary_contact: extractPrimaryContact(r),
-    quotes_count: 0,
-    jobs_count: 0,
-  }));
-
-  return { data: rows, total: count || 0 };
-}
-
-/**
  * Get all customers for a company (no pagination).
  */
 export async function getAllCustomers(
   companyId: string,
-  _filter: CustomerFilter = 'all',
   search: string = '',
   sortField: string = 'name',
   sortDirection: 'asc' | 'desc' = 'asc'
@@ -249,11 +196,18 @@ export async function getCustomerWithRelations(
       .eq('customer_id', customerId),
   ]);
 
+  // A failed count THROWS. It used to be logged and reported as 0, which turned
+  // "we couldn't ask" into "this customer has no quotes and no jobs" — a
+  // definitive negative for a question that was never answered, against
+  // CLAUDE.md's rule that "couldn't check" is never "denied". It also reached
+  // the delete dialog, whose "Used on N quotes, M jobs — kept for history" line
+  // would then tell someone an in-use customer was unreferenced right as they
+  // decided whether to archive it.
   if (quotesRes.error) {
-    console.error('Error fetching quotes count:', quotesRes.error);
+    throw toError(quotesRes.error, "Couldn't load this customer's quote count.");
   }
   if (jobsRes.error) {
-    console.error('Error fetching jobs count:', jobsRes.error);
+    throw toError(jobsRes.error, "Couldn't load this customer's job count.");
   }
 
   const quotesCount = quotesRes.count;
@@ -292,7 +246,10 @@ export async function checkCustomerNameExists(
     .select('id')
     .eq('company_id', companyId)
     .is('deleted_at', null)
-    .ilike('name', name);
+    // Escaped: an unescaped pattern makes % and _ wildcards, so a customer
+    // called "Acme_Co" would report "Bacme1Co" as already existing and block a
+    // legitimate name.
+    .ilike('name', escapeIlikePattern(name));
 
   if (excludeId) {
     query = query.neq('id', excludeId);
@@ -392,11 +349,17 @@ async function reviveArchivedCustomerByName(
   const supabase = getSupabase();
   const name = formData.name.trim();
 
+  // CASE-INSENSITIVE, matching checkCustomerNameExists and the DB's
+  // customers_company_name_ci_unique index. It used to be .eq, and that
+  // disagreement is what let a duplicate through: archive "Acme Corp", create
+  // "acme corp", and this lookup found nothing, so the caller re-threw the
+  // 23505 as a genuine duplicate — or, before the CI index existed, never got
+  // a 23505 at all and simply inserted a second row for the same company.
   const { data: existing } = await supabase
     .from('customers')
     .select('id, deleted_at')
     .eq('company_id', companyId)
-    .eq('name', name)
+    .ilike('name', escapeIlikePattern(name))
     .maybeSingle();
 
   // No archived match (or the collision was with a live customer) → let the caller throw.
@@ -520,89 +483,6 @@ export async function bulkSoftDeleteCustomers(customerIds: string[]): Promise<vo
 }
 
 /**
- * Bulk import customers from CSV. Mapped CSV columns can populate the
- * customers row (name, website) and optionally a single contact row +
- * single address row per imported customer.
- *
- * NOTE: the FastAPI importer in api/routes/import_routes.py is the
- * primary path for production CSV import. This helper exists for
- * client-side imports / tests.
- */
-export async function bulkImportCustomers(
-  companyId: string,
-  rows: Array<CustomerFormData & {
-    contact?: CustomerContactFormData;
-    address?: CustomerAddress;
-  }>,
-): Promise<ImportResult> {
-  const results: ImportResult = { imported: 0, skipped: 0, errors: [] };
-  const supabase = getSupabase();
-
-  const { data: existing } = await supabase
-    .from('customers')
-    .select('name')
-    .eq('company_id', companyId);
-
-  const existingNames = new Set(
-    (existing || []).map((c: { name: string }) => c.name.toLowerCase()),
-  );
-  const importedNames = new Set<string>();
-
-  for (let i = 0; i < rows.length; i++) {
-    const row = rows[i];
-    const rowNum = i + 2;
-
-    if (!row.name?.trim()) {
-      results.errors.push({ row: rowNum, reason: 'Missing name' });
-      results.skipped++;
-      continue;
-    }
-
-    const nameKey = row.name.trim().toLowerCase();
-
-    if (existingNames.has(nameKey)) {
-      results.errors.push({
-        row: rowNum,
-        reason: `Customer name "${row.name}" already exists`,
-      });
-      results.skipped++;
-      continue;
-    }
-
-    if (importedNames.has(nameKey)) {
-      results.errors.push({
-        row: rowNum,
-        reason: `Duplicate customer name "${row.name}" in file`,
-      });
-      results.skipped++;
-      continue;
-    }
-
-    try {
-      await createCustomer(
-        companyId,
-        // Standing terms aren't part of this legacy client-side CSV shape —
-        // the backend importer (api/routes/import_routes.py) owns the mapped
-        // fields. Defaults stay unset rather than being invented per row.
-        { ...EMPTY_CUSTOMER_FORM, name: row.name.trim(), website: row.website ?? '' },
-        row.contact,
-      );
-      results.imported++;
-      importedNames.add(nameKey);
-      existingNames.add(nameKey);
-    } catch (err) {
-      results.errors.push({
-        row: rowNum,
-        reason: err instanceof Error ? err.message : 'insert failed',
-      });
-      results.skipped++;
-    }
-  }
-
-  return results;
-}
-
-/**
  * Return the address tagged default_billing for the customer. When no address
  * is flagged but the customer has exactly one address, that lone address is
  * unambiguously the default and is returned — so single-address customers
@@ -703,7 +583,21 @@ export function hasTermDrift(
 ): boolean {
   const std = customerDefault?.trim();
   if (!std) return false;
-  return (quoteValue ?? '').trim().toLowerCase() !== std.toLowerCase();
+  const onQuote = (quoteValue ?? '').trim();
+  // A quote that states NOTHING is not drifting — it is silent. It promised no
+  // terms, so there is no disagreement between what we offered and what we now
+  // say, and the chip has nothing to report.
+  //
+  // This used to return true here, and the cost was a chip storm: quotes.fob_point
+  // is newer than the quotes themselves, so every pre-existing quote carries
+  // NULL, and the first time a shop filled in a customer's FOB point every one
+  // of that customer's open quotes grew a "FOB differs" chip at once. Same for
+  // payment terms and lead time the first time a shop fills those in. The
+  // comment on the drift block one level up already names this failure for the
+  // shop-default case — "a chip that fires on everything at once is a chip
+  // people learn to ignore" — and it applies identically here.
+  if (!onQuote) return false;
+  return onQuote.toLowerCase() !== std.toLowerCase();
 }
 
 // Helper re-exports so older callers that imported types from this file


### PR DESCRIPTION
Closes #653. Also records the decision to **drop Phases 4 and 5** of the CRM plan.

None of these came from a bug report — they came from reading every claim the rewritten module doc was about to make.

## Two ways to duplicate a customer

Same root cause from opposite directions: **three layers disagreed about whether a name is case-sensitive.**

| Layer | Behaviour |
|---|---|
| `customers_company_name_unique (company_id, name)` | case-**sensitive** |
| `checkCustomerNameExists` (`.ilike`) | case-**insensitive** |
| `reviveArchivedCustomerByName` (`.eq`) | case-**sensitive** |

Archive "Acme Corp", create "acme corp": the pre-check finds nothing (it only looks at live rows), the insert doesn't collide, no `23505` fires, the revive never runs, and **a second row appears for the same company**. The CSV importer gets there from the other side — it decided `is_new` on a lowercased name but upserted on the case-sensitive constraint, so the row was counted as an update, denied its contact and address, and inserted anyway.

Both lookups are now case-insensitive, and the importer rewrites the payload to the **stored** spelling so the upsert lands on the row it meant to update. Consequence worth naming: a re-import can no longer re-case a customer. That's the right trade — a silent duplicate of the entity every quote, job and invoice hangs off beats a capitalisation fix they can make on the customer page.

`customers_company_name_ci_unique` on `(company_id, lower(btrim(name)))` makes the DB the authority. The plain constraint stays beside it because the importer upserts with `on_conflict="company_id,name"` and PostgREST cannot name an expression index — one is the rule, the other is the upsert target.

**Verified on a replayed DB**, not assumed:

```
'acme corp'      -> ERROR: duplicate key ... customers_company_name_ci_unique
'  ACME CORP  '  -> ERROR: duplicate key ...
'Acme Corporation' -> INSERT 0 1
```

**The de-dup backfill renames, it does not merge.** Merging customers means re-pointing quotes, jobs, shipments, addresses and contacts and choosing which history wins; this module refuses merge tooling on purpose. Live beats archived, then oldest wins (the oldest is already frozen onto the most documents), and losers get their own id appended so it reads as something that happened *to* the data. Verified against a seeded three-way collision:

```
before: widget co (archived) | Widget Co | WIDGET CO
after:  widget co [325282ee] | Widget Co | WIDGET CO [03c1a280]
```

## A failed count rendered as a definitive zero

`getCustomerWithRelations` logged a failed quotes/jobs count and reported `0` — turning *"we couldn't ask"* into *"this customer has no quotes and no jobs"*. It also fed the delete dialog, so a dropped request told someone an in-use customer was unreferenced **at the moment they decided whether to archive it**. It throws now.

## A chip that fires on everything at once

`hasTermDrift` reported drift when the quote stated nothing and the customer had a value. `quotes.fob_point` is newer than the quotes, so every pre-existing quote holds NULL — and the first time a shop filled in one customer's FOB point, every open quote for that customer chipped.

A quote that states nothing never promised terms. The test asserting the old behaviour is **reversed deliberately**, with the reasoning recorded: the drift block one level up already warns about exactly this failure for the shop-default case.

## The rest

- Three list columns are read off the embedded primary contact and aren't DB columns, but were left sortable — clicking those headers sent PostgREST a column that doesn't exist.
- An archived customer's page now says so. It's reachable by an ordinary click from any quote or job, and looked completely live, Edit and Delete included.
- `ShipmentForm` in customer mode never fetched carrier accounts, so a shipment created from the customer surface **always saved NULL freight** — even for a customer whose whole arrangement is billing to their own account.
- Removed `bulkImportCustomers` (no callers, discarded standing terms, and **blocked** on an existing name instead of reviving — semantics opposite to the live importer), `getCustomers` (no callers), and the dead `_filter` argument.
- Corrected the access-layer docblock and issued a new `COMMENT` for `jobs.payment_terms`, which claimed to be "editable on the job" when no job UI writes it.

## Phases 4 and 5 are dropped

Recorded in the module doc under *Explicitly not built*, so they're a decision rather than a backlog item that quietly returns. Phase 4's typed-notes half has **negative** evidence (E2's customer comments went entirely unused at the pilot shop) and its attachments half has none; Phase 5 is chrome for a page nobody has said is hard to use. If either returns, it should return with a shop asking for it.

## Worth knowing

`tsconfig.json` **excludes `__tests__`**, so a fixture that drifts from its type does not fail `tsc`. Found while adding `deleted_at` to `Customer`.

## Verification

tsc clean · **1643** Vitest · **245** pytest · lint at baseline. The identity index and the backfill were both exercised against a replayed database (output above).

**Manual, on the preview branch:**

- [ ] Archive a customer, then create the same name in **different case** → revives the archived row, does not create a second.
- [ ] Import a CSV whose customer name differs only in case from an existing one → counted as updated, no new row.
- [ ] Open an archived customer from a quote link → the page shows an **Archived** chip and explains it.
- [ ] Set a customer's FOB point for the first time → **no** drift chips appear on their older quotes.
- [ ] Create a shipment from the customer surface for a customer with a carrier account → the freight panel resolves.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)