### PR TITLE
feat(nav): make the shop floor a real door, not a buried button

### DIFF
--- a/__tests__/components/auth/CompanySelector.test.tsx
+++ b/__tests__/components/auth/CompanySelector.test.tsx
@@ -13,6 +13,11 @@ const setLastCompany = vi.fn();
 vi.mock('@/utils/companyAccess', () => ({
   getUserCompanies: (...args: unknown[]) => getUserCompanies(...args),
   setLastCompany: (...args: unknown[]) => setLastCompany(...args),
+  // Real one-liner rather than a vi.fn(), so these tests assert the destination the
+  // component actually navigates to. The function's own edge cases live in
+  // __tests__/utils/homePathForRole.test.ts.
+  homePathForRole: (role: string | null | undefined, companyId: string) =>
+    role === 'operator' ? `/operator/${companyId}` : `/dashboard/${companyId}`,
 }));
 
 vi.mock('@sentry/nextjs', () => ({
@@ -77,6 +82,23 @@ describe('CompanySelector', () => {
     await waitFor(() => {
       expect(setLastCompany).toHaveBeenCalledWith('user-1', 'co-a');
       expect(routerMocks.push).toHaveBeenCalledWith('/dashboard/co-a');
+    });
+  });
+
+  // A multi-company operator used to be pushed to /dashboard and then bounced back out
+  // by AuthGuard. It worked, but it cost a round trip and a flash on the way in.
+  it('sends an operator straight to the shop floor, not through the dashboard', async () => {
+    getUserCompanies.mockResolvedValueOnce([
+      { user_id: 'user-1', company_id: 'co-a', role: 'operator', companies: { id: 'co-a', name: 'Acme Corp' } },
+      { user_id: 'user-1', company_id: 'co-b', role: 'user', companies: { id: 'co-b', name: 'Beta LLC' } },
+    ]);
+    render(<CompanySelector />);
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByText('Acme Corp'));
+
+    await waitFor(() => {
+      expect(routerMocks.push).toHaveBeenCalledWith('/operator/co-a');
     });
   });
 

--- a/__tests__/components/layout/Header.test.tsx
+++ b/__tests__/components/layout/Header.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '../../test-utils';
+import Header from '@/components/layout/Header';
+
+const mockSignOut = vi.fn();
+vi.mock('@/components/providers/AuthProvider', () => ({
+  useAuth: () => ({
+    user: { id: 'u1', user_metadata: { first_name: 'Shane' } },
+    signOut: mockSignOut,
+  }),
+}));
+
+const mockUseDemoMode = vi.fn();
+vi.mock('@/components/providers/DemoModeProvider', () => ({
+  useDemoMode: () => mockUseDemoMode(),
+}));
+
+vi.mock('@/components/layout/PageTitleProvider', () => ({
+  usePageTitle: () => ({ title: null }),
+}));
+
+describe('Header', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false });
+  });
+
+  // This control is the reason the whole entry-point change exists: on a phone the
+  // sidebar is behind a hamburger, so the header is the only always-visible office
+  // chrome — and a phone is where an owner-operator reaches for the shop floor.
+  it('offers a labelled way to the shop floor', () => {
+    render(<Header />);
+
+    const shopFloor = screen.getByRole('link', { name: /shop floor/i });
+    expect(shopFloor).toHaveAttribute('href', '/operator/test-company-id');
+  });
+
+  it('keeps the shop-floor door visible on a phone, where the sidebar is hidden', () => {
+    render(<Header isMobile />);
+
+    // Labelled at both sizes on purpose. Sign Out collapses to an icon on mobile; this
+    // one must not, because an unlabelled icon assumes the viewer already knows the app
+    // has two surfaces, which is exactly what they don't know.
+    expect(screen.getByRole('link', { name: /shop floor/i })).toBeInTheDocument();
+  });
+
+  it('still renders the page title and sign out', () => {
+    render(<Header />);
+
+    expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument();
+  });
+
+  // The bell that used to sit in this slot was removed in August 2026 — at-risk jobs
+  // were measured wrong and low stock is the parts shortage lens. Pinned so it doesn't
+  // come back by habit.
+  it('has no alerts bell', () => {
+    render(<Header />);
+
+    expect(screen.queryByRole('button', { name: /alert/i })).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/layout/Sidebar.test.tsx
+++ b/__tests__/components/layout/Sidebar.test.tsx
@@ -61,6 +61,29 @@ describe('Sidebar', () => {
     expect(screen.queryByText('Operations')).not.toBeInTheDocument();
   });
 
+  // The Shop floor item is the only one that points off the /dashboard surface, so the
+  // href is the assertion that matters — a regression would silently send people to
+  // /dashboard/{id} (a page that exists), not to a 404 anyone would notice.
+  it('links Shop floor to the operator surface, not a dashboard sub-path', () => {
+    mockUseUserRole.mockReturnValue({ role: 'admin', isAdmin: true, loading: false });
+
+    render(<Sidebar />);
+
+    const shopFloor = screen.getByRole('link', { name: /shop floor/i });
+    expect(shopFloor).toHaveAttribute('href', '/operator/test-company-id');
+  });
+
+  it('keeps Dashboard on the office surface even though both have an empty path', () => {
+    mockUseUserRole.mockReturnValue({ role: 'admin', isAdmin: true, loading: false });
+
+    render(<Sidebar />);
+
+    expect(screen.getByRole('link', { name: /^dashboard$/i })).toHaveAttribute(
+      'href',
+      '/dashboard/test-company-id',
+    );
+  });
+
   it('hides Storage when the locations flag is off — such a shop has no places at all', () => {
     mockUseUserRole.mockReturnValue({ role: 'admin', isAdmin: true, loading: false });
     mockUseCompanyFeatures.mockReturnValue({

--- a/__tests__/components/layout/Sidebar.test.tsx
+++ b/__tests__/components/layout/Sidebar.test.tsx
@@ -61,23 +61,15 @@ describe('Sidebar', () => {
     expect(screen.queryByText('Operations')).not.toBeInTheDocument();
   });
 
-  // The Shop floor item is the only one that points off the /dashboard surface, so the
-  // href is the assertion that matters — a regression would silently send people to
-  // /dashboard/{id} (a page that exists), not to a 404 anyone would notice.
-  it('links Shop floor to the operator surface, not a dashboard sub-path', () => {
+  // The sidebar is office navigation only. The way to the shop floor is the labelled
+  // button in the Header, which reaches every page at every width — this one wouldn't,
+  // since the sidebar is behind a hamburger on a phone. See Header.test.tsx.
+  it('does not duplicate the Header shop-floor door', () => {
     mockUseUserRole.mockReturnValue({ role: 'admin', isAdmin: true, loading: false });
 
     render(<Sidebar />);
 
-    const shopFloor = screen.getByRole('link', { name: /shop floor/i });
-    expect(shopFloor).toHaveAttribute('href', '/operator/test-company-id');
-  });
-
-  it('keeps Dashboard on the office surface even though both have an empty path', () => {
-    mockUseUserRole.mockReturnValue({ role: 'admin', isAdmin: true, loading: false });
-
-    render(<Sidebar />);
-
+    expect(screen.queryByText(/shop floor/i)).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: /^dashboard$/i })).toHaveAttribute(
       'href',
       '/dashboard/test-company-id',

--- a/__tests__/utils/homePathForRole.test.ts
+++ b/__tests__/utils/homePathForRole.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// `homePathForRole` is pure, but it lives in companyAccess.ts alongside the query
+// helpers — and lib/supabase.ts builds a browser client at module scope, which throws
+// without env vars. Same stub every other utils test uses.
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => ({}),
+  getTypedSupabase: () => ({}),
+}));
+
+import { homePathForRole } from '@/utils/companyAccess';
+
+/**
+ * Small function, but it is now the single source of truth for four call sites
+ * (post-login, /launch, the company selector, invite acceptance). Three of those
+ * used to hardcode /dashboard and lean on the AuthGuard bounce to correct it, so
+ * the thing worth pinning is that an operator never gets sent to the office.
+ */
+describe('homePathForRole', () => {
+  const companyId = 'c0ffee00-0000-4000-8000-000000000000';
+
+  it('sends operators to the shop floor', () => {
+    expect(homePathForRole('operator', companyId)).toBe(`/operator/${companyId}`);
+  });
+
+  it('sends admins and users to the office', () => {
+    expect(homePathForRole('admin', companyId)).toBe(`/dashboard/${companyId}`);
+    expect(homePathForRole('user', companyId)).toBe(`/dashboard/${companyId}`);
+  });
+
+  // An unknown or absent role must not resolve to the shop floor: the operator view
+  // has no company-management surface at all, so guessing wrong in that direction
+  // strands the person. The office has its own guards to correct an over-grant.
+  it('defaults to the office when the role is unknown, null or undefined', () => {
+    expect(homePathForRole(null, companyId)).toBe(`/dashboard/${companyId}`);
+    expect(homePathForRole(undefined, companyId)).toBe(`/dashboard/${companyId}`);
+    expect(homePathForRole('something-new', companyId)).toBe(`/dashboard/${companyId}`);
+  });
+});

--- a/app/accept-invite/[invitationId]/page.tsx
+++ b/app/accept-invite/[invitationId]/page.tsx
@@ -18,7 +18,7 @@ import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import posthog from 'posthog-js';
 import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
 import { getSupabase } from '@/lib/supabase';
-import { setLastCompany } from '@/utils/companyAccess';
+import { setLastCompany, homePathForRole } from '@/utils/companyAccess';
 import { getEdgeFunctionUrl } from '@/lib/supabase';
 import { AuthLayout } from '@/components/auth';
 import type { Invitation } from '@/types/team';
@@ -145,8 +145,9 @@ export default function AcceptInvitePage() {
     // Check if invitation is still valid
     if (inv.status !== 'pending') {
       if (inv.status === 'accepted') {
-        // Already accepted — just redirect to dashboard
-        router.replace(`/dashboard/${inv.company_id}`);
+        // Already accepted — send them to their home surface, which for an operator
+        // is the shop floor rather than a dashboard they'd be bounced straight out of.
+        router.replace(homePathForRole(inv.role, inv.company_id));
         return;
       }
       setError(`This invitation has been ${inv.status}. Please contact your admin for a new invitation.`);
@@ -273,8 +274,9 @@ export default function AcceptInvitePage() {
       posthog.identify(userId, { email: invitation.email });
       posthog.capture('invitation_accepted', { role: invitation.role });
 
-      // Redirect to dashboard
-      router.replace(`/dashboard/${companyId}`);
+      // Straight to the surface the invited role actually works on. A new operator's
+      // very first screen used to be a dashboard flash before AuthGuard corrected it.
+      router.replace(homePathForRole(invitation.role, companyId));
     } catch (err) {
       console.error('Error accepting invitation:', err);
       setError(err instanceof Error ? err.message : 'Failed to accept invitation');

--- a/app/dashboard/[companyId]/jobs/page.tsx
+++ b/app/dashboard/[companyId]/jobs/page.tsx
@@ -62,7 +62,6 @@ import {
 import Tooltip from '@mui/material/Tooltip';
 import ScheduleIcon from '@mui/icons-material/Schedule';
 import AddIcon from '@mui/icons-material/Add';
-import PrecisionManufacturingIcon from '@mui/icons-material/PrecisionManufacturing';
 import AcceptPurchaseOrderModal from '@/components/jobs/AcceptPurchaseOrderModal';
 import JobHotBadge from '@/components/jobs/JobHotBadge';
 import type { JobWithRelations, JobFilters, JobLifecycleStage } from '@/types/job';
@@ -704,16 +703,6 @@ export default function JobsPage() {
         )}
 
         <Box sx={{ flex: 1 }} />
-
-        {/* Open the shop-floor (operator) view to watch/monitor jobs live. The
-            operator shell has a matching Dashboard icon to return. */}
-        <Button
-          variant="outlined"
-          startIcon={<PrecisionManufacturingIcon />}
-          onClick={() => router.push(`/operator/${companyId}`)}
-        >
-          Shop floor view
-        </Button>
 
         <Button
           variant="contained"

--- a/app/launch/page.tsx
+++ b/app/launch/page.tsx
@@ -1,0 +1,85 @@
+import { redirect } from 'next/navigation';
+import { createClient } from '@/utils/supabase/server';
+import { homePathForRole } from '@/utils/companyAccess';
+
+/**
+ * The manifest's `start_url` — where a home-screen icon lands.
+ *
+ * ## Why this route exists
+ *
+ * `start_url` used to be `/`, which is the marketing landing page. iOS honours the
+ * manifest's `start_url` over whichever page the user was on when they tapped Add to
+ * Home Screen, so *every* installed icon opened marketing — including the ones added
+ * from the shop-floor view on purpose. For a signed-in visitor that page renders
+ * `null` while a `useEffect` resolves the destination, so the sequence was: blank
+ * screen, then four sequential Supabase round trips (`getPostLoginRoute` →
+ * `getUserCompanies` → `verifyCompanyAccess` → `getUserRole`) before anything painted.
+ * On a phone on shop wifi that is the slowest path in the product, handed to the one
+ * user who most needs the fastest.
+ *
+ * Resolving it here instead means the redirect is decided from the session cookie
+ * *before the first byte of HTML*, so there is no blank frame and no client round
+ * trip. That is the whole point, and it is why this is a Server Component rather than
+ * a page with an effect.
+ *
+ * ## Why it does not look at the device
+ *
+ * A pre-paint server decision cannot see viewport width, and that is a feature rather
+ * than a limitation. The tempting rule — "phone means shop floor" — is wrong for the
+ * salesperson on a 390px phone at a trade show who needs quotes, and unknowable for
+ * iPadOS (desktop UA) or a folding phone. Role is the only signal that is actually
+ * about the person, so role is what this uses; the visible **Shop floor** control in
+ * the sidebar and header covers the rest.
+ *
+ * Deliberately no `setLastCompany` write: this is a router and every extra query is
+ * paid before first paint. `AuthGuard` already records it on arrival.
+ */
+export default async function Launch() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  const { data, error } = await supabase
+    .from('user_company_access')
+    .select('company_id, role, companies(is_demo)')
+    .eq('user_id', user.id);
+
+  // Couldn't read the membership — that is not the same as "no access", so don't
+  // send anyone to /no-access over it. Fall through to `/`, which resolves the same
+  // decision on the client with its own retry path. Slower, but it was the behaviour
+  // before this route existed, so a blip degrades to the old path rather than to a
+  // wrong answer.
+  if (error) {
+    redirect('/');
+  }
+
+  // Demo companies never appear in company lists (mirrors `getUserCompanies`).
+  const companies = (data ?? []).filter((c) => !c.companies?.is_demo);
+
+  if (companies.length === 0) {
+    redirect('/no-access');
+  }
+
+  if (companies.length === 1) {
+    redirect(homePathForRole(companies[0].role, companies[0].company_id));
+  }
+
+  const { data: prefs } = await supabase
+    .from('user_preferences')
+    .select('last_company_id')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  const last = companies.find((c) => c.company_id === prefs?.last_company_id);
+  if (last) {
+    redirect(homePathForRole(last.role, last.company_id));
+  }
+
+  redirect('/select-company');
+}

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -6,25 +6,43 @@ import type { MetadataRoute } from 'next';
  * ## `display: 'browser'` is the load-bearing line, and it is deliberate
  *
  * `docs/modules/inventory.md` §5.10 records why an installed app must NOT run standalone yet: iOS
- * **does not persist camera permission for a standalone PWA** and Safari re-prompts on route
- * navigation at the same origin ([WebKit #185448]), which would make the in-app location scanner
- * ask again on every screen. A scanner that re-asks permission constantly is worse than tapping a
- * banner.
+ * **does not persist camera permission for a standalone PWA**, which would make the in-app location
+ * scanner ask again on every screen. A scanner that re-asks permission constantly is worse than
+ * tapping a banner.
  *
  * §5.10's stated hedge was "drop `apple-mobile-web-app-capable` so the icon opens in Safari". **That
  * advice is obsolete.** Since iOS 16.4 Safari honours *this* manifest's `display` member for Add to
  * Home Screen, and the meta tag is the legacy mechanism it superseded — so omitting the tag while
  * setting `display: 'standalone'` would install standalone anyway and walk straight into the bug.
- * iOS also treats `standalone`, `fullscreen` and `minimal-ui` alike; **`browser` is the only value
- * that keeps the icon opening in Safari.**
+ * iOS also treats `standalone`, `fullscreen` and `minimal-ui` alike.
  *
- * So flipping this to `'standalone'` is the concrete deliverable of §5.10's spike, not a tidy-up:
- * the spike's question is *"does camera permission persist across navigations in standalone mode on
- * current iOS?"*, and this line is what it gates. Answer it on the shop's actual handsets first.
+ * ### Three corrections to the paragraph above, recorded 2026-08-02
  *
- * (Android has no such problem, and would tolerate standalone. This is a route handler, so it
- * *could* branch on user-agent — deliberately not done, because a UA-sniffing manifest is hard to
- * test and easy to get subtly wrong for one line of benefit.)
+ * 1. **The bug this cites by number is the wrong one.** WebKit #185448 was RESOLVED FIXED in iOS
+ *    13.4. The live issue is the separate permission-*persistence* one, still open, with nothing
+ *    announced through Safari 27 beta. The concern is real; the citation was stale.
+ * 2. **`display: 'browser'` no longer opts out on iOS 26+.** WebKit removed installability
+ *    requirements entirely — "Open as Web App" defaults ON and the manifest cannot turn it off. So
+ *    `navigator.standalone` is now true for some users and false for others on this same manifest,
+ *    differing only by iOS version. **Never route on it.** It also means the camera defence is
+ *    already partly lost on new handsets.
+ * 3. **This value is not free.** Chrome's installability check requires `standalone`, `fullscreen`
+ *    or `minimal-ui`, so `browser` costs Android installability *entirely* — no install prompt, no
+ *    WebAPK, only a plain bookmark.
+ *
+ * There is also a stronger argument for `browser` than the camera one, which §5.10 never made: on
+ * iOS a standalone home-screen web app has a **cookie jar separate from Safari**, and since iOS 14
+ * the Camera app opens the *default* browser. Our session lives in cookies. Flip to standalone and
+ * the icon is one session while every scanned traveler QR is another — the zero-tap traveler path
+ * starts demanding a password.
+ *
+ * So flipping this to `'standalone'` remains the deliverable of §5.10's spike, not a tidy-up — but
+ * the spike now has two questions, not one: does camera permission persist, *and* does the QR path
+ * survive the session split. Answer both on the shop's actual handsets first.
+ *
+ * (Android has no such problem. This is a route handler, so it *could* branch on user-agent —
+ * deliberately not done, because a UA-sniffing manifest is hard to test and easy to get subtly
+ * wrong for one line of benefit.)
  */
 export default function manifest(): MetadataRoute.Manifest {
   return {
@@ -34,9 +52,16 @@ export default function manifest(): MetadataRoute.Manifest {
       'Jobs, inventory and shop-floor status for small precision manufacturing shops.',
     // See the note above before changing this.
     display: 'browser',
-    // The operator surface is where a home-screen icon earns its place: it's the only part of the
-    // app designed for a phone, and it's what a scanned QR label opens.
-    start_url: '/',
+    // `/launch` resolves the session server-side and redirects to the member's home before the
+    // first paint. It must NOT be `/` — that is the marketing page, and iOS honours start_url over
+    // whatever page the user installed from, so `/` meant every icon opened marketing and then
+    // resolved the destination on the client. See app/launch/page.tsx.
+    start_url: '/launch',
+    // `id` defaults to `start_url`, so leaving it implicit means any future change to start_url
+    // silently orphans every existing install (the icon becomes a dead app, and a reinstall is a
+    // *different* app). Pinning it to '/' keeps the identity stable — including across the
+    // start_url change above, which is why it is '/' and not '/launch'. Never change this value.
+    id: '/',
     scope: '/',
     background_color: '#111439', // theme.palette.background.default
     theme_color: '#111439',

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -7,6 +7,7 @@ import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
+import Button from '@mui/material/Button';
 import BottomNavigation from '@mui/material/BottomNavigation';
 import BottomNavigationAction from '@mui/material/BottomNavigationAction';
 import Paper from '@mui/material/Paper';
@@ -440,18 +441,24 @@ function OperatorShell({
             )}
           </Box>
 
-          {/* Right: dashboard shortcut for non-operators (admins/leads viewing
-              the operator view). */}
+          {/* Right: the way back to the office, for non-operators (owners/leads who
+              are also admins) viewing the shop floor.
+
+              Labelled, not an icon. A bare dashboard glyph asks the viewer to already
+              know that this app has two surfaces and that this square is the door to
+              the other one — and our audience skews 50-60, where icon recognition is
+              measurably worse. "Office" is the word a shop already uses, and it pairs
+              with "Shop floor" on the way in. */}
           {userRole !== 'operator' && (
-            <IconButton
+            <Button
               color="inherit"
-              onClick={() => router.push(`/dashboard/${companyId}`)}
-              aria-label="Go to dashboard"
               size="small"
-              sx={{ ml: 0.5 }}
+              startIcon={<DashboardIcon fontSize="small" />}
+              onClick={() => router.push(`/dashboard/${companyId}`)}
+              sx={{ ml: 0.5, textTransform: 'none', flexShrink: 0 }}
             >
-              <DashboardIcon fontSize="small" />
-            </IconButton>
+              Office
+            </Button>
           )}
 
           {/*

--- a/components/auth/CompanySelector.tsx
+++ b/components/auth/CompanySelector.tsx
@@ -16,7 +16,12 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Box from '@mui/material/Box';
 import BusinessIcon from '@mui/icons-material/Business';
 import { useAuth } from '@/components/providers/AuthProvider';
-import { getUserCompanies, setLastCompany, UserCompanyAccess } from '@/utils/companyAccess';
+import {
+  getUserCompanies,
+  setLastCompany,
+  homePathForRole,
+  UserCompanyAccess,
+} from '@/utils/companyAccess';
 
 export default function CompanySelector() {
   const router = useRouter();
@@ -49,12 +54,18 @@ export default function CompanySelector() {
     fetchCompanies();
   }, [user, router]);
 
-  const handleCompanySelect = async (companyId: string) => {
+  const handleCompanySelect = async (company: UserCompanyAccess) => {
     if (!user) return;
+
+    const { company_id: companyId, role } = company;
 
     try {
       await setLastCompany(user.id, companyId);
-      router.push(`/dashboard/${companyId}`);
+      // Role-aware, so an operator with more than one company goes straight to the shop
+      // floor. This used to push /dashboard unconditionally and rely on AuthGuard to
+      // bounce them back out — it worked, but it cost a round trip and a visible flash
+      // on one of the two screens that shape a new user's first impression.
+      router.push(homePathForRole(role, companyId));
     } catch (err) {
       console.error('Error setting last company:', err);
       Sentry.captureException(err);
@@ -100,7 +111,7 @@ export default function CompanySelector() {
             <Box key={company.company_id}>
               {index > 0 && <Divider />}
               <ListItemButton
-                onClick={() => handleCompanySelect(company.company_id)}
+                onClick={() => handleCompanySelect(company)}
                 sx={{ py: 2 }}
               >
                 <ListItemIcon>

--- a/components/auth/Login.tsx
+++ b/components/auth/Login.tsx
@@ -34,7 +34,11 @@ interface LoginProps {
 function isValidReturnTo(path: string): boolean {
   try {
     const normalized = new URL(path, window.location.origin);
-    const allowedPrefixes = ['/dashboard', '/accept-invite'];
+    // `/operator` belongs here: without it a session expiry on the shop floor has its
+    // returnTo silently rejected and the operator is dropped in the office — which for
+    // a role='operator' user means an immediate AuthGuard bounce back out. It also broke
+    // the scanned-traveler-QR path, which deep-links into /operator/{id}/login.
+    const allowedPrefixes = ['/dashboard', '/operator', '/accept-invite'];
     return allowedPrefixes.some(p => normalized.pathname.startsWith(p)) && normalized.origin === window.location.origin;
   } catch {
     return false;

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useRouter, usePathname } from 'next/navigation';
+import Link from 'next/link';
+import { useRouter, usePathname, useParams } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
@@ -8,6 +9,7 @@ import IconButton from '@mui/material/IconButton';
 import StatusChip from '@/components/common/StatusChip';
 import LogoutIcon from '@mui/icons-material/Logout';
 import MenuIcon from '@mui/icons-material/Menu';
+import PrecisionManufacturingIcon from '@mui/icons-material/PrecisionManufacturing';
 import { useAuth } from '@/components/providers/AuthProvider';
 import { useDemoMode } from '@/components/providers/DemoModeProvider';
 import { usePageTitle } from './PageTitleProvider';
@@ -148,6 +150,8 @@ interface HeaderProps {
 export default function Header({ isMobile = false, onMenuClick }: HeaderProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const params = useParams();
+  const companyId = params.companyId as string | undefined;
   const { signOut, user } = useAuth();
   const firstName = user?.user_metadata?.first_name;
   const { isDemoMode } = useDemoMode();
@@ -179,17 +183,26 @@ export default function Header({ isMobile = false, onMenuClick }: HeaderProps) {
         zIndex: 1100,
       }}
     >
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+      {/* `minWidth: 0` lets this cluster shrink below its content width, which is what
+          allows the title to truncate instead of shoving the controls on the right off
+          the edge. Titles run long ("Work Center Details") and the right side gained a
+          second control, so on a 375px phone the two sides genuinely compete. */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, minWidth: 0 }}>
         {isMobile && (
           <IconButton
             onClick={onMenuClick}
-            sx={{ color: 'white', mr: 0.5 }}
+            sx={{ color: 'white', mr: 0.5, flexShrink: 0 }}
             aria-label="Open navigation menu"
           >
             <MenuIcon />
           </IconButton>
         )}
-        <Typography variant="h5" component="h1" sx={{ fontWeight: 600, color: 'white' }}>
+        <Typography
+          variant="h5"
+          component="h1"
+          noWrap
+          sx={{ fontWeight: 600, color: 'white', minWidth: 0 }}
+        >
           {pageTitle}
         </Typography>
         {isDemoMode && (
@@ -200,7 +213,7 @@ export default function Header({ isMobile = false, onMenuClick }: HeaderProps) {
           />
         )}
       </Box>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexShrink: 0 }}>
         {!isMobile && firstName && (
           <Typography
             variant="body2"
@@ -208,6 +221,34 @@ export default function Header({ isMobile = false, onMenuClick }: HeaderProps) {
           >
             Welcome, {firstName}
           </Typography>
+        )}
+        {/* The way to the shop floor, from every office page.
+
+            The sidebar carries the same destination, but on a phone the sidebar is
+            behind a hamburger — and a phone is exactly where an owner-operator reaches
+            for the shop floor. So this is the control that actually solves the problem;
+            the sidebar item is its desktop counterpart. Kept labelled at both sizes:
+            an unlabelled icon here asks the viewer to already know the app has two
+            surfaces, which is the thing they don't know. */}
+        {companyId && (
+          <Button
+            component={Link}
+            href={`/operator/${companyId}`}
+            size={isMobile ? 'small' : 'medium'}
+            startIcon={<PrecisionManufacturingIcon />}
+            sx={{
+              color: 'rgba(255, 255, 255, 0.7)',
+              textTransform: 'none',
+              flexShrink: 0,
+              whiteSpace: 'nowrap',
+              '&:hover': {
+                bgcolor: 'rgba(70, 130, 180, 0.16)',
+                color: 'white',
+              },
+            }}
+          >
+            Shop floor
+          </Button>
         )}
         {isMobile ? (
           <IconButton

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -34,13 +34,6 @@ interface MenuItem {
   name: string;
   path: string;
   icon: typeof DashboardIcon;
-  /**
-   * Which top-level surface the item lives on. Defaults to the office
-   * (`/dashboard/{companyId}`); `'operator'` points at the shop floor instead.
-   * Only **Shop floor** uses it — but the alternative was a one-off `absolute`
-   * flag whose handling would have hardcoded the operator path in the renderer.
-   */
-  surface?: 'dashboard' | 'operator';
   adminOnly?: boolean;
   /**
    * When set, the item only renders if the named feature flag is on for
@@ -53,14 +46,10 @@ interface MenuItem {
 
 const menuItems: MenuItem[] = [
   { name: 'Dashboard', path: '', icon: DashboardIcon },
-  // The shop floor is a destination of equal rank to the dashboard, not a section of it —
-  // which is why it sits second rather than filed among the data sections below. Until now
-  // the only way in was one outlined button in the toolbar of the jobs *list* page, so an
-  // owner-operator reaching for it on their phone had to know it was there. Every product
-  // that solves this well (Deputy, Homebase, Procore) makes the frontline surface permanent
-  // nav rather than a mode toggle. No role gate: the sidebar is office chrome, and AuthGuard
-  // bounces operators off /dashboard/* before it ever renders for them.
-  { name: 'Shop floor', path: '', surface: 'operator', icon: PrecisionManufacturingIcon },
+  // No **Shop floor** entry here on purpose. The labelled Shop floor button in the
+  // Header covers every office page at every width, including a phone — where this
+  // sidebar is behind a hamburger and so can't help. A second copy of one destination
+  // would add no reach, only a duplicate label on the same screen.
   { name: 'Activity', path: '/activity', icon: DynamicFeedIcon },
   { name: 'Jobs', path: '/jobs', icon: WorkIcon },
   { name: 'Quotes', path: '/quotes', icon: RequestQuoteIcon },
@@ -99,6 +88,7 @@ export default function Sidebar({ isMobile, open, onClose, onFeedbackClick }: Si
   const pathname = usePathname();
   const params = useParams();
   const companyId = params.companyId as string;
+  const basePath = `/dashboard/${companyId}`;
   const { isAdmin } = useUserRole();
   const { features, loading: featuresLoading } = useCompanyFeatures();
 
@@ -120,7 +110,7 @@ export default function Sidebar({ isMobile, open, onClose, onFeedbackClick }: Si
             // item entirely when the flag is off.
             .filter((item) => !item.featureFlag || featuresLoading || features[item.featureFlag])
             .map((item) => {
-              const fullPath = `/${item.surface ?? 'dashboard'}/${companyId}${item.path}`;
+              const fullPath = `${basePath}${item.path}`;
               // Hold the slot with a skeleton while features load; we don't
               // know yet whether to show the live item.
               if (item.featureFlag && featuresLoading) {
@@ -143,8 +133,8 @@ export default function Sidebar({ isMobile, open, onClose, onFeedbackClick }: Si
               const IconComponent = item.icon;
 
               return (
-                // Keyed by name, not path: Dashboard and Shop floor both have an
-                // empty path (they are each a surface root), so path is no longer unique.
+                // Keyed by name rather than path — names are unique by construction,
+                // paths only happen to be.
                 <ListItem key={item.name} disablePadding>
                   <ListItemButton
                     component={Link}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -34,6 +34,13 @@ interface MenuItem {
   name: string;
   path: string;
   icon: typeof DashboardIcon;
+  /**
+   * Which top-level surface the item lives on. Defaults to the office
+   * (`/dashboard/{companyId}`); `'operator'` points at the shop floor instead.
+   * Only **Shop floor** uses it — but the alternative was a one-off `absolute`
+   * flag whose handling would have hardcoded the operator path in the renderer.
+   */
+  surface?: 'dashboard' | 'operator';
   adminOnly?: boolean;
   /**
    * When set, the item only renders if the named feature flag is on for
@@ -46,6 +53,14 @@ interface MenuItem {
 
 const menuItems: MenuItem[] = [
   { name: 'Dashboard', path: '', icon: DashboardIcon },
+  // The shop floor is a destination of equal rank to the dashboard, not a section of it —
+  // which is why it sits second rather than filed among the data sections below. Until now
+  // the only way in was one outlined button in the toolbar of the jobs *list* page, so an
+  // owner-operator reaching for it on their phone had to know it was there. Every product
+  // that solves this well (Deputy, Homebase, Procore) makes the frontline surface permanent
+  // nav rather than a mode toggle. No role gate: the sidebar is office chrome, and AuthGuard
+  // bounces operators off /dashboard/* before it ever renders for them.
+  { name: 'Shop floor', path: '', surface: 'operator', icon: PrecisionManufacturingIcon },
   { name: 'Activity', path: '/activity', icon: DynamicFeedIcon },
   { name: 'Jobs', path: '/jobs', icon: WorkIcon },
   { name: 'Quotes', path: '/quotes', icon: RequestQuoteIcon },
@@ -84,7 +99,6 @@ export default function Sidebar({ isMobile, open, onClose, onFeedbackClick }: Si
   const pathname = usePathname();
   const params = useParams();
   const companyId = params.companyId as string;
-  const basePath = `/dashboard/${companyId}`;
   const { isAdmin } = useUserRole();
   const { features, loading: featuresLoading } = useCompanyFeatures();
 
@@ -106,12 +120,12 @@ export default function Sidebar({ isMobile, open, onClose, onFeedbackClick }: Si
             // item entirely when the flag is off.
             .filter((item) => !item.featureFlag || featuresLoading || features[item.featureFlag])
             .map((item) => {
-              const fullPath = `${basePath}${item.path}`;
+              const fullPath = `/${item.surface ?? 'dashboard'}/${companyId}${item.path}`;
               // Hold the slot with a skeleton while features load; we don't
               // know yet whether to show the live item.
               if (item.featureFlag && featuresLoading) {
                 return (
-                  <ListItem key={`skeleton-${item.path}`} disablePadding>
+                  <ListItem key={`skeleton-${item.name}`} disablePadding>
                     <Box sx={{ px: 2, py: 1.5, width: '100%' }}>
                       <Skeleton
                         variant="rectangular"
@@ -129,7 +143,9 @@ export default function Sidebar({ isMobile, open, onClose, onFeedbackClick }: Si
               const IconComponent = item.icon;
 
               return (
-                <ListItem key={item.path} disablePadding>
+                // Keyed by name, not path: Dashboard and Shop floor both have an
+                // empty path (they are each a surface root), so path is no longer unique.
+                <ListItem key={item.name} disablePadding>
                   <ListItemButton
                     component={Link}
                     href={fullPath}

--- a/utils/companyAccess.ts
+++ b/utils/companyAccess.ts
@@ -75,6 +75,20 @@ export async function getCompanyMembers(companyId: string): Promise<CompanyMembe
 }
 
 /**
+ * Where a member's home is, given their role in that company.
+ *
+ * Operators live on the shop floor and are bounced out of `/dashboard/*` by
+ * `AuthGuard`; everyone else lands in the office. Exported so the four places
+ * that send someone "home" — post-login, `/launch`, the company selector and
+ * invite acceptance — cannot drift apart. Three of them used to hardcode
+ * `/dashboard` and lean on the AuthGuard bounce to correct it, which worked but
+ * cost an extra round trip and a visible flash on a new user's first screen.
+ */
+export function homePathForRole(role: string | null | undefined, companyId: string): string {
+  return role === 'operator' ? `/operator/${companyId}` : `/dashboard/${companyId}`;
+}
+
+/**
  * Get all companies the user has access to
  */
 export async function getUserCompanies(userId: string): Promise<UserCompanyAccess[]> {
@@ -180,8 +194,7 @@ export async function getPostLoginRoute(userId: string): Promise<string> {
     if (companies.length === 1) {
       const companyId = companies[0].company_id;
       await setLastCompany(userId, companyId);
-      const prefix = companies[0].role === 'operator' ? 'operator' : 'dashboard';
-      return `/${prefix}/${companyId}`;
+      return homePathForRole(companies[0].role, companyId);
     }
 
     // Multiple companies - check for last accessed
@@ -191,8 +204,7 @@ export async function getPostLoginRoute(userId: string): Promise<string> {
       // Verify they still have access to last company
       const match = companies.find((c) => c.company_id === lastCompanyId);
       if (match) {
-        const prefix = match.role === 'operator' ? 'operator' : 'dashboard';
-        return `/${prefix}/${lastCompanyId}`;
+        return homePathForRole(match.role, lastCompanyId);
       }
     }
 

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
+import type { Database } from '@/types/database';
 
 /**
  * Server-side Supabase client for Route Handlers / Server Components.
@@ -13,7 +14,11 @@ import { cookies } from 'next/headers';
 export async function createClient() {
   const cookieStore = await cookies();
 
-  return createServerClient(
+  // `<Database>`-generic, matching `getTypedSupabase()` on the browser side (see
+  // CLAUDE.md "Typed Supabase client"). Without it the select-string parser can't know
+  // a relation's cardinality and types every embed as an array, so `companies(is_demo)`
+  // came back as `{ is_demo }[]` for what is a many-to-one FK.
+  return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {


### PR DESCRIPTION
## Why

Until now the only way into the operator view from the office was **one outlined button in the toolbar of the jobs *list* page**. An owner-operator reaching for the shop floor on their phone had to already know it was there.

Research across ~40 products (Katana, MachineMetrics, Odoo, Tulip, ECI JobBOSS², Toast, Shopify POS, Square, Deputy, Homebase, When I Work, Connecteam, Jobber, Procore) found **none that ship a persona mode-switch**. The field splits two ways: separate front doors the human picks between, or one app where the frontline surface is permanently reachable and stays first-class for managers too. Nobody routes by user-agent or viewport — the only precedent for that is the m-dot era, which survives as a cautionary tale.

So: **land people by role, put one labelled door on every page, and don't guess from the device.** A salesperson on a 390px phone at a trade show needs quotes; every viewport heuristic gets that wrong.

## What changed

- **New `/launch` server component**, now the manifest's `start_url`. Resolves the session from cookies and `redirect()`s *before the first byte of HTML* — no blank frame, no client round trips.
- **`Header` gains a labelled Shop floor button** in the slot the alert bell vacated. This is the control that does the work: the header is the only always-visible office chrome on a phone, where the sidebar is behind a hamburger. Labelled at both widths rather than collapsing to an icon like Sign Out — an unlabelled glyph would assume the viewer already knows the app has two surfaces, which is the thing they don't know.
- **The operator view's unlabelled dashboard icon becomes "Office."** Still exactly one control, so the Fitts's-law reasoning in the comment beside it still holds.
- **The buried jobs-page button is deleted.** Two doors means two things to explain.

**No sidebar entry.** An earlier revision added one; it was dropped after review. It duplicated a label already on screen and added no reach — the header button covers every office page at every width, and the sidebar can't help on a phone. `Sidebar.tsx` is +8/−2 against main: a `key={item.name}` fix (names are unique by construction, paths only happen to be) and a comment recording why there is deliberately no item, so it doesn't get "fixed" back in.

Vocabulary is **Shop floor** / **Office** — both shop words. Not "operator view" / "admin mode".

## Two live bugs fixed on the way

- **`start_url` was `/`.** iOS honours the manifest's `start_url` over whatever page you installed from, so *every* home-screen icon opened the marketing page regardless of the install instructions — then rendered `null` while four sequential Supabase round trips resolved the destination. `id` is now pinned to `'/'` explicitly, because it defaults to `start_url` and changing one without the other silently orphans every existing install.
- **`isValidReturnTo` didn't allow `/operator`.** A session expiry on the shop floor had its `returnTo` silently rejected and dropped you in the office — which for a `role='operator'` user means an immediate AuthGuard bounce back out. It also broke the scanned-traveler-QR path.

`CompanySelector` and both `accept-invite` redirects are now role-aware through one shared `homePathForRole()` helper, instead of hardcoding `/dashboard` and leaning on the AuthGuard bounce to correct it.

## Notes for review

**The manifest comment was wrong in three ways** and is corrected in place: it cited WebKit #185448 (RESOLVED FIXED in iOS 13.4) rather than the still-open permission-*persistence* issue; iOS 26 removed the standalone opt-out entirely, so `navigator.standalone` must never be routed on; and `display: 'browser'` costs Android installability outright (Chrome requires standalone/fullscreen/minimal-ui). I also recorded the stronger argument for keeping `browser` that the original never made — on iOS a standalone home-screen app has a **cookie jar separate from Safari**, and the Camera app opens the default browser, so flipping to standalone would make every scanned traveler QR land in a different session and start demanding a password.

**`utils/supabase/server.ts` is now `<Database>`-generic.** Without it the select-string parser can't know a relation's cardinality and typed the many-to-one `companies` embed as an array. This is the direction CLAUDE.md already asks for on new access code.

**Deliberately not done:** no device/viewport/UA detection; no auto-landing dual-role users on the shop floor (`/operator/{id}` opens on a station picker and persists the answer to `localStorage`, so it would ask an owner which machine he's standing at and pin his personal phone to it); no second installable PWA (web.dev rates same-origin nested scopes "strongly not recommended", and whether two iOS home-screen apps share a cookie jar is undocumented); no surface preference in `user_preferences` (wrong scope — it would follow the user across devices and be wrong on one of them by construction). The per-device cookie is the natural next step when there are enough users to justify it.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run` — 143 files, **1924 tests** passing (new: Header suite, `homePathForRole`, a CompanySelector operator case, and a Sidebar assertion that it does *not* duplicate the header door)
- `pnpm lint` — 0 errors
- Driven locally against the seed data:
  - signed-out `/launch` → `307` to `/login`, no HTML rendered
  - signed-in `/launch` → straight to `/dashboard/{id}`
  - all four header controls still fit at 375px on a long title ("Work Centers — Internal")
  - **Shop floor → Office** round trip works
  - jobs toolbar correct with the old button gone

No migration. `api/` and `supabase/` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
