### PR TITLE
fix(db): unblock the prod migration pipeline on a superuser-only function

### DIFF
--- a/supabase/migrations/20260801024552_revoke_function_execute_from_browser_roles.sql
+++ b/supabase/migrations/20260801024552_revoke_function_execute_from_browser_roles.sql
@@ -112,8 +112,33 @@ REVOKE EXECUTE ON FUNCTION public.user_company_access_fill_email()
   FROM PUBLIC, anon, authenticated;
 
 -- ── 2b. Event-trigger function ────────────────────────────────────────────────
-REVOKE EXECUTE ON FUNCTION public.rls_auto_enable()
-  FROM PUBLIC, anon, authenticated;
+-- GUARDED, and the only guarded revoke in this migration. rls_auto_enable is an
+-- EVENT TRIGGER function, and creating an event trigger requires SUPERUSER —
+-- which `postgres` is on a local stack but is NOT on a hosted Supabase project.
+-- So the baseline creates it everywhere the baseline actually RUNS (local, every
+-- preview branch) and production, where the baseline was marked-as-applied
+-- against the pre-existing database rather than executed, has never had it.
+--
+-- That asymmetry is invisible to CI by construction: every check we run — local
+-- db reset, the preview-branch migration check — runs somewhere the function
+-- exists. Only production raises 42883, and because migrations are atomic and
+-- ordered, this single statement aborted the whole file and blocked the twelve
+-- migrations behind it for two days while the frontend that depended on them
+-- shipped anyway (customer_contacts.is_billing_default → 400 on jobs, quotes
+-- and customers).
+--
+-- Tolerating absence is the correct resolution rather than creating the missing
+-- function: we cannot create an event trigger on hosted Supabase without
+-- superuser, and the revoke is meaningless where the function does not exist.
+-- Everything else in this migration stays unguarded on purpose — a function
+-- missing anywhere else is a real drift signal and should still be loud.
+DO $$
+BEGIN
+  IF to_regprocedure('public.rls_auto_enable()') IS NOT NULL THEN
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION public.rls_auto_enable()'
+         || ' FROM PUBLIC, anon, authenticated';
+  END IF;
+END $$;
 
 -- ── 2c. Internal helpers, reachable only through SECURITY DEFINER parents ─────
 -- inv_* are called by add/adjust/deplete/transfer_stock and enable_location_tracking;


### PR DESCRIPTION
## The outage

Clicking **any** job or quote in production returned "Job not found" / "Quote not found", and the customers list failed too. Supabase logs gave the real cause:

```
column customer_contacts_1.is_billing_default does not exist   (SQLSTATE 42703)
```

The row was never missing — PostgREST rejected the entire `select` with a 400, `getJobWithRelations` threw, and the page fell through to its generic empty state.

## Why the column was missing

**Production's database was 13 migrations behind the frontend deployed against it**, stuck since 2026-08-01 02:28 UTC.

Migrations are atomic and ordered, so one failing statement in `20260801024552` held back everything queued behind it — including the three the shipped frontend depends on:

| Query | Needs | From |
|---|---|---|
| `getJobWithRelations` | `is_billing_default`, `deleted_at`, `customer_carrier_accounts` | `20260802013726`, `20260801024648` |
| `getQuoteWithRelations` | `is_billing_default`, `deleted_at` | `20260802013726` |
| `getAllCustomers` | `is_billing_default`, `deleted_at` | `20260802013726` |

The blocking statement:

```
REVOKE EXECUTE ON FUNCTION public.rls_auto_enable() FROM PUBLIC, anon, authenticated;
ERROR: function public.rls_auto_enable() does not exist (SQLSTATE 42883)
```

`rls_auto_enable` returns `event_trigger`, and creating an event trigger requires **SUPERUSER**. `postgres` is superuser on a local stack and is **not** on a hosted project. So the baseline creates it wherever the baseline actually *runs* — local, every preview branch — while production, where the baseline was marked-as-applied against the pre-existing database rather than executed, has never had it.

## Why every check stayed green

This failure is invisible to CI **by construction**. Every gate we run executes somewhere the function exists — `supabase db reset` locally, and the preview-branch migration check. Both passed, on this migration and on the twelve behind it. Only production raises 42883, and **nothing reports on the production apply**, so the pipeline stalled silently while PRs kept merging green for two days.

## The fix

Guard this one revoke on `to_regprocedure`. Tolerating absence is correct rather than creating the function: an event trigger cannot be created on hosted Supabase without superuser, and the revoke is meaningless where the function does not exist.

Every other revoke in the file stays **unguarded on purpose** — all fourteen were verified present in production, and a function missing anywhere else is real drift that should stay loud.

Editing an already-merged migration is deliberate here. It had never applied to production, and it *had* applied everywhere else, so the edit is a no-op for local and preview. The alternative — `migration repair --status applied` — would have skipped the security hardening in `#640` on prod entirely, leaving `function_execute_leaks()` absent there.

## Verification

All 13 migrations applied to production, confirmed against a fresh schema dump:

| Object | Before | After |
|---|---|---|
| `customer_contacts.is_billing_default` | missing | present |
| `customer_contacts.deleted_at` | missing | present |
| `customer_carrier_accounts` | missing | present |
| `inventory_locations.code` | present | dropped as intended |

`migration list --linked` reports zero pending. A full pre-migration schema + data dump was taken as a rollback point first — **PITR is disabled on this project**, so the only alternative restore point was a daily backup ~3h stale.

## Follow-ups worth filing

1. **Nothing reports on the production migration apply.** This outage's true cost was the two-day silence, not the bad statement. A post-merge check that fails loudly when prod has pending migrations would have caught it on 2026-08-01.
2. **Enable PITR on production.** A pilot shop's live data currently has daily-granularity recovery only.
3. **The baseline contains objects production does not have.** `rls_auto_enable` is one; a diff of baseline-vs-prod would show whether there are others waiting to do the same thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)