### PR TITLE
fix(count): stop the mount-time search debounce resetting the page

### DIFF
--- a/__tests__/components/inventory/InventoryCountPage.test.tsx
+++ b/__tests__/components/inventory/InventoryCountPage.test.tsx
@@ -700,6 +700,49 @@ describe('counting one place', () => {
     );
   });
 
+  /**
+   * The search box debounces into `serverSearch` on a 300ms timer, and that timer also fires
+   * ~300ms after MOUNT, when the term has not changed. It used to reset the page
+   * unconditionally, so paging within 300ms of opening a bin silently yanked the operator
+   * back to page 1. Measured call sequence before the fix:
+   *
+   *     offset 0  (initial load) → offset 2 (the click) → offset 0 (the mount timer)
+   *
+   * Invisible locally, because the timer usually expires before a human can click, and
+   * deterministic on a loaded CI runner — which is how it was found, as the sibling test
+   * above failing on `main` with `offset: 0` where it expected `2`.
+   *
+   * This asserts on the whole call list rather than the last call, so it fails loudly if a
+   * stray reload reappears, and waits well past the debounce on purpose: the point is that
+   * nothing happens when it fires.
+   */
+  it('does not reset the page when the mount-time search debounce fires', async () => {
+    const user = userEvent.setup();
+    asMock(loadLocationCountCandidates).mockResolvedValue({
+      candidates: [here('BUY-ORING-214', 828), here('BUY-BEARING-608ZZ', 580)],
+      total: 9428,
+    });
+    renderPage();
+
+    expect(await screen.findByText(/1–2 of 9,428 here/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    await waitFor(() =>
+      expect(loadLocationCountCandidates).toHaveBeenLastCalledWith(
+        LOC,
+        'Shelf A',
+        expect.objectContaining({ offset: 2 }),
+      ),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 700));
+
+    const offsets = asMock(loadLocationCountCandidates).mock.calls.map(
+      (call: unknown[]) => (call[2] as { offset: number }).offset,
+    );
+    expect(offsets).toEqual([0, 2]);
+  });
+
   /** A tick on page 1 must survive turning to page 2 — the sheet holds rows, not indexes. */
   it('keeps what is already ticked when the page turns', async () => {
     const user = userEvent.setup();

--- a/app/dashboard/[companyId]/inventory/count/page.tsx
+++ b/app/dashboard/[companyId]/inventory/count/page.tsx
@@ -284,6 +284,12 @@ export default function InventoryCountPage() {
    */
   const [serverSearch, setServerSearch] = useState('');
 
+  /**
+   * The term the page-reset has already been applied for. A ref, not state: it must not
+   * be a dependency of the debounce effect, or settling it would re-arm the timer.
+   */
+  const appliedSearchRef = useRef('');
+
   /** Parts held at this location in total — may exceed the page, so the UI can say so. */
   const [hereTotal, setHereTotal] = useState(0);
 
@@ -453,9 +459,22 @@ export default function InventoryCountPage() {
   // is unconditional so the two modes don't need different effect shapes.
   useEffect(() => {
     const id = setTimeout(() => {
-      setServerSearch(search.trim());
+      const next = search.trim();
+      setServerSearch(next);
       // A new term is a new result set; staying on page 3 of the old one shows nothing.
-      setPage(0);
+      //
+      // Only reset when the term actually CHANGED. This timer also fires ~300ms after
+      // mount, when the term has not changed, and an unconditional reset there races
+      // whatever the operator did in the meantime: page to 2 within 300ms of opening a
+      // bin and the reset lands afterwards, silently yanking them back to page 1. It is
+      // invisible locally because the timer usually expires before anyone can click, and
+      // deterministic on a loaded CI runner — which is how it was found, as
+      // `InventoryCountPage.test.tsx > 'pages through a bin instead of showing one
+      // capped page'` failing on main.
+      if (next !== appliedSearchRef.current) {
+        appliedSearchRef.current = next;
+        setPage(0);
+      }
     }, 300);
     return () => clearTimeout(id);
   }, [search]);


### PR DESCRIPTION
**`main` is currently red**, and it is a real bug rather than a flaky test.

`InventoryCountPage.test.tsx > 'pages through a bin instead of showing one capped page'` fails on main ([run](https://github.com/debola31/Jigged/actions/runs/30842319827)) and on every open PR branched from it — including the docs PR #664, which changes nothing but comments and markdown. It reproduces on re-run, so it is deterministic on CI, not intermittent.

## What's wrong

The search box debounces keystrokes into `serverSearch` on a 300ms timer. That timer **also fires ~300ms after mount**, when the term has not changed — and it reset the page unconditionally:

```ts
const id = setTimeout(() => {
  setServerSearch(search.trim());
  setPage(0);            // ← fires on mount too
}, 300);
```

`page` is in the loader effect's dependency list, so the reset re-fetches. Measured call sequence from a probe on the unfixed code:

```
offset 0  (initial load)
offset 2  (the operator clicks Next)
offset 0  (the mount timer, 300ms in)
```

**For an operator:** open a shelf, hit Next within 300ms, and you are silently yanked back to page 1. It is invisible locally because the timer usually expires before a human can click, and deterministic on a loaded CI runner — which is exactly why CI caught it and nobody else did.

## The fix

Reset only when the debounced term **actually changed**. On mount it has not.

The applied term lives in a `useRef`, not state, on purpose: as a dependency it would re-arm the very timer it is meant to settle.

## Verified both directions

The new regression test asserts the whole call list rather than the last call, so a stray reload fails loudly, and it waits well past the debounce on purpose — the point is that nothing happens when it fires.

| | offsets |
|---|---|
| Without the fix | `[0, 2, 0]` — **fails** |
| With the fix | `[0, 2]` — passes |

Full file 63/63, `tsc --noEmit` clean, eslint clean.

Unblocks #664 and #669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)