### PR TITLE
fix(e2e): anchor the station picker on its heading, not the station's name

### DIFF
--- a/e2e/helpers/navigation.ts
+++ b/e2e/helpers/navigation.ts
@@ -27,3 +27,43 @@ export async function waitForGridLoaded(page: Page) {
   // Wait until no loading overlay is visible
   await expect(page.locator('.ag-overlay-loading-center')).toBeHidden({ timeout: 15_000 });
 }
+
+/**
+ * Put the operator on a station, if the station picker is showing.
+ *
+ * Tolerant of a station already being selected: the choice persists in
+ * `localStorage`, so a second visit within one test renders the jobs list
+ * instead of the picker.
+ *
+ * **Anchored on the picker's heading, not on the station's own button, and that
+ * is the whole point.** The seed names the job operation after the work centre
+ * (`global-setup.ts`: `operation_name: WC_INTERNAL_NAME`), the dispatch row
+ * prints `Op: {operation_name}`, and both the picker card and the dispatch row
+ * are `CardActionArea` buttons. Playwright matches accessible names by
+ * substring, so `getByRole('button', { name: 'E2E Internal WC' })` matches BOTH
+ * the moment a station is already selected — a strict-mode violation that
+ * depends on test ordering, which is why it passed for months and then failed.
+ * Same class of bug as `navigateTo` above, and the same fix: scope the query to
+ * something only the intended surface has.
+ *
+ * The heading is safe to key on because the picker and the dispatch list are
+ * mutually exclusive — the jobs page renders the picker only when no station is
+ * selected, and hides the list and its toolbar while it does.
+ */
+export async function selectStationIfPickerShown(
+  page: Page,
+  stationName: string,
+  settledMarker: ReturnType<Page['getByRole']>,
+): Promise<void> {
+  const pickerHeading = page.getByText('Select Your Station');
+  // Wait for one of the two possible states before deciding: isVisible()
+  // resolves immediately, so checking it straight after a goto reports "no
+  // picker" on a page that has simply not rendered yet — and the station then
+  // silently never gets selected.
+  await expect(pickerHeading.or(settledMarker)).toBeVisible({ timeout: 30_000 });
+  if (await pickerHeading.isVisible()) {
+    // Unambiguous here: while the picker is up there are no dispatch rows to
+    // collide with.
+    await page.getByRole('button', { name: stationName }).click();
+  }
+}

--- a/e2e/machine-maintenance.spec.ts
+++ b/e2e/machine-maintenance.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { selectStationIfPickerShown } from './helpers/navigation';
 
 /**
  * The machine logbook, end to end.
@@ -51,9 +52,7 @@ const openList = (page: Page) => page.getByTestId('machine-open-items');
 async function selectStationAndOpenLog(page: Page, companyId: string): Promise<void> {
   await page.goto(`/operator/${companyId}/jobs`);
 
-  const picker = page.getByRole('button', { name: WC_INTERNAL });
-  await expect(picker.or(maintenanceTab(page))).toBeVisible({ timeout: 30_000 });
-  if (await picker.isVisible()) await picker.click();
+  await selectStationIfPickerShown(page, WC_INTERNAL, maintenanceTab(page));
 
   await expect(maintenanceTab(page)).toBeVisible({ timeout: 30_000 });
   await maintenanceTab(page).click();
@@ -69,14 +68,20 @@ test.describe('Machine Maintenance', () => {
 
     // Wait for one of the two states before asserting — a not-yet-rendered page
     // reports "no tab" for the wrong reason.
-    const picker = page.getByRole('button', { name: WC_INTERNAL });
-    await expect(picker.or(maintenanceTab(page))).toBeVisible({ timeout: 30_000 });
+    //
+    // Keyed on the picker's HEADING, not on the station's button: the seed names
+    // the job operation after the work centre, the dispatch row prints it, and
+    // Playwright matches accessible names by substring — so the button matches
+    // both surfaces once a station is already selected. See
+    // `selectStationIfPickerShown`.
+    const pickerHeading = page.getByText('Select Your Station');
+    await expect(pickerHeading.or(maintenanceTab(page))).toBeVisible({ timeout: 30_000 });
 
-    if (await picker.isVisible()) {
+    if (await pickerHeading.isVisible()) {
       // No station yet: the tab must not be offered. There is no machine to have
       // a logbook for.
       await expect(maintenanceTab(page)).toHaveCount(0);
-      await picker.click();
+      await page.getByRole('button', { name: WC_INTERNAL }).click();
     }
 
     await expect(maintenanceTab(page)).toBeVisible({ timeout: 30_000 });

--- a/e2e/operator-completion.spec.ts
+++ b/e2e/operator-completion.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect, type Page } from '@playwright/test';
-import { navigateTo, waitForGridLoaded } from './helpers/navigation';
+import {
+  navigateTo,
+  selectStationIfPickerShown,
+  waitForGridLoaded,
+} from './helpers/navigation';
 
 /**
  * Recording a completion, end to end.
@@ -50,17 +54,12 @@ async function openTravelerWithStation(page: Page, jobNumber: string): Promise<v
   // list shows instead. Requiring it unconditionally made the helper usable only
   // once per test.
   await page.goto(`/operator/${companyId}/jobs`);
-  const picker = page.getByRole('button', { name: WC_INTERNAL });
-  // Wait for one of the two possible states before deciding, for the same reason
-  // as openStep below: isVisible() resolves immediately, so checking it straight
-  // after a goto reports "no picker" on a page that simply has not rendered yet —
-  // and the station silently never gets selected.
-  await expect(picker.or(page.getByRole('button', { name: 'My Station' }))).toBeVisible({
-    timeout: 30_000,
-  });
-  if (await picker.isVisible()) {
-    await picker.click();
-  }
+  await selectStationIfPickerShown(
+    page,
+    WC_INTERNAL,
+    // Settled marker: the lens toggle only renders once a station is chosen.
+    page.getByRole('button', { name: 'My Station' }),
+  );
 
   await page.goto(`/operator/${companyId}/jobs/${jobId}`);
   await expect(page).toHaveURL(/\/parts\/[0-9a-f-]{36}/, { timeout: 30_000 });


### PR DESCRIPTION
The E2E suite went red on `operator-completion.spec.ts` with a **strict-mode violation** — `getByRole('button', { name: 'E2E Internal WC' })` resolved to two elements ([run](https://github.com/debola31/Jigged/actions/runs/30847543270)).

## Why the locator is ambiguous

Three facts combine:

1. **`global-setup.ts:671` seeds the job operation's name equal to the work centre's** — `operation_name: WC_INTERNAL_NAME`, so both are `E2E Internal WC`.
2. **The dispatch row renders `Op: {operation_name}`** (`jobs/page.tsx:205`) and, like the station picker card, is a `CardActionArea` — i.e. `role=button`.
3. **Playwright matches accessible names by substring** unless told otherwise.

So the moment a station is *already* selected — which the helper deliberately tolerates, because the choice persists in `localStorage` — that one locator matches the **picker card and the dispatch row**. Whether it happens depends on test ordering, which is why it passed for months and then failed. The CI log shows both stages: first the lens toggle plus a card, then on retry two cards.

I ruled out the obvious alternative on the way: two work centres with that name are impossible — `work_centers_unique_per_company UNIQUE (company_id, name)` exists in the schema.

## The fix

Key the state check on the picker's **heading**, `Select Your Station`, which appears in exactly one component (`StationSelector.tsx:57`) and cannot collide. It's safe because the two surfaces are mutually exclusive — `jobs/page.tsx:316` renders the picker *or* the list, never both — so inside that branch the station button is unambiguous again.

Extracted as **`selectStationIfPickerShown`** because the same pattern sat at **three call sites across two specs**; `machine-maintenance.spec.ts` would have hit this next. It lives beside `navigateTo`, whose docstring records the identical class of bug (a nav landmark colliding with a breadcrumb) and the identical fix — scope the query to something only the intended surface has.

## Verified against a local stack

| | result |
|---|---|
| With the fix | **all of `machine-maintenance` passes**; the strict-mode violation is gone |
| Control — **main's** specs, same stack, same test | **fails identically** at `openStep` with a 404 |

That control matters: one `operator-completion` test still fails locally on a 404, and it reproduces on main, so it is a **stale shared-local-database artifact rather than this change**. CI starts clean. (`tsc` and `eslint` clean.)

Unblocks #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)