### PR TITLE
fix(ci): read the Vercel IDs from either tab, and name the missing credential

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -167,8 +167,14 @@ jobs:
     needs: gate
     runs-on: ubuntu-latest
     env:
-      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+      # Read from either tab. Neither ID is sensitive — they identify a project,
+      # they do not authorise anything — so a repo VARIABLE is the tidier home
+      # and stays readable in the UI. But they were configured as secrets, and a
+      # deploy silently receiving an empty string is a worse outcome than an
+      # untidy home: `vercel pull` then fails with a message about the TOKEN,
+      # which sends you looking at the wrong setting entirely.
+      VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID || secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID || secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
 
@@ -180,6 +186,37 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
+
+      # Say which setting is missing, before a tool with less context guesses.
+      # The first real run of this workflow had both IDs empty (configured as
+      # secrets while this read vars) and `vercel pull` reported only "The
+      # specified token is not valid" — pointing at the one credential that was
+      # actually present. Ten minutes were spent on the token.
+      - name: Check deploy credentials are present
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          MISSING=""
+          [ -n "${VERCEL_TOKEN:-}" ]      || MISSING="$MISSING VERCEL_TOKEN(secret)"
+          [ -n "${VERCEL_ORG_ID:-}" ]     || MISSING="$MISSING VERCEL_ORG_ID(variable-or-secret)"
+          [ -n "${VERCEL_PROJECT_ID:-}" ] || MISSING="$MISSING VERCEL_PROJECT_ID(variable-or-secret)"
+          if [ -n "$MISSING" ]; then
+            echo "::error::Missing deploy credentials:$MISSING"
+            {
+              echo "## Deploy not attempted — credentials missing"
+              echo
+              echo "Empty:\`$MISSING\`"
+              echo
+              echo "Set under **Settings → Secrets and variables → Actions**."
+              echo "The two IDs are read from either tab; the token must be a secret."
+              echo "Find them in Vercel: token under Account Settings → Tokens,"
+              echo "org ID under Team Settings → General, project ID under the"
+              echo "project's Settings → General."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "All three deploy credentials are present."
 
       - name: Install Vercel CLI
         run: pnpm add -g vercel@48


### PR DESCRIPTION
First real run of the deploy gate, on the #672 merge commit:

| Job | Result |
|---|---|
| **Database is ready for this code** | ✅ **success** |
| Deploy to Vercel production | ❌ failure at `vercel pull` |

**The gate works.** It read Supabase's verdict on a real merge and passed. That was the thing worth proving.

**Shadow mode did exactly its job** — Vercel's git auto-deploy shipped the merge normally, so production was untouched while the unproven path failed in the open. This is the failure we merged in shadow mode to catch.

## What was wrong

`VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` were configured as **secrets**, while the workflow read them from `vars` — so both arrived empty:

```
env:
  VERCEL_ORG_ID:
  VERCEL_PROJECT_ID:
```

Now read from either tab. Neither ID authorises anything, so a variable is the tidier home — but an empty string reaching a deploy is worse than an untidy home.

## The worse problem was the error message

With both IDs blank, `vercel pull` reported only:

```
Error: The specified token is not valid.
```

…naming the one credential that *was* present, and sending the investigation at the wrong setting entirely. So the workflow now checks all three itself first:

```
::error::Missing deploy credentials: VERCEL_ORG_ID(variable-or-secret) VERCEL_PROJECT_ID(variable-or-secret)
```

Verified by replaying both cases — all-present passes, and the real failure reproduces with the correct two named.

## Still needed from you

**`VERCEL_TOKEN` is separately invalid** and has to be reissued — a dashboard action, not a code change:

> Vercel → avatar → **Account Settings → Tokens → Create Token**. Scope it to the team that owns the `jigged` project. Copy immediately; it's shown once. Then update the `VERCEL_TOKEN` secret.

Until that's done this workflow keeps failing on `main` — loudly, and with **no effect on what ships**, which is the correct state for a path that hasn't proven itself yet.

## Do not flip `vercel.json` yet

The deploy half is still unproven. Taking `main` off Vercel's git auto-deploy now would make an untested path the *only* path to production. Sequence: reissue the token → merge this → next merge shows the deploy job green → then flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)