### PR TITLE
docs: cut CLAUDE.md to 258 lines, correct 20 false claims, and enforce citations in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,16 @@ jobs:
         # toward 0 as warnings are paid off (issue #442); never raise it.
         run: pnpm lint
 
+      - name: Docs check — cited paths and link anchors resolve (issue #686)
+        # Deliberately a NAMED step even though `pnpm test` below re-runs the
+        # same spec. Two reasons: a doc-only PR fails here in seconds instead of
+        # after the full suite, and the failure arrives as a step called "Docs
+        # check" rather than one line inside a 2,000-test log — which is the
+        # difference between a rot report someone reads and one they scroll past.
+        # Driven through vitest, like the repo's other source scanners, so it
+        # needs no runner beyond what is already installed.
+        run: pnpm exec vitest run __tests__/standards/docLinkCheck.test.ts
+
       - name: Run tests with coverage (enforced thresholds in vitest.config.ts)
         run: pnpm test --run --coverage
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,59 +1,43 @@
-# Jigged - Manufacturing Data Platform
+# Jigged — Manufacturing Data Platform
 
-## Project Overview
+Web platform for small precision manufacturing shops: jobs, inventory, and shop-floor status.
+Next.js 16 + TypeScript + MUI v7 · FastAPI · Postgres on Supabase · Vercel. Exact versions live in
+`package.json`; the system picture is [docs/architecture.md](docs/architecture.md).
 
-Jigged is a web-based data platform for small-scale precision manufacturing shops. It centralizes jobs, inventory tracking, and shop-floor status with AI-driven insights. The operator app is deliberately minimal — record what you finished, write down what you learned.
+**There is no gamification, and that is a rule rather than a gap.** No operator-facing surface may
+reflect an operator's pace or standing back at them — no counts, streaks, averages, points, badges
+or leaderboards. Existing per-surface tests assert this, but **they only cover the surfaces that
+exist**: a new operator page with a counter ships green. Treat it as a design constraint you apply,
+not one you will be caught violating. Why, and the whole read-back model:
+[operator-view.md](docs/modules/operator-view.md#surveillance-guardrail-non-negotiable).
 
-**There is no gamification, and that is a rule rather than a gap.** No operator-facing surface may reflect an operator's pace or standing back at them — no counts, streaks, averages, points, badges or leaderboards — asserted by test. See [operator-view.md](docs/modules/operator-view.md#surveillance-guardrail-non-negotiable).
+**Where everything is documented:** [docs/README.md](docs/README.md) is the index.
+Writing or editing a doc? [docs/writing-docs.md](docs/writing-docs.md) is the standard, and it is
+enforced — [`scripts/docLinkCheck.ts`](scripts/docLinkCheck.ts) fails CI on a cited path that does
+not exist or a link that does not resolve.
 
-## Tech Stack
+---
 
-- **Frontend:** Next.js 16+ with TypeScript, Material-UI (MUI) v7+
-- **Backend:** FastAPI (Python)
-- **Database:** PostgreSQL on Supabase
-- **Authentication:** Supabase Auth
-- **Hosting:** Vercel
+## API and data access
 
-## API Architecture Rule
+**Supabase-first.** Simple CRUD goes through the Supabase client (`utils/*Access.ts`). The FastAPI
+backend (`api/`) is only for the four criteria in
+[architecture.md §8.1](docs/architecture.md#81-when-to-use-fastapi-backend): AI operations,
+service-role work (`auth.admin.*`), complex multi-step logic, and third-party secrets or inbound
+webhooks (Stripe, QuickBooks OAuth). **Do not add a FastAPI endpoint for standard CRUD.**
 
-**Supabase-first architecture.** All simple CRUD operations go through the Supabase client (`utils/*Access.ts` files). The FastAPI backend (`api/`) is ONLY for:
-1. AI-powered operations (requires API keys not safe for browser)
-2. Operations requiring Supabase service role key (`auth.admin.*`, `auth.users` access)
-3. Complex multi-step business logic (import pipelines with conflict detection)
+**Every app route is company-scoped** (`/dashboard/{companyId}/…`) and isolation is enforced by RLS
+over `user_company_access`, not by the URL. One user can hold access to several companies, with
+roles `admin | user | operator` — and operators land on `/operator/{companyId}`, not `/dashboard`
+([`homePathForRole`](utils/companyAccess.ts)). Model and auth flow:
+[architecture.md §3](docs/architecture.md).
 
-**Do NOT create new FastAPI endpoints for standard CRUD.** See `docs/architecture.md` Section 8 for the full standard and decision checklist.
-
-### Typed Supabase client (incremental adoption)
-
-`lib/supabase.ts` exposes two getters that share one singleton:
-
-- `getSupabase()` — untyped. Existing `utils/*Access.ts` files use this. Schema mistakes compile silently (this is how the May 2026 `jobs.status` regression shipped).
-- `getTypedSupabase()` — `<Database>`-generic. Every `.from('table').select('...')` chain is checked against [`types/database.ts`](types/database.ts), generated from the **local** Supabase stack (migrations replayed) — see the regen + CI-enforcement note below.
-
-**Use `getTypedSupabase()` for any new access function.** When converting an existing file, expect `tsc` to surface real bugs (column drift, narrow-enum mismatches, missing NOT-NULL columns on inserts) — fix them rather than papering over with `as any`. The [`schemaEmbedCheck`](scripts/schemaEmbedCheck.ts) test catches the embed-string class of drift today; typed mode catches everything else.
-
-Regenerate types after every migration that changes columns — run it against a
-running local stack (`supabase start`), since it now reads the local DB (not a
-remote project):
-
-```bash
-pnpm gen:db-types  # wraps: supabase gen types typescript --local
-```
-
-CI enforces that the committed `types/database.ts` matches the migrations: the
-backend job in [`.github/workflows/test.yml`](.github/workflows/test.yml)
-regenerates types from the migration-replayed local stack and fails on any diff
-(issue #406) — so a schema change without a regen, or a hand-edited types file,
-goes red.
-
-Because that check diffs a `--local` regen, the **generator version is pinned in
-the `gen:db-types` script itself** (`npx supabase@<version>`), so your globally
-installed `supabase` CLI can auto-update freely without ever affecting type
-generation. The same version is pinned in the two CI workflows' `setup-cli`. To
-move to a newer CLI, bump the version in **three places together** —
-`package.json` (`gen:db-types`), `.github/workflows/test.yml`, and
-`.github/workflows/e2e-tests.yml` — then `pnpm gen:db-types` and commit. Treat
-`types/database.ts` like a lockfile.
+**Use `getTypedSupabase()` for every new access function** — it type-checks each `.from().select()`
+against [`types/database.ts`](types/database.ts). The untyped `getSupabase()` still exists but no
+`utils/*.ts` imports it any more; schema mistakes compile silently through it, which is how the
+May 2026 `jobs.status` regression shipped. **Regenerate types after any migration that changes
+columns** (`pnpm gen:db-types`, against a running local stack); CI fails on a diff. Details, and the
+three places the generator version is pinned: [architecture.md §6](docs/architecture.md).
 
 ---
 
@@ -61,577 +45,214 @@ move to a newer CLI, bump the version in **three places together** —
 
 ### AI calls require an explicit user action
 
-Anthropic calls cost real credits. Never invoke an AI endpoint (Claude, OpenAI, Gemini — anything that bills per token) from a `useEffect`, page load, route mount, auto-refresh, or polling loop. The user must have taken a deliberate action — clicked a button, submitted a question, explicitly requested a refresh.
+Anthropic calls cost real credits. **Never invoke an AI endpoint from a `useEffect`, page load,
+route mount, auto-refresh, or polling loop.** The user must have clicked, submitted, or explicitly
+asked. This binds at every layer: no fetch-on-mount in the frontend; no endpoint that generates AI
+summaries as a read side effect; background jobs only if infrequent and rate-limited per company,
+and never wired to login or page view.
 
-This applies to every layer:
-- Frontend: no `getDashboardInsights`-style fetches on mount. A bell icon, a dashboard page, a header component — none of them should trigger AI work just by rendering.
-- Backend: no endpoint that generates AI summaries "on read" as a side effect. If an endpoint is called by a mounting component, it must not be able to reach a paid AI provider.
-- Background jobs: fine, but must be infrequent (e.g. hourly or daily) and rate-limited per company. Never wire a background job to "on user login" or "on page view".
+**Why:** a header alert badge once called `/api/insights/{id}/dashboard`, firing 5 Anthropic calls
+on every dashboard load. Nobody ever read the output — the badge only used the raw metric arrays.
+Credits ran out in days. Both the badge and the endpoint are gone; the failure mode is the point.
 
-**Why:** we once had a header alert badge calling `/api/insights/{id}/dashboard`, firing 5 Anthropic calls on every dashboard page load. Users never saw the AI summaries — the bell icon only read the raw metric arrays. Credits ran out in days. (Both the endpoint and the badge have since been removed, but the failure mode is what matters.) Every new AI feature must pass the "what user action triggered this?" test before merging.
-
-**How to apply:** when adding an AI feature, the entry point must be a button, form submit, or explicit refresh gesture — not a lifecycle hook. If you need fresh data for a passive UI (badge counts, dashboards), compute it from Supabase without AI, or cache it in a dedicated table populated by a scheduled job. If you're unsure whether a code path can fire on mount, grep for `useEffect`/`onMount` callers and trace up from the AI call site.
-
----
+**How to apply:** the entry point must be a button, form submit, or explicit refresh — not a
+lifecycle hook. For passive UI (badges, dashboards) compute from Supabase without AI, or cache in a
+table populated by a scheduled job. Unsure whether a path can fire on mount? Trace up from the call
+site through its `useEffect` callers. **Nothing enforces this** — it is prose and a code review.
 
 ### No silent runtime fallbacks for data-at-rest issues
 
-If a schema change leaves existing rows in an inconsistent state (e.g. a new snapshot table that's empty for pre-existing records), **fix the data at rest** with a backfill migration. Do NOT paper over it with a "if empty, compute live" fallback in the access layer or UI. Fallbacks:
+If a schema change leaves existing rows inconsistent, **fix the data at rest** with a backfill
+migration. Do NOT paper over it with an "if empty, compute live" fallback in the access layer or UI.
+Fallbacks hide data-quality problems, create two code paths to one answer that can silently diverge,
+and compound as tech debt.
 
-- Hide data-quality problems — you stop seeing the cases where the invariant was broken.
-- Multiply sources of truth — two code paths to the same answer that can silently diverge.
-- Accumulate as tech debt — each one "works" alone but they compound over time.
-
-**The rule:** after a schema change, every existing row must satisfy the new invariant by the time the migration finishes. The read path should have a single clean shape with no branching on "what if the snapshot is missing."
-
-If a backfill is genuinely impossible (truly lost history), prefer an explicit "no data available" UI state over a silent recomputation — it surfaces the gap rather than hiding it.
-
----
+**The rule:** after a schema change every existing row must satisfy the new invariant by the time
+the migration finishes, and the read path should have one shape with no "what if it's missing"
+branch. If a backfill is genuinely impossible, prefer an explicit "no data available" state — it
+surfaces the gap instead of hiding it.
 
 ### Observability: Sentry owns errors, and never lies about them
 
-Full runbook — CLI recipes, triage steps, and the traps that cost real debugging time — is
-in **[docs/observability.md](docs/observability.md)**. Read it before touching Sentry config
-or triaging an issue. The rules that bind while writing code:
+Full runbook, CLI recipes and traps: **[docs/observability.md](docs/observability.md)** — read it
+before touching Sentry config or triaging. The rules that bind while writing code:
 
-- **Sentry is the error tracker; PostHog is product analytics.** Never add a second error
-  tracker — `capture_exceptions` stays `false` in `instrumentation-client.ts`. Vercel has no
-  JS error tracking at all, so it substitutes for neither.
-- **Vercel Web Analytics (`<Analytics />` in `app/layout.tsx`) is kept on purpose**, even
-  though it overlaps PostHog. It's the free tier and costs one script tag: basic pageview
-  counts and Web Vitals with zero per-feature instrumentation. PostHog owns the journeys,
-  funnels and retention. Don't remove either as "redundant".
-- **Never pass a raw Supabase error to `Sentry.captureException`.** It rejects with a plain
-  object, which Sentry can't fingerprint — you get an issue titled `"e"` and the real
-  message buried in a `__serialized__` extra. Wrap it: `captureException(toError(err, '…'))`
-  from [`lib/supabaseErrors.ts`](lib/supabaseErrors.ts).
-- **"Couldn't check" is never "denied."** An access check that *fails* must not render as a
-  definitive negative. `verifyCompanyAccess` swallowing errors into `return false` is how one
-  dropped request showed "You don't have access to this company" to a user who did. Return a
-  definitive answer only for a definitive result; otherwise throw and give the UI a distinct
-  retryable state.
-- **Transient aborts are not failures.** `AbortError: Lock was stolen` is `@supabase/auth-js`
-  recovering an orphaned token-refresh lock — it means *superseded*, not *failed*. Classify
-  with `isTransientAbortError` and retry; never report it, never surface it as an error.
-- **The SDKs are off outside a production build** (`enabled: NODE_ENV === "production"`, and
-  a `"pytest" in sys.modules` guard on the backend). Don't remove those — 90% of the issue
-  queue was once this repo's own test runs, which is why nobody read the alerts.
-- **Every `ignoreErrors` entry needs a recorded reason** in `docs/observability.md`. A queue
-  you don't trust is worse than no queue.
-
-**Two gotchas worth knowing before you debug for an hour:** `sentry alert issues edit` is
-broken for this org (alert rules moved to the Workflow Engine — the old `rules/` endpoint is
-retired), and `--json` returns `{"data": [...]}`, so `jq 'length'` silently counts object
-keys. Both are covered in the runbook.
-
----
+- **Sentry is the error tracker; PostHog is product analytics.** Never add a second error tracker.
+  **Vercel Web Analytics (`<Analytics />`) is kept deliberately** despite overlapping PostHog — do
+  not remove either as "redundant".
+- **Never pass a raw Supabase error to `Sentry.captureException`** — it can't fingerprint a plain
+  object and you get an issue titled `"e"`. Wrap with `toError` from
+  [`lib/supabaseErrors.ts`](lib/supabaseErrors.ts).
+- **"Couldn't check" is never "denied."** A failed access check must not render as a definitive
+  negative — throw and give the UI a retryable state.
+- **Transient aborts are not failures.** `AbortError: Lock was stolen` means superseded; classify
+  with `isTransientAbortError` and retry.
+- **The SDKs are off outside production builds.** Don't remove those guards — 90% of the issue queue
+  was once this repo's own test runs.
 
 ### Deletion is archive (soft-delete), and never blocks
 
-Every user-facing entity (`parts`, `customers`, `vendors`, `work_centers`, `jobs`, `quotes`) has a nullable `deleted_at`. The UI "Delete" action sets `deleted_at` — it must **never** issue a hard `DELETE` and **never** block on a foreign-key reference. The row survives so quotes/jobs/shipments/BOMs that reference it keep resolving. See `docs/architecture.md` §16 for the full standard.
+Every user-facing entity has a nullable `deleted_at`. "Delete" sets it — **never** a hard `DELETE`,
+**never** blocked by a foreign key. Referencing quotes, jobs, shipments and BOMs keep resolving.
+Full standard, including which tables carry it: [architecture.md §16](docs/architecture.md).
 
-**How to apply when writing new code:**
-- **Every list / search / picker / count / dashboard query must filter `deleted_at IS NULL`.** A missing filter silently leaks archived rows — the classic soft-delete bug. By-id reads (a detail page, a document's retained FK) intentionally do *not* filter.
-- **Name is the identity: reuse revives, never duplicates.** Keep the `(company_id, name)` unique constraints FULL (not partial) — the importers upsert on them. A re-import (`deleted_at = None` in the payload) or a manual re-create (revive on `23505`) un-archives the existing row; only a collision with a *live* row is a duplicate error.
-- **Don't re-introduce records-of-value delete guards.** Archiving preserves the record, so an invoiced/shipped job archives like anything else; money-record protection belongs only at a future permanent-purge step.
+- **Every list / search / picker / count / dashboard query must filter `deleted_at IS NULL`.**
+  By-id reads (a detail page, a document's retained FK) intentionally must **not**.
+- **Name is identity: reuse revives, never duplicates.** Keep `(company_id, name)` unique
+  constraints FULL, not partial — importers upsert on them; revive on `23505`.
+- Don't re-introduce records-of-value delete guards. An invoiced job archives like anything else.
 
-**Why:** the old model blocked deleting anything referenced (`ON DELETE RESTRICT`), trapping users (e.g. the "Delete (8395)" parts bulk-delete that refused every referenced part). Archive makes delete always work while keeping history intact.
-
----
+**Nothing enforces this** ([#687](https://github.com/debola31/Jigged/issues/687)), and it is the
+most-violated rule in the repo — a missing filter is silent. Two live violations: #682, #684.
 
 ### Never make changes directly on the main branch
 
-Always create a new feature branch before modifying code, schema, or configuration. No exceptions for "small fixes" or "hotfixes."
-
-**Why:** Direct edits to main bypass code review, make rollbacks harder, and can clobber teammates' in-progress work. Feature branches keep history linear and reviewable.
-
-**How to apply:** Before touching files, run `git checkout -b feature/<short-description>` (e.g., `feature/pricing-tiers-and-markup`). Commit with clear messages, push with `-u origin`, and open a PR for merge. If you're ever uncertain what branch you're on, check `git branch --show-current` before editing.
+Create a feature branch before modifying code, schema, or config. No exceptions for "small fixes".
+Direct edits bypass review, make rollbacks harder, and can clobber in-progress work.
+`git checkout -b <prefix>/<short-description>` — this repo uses `feature/`, `fix/`, `docs/` and
+`chore/`. **`main` is not branch-protected**, so this rule is the only barrier; check
+`git branch --show-current` if unsure.
 
 ---
 
-### Creating new database migrations
+## Database changes
 
-Always create migration files with `supabase migration new <slug>` (NOT by writing files into `supabase/migrations/` directly). The CLI generates a unique 14-digit timestamp (`YYYYMMDDHHMMSS`); writing files by hand with date-only prefixes can collide with same-day migrations and break `schema_migrations` tracking.
+Procedure, the PR/preview/merge pipeline, and the 2026-08-03 outage:
+**[docs/runbooks/database-migrations.md](docs/runbooks/database-migrations.md)**. What binds as you
+write one:
 
-**Why:** the CLI tracks migrations by `(version, name)` in `supabase_migrations.schema_migrations`. Two files sharing a version collapse to one row, leaving the rest invisible to the tracker — `db push` then sees them as pending and tries to re-run them. We hit exactly this when legacy 8-digit date-prefixed files (`20260313_…`) accumulated multiple migrations per date.
-
-**How to apply (workflow per change):**
-1. `supabase migration new <slug>` — creates the file with a fresh 14-digit timestamp.
-2. Write the SQL into the new file.
-3. **If the migration creates a table in `public`, grant it explicitly** — in the same migration, alongside `ENABLE ROW LEVEL SECURITY` and the policies. See "Data API grants" below. Without a `GRANT` the table is invisible to PostgREST/supabase-js and the FastAPI backend.
-4. **Verify locally:** `supabase db reset` replays the baseline + migrations + `supabase/seed.sql` on a fresh local DB — run it plus the relevant tests. This is the deterministic check; there is **no staging project to push to anymore** (we run on Supabase Branching now).
-5. **Open a PR.** Supabase Branching auto-creates a preview branch, applies the migration to it, and reports the **required migration status check**; the Vercel preview points at that branch's DB. If the check is red, fix the migration — it blocks merge.
-   **A green PR does not mean the migration will apply to production.** A preview branch is built by replaying migrations from the baseline; production never was. An object the baseline creates can exist on every preview and not exist on prod — which is exactly how one `REVOKE` blocked the pipeline for two days (2026-08-03).
-6. **Merge to `main` applies migrations to production.** Supabase runs them and posts its verdict as a check on the **merge commit** — not on the PR, which is closed and frozen green by then. Do NOT run `supabase db push` (or `supabase link`) against prod manually; the branching pipeline owns it.
-7. **The frontend deploys only after that verdict is green.** [`deploy-production.yml`](.github/workflows/deploy-production.yml) waits for Supabase's check on the merge commit and runs `vercel deploy --prod` only on success. Vercel's own git auto-deploy is off for `main` (`git.deploymentEnabled` in [`vercel.json`](vercel.json)) so this is the only path to production.
-   **Why:** these used to run in parallel with no ordering. The migration failed, the frontend shipped anyway, and code went live selecting a column production did not have. The gate fails closed — no verdict means no deploy — because shipping against an unverified schema is the failure it exists to prevent.
-   If it blocks, fix the migration and merge again. The manual escape hatch is `vercel deploy --prod`.
-8. Nothing to regenerate afterwards except `types/database.ts` (`pnpm gen:db-types`), which CI enforces. There is deliberately no prod schema snapshot to refresh — see "Schema source-of-truth" below.
-
-Never use the 8-digit date-only prefix for new files — always let the CLI generate the timestamp.
+**Always create the file with `supabase migration new <slug>`** — never by hand. The CLI generates a
+unique 14-digit timestamp; hand-written date-only prefixes collide and break `schema_migrations`
+tracking (two files sharing a version collapse to one row, and the rest go invisible). Verify with
+`supabase db reset` before opening the PR.
 
 ### Data API grants (new tables in `public`)
 
-**Every new table in `public` needs explicit grants in its own migration.** Nothing is exposed to the Data API automatically any more — [`20260716025048_align_data_api_default_privileges.sql`](supabase/migrations/20260716025048_align_data_api_default_privileges.sql) revoked the default privileges that used to do it for you, matching what Supabase enforces on all projects from 2026-10-30 ([changelog #45329](https://supabase.com/changelog/45329-breaking-change-tables-not-exposed-to-data-and-graphql-api-automatically)).
-
-Bundle the grants with the RLS + policy block, in the same migration as the `CREATE TABLE`:
+**Every new table in `public` needs explicit grants in its own migration.** Nothing is exposed to
+the Data API automatically —
+[`20260716025048`](supabase/migrations/20260716025048_align_data_api_default_privileges.sql) revoked
+the defaults that used to do it, matching what Supabase enforces on all projects from 2026-10-30.
+Bundle grants with the RLS + policy block, in the same migration as the `CREATE TABLE`:
 
 ```sql
-CREATE TABLE public.your_table (...);
-ALTER TABLE public.your_table ENABLE ROW LEVEL SECURITY;
-CREATE POLICY ... ON public.your_table ...;
-
 GRANT SELECT ON public.your_table TO anon;
 GRANT SELECT, INSERT, UPDATE, DELETE ON public.your_table TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON public.your_table TO service_role;
 ```
 
-**Grants and RLS are different layers.** A grant decides whether a role can touch the table *at all*; RLS decides *which rows*. RLS with no matching grant is unreachable, and a grant with no RLS policy is denied — you need both. Tailor the roles to the table:
-
-- Most tables are member-scoped by RLS, and `anon` rarely needs more than `SELECT` (often nothing at all — drop the `anon` line if the table is never read logged-out).
-- Backend-only tables (secrets, tokens) should grant `service_role` **only**, and explicitly `REVOKE` from `anon`/`authenticated` — see [`quickbooks_connections`](supabase/migrations/20260620122700_quickbooks_integration.sql#L50-L51).
-- Do **not** write `REVOKE`-down-from-`ALL` to express intent. That idiom relied on the old permissive default having granted everything first; under the current default it revokes privileges that were never granted, leaving the table exposed to nobody.
-
-**Symptom of a missing grant:** PostgREST returns `42501 permission denied`, and its error hint names the grant to add. Because local now matches prod, this fails in dev rather than only in production.
+**Grants and RLS are different layers.** A grant decides whether a role can touch the table at all;
+RLS decides which rows. RLS with no grant is unreachable; a grant with no policy is denied — you
+need both. Tailor the roles: `anon` often needs nothing; backend-only tables grant `service_role`
+only and explicitly `REVOKE` from `anon`/`authenticated`. Do **not** write `REVOKE`-down-from-`ALL`
+to express intent — that idiom relied on the old permissive default and now revokes privileges that
+were never granted. **Symptom of a missing grant:** PostgREST `42501`, whose hint names the grant.
 
 ### Function EXECUTE grants (new functions in `public`)
 
-**A new function is browser-callable unless you revoke it.** Postgres grants `EXECUTE` to `PUBLIC` on every function it creates, and `authenticated` is a member of `PUBLIC`. So a `SECURITY DEFINER` helper you intend as backend-only is reachable from the browser the moment it exists — and because that function bypasses RLS by definition, the grant is the *only* thing between a caller and the data.
-
-To make one service-role-only, **name the roles**:
+**A new function is browser-callable unless you revoke it.** Postgres grants `EXECUTE` to `PUBLIC`
+on every function, and `authenticated` is a member of `PUBLIC` — so a `SECURITY DEFINER` helper you
+intend as backend-only is reachable from the browser the moment it exists, and since it bypasses RLS
+the grant is the *only* thing between a caller and the data. To make one service-role-only, **name
+the roles**:
 
 ```sql
 REVOKE EXECUTE ON FUNCTION public.your_function(uuid) FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION public.your_function(uuid) TO service_role;
 ```
 
-**Why the roles are named explicitly**, when `FROM PUBLIC` looks sufficient: until [`20260801024552`](supabase/migrations/20260801024552_revoke_function_execute_from_browser_roles.sql) the schema also carried `ALTER DEFAULT PRIVILEGES ... GRANT ALL ON FUNCTIONS TO anon, authenticated`, so every new function landed with **explicit** browser grants on top of PUBLIC's. `REVOKE ... FROM PUBLIC` removed only PUBLIC's and left the rest, which meant eight migrations claimed "service-role only" in their comments and none of them were ([#640](https://github.com/debola31/Jigged/issues/640)). That default is now revoked, so `FROM PUBLIC` alone *is* enough today — the explicit form is kept because it is correct under either state and costs nothing.
+`FROM PUBLIC` alone is sufficient today, but the explicit form is correct under either state and
+costs nothing — until [`20260801024552`](supabase/migrations/20260801024552_revoke_function_execute_from_browser_roles.sql)
+a default privilege also granted the browser roles directly, so eight migrations claimed
+"service-role only" and none were ([#640](https://github.com/debola31/Jigged/issues/640)).
 
-Three cases need **no** grant at all, and revoking from them is free:
+Three cases need no grant, and revoking is free: **trigger functions** and **event-trigger
+functions** (permission is checked when the trigger is created, not when it fires), and **helpers
+called only from `SECURITY DEFINER` parents** (the parent runs as its owner). Both claims are
+asserted behaviourally in
+[`test_function_execute_grants.py`](api/tests/integration/test_function_execute_grants.py).
 
-- **Trigger functions** — permission is checked when the trigger is created, not each time it fires.
-- **Event-trigger functions** — same.
-- **Helpers called only from `SECURITY DEFINER` parents** — the parent body runs as the function owner, so the caller's privileges are irrelevant.
-
-Both non-obvious claims above are asserted behaviourally in [`test_function_execute_grants.py`](api/tests/integration/test_function_execute_grants.py), because getting them wrong breaks writes in production rather than failing loudly.
-
-**Enforced in CI:** `function_execute_leaks()` lists any `SECURITY DEFINER` function in `public` a browser role can execute that is not on its reviewed allowlist, and a test asserts it is empty. Adding a function to that allowlist should come with a sentence in the PR saying why the browser needs to call it. **This guard exists because over-granting is silent** — it produces no error, no broken page, no symptom; `part_playbook_notes` was left `anon`-executable by a `DROP FUNCTION` for three days and nothing noticed. A `DROP FUNCTION` destroys a function's ACL *and* its `COMMENT`, so any migration that drops and recreates one must re-issue both.
+**Enforced in CI:** `function_execute_leaks()` lists any `SECURITY DEFINER` function a browser role
+can execute off its reviewed allowlist. The guard exists because over-granting is silent — no error,
+no broken page. It is an *allowlist*, so the cheap way to green it is to add your function: don't,
+without a sentence in the PR saying why the browser needs it. **A `DROP FUNCTION` destroys both the
+ACL and the `COMMENT`** — any migration that drops and recreates one must re-issue both.
 
 ### Billing write-gate (new tenant tables)
 
-Entitlement is enforced at the DB layer: every browser-writable tenant table carries `billing_gate_*` restrictive RLS policies that call `company_can_write(company_id)`, so a lapsed/unsubscribed shop can't write (reads stay open). RLS is per-table — **a new `company_id` table without the gate silently bypasses billing.** When you add a tenant table:
-
-- Gate it in the same migration (direct-`company_id` tables): `SELECT public.apply_billing_write_gate('public.your_table');` (parent-resolved child tables need hand-written policies resolving the parent's company — see the `stripe_write_enforcement` migration).
-- Or, if it's genuinely exempt (identity/bootstrap or service-role-only), add it to the exempt list in `tenant_tables_missing_write_gate()`.
-
-The CI test [`test_no_tenant_table_left_ungated`](api/tests/integration/test_billing_enforcement.py) fails if any `company_id` table is neither gated nor exempt — so a forgotten gate is a red build, not silent tech debt. Full standard: [docs/modules/billing.md](docs/modules/billing.md) §4. If you change the entitlement rule, change **both** `lib/entitlement.ts` `getEntitlement` and the SQL `company_can_write` (parity is tested).
+Every browser-writable tenant table carries `billing_gate_*` restrictive RLS calling
+`company_can_write(company_id)`; reads stay open. RLS is per-table, so **a new `company_id` table
+without the gate silently bypasses billing.** Gate it in the same migration —
+`SELECT public.apply_billing_write_gate('public.your_table');` — or add it to the exempt list in
+`tenant_tables_missing_write_gate()`. `test_no_tenant_table_left_ungated` fails the build either
+way. Change the entitlement rule in **both** `lib/entitlement.ts` and the SQL `company_can_write`
+(parity is tested). Full standard: [billing.md](docs/modules/billing.md) §4.
 
 ### Schema source-of-truth
 
-Different questions have different answers. Conflating them is what made the 2026-08-03 outage hard to diagnose.
+Different questions have different answers. Conflating them is what made the 2026-08-03 outage hard
+to diagnose.
 
 | Question | Ask |
 |---|---|
-| What *should* the schema be? | `supabase/migrations/` — the executable history, and the only source of truth. New changes land here as new files. |
-| What columns exist? | [`types/database.ts`](types/database.ts) — generated from the migration-replayed schema, CI-enforced byte-exact (#406). |
-| RLS policies, grants, CHECK constraints, function bodies | The migrations. **None of these appear in `types/database.ts`.** |
-| What does *production* actually have? | Query it — the Supabase MCP server. No file in this repo can answer this honestly. |
+| What *should* the schema be? | `supabase/migrations/` — the executable history, and the only source of truth |
+| What columns exist? | [`types/database.ts`](types/database.ts) — generated, CI-enforced byte-exact (#406) |
+| RLS policies, grants, CHECK constraints, function bodies | The migrations. **None of these appear in `types/database.ts`** — an agent trusting the generated types will conclude a policy is absent when it is present |
+| What does *production* actually have? | Query it, via the Supabase MCP server. No file in this repo answers this honestly |
 
-**There is deliberately no cached prod schema file.** `supabase/schema.prod.sql` existed for the "what does column X look like today" lookup and was deleted because it could — and did — lie. It was hand-edited inside a feature PR to add `customer_contacts.is_billing_default` while production had no such column, its `Generated:` header left untouched, and it asserted that falsehood for two days. During the outage it was worse than useless: it had to be ignored in favour of dumping prod live.
-
-A snapshot that can be confidently wrong is worse than none — the same failure shape as a green check reporting on a preview branch while production burned. **Do not re-introduce a hand-maintainable mirror of production.**
-
-Note that migrations and production *can* legitimately diverge for a while: the merge applies them, and until it succeeds prod is behind. That gap is what [`deploy-production.yml`](.github/workflows/deploy-production.yml) exists to stop the frontend from stepping into.
-
----
-
-### Minimize unnecessary approval prompts (shell command hygiene)
-
-Claude Code's permission allowlist matches on command **names/prefixes**, not on arbitrary code payloads. Two command shapes defeat the allowlist and force a manual approval even when every tool involved is already allowed — avoid them:
-
-1. **Inline-code execution** — `python3 -c "…"`, `python -c`, `node -e "…"`, `psql … -c "<SQL>"`, `agent-browser eval`. These hand the shell an arbitrary code/query payload, which the permission system **always** confirms by design; no allow rule generalizes across payloads (each dialog only offers to allow that one exact snippet). Don't reach for them for routine work:
-   - To inspect a file, use the `Read` tool, or `jq`/`grep`/`cat` — not `python3 -c "import json…"`.
-   - **Never re-validate a file right after `Edit`/`Write`** — the tool already confirmed the write succeeded. That redundant `python3 -c` JSON check is the most common self-inflicted prompt.
-   - For DB reads, prefer `psql "postgresql://…" -f <file.sql>` (a committed query file) over an inline `-c "<SQL>"`; keep any inline query to a single standalone command you accept will prompt once.
-
-2. **Compound commands** — chaining with `&&`, `;`, `|`, or heredocs. Approval requires **every** segment to match an allow rule, so one un-allowable segment (e.g. an inline `eval`) forces the whole block to prompt — including the innocent `cd`/`echo` in front. Prefer single-purpose commands; never bury an inline-code step inside a chain.
-
-Plain allowlisted single commands (`grep`, `cat`, `ls`, `find`, `awk`, `curl`, `git …`, `pnpm …`, `psql … -f`, etc.) run without prompting. Working in a **git worktree has no effect** on this — prompts are about command *shape*, not location.
+**There is deliberately no cached prod schema file.** `supabase/schema.prod.sql` was deleted because
+it could — and did — lie: hand-edited in a feature PR to add a column production did not have, its
+`Generated:` header untouched, asserting that falsehood for two days. A snapshot that can be
+confidently wrong is worse than none. **Do not re-introduce a hand-maintainable mirror of
+production.**
 
 ---
 
 ## Design System: Jigged Manufacturing Data Platform (Material-UI)
 
-> **Source of Truth:** `lib/theme.ts` contains all design values with inline documentation.
-> **Detailed Reference:** `docs/design-system.md` explains principles and rationale.
+**Source of truth:** [`lib/theme.ts`](lib/theme.ts) holds the values.
+**Rationale, layouts, and the accessibility bar:** [docs/design-system.md](docs/design-system.md).
+**Normative interaction rules** are machine-enforced —
+[interaction-standards.md](docs/interaction-standards.md) +
+[`scripts/interactionStandardsCheck.ts`](scripts/interactionStandardsCheck.ts).
 
-**Framework:** Material-UI (MUI) v7+ with Material Design 3 principles
+Use MUI components and the `sx` prop; use the theme palette and `theme.spacing(n)` rather than
+hardcoded colours or pixels. Audience is 50–60 year old shop owners: professional and substantial,
+not trendy or playful, and readable under bright shop lighting. Single dark theme.
 
 ### Who uses what, on what — the device model
 
 **There is no single "primary device". There are three surfaces, and two of them are ours.**
-Corrected 2026-07-31 from founder observation: *"no one used a shop tablet in Contour or any
-shop I've seen."* The docs had assumed shop-floor tablets throughout, and that was wrong.
+Corrected 2026-07-31 from founder observation: *"no one used a shop tablet in Contour or any shop
+I've seen."* The docs had assumed shop-floor tablets throughout, and that was wrong.
 
-| Surface | Who | Device | What follows from it |
+| Surface | Who | Device | What follows |
 |---|---|---|---|
-| **Admin & User** — Storage, Parts, Quotes, Jobs, all data setup | owner, salesperson, scheduler | **Office computer**, mouse + keyboard | Hover is available. Drag is viable. Bundle weight is cheap (office wifi). Dense tables are fine. |
-| **Operator** — jobs, scan, notes | shop floor | **Their own phone** | Touch only, no hover. Bundle weight is expensive (cellular). One-handed reach. Bright ambient light. |
-| **Machine control** | machinist at the machine | The machine's own **HMI** (Haas, Fanuc, …) | **Not a Jigged surface at all.** We never render here; don't design for it. |
+| **Admin & User** — Storage, Parts, Quotes, Jobs, data setup | owner, salesperson, scheduler | **Office computer**, mouse + keyboard | Hover available. Drag viable. Bundle weight cheap. Dense tables fine. |
+| **Operator** — jobs, scan, notes | shop floor | **Their own phone** | Touch only, no hover. Bundle weight expensive (cellular). One-handed reach. Bright ambient light. |
+| **Machine control** | machinist at the machine | The machine's own **HMI** (Haas, Fanuc…) | **Not a Jigged surface.** We never render here; don't design for it. |
 
-**How to apply:** decide which surface a change lands on before reasoning about its
-interaction. The two mistakes this table exists to prevent are (a) rejecting a mouse
-interaction on an admin screen because "touch is unreliable", and (b) treating a phone on
-cellular as though it had an office connection.
-
-Most existing touch rules survive the correction unchanged, because **a phone is at least as
-constrained as a tablet** — the 48px floor, no hover-dependent UI, and high contrast all still
-hold on the operator surface, and more strongly than before.
-
-### Design Principles
-
-1. **Professional, Not Trendy** - Must appeal to 50-60 year old shop owners. Focus on clarity and function.
-2. **Substantial, Not Playful** - Industrial aesthetic. Cards should feel solid and grounded.
-3. **Readable in Bright Environments** - Ensure sufficient contrast for use under bright fluorescent lighting, on a phone held on the shop floor.
-4. **Single Dark Theme** - Optimized for shop floor environments with consistent dark UI.
-
-### Quick Reference
-
-| Element | Approach |
-|---------|----------|
-| Colors | Use theme palette (`color="primary"`) - never hardcode |
-| Spacing | Use `theme.spacing(n)` - never hardcode pixels |
-| Cards | Use default `<Card elevation={2}>` - theme handles glassmorphism |
-| Touch targets | Minimum 48px (theme enforces this) |
-
-### Component Guidelines
-
-**Always use MUI components:**
-- `Button`, `TextField`, `Card`, `Paper`, `Box`, `Typography`
-- `List`, `ListItem`, `ListItemButton`, `ListItemText`
-- `Alert`, `CircularProgress`, `Chip`
-- `Container`, `Grid`, `Stack`
-
-**Styling approach:**
-- Use MUI's `sx` prop for component-level styles
-- Let cards use theme defaults - don't override backgrounds unless necessary
-- Never use external CSS files for MUI components
-- Never use plain HTML elements when MUI equivalents exist
-
-**Standard elevation values:**
-- `2`: Standard cards (default)
-- `3`: Auth cards, modals
-- `4`: App bar, floating elements
-
-### Page Layout Patterns
-
-**IMPORTANT:** All dashboard pages must follow consistent layout patterns. The page title is displayed in the top Header component, so pages should NOT include redundant inline titles.
-
-**List Pages (e.g., Parts, Customers, Resources):**
-```tsx
-<Box>
-  {/* Toolbar - single row */}
-  <Box sx={{ display: 'flex', gap: 2, mb: 3, flexWrap: 'wrap', alignItems: 'center' }}>
-    <TextField placeholder="Search..." size="small" sx={{ width: 300 }} />
-    <Box sx={{ flex: 1 }} />  {/* Spacer */}
-    <Button variant="outlined">Import</Button>
-    <Button variant="contained">New Item</Button>
-  </Box>
-  {/* Content (cards, tables, etc.) */}
-</Box>
-```
-
-**Create/Edit Pages:**
-- Use `<Box>` container with NO padding (layout provides padding)
-- Do NOT add inline page titles - the Header component displays the title
-- Render the form component directly
-
-**Import Pages:**
-- Use `<Box>` container with NO padding
-- Include a simple "Back" button at top left (no redundant page title)
-- Content follows below
-
-### Mobile/Shop Floor Requirements
-
-1. **Large Touch Targets:** Minimum 48px height for buttons/inputs
-2. **Readable Text:** Minimum 16px font size for body text
-3. **Simple Navigation:** Use bottom navigation for primary actions on mobile
-4. **QR Code Scanning:** Design with large scanning area
-5. **Landscape Support:** Ensure job details are usable in landscape mode
-
-### Accessibility (WCAG 2.1 Level A)
-
-- Color contrast: Text on background minimum 4.5:1
-- Large text (18pt+): Minimum 3:1
-- All elements keyboard accessible with visible focus indicators
-- Touch targets: Minimum 48px x 48px
-- Use semantic HTML and proper ARIA labels
+Decide which surface a change lands on before reasoning about its interaction. The two mistakes this
+prevents: rejecting a mouse interaction on an admin screen because "touch is unreliable", and
+treating a phone on cellular as though it had an office connection. Touch rules survive the
+correction unchanged — **a phone is at least as constrained as a tablet.**
 
 ---
 
-## Multi-Tenancy Model
-
-Jigged is a multi-tenant SaaS application where each company's data is isolated, but a single user can have access to multiple companies.
-
-### Database Schema
-
-```sql
--- Companies table
-companies (id, name, created_at, updated_at)
-
--- User-Company access junction table
-user_company_access (id, user_id, company_id, role, created_at)
-
--- User preferences
-user_preferences (id, user_id, last_company_id, created_at, updated_at)
-```
-
-### URL Structure
-
-All app routes include a `companyId` to ensure data isolation:
-- `/dashboard/{companyId}`
-- `/dashboard/{companyId}/parts`
-- `/dashboard/{companyId}/parts/{partId}` -- Part detail; routing (operations + materials) is edited inline on this page
-- `/dashboard/{companyId}/quotes`
-- `/dashboard/{companyId}/jobs`
-- `/dashboard/{companyId}/operations`
-
-### Auth Flow
-
-1. User logs in
-2. System checks companies user has access to
-3. If 1 company: Direct to `/dashboard/{companyId}`
-4. If multiple companies + has last_company_id: Direct to that dashboard
-5. If multiple companies + no preference: Show company selector
-6. If no companies: Show no-access page
-
----
-
-## Development Commands
+## Local development
 
 > **Backend Python runs in the `jigged` conda environment.** Always use it
-> (`conda run -n jigged <cmd>` or activate it) for `python index.py`, `pytest`,
-> and backend scripts — the system `python3` lacks the API deps. Never create
-> per-repo venvs.
+> (`conda run -n jigged <cmd>`) for `python index.py`, `pytest`, and backend scripts — the system
+> `python3` lacks the API deps. **Never create per-repo venvs.**
 
-```bash
-# Install dependencies
-pnpm install
+`pnpm install` · `pnpm dev` · `cd api && conda run -n jigged python index.py` · `pnpm build`.
+Test and lint commands live in `package.json`; don't invent new harness commands.
 
-# Run frontend dev server
-pnpm dev
+`supabase db reset` (alias `pnpm seed`) replays migrations plus `supabase/seed.sql`, the canonical
+dev/preview seed — a rich company with dynamic dates and fixed UUIDs. It writes `auth.users`
+directly, so it is **local/preview only, never prod**. Logins are listed at the top of
+`supabase/seed.sql`.
 
-# Run backend dev server (separate terminal) — jigged conda env
-cd api && conda run -n jigged python index.py
-
-# Build for production
-pnpm build
-```
-
-### Local dev data (seeding)
-
-`supabase/seed.sql` is the canonical dev / preview seed — a rich "Vanguard
-Precision Works" company (parts + multi-level BOMs, inventory, customers,
-quotes → jobs → operations → shipments, activity) with **dynamic dates** (jobs
-and quotes are always current, computed via `now() - interval`) and fixed
-UUIDs. It runs automatically on `supabase db reset` and on every Supabase
-preview-branch creation:
-
-```bash
-supabase db reset   # replays migrations + supabase/seed.sql   (alias: pnpm seed)
-```
-
-Login: `dev@jigged.test` / `jigged-dev-1234`. It writes `auth.users` directly,
-so it is **local / preview only** — never run against prod. (Replaced the old
-`scripts/seed-dev.ts`.)
-
----
-
-## Running tests
-
-The repo has three test runners. Use these directly — don't invent
-new harness commands.
-
-```bash
-# Frontend unit / component tests (Vitest, watch mode)
-pnpm test
-
-# Vitest: run once (CI-style), with coverage, or via UI
-pnpm exec vitest run
-pnpm test:coverage
-pnpm test:ui
-
-# Backend API tests (pytest; from /api)
-# ALWAYS use the "jigged" conda env — it has all backend deps. Do NOT create a new
-# venv (python -m venv / virtualenv); use `conda run -n jigged <cmd>` or activate it.
-cd api && conda run -n jigged pytest                      # full suite
-cd api && conda run -n jigged pytest tests/unit/          # only unit tests
-cd api && conda run -n jigged pytest -m integration       # integration marker (needs DB)
-
-# Type-check the whole frontend (no emit)
-pnpm exec tsc --noEmit -p tsconfig.json
-
-# Lint
-pnpm lint
-
-# E2E (Playwright)
-pnpm test:e2e                                                 # full suite
-pnpm test:e2e:ui                                              # interactive UI mode
-pnpm exec playwright test e2e/<spec>.spec.ts --reporter=list  # one spec, clean output
-pnpm exec playwright test e2e/<spec>.spec.ts --headed --debug # step-through
-```
-
-### Pre-PR validation (smart-scope)
-
-Don't run "everything" before every PR. `next build` (which Vercel runs on
-every preview) already type-checks and lints, so re-running those locally
-is mostly redundant. The actual local-vs-CI gap is **tests** — Vitest,
-pytest, and Playwright run only in the CI workflows ([test.yml](.github/workflows/test.yml),
-[e2e-tests.yml](.github/workflows/e2e-tests.yml)). Match the local check
-to what the change actually risks breaking. CI remains the authoritative
-gate; this is just to shorten the feedback loop before push.
-
-| Change | Run before opening PR |
-|---|---|
-| Component / page / logic in `app/`, `components/`, or `lib/` | `pnpm test --run __tests__/<path>.test.ts` (file-scoped). Fall back to full `pnpm test --run` if the change is to a widely-imported helper. |
-| `utils/*Access.ts` or other Supabase access | `pnpm exec tsc --noEmit -p tsconfig.json` + matching `pnpm test --run __tests__/utils/<file>.test.ts`. |
-| Backend (`api/**/*.py`) | `cd api && pytest tests/unit/test_<area>.py` (or `pytest -m unit` for the fast suite). |
-| `supabase/migrations/*` schema work | `supabase db reset` (replays the migration + seed on a fresh local DB) and skim for errors; the PR's preview branch is the real gate. Spot-check any access layer that touched the changed columns/tables. |
-| `e2e/*.spec.ts`, or UI on a path a spec exercises (parts page, routing builder, auth flow) | Run the affected spec only: `pnpm exec playwright test e2e/<spec>.spec.ts --reporter=list`. |
-| Doc / config / CI YAML / `.gitignore` / `scripts/` | Skip pre-PR validation. CI is the right gate. |
-
-Use **copy-pasteable, file-scoped** commands — `pnpm test --run __tests__/utils/partsAccess.test.ts`,
-not "run the tests". File-scoped runs in seconds; project-wide takes minutes
-and trains everyone to ignore the result.
-
-Anti-patterns to skip:
-
-- **Running the full E2E suite before every PR.** `next build` already
-  covers what's deterministic, and the failures you'd find are usually
-  env drift you can't fix from this side. The `csv-import` spec also
-  needs the FastAPI backend running locally — see E2E gotchas below.
-- **Re-running tsc / lint for doc-only PRs.** The build catches them
-  anyway, and the runs add nothing.
-- **Treating "local pass + CI fail" as a code bug.** That's expected env
-  drift (cache state, machine differences, parallelism). Read the CI log
-  and fix the actual failure; don't try to make local mirror CI exactly.
-
-If unsure what the change touches: tsc is the universally-cheap default
-(~15s, runs on the whole frontend). Backend changes get one
-`pytest -m unit` (~few seconds). Anything beyond that should be motivated
-by the specific change.
-
-### Runbooks — E2E, worktrees, previews
-
-Those procedures live in **[docs/runbooks/local-dev-and-testing.md](docs/runbooks/local-dev-and-testing.md)**:
-one-time E2E setup, running E2E or `pnpm dev` from a git worktree, visual verification on a
-protected Vercel preview, and the E2E gotchas (the CI-skipped `csv-import` spec, why not to pass
-`CI=1` locally, and how a worktree can silently test the *wrong branch*).
-
-They moved out of this file on 2026-08-03: they are runbook rather than rule, and they cost every
-session — including the many that never run E2E — about 4,300 tokens.
-### Where the detailed docs live
-
-- [docs/testing/README.md](docs/testing/README.md) — where each layer lives, the invariant
-  guards, the local-Supabase JWT fixtures, conventions and known holes
-- [e2e/README.md](e2e/README.md) — env contract + what the seed creates
-
----
-
-## Documentation
-
-Product documentation is version-controlled in the `/docs` folder.
-
-### Key Documents
-
-| Document | Path |
-|----------|------|
-| Product Requirements | [docs/prd.md](docs/prd.md) |
-| System Architecture | [docs/architecture.md](docs/architecture.md) |
-| Design System | [docs/design-system.md](docs/design-system.md) |
-| Observability (Sentry / PostHog / Vercel) | [docs/observability.md](docs/observability.md) |
-
-### Module Specifications
-
-See [docs/modules/](docs/modules/) for detailed module specs:
-- [Customers](docs/modules/customers.md)
-- [Parts](docs/modules/parts.md)
-- [Quotes](docs/modules/quotes.md)
-- [Jobs](docs/modules/jobs.md)
-- [Invoicing](docs/modules/invoicing.md)
-- [Work Centers](docs/modules/work-centers.md) (formerly Operations)
-- [Dashboard](docs/modules/dashboard.md)
-- [Routings](docs/modules/routings.md)
-- [Inventory](docs/modules/inventory.md)
-- [Operator View](docs/modules/operator-view.md) — carries the operator journeys too
-- [Machine Maintenance](docs/modules/machine-maintenance.md) (operator-logged machine logbook; flag-gated pilot with a written kill criterion)
-- [Invitation System](docs/modules/invitation-system.md)
-- [Data Import](docs/modules/data-import.md) (guided onboarding import — PRD + technical design in one doc)
-- [Billing & Subscriptions](docs/modules/billing.md) (Stripe-hosted checkout/portal; DB-enforced entitlement)
-- [Shipments](docs/modules/shipments.md)
-- [Vendors](docs/modules/vendors.md)
-- [AI Insights](docs/modules/ai-insights.md) (text-to-SQL chat; the table allow/denylist is a security boundary)
-- [Demo Mode](docs/modules/demo-mode.md) (hidden per-company demo behind a mode toggle)
-
-### Testing Documentation
-
-See [docs/testing/](docs/testing/) for testing strategy and guides.
-
-### Guidelines
-
-- **Consult PRD** before implementing new features
-- **Check module specs** for detailed requirements
-- **Keep docs in sync** — update docs if implementation diverges
-
-### Writing docs: the concision standard
-
-Established by the [#634](https://github.com/debola31/Jigged/issues/634) condensation, which took
-`docs/` from ~166,000 words to roughly half that. **Most information in the fewest words, losing
-none of it.** The test is whether a reader gets the same decisions and constraints in a fraction
-of the reading.
-
-**The core rule: a claim no build can falsify will rot.** That is not a slogan, it is what the
-audit measured. Update frequency did not predict accuracy — the two most-edited module docs both
-rotted while the two least-edited stayed correct. Being edited in the same commit as the code did
-not predict it either. What predicted it was whether a red build would have caught the claim
-being wrong.
-
-**What earns its tokens:** pitfalls; rationale; conventions that differ from tool defaults;
-**withdrawn arguments**; measured numbers; "why not the obvious alternative"; named gaps.
-
-**What does not:** anything derivable by reading the code — directory layouts, dependency lists,
-architecture overviews, file-by-file descriptions, prose restating a function — and **counts of
-anything**. Put a count next to the thing that enforces it, or do not write it. Every count in
-`docs/testing/` was wrong by 3–6× for ten weeks while `vitest.config.ts` carried the true numbers
-on the same line as the enforcement.
-
-**Form.** Decision plus a one-line why. Superseded reasoning becomes one line
-(`**Withdrawn:** <claim> — wrong because <reason>`) — never deleted, never expanded, because
-recording that a reason was *wrong* is what stops the next person rebuilding on it. Prose becomes
-a table when the content is really rows. Say it once and link the rest. Cite migration IDs and
-file paths, never test titles. Use as-built framing with a verification date. **If you are
-tempted to add length, add it as a table row.**
-
-**Cite tests as file + `describe`, with an `it` count — never a nested `describe > 'it title'`
-string, and never truncated with an ellipsis.** A title is free text nothing checks; one audited
-section had 15 of 23 citations dangling. Every path a doc cites must exist.
-
-**The failure mode to hunt for**, found in five of six docs condensed by hand: **a superseded
-mechanic left standing beside its replacement**, usually within 100 lines, with nothing saying the
-first one is dead. Deleting the dead half is the cheapest, highest-value edit available.
-
-**Deletion is a first-class edit.** Every doc PR should say what it removes; an add-only change
-needs a reason. Context files grow by accretion and are almost never pruned — that is how this
-got to 166,000 words.
-
-**Exemplars:** [inventory.md](docs/modules/inventory.md) (journey/decision),
-[customers.md](docs/modules/customers.md) (reference), [billing.md](docs/modules/billing.md)
-(invariant — as-built framing, a truth table, the load-bearing *why*, and an invariant named
-against the CI test that enforces it).
-
-**Not yet mechanical, and it should be.** Nothing checks that a cited path exists, that a link
-resolves, or that a doc's copy of a list still matches the code — `ai-insights.md` drifted to
-"20 tables" against a 19-element frozenset with one denylist entry missing. A link check plus a
-cited-path check would catch that class; they belong with the guards this repo already runs
-(`function_execute_leaks()`, `tenant_tables_missing_write_gate()`, `schemaEmbedCheck`).
-
+**Which tests to run before a PR, E2E setup, running from a worktree, preview verification, and
+shell-command hygiene** (which command shapes force an approval prompt, and why a worktree makes no
+difference): [docs/runbooks/local-dev-and-testing.md](docs/runbooks/local-dev-and-testing.md).
+CI is the authoritative gate; local runs just shorten the loop.

--- a/__tests__/standards/docLinkCheck.test.ts
+++ b/__tests__/standards/docLinkCheck.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import {
+  ALLOWLIST,
+  slugify,
+  headingSlugs,
+  stripFencedBlocks,
+  extractLinkCitations,
+  extractCodePathCitations,
+  resolveCitation,
+  scanProject,
+  unusedAllowlistEntries,
+  type DocIssue,
+} from '../../scripts/docLinkCheck';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+describe('docLinkCheck — GitHub anchor slugs', () => {
+  /**
+   * THE CASE THIS CHECK EXISTS TO GET RIGHT. GitHub replaces each space with
+   * one hyphen and does NOT collapse runs, so an em dash surrounded by spaces
+   * is stripped and leaves a DOUBLE hyphen behind. A slugifier that collapses
+   * whitespace produces a slug that looks correct and 404s — that bug cost real
+   * time during #634, and this heading is a live anchor in CLAUDE.md.
+   */
+  it('leaves a double hyphen where a spaced em dash was', () => {
+    expect(slugify('Who uses what, on what — the device model')).toBe(
+      'who-uses-what-on-what--the-device-model',
+    );
+  });
+
+  it('keeps underscores and hyphens, strips other punctuation', () => {
+    expect(slugify('Data API grants (new tables in `public`)')).toBe(
+      'data-api-grants-new-tables-in-public',
+    );
+    expect(slugify('§5.9 `job_materials` — RESOLVED: drop it')).toBe(
+      '59-job_materials--resolved-drop-it',
+    );
+    expect(slugify('Delete = archive (soft-delete), never blocks')).toBe(
+      'delete--archive-soft-delete-never-blocks',
+    );
+  });
+
+  it('uses only the label of a link in the heading, never the URL', () => {
+    expect(slugify('Known importer bug ([#549](https://example.com/549))')).toBe(
+      'known-importer-bug-549',
+    );
+  });
+
+  it('drops a trailing closing-hash sequence and surrounding space', () => {
+    expect(slugify('  Scales  ')).toBe('scales');
+  });
+});
+
+describe('docLinkCheck — heading extraction', () => {
+  it('numbers duplicate headings the way GitHub does', () => {
+    const slugs = headingSlugs('# Notes\n\n## Notes\n\n### Notes\n');
+    expect([...slugs].sort()).toEqual(['notes', 'notes-1', 'notes-2']);
+  });
+
+  it('ignores `#` comment lines inside fenced code blocks', () => {
+    // Every bash block in CLAUDE.md opens with one of these. Treating them as
+    // headings would invent anchors that GitHub does not publish.
+    const md = ['# Real heading', '', '```bash', '# Install dependencies', 'pnpm install', '```'].join(
+      '\n',
+    );
+    expect([...headingSlugs(md)]).toEqual(['real-heading']);
+  });
+
+  it('blanks fenced blocks without shifting line numbers', () => {
+    const md = ['a', '```', 'b', '```', 'c'].join('\n');
+    expect(stripFencedBlocks(md).split('\n')).toEqual(['a', '', '', '', 'c']);
+  });
+
+  it('does not end a ~~~ fence on a shorter inner fence', () => {
+    const md = ['~~~~', '```', '# not a heading', '```', '~~~~', '# heading'].join('\n');
+    expect([...headingSlugs(md)]).toEqual(['heading']);
+  });
+});
+
+describe('docLinkCheck — citation extraction', () => {
+  it('takes relative link targets and skips external URLs', () => {
+    const md =
+      '[a](modules/parts.md) [b](https://example.com/x) [c](mailto:x@y.z) [d](../lib/theme.ts)';
+    expect(extractLinkCitations(md, 'docs/README.md').map((c) => c.target)).toEqual([
+      'modules/parts.md',
+      '../lib/theme.ts',
+    ]);
+  });
+
+  it('splits an #anchor off a link target', () => {
+    const [c] = extractLinkCitations('[x](modules/jobs.md#material-cost)', 'docs/README.md');
+    expect(c.target).toBe('modules/jobs.md');
+    expect(c.anchor).toBe('material-cost');
+  });
+
+  /**
+   * Real shape in docs/design-system.md. A `[^\]]*` label stops at the first
+   * inner `]` and matches nothing, so links whose label is a Next.js route path
+   * — the ones most likely to rot, since route folders get renamed — went
+   * unchecked while the scan still looked clean.
+   */
+  it('reads a link whose label contains bracketed route segments', () => {
+    const md = '[`app/operator/[companyId]/layout.tsx`](../app/operator/[companyId]/layout.tsx)';
+    expect(extractLinkCitations(md, 'docs/design-system.md').map((c) => c.target)).toEqual([
+      '../app/operator/[companyId]/layout.tsx',
+    ]);
+  });
+
+  it('percent-decodes a link target', () => {
+    // Next.js route segments get encoded by editors that auto-link paths.
+    const [c] = extractLinkCitations(
+      '[x](../../app/dashboard/%5BcompanyId%5D/import/page.tsx)',
+      'docs/modules/data-import.md',
+    );
+    expect(c.target).toBe('../../app/dashboard/[companyId]/import/page.tsx');
+  });
+
+  it('keeps a bare #anchor link, to be checked against the doc itself', () => {
+    const [c] = extractLinkCitations('[x](#status-model)', 'docs/modules/jobs.md');
+    expect(c.target).toBe('');
+    expect(c.anchor).toBe('status-model');
+  });
+
+  it('reads inline-code paths only for known repo prefixes', () => {
+    const md = '`utils/jobsAccess.ts` and `deleted_at IS NULL` and `jobs/foo.ts`';
+    expect(extractCodePathCitations(md, 'docs/x.md').map((c) => c.target)).toEqual([
+      'utils/jobsAccess.ts',
+    ]);
+  });
+
+  it('skips globs, brace expansions and placeholders', () => {
+    const md = [
+      '`utils/*Access.ts`',
+      '`api/**/*.py`',
+      '`__tests__/components/operator/{A,B}.test.tsx`',
+      '`utils/<entity>Access.ts`',
+    ].join(' ');
+    expect(extractCodePathCitations(md, 'docs/x.md')).toHaveLength(0);
+  });
+
+  it('keeps Next.js [param] segments, which are real directory names', () => {
+    const [c] = extractCodePathCitations('`app/dashboard/[companyId]/jobs/`', 'docs/x.md');
+    expect(c.target).toBe('app/dashboard/[companyId]/jobs/');
+  });
+
+  it('strips a trailing test name, pytest node id, or symbol fragment', () => {
+    const md = [
+      '`__tests__/utils/customerAccess.test.ts > createCustomer > revives`',
+      '`api/tests/integration/test_billing_enforcement.py::test_no_tenant_table_left_ungated`',
+      '`utils/jobsAccess.ts#deleteJob`',
+    ].join('\n');
+    expect(extractCodePathCitations(md, 'docs/x.md').map((c) => c.target)).toEqual([
+      '__tests__/utils/customerAccess.test.ts',
+      'api/tests/integration/test_billing_enforcement.py',
+      'utils/jobsAccess.ts',
+    ]);
+  });
+});
+
+describe('docLinkCheck — resolution bases', () => {
+  const cite = (over: Partial<Parameters<typeof resolveCitation>[2]>) => ({
+    raw: '',
+    target: '',
+    anchor: null,
+    line: 1,
+    base: 'repo-root' as const,
+    ...over,
+  });
+
+  it('resolves a markdown link against the doc directory', () => {
+    const found = resolveCitation(
+      REPO_ROOT,
+      'docs/modules/jobs.md',
+      cite({ target: '../../utils/jobsAccess.ts', base: 'doc-dir' }),
+    );
+    expect(found).toBe(path.join(REPO_ROOT, 'utils/jobsAccess.ts'));
+  });
+
+  it('resolves an inline-code path against the repo root, from any doc depth', () => {
+    const found = resolveCitation(
+      REPO_ROOT,
+      'docs/modules/jobs.md',
+      cite({ target: 'utils/jobsAccess.ts' }),
+    );
+    expect(found).toBe(path.join(REPO_ROOT, 'utils/jobsAccess.ts'));
+  });
+
+  it('resolves an extensionless module reference, as the imports do', () => {
+    const found = resolveCitation(
+      REPO_ROOT,
+      'docs/interaction-standards.md',
+      cite({ target: 'components/common/DeleteIconButton' }),
+    );
+    expect(found).toBe(path.join(REPO_ROOT, 'components/common/DeleteIconButton.tsx'));
+  });
+
+  it('does NOT guess an extension for a markdown link — a link is a URL', () => {
+    expect(
+      resolveCitation(
+        REPO_ROOT,
+        'docs/interaction-standards.md',
+        cite({ target: '../components/common/DeleteIconButton', base: 'doc-dir' }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for a path that does not exist', () => {
+    expect(
+      resolveCitation(REPO_ROOT, 'docs/README.md', cite({ target: 'utils/nopeAccess.ts' })),
+    ).toBeNull();
+  });
+});
+
+describe('docLinkCheck — docs are clean', () => {
+  it('every cited path exists and every link anchor resolves', () => {
+    const result = scanProject(REPO_ROOT);
+
+    /**
+     * Self-check: a scanner that found nothing must not pass. The floors sit
+     * just under what the tree actually holds (32 docs / 1,072 citations / 143
+     * anchors on 2026-08-03) rather than at 1, because every plausible way for
+     * an extractor to break — stopping after the first doc, swallowing
+     * everything after the first fenced block, dropping the anchor half —
+     * still returns a positive number and would otherwise report a clean tree.
+     */
+    expect(result.docsScanned).toBeGreaterThan(25);
+    expect(result.citationsChecked).toBeGreaterThan(800);
+    expect(result.anchorsChecked).toBeGreaterThan(110);
+
+    expect(format(result.issues), format(result.issues)).toBe('');
+  });
+
+  /**
+   * Proves the case above is not trivially green: with the allowlist off, every
+   * one of its entries must still raise the issue it excuses. It also fails an
+   * entry that has gone stale — a standing licence to re-break that citation.
+   */
+  it('has no stale allowlist entry, and each one still suppresses a real miss', () => {
+    expect(ALLOWLIST.size).toBeGreaterThan(0);
+    const stale = unusedAllowlistEntries(REPO_ROOT);
+    expect(stale, `stale ALLOWLIST entries:\n${stale.join('\n')}`).toEqual([]);
+  });
+
+  it('catches a synthetic rename of a heading another doc links to', () => {
+    // A heading is an interface; renaming it must be detectable.
+    expect(headingSlugs('## Stations (work centers)\n').has('stations-work-centers')).toBe(true);
+    expect(headingSlugs('## Stations (work centres)\n').has('stations-work-centers')).toBe(false);
+  });
+});
+
+function format(issues: DocIssue[]): string {
+  return issues.map((i) => `${i.file}:${i.line} [${i.kind}] ${i.message}`).join('\n');
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,8 +3,8 @@
 Jigged is a data platform for small precision manufacturing shops.
 
 **Start with [CLAUDE.md](../CLAUDE.md)** — it carries the rules that bind every change (API
-architecture, migrations, grants, the billing write-gate, the design system, and the doc-writing
-standard). This tree carries the detail.
+architecture, migrations, grants, the billing write-gate, the design system). This tree carries
+the detail, including the doc-writing standard in [writing-docs.md](writing-docs.md).
 
 ## Product
 
@@ -59,7 +59,7 @@ criterion · [inventory.md](modules/inventory.md)
 
 ## How these are written
 
-The doc-writing standard lives in [CLAUDE.md](../CLAUDE.md#writing-docs-the-concision-standard):
+The doc-writing standard lives in [writing-docs.md](writing-docs.md):
 most information in the fewest words, losing none of it, on the principle that **a claim no build
 can falsify will rot**. Exemplars: [inventory.md](modules/inventory.md) for a journey/decision doc,
 [customers.md](modules/customers.md) for a reference doc, [billing.md](modules/billing.md) for an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,10 @@
 # System Architecture
 
 > **Rewritten 2026-08-03 (#634), verified against the code the same day; adversarial
-> re-check the same day restored §9 (below).
-> 3,424 → ~4,300 words — it grew, and that is the honest number.** ~300 words of
+> re-check the same day restored §9 (below), and a third pass took ownership of two
+> topics from CLAUDE.md (§6.1 typed client, §16 soft delete) as CLAUDE.md was cut to
+> pointers — 3,424 → ~5,200 words.
+> It grew, and that is the honest number.** ~300 words of
 > stale or duplicated material came out; the rest of the delta is correction,
 > citation and previously-undocumented behaviour. **Cut:** §10 Development Commands
 > (CLAUDE.md owns it, and this copy said `pip install -r requirements.txt` /
@@ -20,13 +22,16 @@
 > in the local-dev runbook, not in `.env.local.example`. The restored §9 is the
 > corrected, current contract, not the 2026-04 copy.
 >
-> **Ten corrections, marked inline:** `operation_types` listed live twice (dropped
+> **Corrections, marked inline:** `operation_types` listed live twice (dropped
 > for `work_centers`); `jobs.status` (no such column — three orthogonal axes);
 > `quotes.converted_to_job_id` (no such column); an `owner` role (never in the
 > CHECK); two wrong theme hexes; `stripe_routes.py` absent; insights endpoints 4×
 > overcounted; a `getCustomers()` paginated pattern that does not exist;
 > `supabase/schema.staging.sql` and `schema.prod.sql` (both since deleted); a `shipments/` route
-> "feature-flagged per tenant" (neither exists).
+> "feature-flagged per tenant" (neither exists); "`utils/*Access.ts` use the untyped
+> `getSupabase()`" (the access layer is fully converted — §6.1); and §16's soft-delete
+> guard cited as `#367`, which is the E2E reload-convention parent (the real issue is
+> `#687`).
 
 Multi-tenant data platform for small-scale precision manufacturing shops.
 Environment variables are §9; dev/test commands and pre-PR validation live in
@@ -152,10 +157,77 @@ value of 500 "kept the IN () list well inside PostgREST's URL limits" — wrong 
 more than double, so any shop with ~200+ stocked parts got a hard 414 on every
 chunk. One home, because four files had independently picked the same wrong number.
 
-**Typed vs untyped client.** `getSupabase()` (untyped, legacy) and
-`getTypedSupabase()` (`<Database>`-generic against [`types/database.ts`](../types/database.ts))
-share one singleton in [`lib/supabase.ts`](../lib/supabase.ts). New access functions
-use the typed getter; conversion is per-file. Regen + CI drift rules: CLAUDE.md.
+#### 6.1 The typed client and `types/database.ts`
+
+*This subsection owns the typed-client contract — CLAUDE.md points here.*
+
+[`lib/supabase.ts`](../lib/supabase.ts) exposes two getters over **one singleton**.
+`getTypedSupabase()` applies the `<Database>` generic from
+[`types/database.ts`](../types/database.ts), so every `.from('t').select('…')` chain
+is checked at compile time; `getSupabase()` returns the *same runtime instance* with
+the generic erased. Same client, different type.
+
+**As built (2026-08-03): the access layer is fully converted.** Every file under
+[`utils/`](../utils) that touches the client imports `getTypedSupabase`, almost always
+aliased `as getSupabase` so the call sites read unchanged. *(This doc and CLAUDE.md
+both said "existing `utils/*Access.ts` files use `getSupabase()`" — true when the
+migration started, false since it finished; the alias is what made it look otherwise.)*
+The untyped getter survives only at the page/component paths in the `files:` grandfather
+block at the bottom of [`eslint.config.mjs`](../eslint.config.mjs) — mostly `supabase.auth.*`
+callers, where the table generic buys nothing. **Drain that block, never extend it**
+([#573](https://github.com/debola31/Jigged/issues/573)).
+
+**Enforced, not aspirational.** `no-restricted-imports` in `eslint.config.mjs` makes
+`import { getSupabase } from '@/lib/supabase'` an **error**, with the grandfathered paths
+as an explicit exemption list, so it ratchets. It exists because the material-yield PR
+dropped `part_procurement_tiers.vendor_id`, `types/database.ts` was regenerated correctly,
+and `PartBomPanel`'s **untyped** cost-ladder query kept filtering the dropped column — it
+compiled clean and shipped a false "No cost on file" on every bought material.
+
+**Regen after any migration that changes columns:** `pnpm gen:db-types`, against a
+**running local stack** (`supabase start`). The generator reads `--local`, not a remote
+project, so without a started stack it has nothing to read.
+
+**CI fails on drift ([#406](https://github.com/debola31/Jigged/issues/406)).** The backend
+job in [`.github/workflows/test.yml`](../.github/workflows/test.yml) replays
+`supabase/migrations/` into a fresh local stack, regenerates, and `git diff --exit-code`s
+`types/database.ts`. A schema change without a regen — or a hand-edited types file — goes
+red. **Treat `types/database.ts` like a lockfile.**
+
+**The CLI version is pinned in three places that must move together**, because that check
+diffs a `--local` regen and any skew is a spurious red: `package.json` → `gen:db-types`
+(`npx --yes supabase@<version>`), `.github/workflows/test.yml` → `setup-cli`, and
+[`.github/workflows/e2e-tests.yml`](../.github/workflows/e2e-tests.yml) → `setup-cli`.
+Bump all three, run `pnpm gen:db-types`, commit the result. Pinning *inside the script*
+is deliberate: a globally-installed `supabase` CLI may then auto-update freely without
+ever affecting generation. A fourth value tracks the CLI — test.yml's
+`POSTGRES_META_VERSION` pre-pull — because `gen types --local` starts its **own**
+postgres-meta container and, unlike `supabase start`, ignores
+`SUPABASE_INTERNAL_IMAGE_REGISTRY`; without the GHCR pull-and-retag it goes straight to
+`public.ecr.aws` and re-flakes on the Docker rate limit.
+
+**What the generated types do NOT contain.** Tables, views, and function *signatures* —
+that is all. **No RLS policies, no `GRANT`s, no `CHECK` constraints, no function bodies.**
+So `jobs.production_status` types as bare `string` although it is CHECK-constrained to
+four values (§7); `Enums` is `{ [_ in never]: never }`; `company_can_write` appears as
+`Args`/`Returns` with nothing about what it enforces. **Absence in this file is not
+absence in the database** — grepping it for a policy or a grant yields "not found" for
+things that exist and are load-bearing. `supabase/migrations/` is the only source for
+those.
+
+**Typed mode does not subsume [`scripts/schemaEmbedCheck.ts`](../scripts/schemaEmbedCheck.ts)
+— measured, not assumed.** Injecting a bogus embed column and running `tsc` project-wide:
+the `jobs → job_parts → parts` embed in `jobsAccess` **errors**; `QUOTE_DETAIL_SELECT` in
+`quotesAccess` produces **nothing**. **Withdrawn:** that the difference is how the select
+string is declared — `as const` and full inlining at the call site were both tested against
+a `jobsAccess` positive control in the same run, and neither helped. It is the select's own
+breadth/depth (`quotes → customers → contacts + addresses`, alongside `line_items → parts`);
+past some size supabase-js's type-level parser silently widens instead of erroring, and
+silence is indistinguishable from success. So the largest, most-nested selects — including
+`quotesAccess.ts`, where the May 2026 `jobs.status` incident actually lived — are covered
+by the scanner only. Driven from
+[`__tests__/schema/embedCheck.test.ts`](../__tests__/schema/embedCheck.test.ts) →
+`describe('schemaEmbedCheck — full project scan')` (2 `it`s).
 
 ---
 
@@ -436,8 +508,11 @@ customer-facing/financial documents; apply the standard above when closing them.
 
 **"Delete" = archive (soft-delete), universally.** Every user-facing entity —
 `parts`, `customers`, `customer_contacts`, `customer_carrier_accounts`, `vendors`,
-`work_centers`, `jobs`, `quotes` — carries a nullable `deleted_at timestamptz`. The
-UI Delete action sets it instead of issuing a SQL `DELETE`, and **never blocks**:
+`work_centers`, `jobs`, `quotes` — carries a nullable `deleted_at timestamptz`. That
+list is not a maintained copy: it is exactly the set of tables with a `deleted_at`
+column in [`types/database.ts`](../types/database.ts) (re-derive with `grep -n deleted_at`),
+re-checked 2026-08-03. *(CLAUDE.md's copy named six, omitting the two customer children.)*
+The UI Delete action sets it instead of issuing a SQL `DELETE`, and **never blocks**:
 the row survives, so every downstream reference (quote lines, job parts, shipments,
 invoices, BOM edges) keeps resolving and no foreign key can trap the user.
 **Withdrawn:** the prior model blocked deletion of anything referenced via
@@ -491,6 +566,9 @@ a shipped/invoiced job or a converted quote is safe — its shipment/invoice/chi
 history is intact, just hidden. **Withdrawn:** the "kept for recordkeeping" hard
 guards on `deleteJob` (`countShipmentsForJob` / invoice checks) — wrong because
 archiving already preserves the record, so the guard only blocked a safe action.
+**Do not re-introduce a records-of-value delete guard** — an invoiced or shipped job
+archives like anything else, and money-record protection belongs only at a future
+permanent-purge step. (One such guard is still live in the UI: #682, below.)
 Jobs keep an orthogonal `cancelled` **production** status (`cancelJob`/`reopenJob`)
 — a shop-floor outcome, not deletion.
 
@@ -505,6 +583,7 @@ retention/purge job must carry the `company_id` tenant predicate under RLS.
 |---|---|---|---|
 | parts | archive; `archive_parts` RPC also strips BOM-child edges | revives | impact dialog shows quote/job/BOM-cost counts |
 | customers, vendors, work_centers | archive (`UPDATE deleted_at`) | revives | import upsert + manual create both revive |
+| customer_contacts, customer_carrier_accounts | archive (`archiveCustomerContact` / `archiveCarrierAccount`) | n/a — customer-scoped, no company-wide name key | children of a customer; their list reads filter, and documents' retained FKs still resolve |
 | jobs | archive (`UPDATE deleted_at`) | n/a | `cancelled` production status is separate; records-of-value guards removed |
 | quotes | archive (`UPDATE deleted_at`) | n/a | `sweepExpiredQuotes` is a status change, not deletion |
 
@@ -516,9 +595,29 @@ Archive behaviour is pinned by the top-level `describe` in each `*Access` suite:
 [`jobsAccess.test.ts`](../__tests__/utils/jobsAccess.test.ts) `describe('jobsAccess')`,
 [`quotesAccess.test.ts`](../__tests__/utils/quotesAccess.test.ts) `describe('quotesAccess utilities')`.
 Revive-on-re-import is pinned server-side in
-[`test_parts_import_api.py`](../api/tests/integration/test_parts_import_api.py). The
-"no list query forgot `deleted_at IS NULL`" invariant has **no automated guard** —
-`automation-pending (#367)`.
+[`test_parts_import_api.py`](../api/tests/integration/test_parts_import_api.py).
+
+**Named gap: this whole policy has no systemic enforcement.** The
+"no list/search/picker/count read forgot `deleted_at IS NULL`" invariant is scoped and
+unbuilt as [#687](https://github.com/debola31/Jigged/issues/687) — a source scanner
+reusing [`scripts/schemaEmbedCheck.ts`](../scripts/schemaEmbedCheck.ts)'s schema parser
+(soft-deletable *is* "has a `deleted_at` column"), classifying by query **shape** so it
+never flags the by-id reads that must stay unfiltered. *(Previously cited here as `#367`,
+which is the E2E reload-convention parent and has nothing to do with soft delete.)*
+Because nothing checks it, **two violations are open right now**, both found by reading
+docs rather than by looking for them:
+
+- [#684](https://github.com/debola31/Jigged/issues/684) — `getCount()` in
+  [`utils/dashboardAccess.ts`](../utils/dashboardAccess.ts) omits the filter, so the
+  `open_quotes` / `not_started_jobs` / `in_progress_jobs` tiles count archived rows,
+  while `getOverdueJobs` and `getCompletedJobsInRange` in the same file get it right.
+- [#682](https://github.com/debola31/Jigged/issues/682) — `app/dashboard/[companyId]/jobs/[jobId]/page.tsx`
+  still refuses to delete a job that has shipments or a QuickBooks invoice link (the
+  records-of-value guard withdrawn above), and its confirm dialog promises a permanent,
+  irreversible delete that does not happen.
+
+The failure is **silent** in every case: an archived customer reappears in a dropdown, a
+count is quietly wrong, nothing errors. Audit every new query by hand until #687 ships.
 
 **Relationship to §15:** complementary. Snapshots keep a document readable if its
 master is edited or deleted; archive means the master usually is *not* deleted at

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,28 +1,82 @@
 # Design System
 
-> **Condensed 2026-08-03 · 4,546 → 4,079 words (`wc -w`).** Cut: ~1,400 words restating CLAUDE.md
-> (principles 1–5, component-usage rules, list/create-edit/import layouts, mobile requirements,
-> WCAG); the ~450-word theme-provider example and the `WorkOrderCard` sample; pasted
-> `<Card>`/`<TextField>` snippets; the unused MUI 0–24 elevation ladder; a Do's/Don'ts list that
-> repeated CLAUDE.md. Roughly **950 words of new, code-verified correction** went back in, which is
-> why the net cut is modest — the pre-correction equivalent is ~3,130. Kept deliberately: every
+> **Condensed 2026-08-03 · 4,546 → 4,079 words (`wc -w`), then re-expanded to 5,764 by the inversion
+> below.** Cut in the first pass: the ~450-word theme-provider example and the `WorkOrderCard`
+> sample; pasted `<Card>`/`<TextField>` snippets; the unused MUI 0–24 elevation ladder; a Do's/Don'ts
+> list. Roughly **950 words of code-verified correction** went back in. Kept deliberately: every
 > withdrawn argument, every measured value, every citation.
 >
-> **Nine corrections, marked inline.** Largest: the steel-blue-centre gradient this doc called
-> "CRITICAL … must be present on all pages" was removed app-wide for a 4.11:1 contrast failure; the
-> drawn storage board behind "tile-and-sheet" was deleted in `db58ae8`; and the pasted `statusColors`
-> map named nine job statuses that do not exist.
+> **Inverted 2026-08-03 (same day).** The first pass also cut ~1,400 words as "restating CLAUDE.md"
+> and *delegated* principles, component usage, page layouts, mobile requirements and WCAG **to**
+> CLAUDE.md. That was backwards: CLAUDE.md is loaded into every session whether or not anyone is
+> touching UI, so the delegation parked the derivable half in the expensive place and left this file
+> pointing at it. **This file now owns all six**, re-absorbed and verified against the code;
+> CLAUDE.md keeps a pointer here. Four of the six arrived wrong — see [Reach &
+> accessibility](#reach--accessibility) (the 48px claim and the WCAG level), [Scales](#scales) (the
+> 16px body-text minimum) and [Glass cards](#glass-cards) (the elevation ladder).
+>
+> **Nine corrections from the first pass, marked inline.** Largest: the steel-blue-centre gradient
+> this doc called "CRITICAL … must be present on all pages" was removed app-wide for a 4.11:1
+> contrast failure; the drawn storage board behind "tile-and-sheet" was deleted in `db58ae8`; and the
+> pasted `statusColors` map named nine job statuses that do not exist.
 >
 > **Values live in [`lib/theme.ts`](../lib/theme.ts).** This file holds rationale and the decisions
-> no token can express. Delegated: principles / component usage / list-create-import layouts /
-> mobile / WCAG → [CLAUDE.md](../CLAUDE.md#design-system-jigged-manufacturing-data-platform-material-ui);
-> destructive actions + saving → [interaction-standards.md](interaction-standards.md); logo,
-> marketing palette, voice → [brand-guide.md](brand-guide.md).
+> no token can express. Elsewhere: destructive actions + saving →
+> [interaction-standards.md](interaction-standards.md); logo, marketing palette, voice →
+> [brand-guide.md](brand-guide.md); **which surface a change lands on** (office computer / operator
+> phone / machine HMI) → [the device model in
+> CLAUDE.md](../CLAUDE.md#who-uses-what-on-what--the-device-model), which every rule here about
+> hover, density and touch depends on.
 
 Material-UI **v7.3.6** *(this doc previously said "MUI v5+")*, Material Design 3, single dark theme,
 no light/dark toggle. The dark theme is the one visual decision carrying direct user validation — a
 manufacturing user's verdict on it was *"pretty fucking awesome"* — which is why there is no toggle
 and no second theme to keep in sync.
+
+---
+
+## Principles
+
+Four. They are not decoration on the theme — each is the reason a specific decision below went the
+way it did, and the audience is what makes them non-obvious: 50–60 year old shop owners and
+machinists, not designers.
+
+| Principle | Because the reader is | Where it bites |
+|---|---|---|
+| **Professional, not trendy** | someone who reads novelty as *unfinished* | [Callouts & insets](#callouts--insets-no-decorative-accent-borders) — no decorative side-accents; [Placeholders](#placeholders) — nothing that could pass for entered data |
+| **Substantial, not playful** | in a shop, looking at money and schedule | [Glass cards](#glass-cards) — a deep opaque panel, not a pale floating one; deliberately 2D, no 3D scene or video behind live data |
+| **Readable in a bright room** | holding a phone under 500–1000 lux of fluorescent light | [The app canvas](#the-app-canvas) — contrast measured against the room, not the desk |
+| **One dark theme, no toggle** | one validated look, not two kept in sync | the paragraph above — the only visual decision here carrying direct user validation |
+
+**Named gap:** nothing checks any of the four. They earn their place only by being cited at the
+decisions they produced, which is the sole way a reader can tell whether a new screen honours them.
+
+---
+
+## Writing UI
+
+**MUI components, always** — `Button`, `TextField`, `Card`, `Paper`, `Box`, `Typography`, `List` /
+`ListItem` / `ListItemButton` / `ListItemText`, `Alert`, `CircularProgress`, `Chip`, `Container`,
+`Grid`, `Stack`. When you need semantic markup, reach for the **`component` prop**
+(`<Card component="li">`, `<Box component="form">`) rather than dropping to a raw element — it keeps
+the theme applied *and* the HTML semantic, and it is what the repo already does far more often than
+it writes a bare `<div>`.
+
+**Style with `sx`; there is no stylesheet.** The repo contains **no `.css` file at all** outside
+`node_modules` — no global stylesheet, no CSS module, nothing imported by
+[`app/layout.tsx`](../app/layout.tsx). That is a deliberate deviation from Next.js, which supports
+both out of the box. A rule declared in CSS lives outside `lib/theme.ts` *and* outside every
+component's `sx`, so it is invisible from the two places anyone looks when the dark palette breaks.
+Keep it at zero.
+
+**Never hardcode a colour or a pixel in a component.** `color="primary"`,
+`sx={{ color: 'text.secondary', p: 3 }}`. Raw hex belongs in [`lib/theme.ts`](../lib/theme.ts) and in
+the [sanctioned exempt chips](#status-badges) — nowhere else.
+
+**Let theme defaults be the default.** `<Card>` already carries elevation 2, the glass fill and the
+hairline; `<TextField>` is already outlined and 48px tall. Most call sites still pass `elevation={2}`
+explicitly — redundant rather than wrong, but it means a deliberate deviation doesn't stand out, so
+don't add more.
 
 ---
 
@@ -87,6 +141,87 @@ white 0.15"; the `MuiCard` block below it is authoritative.)*
 Elevations in use: **0, 1, 2** (default), **3** (auth/emphasis), **4** (`/admin` AppBar). 5–24 unused;
 dialogs and menus get solid `#111439` / `#1a1f4a` overrides instead.
 
+**Withdrawn:** the ladder "2 = standard cards · 3 = auth cards **and modals** · 4 = **app bar,
+floating elements**" — wrong at both ends. It omitted **0** and **1**, which are in use (flat
+`Accordion`s and `Paper` insets; the import `StatusCards`). Elevation 4 describes exactly one surface,
+[`app/admin/layout.tsx`](../app/admin/layout.tsx) — the operator app bar is `elevation={0}` and the
+dashboard [`Header`](../components/layout/Header.tsx) isn't an `AppBar` at all. And modals never sat
+on the ladder: `MuiDialog` takes a solid paper override instead, so its elevation is moot.
+
+---
+
+## Reach & accessibility
+
+### The 48px floor
+
+**Everything tappable is at least 48px in its smallest dimension.** That is a rule you have to
+uphold, not a guarantee the theme gives you — and the difference is the single claim that was written
+down wrong for as long as it existed.
+
+**Corrected 2026-08-03.** "Touch targets: minimum 48px (theme enforces this)" overclaimed.
+[`lib/theme.ts`](../lib/theme.ts) sets `minHeight: 48` on **three** components and nothing else:
+
+| Control | Floored at 48? |
+|---|---|
+| `Button` · `TextField` (on `.MuiInputBase-root`) · `ListItemButton` | **Yes**, by `lib/theme.ts` |
+| Operator bottom-nav actions | **Yes** — `minHeight: 56`, set by hand in [`app/operator/[companyId]/layout.tsx`](../app/operator/[companyId]/layout.tsx) |
+| `IconButton`, including [`DeleteIconButton`](../components/common/DeleteIconButton.tsx) — which defaults to `size="small"` | **No.** MUI's own padding leaves it well under the floor |
+| `Checkbox` · `Chip` · `Tab` · `ToggleButton` · a hand-rolled `<Box onClick>` or `CardActionArea` | **No.** Nothing constrains them |
+
+**Named gap: nothing measures a target.**
+[`interactionStandardsCheck.ts`](../scripts/interactionStandardsCheck.ts) scans for button colour,
+value-shaped placeholders and grey delete icons — not size. An undersized tap target ships green.
+
+**Where the gap is tolerable, and where it isn't.** Undersized `IconButton`s cluster on admin
+surfaces, which are mouse-driven office computers, and a mouse hits a 30px target fine. On the
+operator surface the floor is real and unforgiving — a phone, one-handed, sometimes gloved. That is
+also the whole origin of [row-and-sheet](#row-and-sheet-one-tap-target-a-sheet-that-owns-every-action):
+the forcing case was an element drawn ~6px tall that could not be raised to 48px in place.
+
+### The operator surface is a phone
+
+What the shell enforces, all in
+[`app/operator/[companyId]/layout.tsx`](../app/operator/[companyId]/layout.tsx) unless noted:
+
+- **Bottom navigation, not a sidebar** — five thumb-reachable slots, the only primary nav on the
+  operator surface. Its `minWidth: '0px'` override is load-bearing, not tidying: MUI's 80px default
+  made five slots demand 400px and clipped both *ends* at a 375px viewport. The measurement lives in
+  the file; don't restate it, don't undo it.
+- **The content column is capped at `maxWidth: 680`**, even in a desktop browser. Uncapped, a
+  four-line movement row rendered ~1,900px wide with its text in the leftmost fifth — which is what
+  made the activity feed read as sparse rather than dense.
+- **Landscape is deliberate** — `orientation: 'any'` in [`app/manifest.ts`](../app/manifest.ts), so
+  job details stay usable turned sideways. *(Its inline comment still says "on a tablet" — the
+  withdrawn device assumption. The setting is right; the reason is stale.)*
+- **QR scanning gets the viewport, not a framed box** —
+  [`LocationScanner`](../components/scanner/LocationScanner.tsx) renders the camera at full width and
+  height with `objectFit: 'cover'`.
+
+### Contrast, keyboard, semantics
+
+**The live standard is the one in [The app canvas](#the-app-canvas):** 4.5:1 body and 3:1 large text
+as a *floor*, measured against a 500–1000 lux shop floor rather than an office monitor, and treated
+as a hard limit rather than a number to squeak past. Every ratio in this file was measured by hand.
+
+**Withdrawn:** the heading "Accessibility (WCAG 2.1 **Level A**)" — wrong twice. Level A imposes no
+contrast requirement at all; 4.5:1 body / 3:1 large text are Level **AA** (SC 1.4.3). And 48px is not
+a WCAG number in any version — WCAG 2.2 asks 24×24 CSS px at AA (SC 2.5.8) and 44×44 at AAA
+(SC 2.5.5). 48px is the Material Design touch-target guideline, which is stricter, which is why we
+keep it. Two standards were live in two files with nothing marking either dead; this is the survivor.
+
+The rest of that block stands, because it is right and cheap:
+
+- **Keyboard-reachable, with a visible focus indicator.** The
+  [row-and-sheet](#row-and-sheet-one-tap-target-a-sheet-that-owns-every-action) rule that a row's name
+  stays a real `<button>` — rather than a `<tr>` pretending to be a control — exists for this.
+- **Semantic HTML and real ARIA labels.** Use MUI's `component` prop for the element, and label every
+  icon-only control: [`DeleteIconButton`](../components/common/DeleteIconButton.tsx) makes
+  `ariaLabel` a *required* prop precisely so it cannot be skipped.
+
+**Named gap: there is no automated accessibility check.** No axe, no contrast assertion, no
+target-size rule anywhere in the Vitest, Playwright or scanner layers. Contrast regressions are caught
+by someone looking — which is how the 4.11:1 canvas survived as long as it did.
+
 ---
 
 ## Buttons
@@ -98,7 +233,8 @@ dialogs and menus get solid `#111439` / `#1a1f4a` overrides instead.
 done* — exactly the trap we hit with green "Complete" / "Mark Received" buttons.
 
 `color` is almost always **omitted** (theme default `primary`). `size="large"` is never needed — the
-theme floors every button at a **48px** touch target.
+theme floors every `Button` at a **48px** touch target. (One of only three components it floors; an
+`IconButton` is not among them — [the 48px floor](#the-48px-floor).)
 
 | Rank | Style | Use for |
 |---|---|---|
@@ -370,6 +506,19 @@ system stack as fallback, `textTransform: 'none'` on buttons.
 | size | 2.5rem / 40px | 2rem / 32px | 1.75rem / 28px | 1.5rem / 24px | 1.25rem / 20px | 1rem / 16px | 1rem / 16px | 0.875rem / 14px | 0.75rem / 12px |
 | use | Page titles | Section headings | Subsections | Card titles | Component headings | Small headings | Body | Secondary body (`#C8CCD4`) | Helper text |
 
+*(`lib/theme.ts` defines h1–h6, `body1`, `body2` and `button` only. `caption` — and `subtitle1` /
+`subtitle2`, unused — are MUI's defaults, listed here because they render, not because we set them.)*
+
+**Use the named variants; never set `fontSize` in `sx`.** `body1` (16px) is the floor for *primary*
+body copy — the thing the user came to read. `body2` (14px) and `caption` (12px) sit below it on
+purpose and are the documented homes for secondary and helper text.
+
+**Withdrawn:** "Readable Text: minimum 16px font size for body text" — wrong as stated, and
+contradicted by the very theme it was describing: `body2` is `0.875rem` (14px) in `lib/theme.ts`,
+carries the `#C8CCD4` label colour, and is in use for secondary text throughout. What it was reaching
+for is the rule above (don't shrink *primary* copy) plus the contrast floor — contrast, not size, is
+what carries 14px in a bright room, which is why `text.secondary` was lightened to hold ≥4.5:1.
+
 **Spacing** — MUI 8px base via `theme.spacing(n)`: 1 = 8px, 2 = 16px, 3 = 24px, 4 = 32px, 6 = 48px,
 8 = 64px. Use `sx={{ p: 3 }}`, never `padding: '24px'`.
 
@@ -400,11 +549,32 @@ it describes: [`types/job.ts`](../types/job.ts) → `PRODUCTION_STATUS_CONFIG` (
 
 ---
 
-## Detail-page layout patterns
+## Page layout patterns
 
-CLAUDE.md covers list, create/edit and import pages. This covers **detail pages** — one record of one
-entity. Three patterns; don't mix them. **Pick by what the user came to do, not by entity size:** a
-*reference* entity is opened to read settings and see relations, not to drive anything; a
+**No page renders its own title.** [`Header`](../components/layout/Header.tsx) derives one from the
+pathname, and [`PageTitleProvider`](../components/layout/PageTitleProvider.tsx) lets a page override
+it with the record's identity (the part page sets the part number) — the app bar sticks, so that
+identity stays visible while scrolling. An inline `<Typography variant="h4">Parts</Typography>` at the
+top of a page is a duplicate that also *loses* the sticky behaviour it duplicates.
+
+**List pages** — `<Box>` with no padding (the layout supplies it) → one flex toolbar row → content.
+The toolbar reads left to right: search `TextField` (`size="small"`), any selection-dependent bulk
+actions, a `<Box sx={{ flex: 1 }} />` spacer, then `outlined` Import and `contained` New … pinned to
+the right edge. Content is a `<Card>` wrapping an AG Grid, swapped for a centred empty-state card at
+zero rows — which is why the Card hairline is tuned for full-width tables ([Glass cards](#glass-cards)).
+Cleanest read: [`customers/page.tsx`](../app/dashboard/[companyId]/customers/page.tsx).
+
+**Create / edit pages** — `<Box>` with no padding, no inline title, the form component rendered
+directly. The form owns its own cards.
+
+**Import pages** — `<Box>` with no padding, an `ArrowBackIcon` "Back" button at top left, content
+below.
+
+### Detail pages
+
+One record of one entity. Three patterns; don't mix them. **Pick by what the user came to do, not by
+entity size:** a *reference* entity is opened to read settings and see relations, not to drive
+anything; a
 *workflow / document* entity is opened to act on a process (ship, cancel, send PDF) or to step through
 a child collection (operations, line items); a *workspace* is opened to keep editing the record
 itself. As-built, verified 2026-08-03:

--- a/docs/modules/billing.md
+++ b/docs/modules/billing.md
@@ -88,18 +88,40 @@ the existing membership policy. **SELECT is never gated.** `service_role` and
 seeder are unaffected.
 
 > ### ⚠ Invariant: every new tenant table must be billing-gated
-> A new `company_id` table without the gate **silently bypasses billing**. To make
-> that a *loud CI failure* instead of tech debt:
-> - Gate a new direct-`company_id` table in one line, in its migration:
->   `SELECT public.apply_billing_write_gate('public.your_table');`
->   (Parent-resolved child tables — no `company_id` — still need hand-written
->   policies that resolve the parent's company; see the
->   `stripe_write_enforcement` migration for the pattern.)
-> - The CI test **`test_no_tenant_table_left_ungated`** calls
->   `public.tenant_tables_missing_write_gate()` and fails if any `company_id` table
->   is neither gated nor on the explicit exempt list. Add a genuinely-exempt table
->   (identity/bootstrap or service-role-only) to that function's list — a conscious
->   one-line decision.
+> A new `company_id` table without the gate **silently bypasses billing** — no error,
+> no broken page, no symptom. Two guards in
+> `api/tests/integration/test_billing_enforcement.py` make that a red build instead of
+> tech debt:
+>
+> | SQL check → CI test | Catches | Fix |
+> |---|---|---|
+> | `tenant_tables_missing_write_gate()` → `test_no_tenant_table_left_ungated` | a `company_id` table with no `billing_gate_insert` policy | `SELECT public.apply_billing_write_gate('public.your_table');` in that table's own migration |
+> | `definer_writers_missing_write_gate()` → `test_no_definer_function_walks_past_the_gate` | a `SECURITY DEFINER` function that writes a gated table without consulting the gate | `PERFORM public.inv_assert_can_write(<company>);` after the membership check |
+>
+> `apply_billing_write_gate` only works on a **direct `company_id`** table.
+> Parent-resolved children (no `company_id`) need hand-written policies that resolve
+> the parent's company — pattern in
+> [`20260725210136_stripe_write_enforcement.sql`](../../supabase/migrations/20260725210136_stripe_write_enforcement.sql).
+>
+> **The first guard checks that a policy *exists*, so it is blind to a definer function
+> walking past a policy that does.** That is how the five location-stock RPCs shipped
+> with no entitlement check (#645), which made billing depend on a feature flag: a
+> lapsed shop with `inventory_locations` OFF was blocked (direct browser insert, gate
+> applies) and the same shop with it ON wrote freely. The second guard exists only
+> because of that blind spot —
+> [`20260801150944_inventory_rpc_billing_write_gate.sql`](../../supabase/migrations/20260801150944_inventory_rpc_billing_write_gate.sql).
+>
+> A genuinely-exempt table (identity/bootstrap, or service-role-only) goes on the exempt
+> list inside `tenant_tables_missing_write_gate()` — a conscious one-line edit.
+> **A false rationale on that list is the failure mode:** `part_location_stock` sat under
+> "writes never come from the browser" while the browser was writing it through definer
+> RPCs, and that one sentence is what carried #645 through review. It has since been
+> removed from the list and gated.
+>
+> **Named gap:** `create_shipment_with_line_items` is browser-callable, writes gated
+> tables, and does not check. It is on the definer exempt list so the guard stays green
+> on a *filed* gap rather than being ignored — whether a lapsed shop may still ship an
+> order it already placed is a billing policy question, tracked separately.
 
 **Storage:** the private `attachments` bucket's `storage.objects` INSERT/DELETE
 policies also call `company_can_write` (company derived from the first path
@@ -206,7 +228,7 @@ backend loads env at startup — restart `python api/index.py` after changing th
 
 - **DB-only (CI, no Stripe):** `api/tests/integration/test_billing_enforcement.py` —
   the RLS write-gate across every state, read-still-works, TS↔SQL parity, the
-  `apply_stripe_subscription` guard, and the completeness check.
+  `apply_stripe_subscription` guard, and both §4 completeness guards.
   `__tests__/lib/entitlement.test.ts` (Vitest) + `scripts/verify_billing_parity.sql`
   cover the entitlement rule. `api/tests/unit/test_stripe_routes.py` covers endpoint
   logic (mocked Stripe).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -12,12 +12,18 @@ they *do* overlap are handled deliberately — one avoided, one knowingly accept
 
 ### Overlap 1 — error tracking: avoided
 
-**Sentry owns errors. PostHog must not.** `capture_exceptions` is deliberately `false` in
+**Sentry owns errors. PostHog must not. Never add a second error tracker.**
+`capture_exceptions` is deliberately off in
 [`instrumentation-client.ts`](../instrumentation-client.ts) — Sentry has the grouping,
 breadcrumbs and source-map upload that make a solo triage queue workable, and PostHog's
 error tracking has no advanced grouping. Two trackers means double ingest and two places to
 look during an incident. Turning it on would also make PostHog source-map upload a hard CI
 requirement; leaving it off deletes that work item.
+
+**Named gap:** the option is never *written*. `capture_exceptions` appears in that file only
+inside a comment, so no test and no grep fails if someone turns it on. Verified behaviourally
+instead — the PostHog project has never ingested an `$exception` event; the name is absent
+from its taxonomy entirely (checked 2026-08-03).
 
 **Vercel has no JavaScript error tracking at all**, so it substitutes for neither. A
 client-side crash is invisible in Vercel logs.
@@ -34,9 +40,14 @@ deliberate choice, not an oversight — do not "clean it up".**
   journeys, funnels, retention, drop-off, session replay, feature flags. Vercel can tell you
   conversions fell; only PostHog can tell you where.
 
+**The overlap is also smaller than it looks: Web Vitals are Vercel-only.** PostHog has never
+ingested a `$web_vitals` event here — the name is absent from its taxonomy (checked
+2026-08-03), because nothing turns on `capture_performance`. Deleting `<Analytics />` would
+not move Web Vitals to PostHog; it would end them.
+
 The redundancy costs one script tag. Removing it would trade a free, always-correct traffic
 number for a marginal bundle saving and a dependency on PostHog events being instrumented
-correctly. Keep both.
+correctly. **Keep both — neither is "redundant".**
 
 ---
 
@@ -245,7 +256,22 @@ In [`instrumentation-client.ts`](../instrumentation-client.ts):
 | `EmptyRanges` | A Safari extension. Absent from source, `node_modules` **and** the built bundle |
 | `Lock was stolen` | auth-js's own recovery working as designed; no user-visible effect |
 
-Add to this list only with a verified reason, and record it here.
+Add to this list only with a verified reason, and record it here. An entry with no recorded
+reason is indistinguishable from a mistake.
+
+### Don't re-enable the SDKs outside a production build
+
+`enabled: process.env.NODE_ENV === "production"` guards all three JS configs —
+[`instrumentation-client.ts`](../instrumentation-client.ts),
+[`sentry.server.config.ts`](../sentry.server.config.ts),
+[`sentry.edge.config.ts`](../sentry.edge.config.ts) — and `"pytest" in sys.modules` guards
+the backend (next section). `pnpm dev` and the Playwright suite both run with
+`NODE_ENV=development`, and their errors used to land in the same queue as production; that
+noise is what made the alerts ignorable ([why](#why-any-of-this-matters)).
+
+**The guard costs no deployment coverage.** Vercel builds *previews* with
+`NODE_ENV=production` too — which is where `vercel-preview` in the environment table above
+comes from. Only local and CI runs are silenced.
 
 ---
 

--- a/docs/runbooks/database-migrations.md
+++ b/docs/runbooks/database-migrations.md
@@ -1,0 +1,165 @@
+# Runbook — database migrations
+
+> As-built, verified **2026-08-03** against `supabase/migrations/`, `supabase/config.toml`,
+> [`deploy-production.yml`](../../.github/workflows/deploy-production.yml),
+> [`test.yml`](../../.github/workflows/test.yml) and [`vercel.json`](../../vercel.json).
+>
+> Moved out of `CLAUDE.md` under [#634](https://github.com/debola31/Jigged/issues/634) — ceremony you
+> follow when writing a migration, not a rule binding every change. Three rules bind at *creation*
+> time and stayed inline in `CLAUDE.md`: use `supabase migration new`; a new `public` table needs
+> explicit `GRANT`s in the same migration; a new function is browser-callable unless you
+> `REVOKE EXECUTE`. This file is the surrounding procedure.
+
+## The workflow, per change
+
+1. **`supabase migration new <slug>`** — creates the file with a fresh 14-digit timestamp. Never
+   write a file into `supabase/migrations/` by hand (see "Why the CLI owns the timestamp").
+2. Write the SQL into the new file.
+3. **If the migration creates a table in `public`, grant it explicitly** — in the same migration,
+   alongside `ENABLE ROW LEVEL SECURITY` and the policies. Without a `GRANT` the table is invisible
+   to PostgREST/supabase-js and the FastAPI backend. Same migration, same block: the billing
+   write-gate (`apply_billing_write_gate`) if it carries `company_id`, and an `EXECUTE` revoke on
+   any `SECURITY DEFINER` function. All three standards live in `CLAUDE.md`.
+4. **Verify locally:** `supabase db reset` replays the baseline + migrations + `supabase/seed.sql`
+   on a fresh local DB — run it plus the relevant tests. This is the deterministic check; there is
+   **no staging project to push to anymore** (we run on Supabase Branching now).
+5. **Open a PR.** Supabase Branching auto-creates a preview branch, applies the migration to it, and
+   reports the **required migration status check**; the Vercel preview points at that branch's DB.
+   If the check is red, fix the migration — it blocks merge.
+   **A green PR does not mean the migration will apply to production.** See "Why a green PR proves
+   less than it looks like" below — this is the single most expensive thing on this page.
+6. **Merge to `main` applies migrations to production.** Supabase runs them and posts its verdict as
+   a check on the **merge commit** — not on the PR, which is closed and frozen green by then. Do NOT
+   run `supabase db push` (or `supabase link`) against prod manually; the branching pipeline owns it.
+   The human still owns clicking merge.
+7. **The frontend deploys only after that verdict is green** — see "The production gate".
+8. Nothing to regenerate afterwards except `types/database.ts` (`pnpm gen:db-types`, which pins its
+   own generator version), enforced byte-exact by the backend job in `test.yml`. There is
+   deliberately no prod schema snapshot to refresh — see "Schema source-of-truth".
+
+## Why the CLI owns the timestamp
+
+The CLI tracks migrations by `(version, name)` in `supabase_migrations.schema_migrations`. Two files
+sharing a version **collapse to one row**, leaving the rest invisible to the tracker — `db push` then
+sees them as pending and tries to re-run them. We hit exactly this when legacy 8-digit date-prefixed
+files (`20260313_…`) accumulated multiple migrations per date. Never use the 8-digit date-only prefix
+for new files; always let the CLI generate the 14-digit `YYYYMMDDHHMMSS`.
+
+## Why a green PR proves less than it looks like
+
+**Every pre-merge gate in this repo builds its database by replaying the migrations** — `supabase db
+reset`, the Supabase preview-branch check, the E2E stack. They are therefore green *by construction*
+whenever the migration files are internally consistent. Production was never built that way: its
+baseline was **marked-as-applied against the pre-existing database rather than executed**. So an
+object the baseline creates exists on every preview branch and on every local stack, and does not
+exist on prod.
+
+That asymmetry caused the **2026-08-03 outage**, and it is documented at the site of the fix in
+[`20260801024552_revoke_function_execute_from_browser_roles.sql`](../../supabase/migrations/20260801024552_revoke_function_execute_from_browser_roles.sql)
+(§2b):
+
+- `REVOKE EXECUTE ON FUNCTION public.rls_auto_enable()` raised `42883` on production only.
+  `rls_auto_enable` returns `event_trigger`, and creating an event trigger requires **SUPERUSER** —
+  which `postgres` is on a local stack and is **not** on hosted Supabase. The baseline creates it
+  wherever the baseline actually *runs*; prod never had it.
+- Migrations are atomic and ordered, so that one statement aborted its whole file and blocked **the
+  twelve behind it**, from 2026-08-01 to 2026-08-03.
+- Vercel shipped the frontend anyway. PR #654 then went live selecting
+  `customer_contacts.is_billing_default` — a column the blocked migrations were supposed to create —
+  and every job and quote page rendered "Job not found", because PostgREST rejects the *whole* select
+  on one bad column (`42703`, surfaced as a 400).
+
+The resolution was to **tolerate the absence** (guard the revoke with `to_regprocedure(...) IS NOT
+NULL`) rather than create the missing function: an event trigger cannot be created on hosted Supabase
+without superuser, and the revoke is meaningless where the function does not exist. Everything else in
+that migration stays unguarded on purpose — a function missing anywhere else is real drift and should
+still be loud.
+
+**How to apply.** When a migration behaves differently on prod than locally, **suspect privilege level
+first** (superuser-only objects: event triggers, some extensions). When the app says data is missing,
+check for a 400 + SQLSTATE in the Supabase logs before assuming the rows are gone.
+
+**Never clear a stuck migration with `migration repair --status applied`.** It records the file as done
+without running it, so its contents never reach production and the next migration that depends on them
+fails the same way.
+
+## The production gate
+
+[`.github/workflows/deploy-production.yml`](../../.github/workflows/deploy-production.yml) — `on: push`
+to `main`, plus `workflow_dispatch` for re-running after a migration is fixed. Two jobs:
+
+| Job | What it does |
+|---|---|
+| `gate` — "Database is ready for this code" | Polls the check runs on the merge commit every 15s for the newest run named by `SUPABASE_CHECK_NAME`. `success` → exit 0. Any other conclusion → exit 1, printing Supabase's `.output.summary`. No verdict inside `GATE_TIMEOUT_SECONDS` (600) → exit 1. |
+| `deploy` — needs `gate` | `vercel pull --environment=production`, `vercel build --prod`, `vercel deploy --prebuilt --prod`. |
+
+**Why it exists:** the migration apply and the frontend build used to run in parallel with no ordering,
+so when one failed the other shipped anyway — the 2026-08-03 outage above. **It fails closed**: no
+verdict is not the same as a good verdict, so a Supabase outage blocks deploys. That cost is
+deliberate. If it blocks, fix the migration and merge again.
+
+**Withdrawn:** an earlier attempt polled production's `schema_migrations` over a direct database
+connection — wrong because it put a prod DB credential in CI and created a second source of truth that
+could disagree with Supabase's own verdict. The gate reads the verdict that already exists instead.
+
+### Gotchas in the gate, each of which cost real time
+
+- **The check is named `Supabase Preview` on the merge commit too** — same name, but there it reports
+  the *production* apply. If Supabase renames it, `SUPABASE_CHECK_NAME` is the one line to change; the
+  gate fails closed until it is corrected.
+- **The gate parses status and conclusion only, never the summary.** Supabase puts a raw multi-line SQL
+  error in `.output.summary`; folding it into the delimited row makes it many lines and every parsed
+  field garbage — which reads as a *timeout* rather than a *failure*, the most dangerous possible
+  misreading here.
+- **Nobody saw the original failures, for two structural reasons.** The check lands on the merge commit,
+  created *after* the PR page freezes, so a closed PR stays green forever; and GitHub sends no
+  notification for third-party App check runs — subscribable failure emails cover Actions workflows only
+  ([community#55379](https://github.com/orgs/community/discussions/55379), still open). Making the gate
+  an Actions workflow closes that notification gap as a side effect, which is the real reason to prefer
+  it.
+- **`cancel-in-progress` is deliberately `false`.** Cancelling would kill a deploy midway through
+  `vercel deploy`, the one moment where interruption can leave production indeterminate. Two rapid
+  merges deploy in order; the later wins because it runs last.
+- **`VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` are read from `vars` *or* `secrets`.** They were configured as
+  secrets while the workflow read `vars`; `vercel pull` then failed with "The specified token is not
+  valid", pointing at the one credential that *was* present. A preflight step now names the missing
+  setting instead.
+
+### Is the workflow the only path to production?
+
+**UNVERIFIED — and the claim it replaces was false.** `CLAUDE.md` asserted Vercel's git auto-deploy was
+off for `main` via `git.deploymentEnabled` in `vercel.json`. It is not: [`vercel.json`](../../vercel.json)
+holds only `functions` and `rewrites`, and the *only* occurrence of `deploymentEnabled` anywhere in the
+repo was that sentence describing itself.
+
+Verifiable from files: the workflow deploys production on every push to `main` and gates it on the
+migration verdict. Whether Vercel's git integration *also* auto-deploys `main` is a dashboard setting
+with no representation in this repo — confirm it in Vercel before treating the gate as an exclusive
+chokepoint. `vercel deploy --prod` is in any case a documented manual escape hatch, so the workflow is
+not the only *possible* path.
+
+## Schema source-of-truth
+
+Different questions have different answers. Conflating them is what made the 2026-08-03 outage hard to
+diagnose.
+
+| Question | Ask |
+|---|---|
+| What *should* the schema be? | `supabase/migrations/` — the executable history, and the only source of truth. New changes land here as new files. |
+| What columns exist? | [`types/database.ts`](../../types/database.ts) — generated from the migration-replayed local stack, CI-enforced byte-exact ([#406](https://github.com/debola31/Jigged/issues/406)). |
+| RLS policies, grants, CHECK constraints, function bodies | The migrations. **None of these appear in `types/database.ts`.** |
+| What does *production* actually have? | Query it — the Supabase MCP server. No file in this repo can answer this honestly. |
+
+**There is deliberately no cached prod schema file.** `supabase/schema.prod.sql` existed for the "what
+does column X look like today" lookup and was deleted because it could — and did — lie. It was
+hand-edited inside a feature PR to add `customer_contacts.is_billing_default` while production had no
+such column, its `Generated:` header left untouched, and it asserted that falsehood for two days.
+During the outage it was worse than useless: it had to be ignored in favour of dumping prod live.
+
+A snapshot that can be confidently wrong is worse than none — the same failure shape as a green check
+reporting on a preview branch while production burned. **Do not re-introduce a hand-maintainable mirror
+of production.**
+
+Migrations and production *can* legitimately diverge for a while: the merge applies them, and until it
+succeeds prod is behind. That gap is what `deploy-production.yml` exists to stop the frontend from
+stepping into.

--- a/docs/runbooks/local-dev-and-testing.md
+++ b/docs/runbooks/local-dev-and-testing.md
@@ -1,52 +1,118 @@
 # Runbook — local dev, tests, worktrees and previews
 
-> Moved out of `CLAUDE.md` on 2026-08-03 under [#634](https://github.com/debola31/Jigged/issues/634).
-> It is **runbook, not rule**: procedures you follow when doing a specific thing, rather than
+> Moved out of `CLAUDE.md` on 2026-08-03 under [#634](https://github.com/debola31/Jigged/issues/634):
+> E2E/worktree/preview procedures first, then pre-PR validation and shell-command hygiene.
+> It is **runbook, not rule** — procedures you follow when doing a specific thing, rather than
 > constraints that bind every change. Keeping it in the always-loaded file cost roughly 4,300
-> tokens on every session, including the many that never run E2E. Nothing here was cut — it moved.
+> tokens on every session, including the many that never run E2E. Nothing was cut — it moved.
 >
 > The rules that *do* bind every change stayed in `CLAUDE.md`.
+
+## Pre-PR validation (smart-scope)
+
+Don't run "everything" before every PR. **CI is the authoritative gate and it already runs all of
+it:** [`test.yml`](../../.github/workflows/test.yml) runs `pnpm exec tsc --noEmit`, `pnpm lint`,
+Vitest with coverage thresholds and pytest with a coverage floor;
+[`e2e-tests.yml`](../../.github/workflows/e2e-tests.yml) runs the whole Playwright suite. Local
+runs exist only to shorten the feedback loop — match the check to what the change risks breaking.
+
+> **Withdrawn:** "`next build` already type-checks and lints, so re-running them locally is
+> redundant." The conclusion survives but the reason was wrong, and it named the wrong enforcer.
+> The steps that go red are `Type check` and `Lint` in `test.yml`'s frontend job. In particular
+> `pnpm lint` is `eslint --max-warnings <N>` (cap lives in `package.json`, ratcheting down under
+> [#442](https://github.com/debola31/Jigged/issues/442)) — a Vercel build enforces no such cap, so
+> it cannot be what keeps the number falling.
+
+| Change | Run before opening PR |
+|---|---|
+| Component / page / logic in `app/`, `components/`, or `lib/` | `pnpm test --run __tests__/<path>.test.ts` (file-scoped). Fall back to full `pnpm test --run` if the change is to a widely-imported helper. |
+| `utils/*Access.ts` or other Supabase access | `pnpm exec tsc --noEmit -p tsconfig.json` + matching `pnpm test --run __tests__/utils/<file>.test.ts`. |
+| Backend (`api/**/*.py`) | `cd api && conda run -n jigged pytest tests/unit/test_<area>.py` (or `pytest -m unit` for the fast suite). |
+| `supabase/migrations/*` schema work | `supabase db reset` (replays the migration + seed on a fresh local DB) and skim for errors; the PR's preview branch is the real gate. Spot-check any access layer that touched the changed columns/tables. **From a worktree, don't reset the shared stack** — see below. |
+| `e2e/*.spec.ts`, or UI on a flow a spec exercises | Run that spec only: `pnpm exec playwright test e2e/<spec>.spec.ts --reporter=list`. `ls e2e/*.spec.ts` names them by flow — check it rather than trusting a list written here, which is exactly the kind that rots. |
+| Doc / config / CI YAML / `.gitignore` / `scripts/` | Skip pre-PR validation. CI is the right gate. |
+
+Use **copy-pasteable, file-scoped** commands — `pnpm test --run __tests__/utils/partsAccess.test.ts`,
+not "run the tests". File-scoped runs in seconds; project-wide takes minutes and trains everyone to
+ignore the result. If unsure what a change touches, `tsc` is the universally-cheap default (~15s,
+whole frontend); backend changes get one `pytest -m unit` (~seconds). Anything beyond that should be
+motivated by the specific change.
+
+**Anti-patterns:**
+
+- **Running the full E2E suite before every PR.** CI runs it on every PR against a fresh stack, and
+  locally it wants the whole four-service orchestration (below) for minutes. Run the affected spec.
+- **Re-running tsc / lint for doc-only PRs.** Adds nothing a CI step won't do.
+- **Treating "local pass + CI fail" as a code bug.** That's expected env drift (cache state, machine
+  differences, parallelism). Read the CI log and fix the actual failure; don't try to make local
+  mirror CI exactly.
+
+## Shell hygiene: the two command shapes that force an approval prompt
+
+Claude Code's permission allowlist matches on command **names/prefixes**, not on arbitrary code
+payloads. Two shapes defeat it and force a manual approval even when every tool involved is already
+allowed:
+
+1. **Inline-code execution** — `python3 -c "…"`, `python -c`, `node -e "…"`, `psql … -c "<SQL>"`,
+   `agent-browser eval`. These hand the shell an arbitrary code/query payload, which the permission
+   system **always** confirms by design; no allow rule generalizes across payloads (each dialog only
+   offers to allow that one exact snippet).
+   - To inspect a file, use the `Read` tool, or `jq`/`grep`/`cat` — not `python3 -c "import json…"`.
+   - **Never re-validate a file right after `Edit`/`Write`.** The tool already confirmed the write
+     succeeded. That redundant `python3 -c` JSON check is the most common self-inflicted prompt.
+   - For DB reads prefer `psql "postgresql://…" -f <file.sql>` (a committed query file) over an
+     inline `-c "<SQL>"`. Keep any inline query to a single standalone command you accept will
+     prompt once.
+2. **Compound commands** — chaining with `&&`, `;`, `|`, or heredocs. Approval requires **every**
+   segment to match an allow rule, so one un-allowable segment (e.g. an inline `eval`) forces the
+   whole block to prompt, including the innocent `cd`/`echo` in front. Prefer single-purpose
+   commands; never bury an inline-code step inside a chain.
+
+Plain allowlisted single commands (`grep`, `cat`, `ls`, `find`, `awk`, `curl`, `git …`, `pnpm …`,
+`psql … -f`) run without prompting. Working in a **git worktree has no effect** on this — prompts
+are about command *shape*, not location.
 
 ## E2E setup (only needed once per machine)
 
 ```bash
-# Install the Chromium build Playwright uses
 pnpm exec playwright install chromium
 ```
 
-E2E runs against an **ephemeral local Supabase** (`supabase start`), not
-staging. `e2e/global-setup.ts` provisions the test user, company, and the
-whole data graph itself (find-or-insert) with the local **service-role** key
-— so no committed login is needed, only two env vars taken from the running
-local stack:
+E2E runs against an **ephemeral local Supabase** (`supabase start`), not staging.
+`e2e/global-setup.ts` provisions the test user, company and the whole data graph itself
+(find-or-insert) with the local **service-role** key — so no committed login is needed, only two env
+vars taken from the running local stack:
 
 - `TEST_SUPABASE_URL` = `API_URL` from `supabase status`
 - `TEST_SUPABASE_SECRET_KEY` = `SERVICE_ROLE_KEY` from `supabase status`
 
-These are the local stack's keys and **rotate every `supabase start`** — fetch
-them fresh via the CLI, never hardcode. Standard local run (what
-`.github/workflows/e2e-tests.yml` does in CI):
+These are the local stack's keys and **rotate every `supabase start`** — fetch them fresh via the
+CLI, never hardcode.
+
+**`pnpm test:e2e:local` is the whole run, and it is exactly what CI invokes.** It runs
+[`e2e/run-stack.mjs`](../../e2e/run-stack.mjs), which spawns the Anthropic mock (9876), FastAPI
+(8000) and Next.js (3000), waits for each readiness URL, then runs Playwright and tears them all
+down. Full env contract in [`e2e/README.md`](../../e2e/README.md); don't duplicate it here.
 
 ```bash
-supabase start                        # one local Postgres + Supabase stack
-eval "$(supabase status -o env)"      # exports API_URL / ANON_KEY / SERVICE_ROLE_KEY
-export TEST_SUPABASE_URL=$API_URL
-export TEST_SUPABASE_SECRET_KEY=$SERVICE_ROLE_KEY
-export NEXT_PUBLIC_SUPABASE_URL=$API_URL          # point the app at the same stack
-export NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY
-pnpm exec playwright test --grep-invert "CSV Import"
+supabase start
+eval "$(supabase status -o env)"      # API_URL / ANON_KEY / SERVICE_ROLE_KEY
+# …export the TEST_* / NEXT_PUBLIC_* / SUPABASE_* / ANTHROPIC_* set from e2e/README.md…
+pnpm test:e2e:local                   # add --grep <name> to narrow
 ```
 
-Playwright auto-launches `pnpm dev` on `localhost:3000` when not in CI
-(see `playwright.config.ts`); reuses an existing dev server if one is
-already running.
+> **Withdrawn (both were true before `run-stack.mjs`):** "Playwright auto-launches `pnpm dev` when
+> not in CI" — `playwright.config.ts` has no `webServer` any more; orchestration owns service
+> lifecycle and Playwright just trusts `localhost:3000`. And "the `csv-import` spec skips in CI, so
+> filter it with `--grep-invert 'CSV Import'`" — the skip is gone, the AI column analysis it needs
+> is served by `e2e/mocks/anthropic-server.mjs`, and CI runs the suite unfiltered.
 
 ## Running E2E (or `pnpm dev`) from a git worktree
 
-Git worktrees do **not** inherit gitignored files, so a fresh worktree has no
-`.env.local` (or any `.env*`). `pnpm dev` and anything that reads Supabase
-creds will fail until you pull them from the **primary checkout** (the first
-entry in `git worktree list`). Do this once at the top of a worktree session:
+Git worktrees do **not** inherit gitignored files, so a fresh worktree has no `.env.local` (or any
+`.env*`). `pnpm dev` and anything that reads Supabase creds will fail until you pull them from the
+**primary checkout** (the first entry in `git worktree list`). Do this once at the top of a worktree
+session:
 
 ```bash
 PRIMARY=$(git worktree list --porcelain | head -1 | sed 's/^worktree //')
@@ -55,52 +121,48 @@ cp "$PRIMARY/.env.local" .                   # dev-server Supabase creds
 [ -f "$PRIMARY/e2e/.env.test.local" ] && cp "$PRIMARY/e2e/.env.test.local" e2e/
 ```
 
-They land gitignored in the worktree, so they're never committed. Note the
-**E2E local-Supabase vars are *not* copied** — `TEST_SUPABASE_URL` /
-`TEST_SUPABASE_SECRET_KEY` come from `supabase status -o env` of the running
-local stack (above), so they're correct in any worktree without copying.
-(Claude can run `supabase status -o env`, and `supabase start` if the stack
-isn't up, to fetch them — they're local-only, not secrets.)
+They land gitignored in the worktree, so they're never committed. Note the **E2E local-Supabase vars
+are *not* copied** — `TEST_SUPABASE_URL` / `TEST_SUPABASE_SECRET_KEY` come from
+`supabase status -o env` of the running local stack (above), so they're correct in any worktree
+without copying. (Claude can run `supabase status -o env`, and `supabase start` if the stack isn't
+up, to fetch them — they're local-only, not secrets.)
 
-**Node deps + Python env in a worktree.** `node_modules` is gitignored too, so
-a fresh worktree has none — run `pnpm install` **inside the worktree** (fast:
-pnpm hardlinks from its global store, so it's correct for that branch's exact
-deps and costs almost no extra disk). Do **not** symlink the primary's
-`node_modules` — it silently breaks when a branch's deps differ, and a stray
-`pnpm install` would mutate the primary. Backend Python uses the shared
-`jigged` conda env (`conda run -n jigged …`) — nothing to install per worktree.
+**Node deps + Python env in a worktree.** `node_modules` is gitignored too, so a fresh worktree has
+none — run `pnpm install` **inside the worktree** (fast: pnpm hardlinks from its global store, so
+it's correct for that branch's exact deps and costs almost no extra disk). Do **not** symlink the
+primary's `node_modules` — it silently breaks when a branch's deps differ, and a stray
+`pnpm install` would mutate the primary. Backend Python uses the shared `jigged` conda env — nothing
+to install per worktree.
 
 ```bash
 pnpm install                                       # node deps for THIS worktree
 conda run -n jigged python -m pytest tests/unit/   # backend tests, jigged env
 ```
 
-**The local Supabase stack is a machine-wide singleton, shared by every
-worktree — it is NOT per-worktree.** There is one Postgres container set per
-machine. `supabase start` / `supabase db reset` replay migrations from whatever
-directory invokes them into that one shared DB, so a `db reset` from any
-worktree **replaces the stack for every other worktree** too. It does not track
-a branch; it holds whatever was last replayed into it — in practice the
-primary's, since that's where resets usually run. So when working from a
-worktree:
+**The local Supabase stack is a machine-wide singleton, shared by every worktree — it is NOT
+per-worktree.** There is one Postgres container set per machine. `supabase start` / `supabase db
+reset` replay migrations from whatever directory invokes them into that one shared DB, so a
+`db reset` from any worktree **replaces the stack for every other worktree** too. It does not track
+a branch; it holds whatever was last replayed into it — in practice the primary's, since that's
+where resets usually run. So when working from a worktree:
 
-- **No migration changes in your branch?** The shared local stack is a valid
-  substrate — run `pnpm dev`, unit tests, and E2E against it from the worktree
-  normally (the schema it needs already exists).
-- **Your branch adds or edits migrations?** **Verify them on the PR's Supabase
-  preview branch**, which applies the migration to its own isolated DB — that's
-  the gate. Do **not** `db reset` the shared stack from a worktree to pick up
-  your migrations: with concurrent worktree agents it clobbers the DB the others
-  depend on, and even solo it just confuses what the stack represents. **The
-  rule: worktree migrations go to the preview branch, never the shared local
-  stack.**
-- **Need `types/database.ts` regenerated for a worktree migration?** `pnpm
-  gen:db-types` introspects the shared `--local` stack, so it has the same
-  hazard. Prefer letting **CI regenerate + diff-check** types on the PR (the
-  backend job already fails on a mismatch), or regenerate against a throwaway
-  DB — don't `db reset` the shared stack mid-flight just to gen types. Do **not**
-  hand-edit the file: the drift check diffs a byte-exact regen, so a hand-edit
-  fails CI even when every column is right.
+- **No migration changes in your branch?** The shared local stack is a valid substrate — run
+  `pnpm dev`, unit tests and E2E against it from the worktree normally (the schema it needs already
+  exists).
+- **Your branch adds or edits migrations?** **Verify them on the PR's Supabase preview branch**,
+  which applies the migration to its own isolated DB — that's the gate. Do **not** `db reset` the
+  shared stack from a worktree to pick up your migrations: with concurrent worktree agents it
+  clobbers the DB the others depend on, and even solo it just confuses what the stack represents.
+  **The rule: worktree migrations go to the preview branch, never the shared local stack.**
+- **Merge → local is manual.** Merging to `main` auto-applies the migration to **prod** (the
+  branching pipeline), but your **local** stack only picks it up when you `git pull` in the primary
+  and `supabase db reset` again.
+- **Need `types/database.ts` regenerated for a worktree migration?** `pnpm gen:db-types`
+  introspects the shared `--local` stack, so it has the same hazard. Prefer letting **CI regenerate
+  + diff-check** types on the PR (the backend job already fails on a mismatch), or regenerate
+  against a throwaway DB — don't `db reset` the shared stack mid-flight just to gen types. Do
+  **not** hand-edit the file: the drift check diffs a byte-exact regen, so a hand-edit fails CI even
+  when every column is right.
 
   The generator accepts `--db-url`, so a throwaway container works:
 
@@ -113,24 +175,22 @@ worktree:
     --db-url "postgresql://postgres:x@127.0.0.1:55499/jigged" > types/database.ts
   ```
 
-  **Gotcha that costs a red CI run:** a bare Postgres has no `pg_graphql`, so the
-  generator silently omits the `graphql_public` schema — in **two** places, the
-  schema block *and* the trailing `Constants` export. Splice both back from
-  `main` (this migration never touches them), then diff against `main` and
-  confirm only your intended tables/functions changed. Keep the generator version
+  **Gotcha that costs a red CI run:** a bare Postgres has no `pg_graphql`, so the generator silently
+  omits the `graphql_public` schema — in **two** places, the schema block *and* the trailing
+  `Constants` export. Splice both back from `main` (this migration never touches them), then diff
+  against `main` and confirm only your intended tables/functions changed. Keep the generator version
   matching the one pinned in `gen:db-types`.
 
 ## Visual verification on a Vercel preview (worktrees, agents)
 
-Preview deployments sit behind Deployment Protection, so an agent gets a login
-page. The project has a **Protection Bypass for Automation** secret; it lives in
-`.env.local` as `VERCEL_AUTOMATION_BYPASS_SECRET` (gitignored — copy `.env.local`
-from the primary checkout in a fresh worktree, and re-copy if it was added after
-your worktree was created).
+Preview deployments sit behind Deployment Protection, so an agent gets a login page. The project has
+a **Protection Bypass for Automation** secret; it lives in `.env.local` as
+`VERCEL_AUTOMATION_BYPASS_SECRET` (gitignored — copy `.env.local` from the primary checkout in a
+fresh worktree, and re-copy if it was added after your worktree was created).
 
-Pass it as **headers**, not query params, so the secret never lands in a URL,
-shell history, or an agent transcript. `x-vercel-set-bypass-cookie` sets a cookie
-so in-app navigation after the first load keeps working:
+Pass it as **headers**, not query params, so the secret never lands in a URL, shell history, or an
+agent transcript. `x-vercel-set-bypass-cookie` sets a cookie so in-app navigation after the first
+load keeps working:
 
 ```bash
 export S=$(grep '^VERCEL_AUTOMATION_BYPASS_SECRET=' .env.local | cut -d= -f2- | tr -d '"'"'"' \r')
@@ -138,70 +198,57 @@ export HDRS=$(python3 -c "import json,os;print(json.dumps({'x-vercel-protection-
 agent-browser open "$PREVIEW_URL/login" --headers "$HDRS"
 ```
 
-Then sign in with the seed account (`dev@jigged.test` / `jigged-dev-1234`) — the
-preview branch runs `supabase/seed.sql`, so it has the full Vanguard Precision
-Works data graph. Get `$PREVIEW_URL` from the PR's Vercel comment or
-`gh pr view <n> --json comments`.
+(The `python3 -c` is one of the accepted one-off prompts described above — there's no allowlisted
+way to build that JSON.)
 
-**Use a fresh `--session` per preview domain.** The bypass cookie is set for one
-host; carrying a session over from a previous PR's preview makes the new domain
-bounce to Vercel's SSO login even though the headers are correct. `agent-browser
-open … --session <pr-number>` avoids it.
+Then sign in with the seed account (`dev@jigged.test` / `jigged-dev-1234`) — the preview branch runs
+`supabase/seed.sql`, so it has the full Vanguard Precision Works data graph. Get `$PREVIEW_URL` from
+the PR's Vercel comment or `gh pr view <n> --json comments`.
 
-**If the app shows "Something Went Wrong" on every route, it is almost certainly
-not your code.** Check `agent-browser console` for:
+**Use a fresh `--session` per preview domain.** The bypass cookie is set for one host; carrying a
+session over from a previous PR's preview makes the new domain bounce to Vercel's SSO login even
+though the headers are correct. `agent-browser open … --session <pr-number>` avoids it.
+
+**If the app shows "Something Went Wrong" on every route, it is almost certainly not your code.**
+Check `agent-browser console` for:
 
 ```
 @supabase/ssr: Your project's URL and API key are required to create a Supabase client!
 ```
 
-That means the deployment has no `NEXT_PUBLIC_SUPABASE_*`. Those are inlined at
-**build** time, so the first Vercel build of a new preview branch can outrun
-Supabase Branching provisioning and bake in empty values. Observed on two
-consecutive PRs. **A rebuild fixes it with no code change** — push any commit, or
-redeploy from the Vercel dashboard.
+That means the deployment has no `NEXT_PUBLIC_SUPABASE_*`. Those are inlined at **build** time, so
+the first Vercel build of a new preview branch can outrun Supabase Branching provisioning and bake
+in empty values. Observed on two consecutive PRs. **A rebuild fixes it with no code change** — push
+any commit, or redeploy from the Vercel dashboard.
 
 It presents as a total outage rather than a broken page because
-[`lib/supabase.ts`](lib/supabase.ts) creates the client eagerly at module scope
-(`export const supabase = typeof window !== 'undefined' ? getSupabase() : null`),
-so the throw happens during module evaluation and nothing renders anywhere.
+[`lib/supabase.ts`](../../lib/supabase.ts) creates the client eagerly at module scope
+(`export const supabase = typeof window !== 'undefined' ? getSupabase() : null`), so the throw
+happens during module evaluation and nothing renders anywhere.
 
-Notes: `agent-browser get text` needs a selector (`get text body`); prefer
-`snapshot -i -c` or `eval` since a not-yet-hydrated App Router page returns raw
-RSC payload. `agent-browser console` / `errors` are the fastest triage. Docs:
+Notes: `agent-browser get text` needs a selector (`get text body`); prefer `snapshot -i -c` or
+`eval` since a not-yet-hydrated App Router page returns raw RSC payload. `agent-browser console` /
+`errors` are the fastest triage. Docs:
 <https://vercel.com/docs/deployment-protection/automated-agent-access>
-- **Merge → local:** merging to `main` auto-applies the migration to **prod**
-  (branching pipeline), but your **local** stack only picks it up when you
-  `git pull` in the primary and `supabase db reset` again. Merge→prod is
-  automatic; merge→local is a manual replay.
 
 ## E2E gotchas
 
-- **`csv-import` spec skips in CI** via `test.skip(!!process.env.CI)`.
-  Locally it requires the FastAPI backend (`cd api && python index.py`)
-  for AI column analysis — without it, the spec fails with
-  `Failed to fetch (localhost:8000)`. Filter with
-  `--grep-invert "CSV Import"` if you don't want to run it.
-- **CI mirror locally:** `pnpm exec playwright test --grep-invert "CSV Import"`
-  reproduces the CI-equivalent outcome (5 passing).
-- Don't pass `CI=1` to simulate CI locally — `playwright.config.ts`
-  disables the auto-launched dev server in CI mode, so nothing serves
-  on `localhost:3000`.
-- **Seed contract:** any new spec that depends on a particular data
-  shape (pricing tiers, routings, BOM rows, addresses, …) should
-  extend `e2e/global-setup.ts` rather than runtime-skipping. Skips
-  hide real regressions — see the `jobs.status` prod incident
-  (May 2026) where a runtime-skipped spec masked a broken SELECT.
-- **From a worktree, Playwright will happily test the WRONG BRANCH.**
-  `playwright.config.ts` no longer launches a dev server — it trusts
-  whatever is already serving `localhost:3000`. Run E2E from a worktree
-  while the primary checkout's `pnpm dev` is up and the whole suite
-  exercises the primary's code against your branch's expectations. It
-  fails, or worse passes, for reasons unrelated to your change. The tell
-  is a stale string: renamed UI still showing its old label.
+- **Don't pass `CI=1` to simulate CI locally.** It changes `forbidOnly`, retries, worker count and
+  reporter in `playwright.config.ts` — you get a serialized run that fails on a stray `.only`, not a
+  faithful CI mirror. `pnpm test:e2e:local` *is* the faithful mirror: CI runs that exact script.
+- **Seed contract:** any new spec that depends on a particular data shape (pricing tiers, routings,
+  BOM rows, addresses, …) should extend `e2e/global-setup.ts` rather than runtime-skipping. Skips
+  hide real regressions — see the `jobs.status` prod incident (May 2026) where a runtime-skipped
+  spec masked a broken SELECT.
+- **From a worktree, Playwright will happily test the WRONG BRANCH.** Playwright launches no dev
+  server — it trusts whatever is already serving `localhost:3000`. Run E2E from a worktree while the
+  primary checkout's `pnpm dev` is up and the whole suite exercises the primary's code against your
+  branch's expectations. It fails, or worse passes, for reasons unrelated to your change. The tell
+  is a stale string: renamed UI still showing its old label. Confirm which checkout owns port 3000
+  before trusting a local run: `lsof -p $(lsof -ti:3000) -a -d cwd`.
 
-  Serve your own port and point Playwright at it — no need to stop
-  anyone else's server:
+  `run-stack.mjs` hardcodes 3000, so to serve your own port you drive Playwright directly — fine for
+  any spec that doesn't need FastAPI or the Anthropic mock:
 
   ```bash
   eval "$(supabase status -o env)"
@@ -212,11 +259,9 @@ RSC payload. `agent-browser console` / `errors` are the fastest triage. Docs:
   pnpm exec playwright test e2e/<spec>.spec.ts --reporter=list
   ```
 
-  Confirm which checkout owns port 3000 before trusting a local E2E run:
-  `lsof -p $(lsof -ti:3000) -a -d cwd`.
-- **`global-setup` is find-or-insert, so an incomplete row STAYS
-  incomplete.** A seeder that early-returns on "the job exists" will
-  never backfill something added to it later — the local stack keeps
-  whatever the first run created until `supabase db reset`. When
-  extending a seeder, ensure each child record separately rather than
-  behind the parent's existence check, and remember CI always starts
+- **`global-setup` is find-or-insert, so an incomplete row STAYS incomplete.** A seeder that
+  early-returns on "the job exists" will never backfill something added to it later — the local
+  stack keeps whatever the first run created until `supabase db reset`. When extending a seeder,
+  ensure each child record separately rather than behind the parent's existence check. CI always
+  starts from an empty database, so this is a local-only symptom of a real seeder bug: green in CI,
+  mystifying locally.

--- a/docs/writing-docs.md
+++ b/docs/writing-docs.md
@@ -1,0 +1,79 @@
+# Writing docs: the concision standard
+
+**As-built, verified 2026-08-03.** This is the standard the whole `docs/` tree is now written to,
+established by the [#634](https://github.com/debola31/Jigged/issues/634) condensation that cut the
+tree down doc by doc. Each condensed doc records its own before/after in its opening line — which
+is the only place a number like that belongs, next to the thing it measures.
+
+**Most information in the fewest words, losing none of it.** The test is whether a reader gets the
+same decisions and constraints in a fraction of the reading.
+
+**The core rule: a claim no build can falsify will rot.** That is not a slogan, it is what the
+audit measured. Update frequency did not predict accuracy — the two most-edited module docs both
+rotted while the two least-edited stayed correct. Being edited in the same commit as the code did
+not predict it either. What predicted it was whether a red build would have caught the claim being
+wrong.
+
+**What earns its tokens:** pitfalls; rationale; conventions that differ from tool defaults;
+**withdrawn arguments**; measured numbers; "why not the obvious alternative"; named gaps.
+
+**What does not:** anything derivable by reading the code — directory layouts, dependency lists,
+architecture overviews, file-by-file descriptions, prose restating a function — and **counts of
+anything**. Put a count next to the thing that enforces it, or do not write it. Every count in
+[testing/](testing/) was wrong by 3–6× for ten weeks while `vitest.config.ts` carried the true
+numbers on the same line as the enforcement.
+
+**Form.** Decision plus a one-line why. Superseded reasoning becomes one line
+(`**Withdrawn:** <claim> — wrong because <reason>`) — never deleted, never expanded, because
+recording that a reason was *wrong* is what stops the next person rebuilding on it. Prose becomes
+a table when the content is really rows. Say it once and link the rest. Cite migration IDs and
+file paths, never test titles. Use as-built framing with a verification date. **If you are
+tempted to add length, add it as a table row.**
+
+**Cite tests as file + `describe`, with an `it` count — never a nested `describe > 'it title'`
+string, and never truncated with an ellipsis.** A title is free text nothing checks; one audited
+section had 15 of 23 citations dangling. Every path a doc cites must exist.
+
+**The failure mode to hunt for**, found in five of six docs condensed by hand: **a superseded
+mechanic left standing beside its replacement**, usually within 100 lines, with nothing saying the
+first one is dead. Deleting the dead half is the cheapest, highest-value edit available.
+
+**Deletion is a first-class edit.** Every doc PR should say what it removes; an add-only change
+needs a reason. Context files grow by accretion and are almost never pruned — that is how the tree
+got big enough to need #634 in the first place.
+
+**Exemplars:** [modules/inventory.md](modules/inventory.md) (journey/decision),
+[modules/customers.md](modules/customers.md) (reference), [modules/billing.md](modules/billing.md)
+(invariant — as-built framing, a truth table, the load-bearing *why*, and an invariant named
+against the CI test that enforces it).
+
+## What a build now falsifies
+
+Two of this standard's conventions are machine-checkable, and
+[`scripts/docLinkCheck.ts`](../scripts/docLinkCheck.ts) ([#686](https://github.com/debola31/Jigged/issues/686))
+checks them:
+
+| Check | Why it exists |
+|---|---|
+| **Every path a doc cites exists on disk** | Deleting one file rots citations in docs nobody is editing. Commit `b6b912a` deleted the prod schema snapshot and left ten citations dangling across nine docs at once — caught by hand during a merge, which is not a process. |
+| **Relative links and heading anchors resolve** | **A heading another doc links to is an interface.** `#stations-work-centers`, `#surveillance-guardrail-non-negotiable` and friends are load-bearing; renaming the heading breaks the inbound link silently. |
+
+**Anchor slugs, the trap:** GitHub lowercases, strips punctuation except hyphen and underscore, and
+replaces **each space individually** — so an em dash surrounded by spaces leaves a *double* hyphen
+(`## Foo — bar` → `#foo--bar`). Collapsing the whitespace produces a wrong slug that looks right;
+that bug cost real time during #634.
+
+**Still not mechanical:** nothing checks that a doc's copy of a list still matches the code. That
+gap produced the one security-boundary error the condensation found —
+[modules/ai-insights.md](modules/ai-insights.md) stated a table count that disagreed with its own
+list, and its `SENSITIVE_TABLES` denylist was short the entry holding customer carrier-account
+numbers, against `api/tools/schema_context.py`. **Both are fixed**; the doc
+records the correction as history and still names the missing guard under its Known gaps. A test
+asserting a doc's lists against the frozensets is the shape that would close it, alongside the
+guards this repo already runs (`function_execute_leaks()`, `tenant_tables_missing_write_gate()`,
+[`scripts/schemaEmbedCheck.ts`](../scripts/schemaEmbedCheck.ts)).
+
+**Known scope limit:** the path check reads Markdown, so a citation living in a `COMMENT ON
+FUNCTION` or a pytest docstring still rots unseen — exactly [#685](https://github.com/debola31/Jigged/issues/685).
+Extending it to `.sql` and `.py` comments is the natural next step; the Markdown pass is the cheap
+80%.

--- a/scripts/docLinkCheck.ts
+++ b/scripts/docLinkCheck.ts
@@ -1,0 +1,490 @@
+/**
+ * docLinkCheck — turns two of the doc-writing standard's conventions into a CI
+ * gate (issue #686). See docs/writing-docs.md, "What a build now falsifies".
+ *
+ *   1. Every code path a doc cites exists on disk. Deleting one file rots
+ *      citations in docs nobody is editing: commit b6b912a removed the prod
+ *      schema snapshot and left ten dangling citations across nine docs, caught
+ *      by hand during a merge — which is not a process.
+ *   2. Every relative markdown link resolves, and if it carries an `#anchor`,
+ *      a heading in the TARGET file produces that slug. A heading another doc
+ *      links to is an interface; renaming it breaks the inbound link silently.
+ *
+ * Mirrors scripts/interactionStandardsCheck.ts and scripts/schemaEmbedCheck.ts:
+ * pure functions a vitest spec drives, plus a main() for `pnpm exec tsx`.
+ *
+ * TWO RESOLUTION BASES, and the difference is not cosmetic:
+ *   - A markdown link target resolves against the DOC'S OWN DIRECTORY, because
+ *     that is what a browser does with it.
+ *   - An inline-code path (`utils/jobsAccess.ts`) resolves against the REPO
+ *     ROOT, because that is the convention these docs are written in — it is
+ *     prose naming a file, not a clickable link.
+ *
+ * SCOPE LIMITS, deliberate:
+ *   - Fenced code blocks are skipped entirely. Their `#` lines are shell
+ *     comments, not headings, and their paths carry globs and flags. This also
+ *     means a citation that lives only inside a fence goes unchecked.
+ *   - A citation inside a `COMMENT ON FUNCTION` or a pytest docstring is
+ *     invisible here — that is issue #685, and the Markdown pass is the cheap
+ *     80%.
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import path from 'path';
+
+export interface DocIssue {
+  file: string; // doc, relative to repo root
+  line: number;
+  kind: 'missing-path' | 'missing-anchor';
+  target: string;
+  message: string;
+}
+
+/**
+ * Escape hatch for genuine exceptions, keyed `relativePath::snippet` — NOT
+ * `path:line`, because line numbers shift under every edit and a stale key
+ * silently stops suppressing.
+ *
+ * The legitimate case is a doc deliberately naming a file that no longer
+ * exists, which is how this repo records history ("X was deleted because…").
+ * A dangling citation to a file that was supposed to still be there is a BUG;
+ * fix the doc rather than adding a row here.
+ */
+export const ALLOWLIST = new Map<string, string>([
+  [
+    'CLAUDE.md::supabase/schema.prod.sql',
+    'Records that the cached prod schema snapshot was deleted (2026-08-03) — the absence is the point.',
+  ],
+  [
+    'docs/runbooks/database-migrations.md::supabase/schema.prod.sql',
+    'Same deletion, restated where the migration workflow used to tell you to regenerate it.',
+  ],
+  [
+    'docs/architecture.md::supabase/schema.staging.sql',
+    'Names the staging snapshot deleted when staging was retired for Supabase Branching.',
+  ],
+  [
+    'docs/architecture.md::scripts/export_schema.py',
+    'Names the exporter deleted alongside schema.prod.sql (2026-08-03).',
+  ],
+  [
+    'docs/modules/parts.md::supabase/schema.prod.sql',
+    'Historical note about what the old snapshot still showed; the snapshot is gone.',
+  ],
+  [
+    'docs/modules/demo-mode.md::scripts/seed-demo-template.sql',
+    'Known gap #550 — names the template that does NOT exist yet. Deleting the citation deletes the gap.',
+  ],
+  [
+    'docs/README.md::docs/inventory-flow.md',
+    'Names a journey doc that was folded into modules/inventory.md and deleted; the failure is the lesson.',
+  ],
+  [
+    'docs/README.md::docs/operator-paperless-flow.md',
+    'Same — folded into modules/operator-view.md and deleted.',
+  ],
+  [
+    'docs/modules/inventory.md::docs/inventory-flow.md',
+    'Records the split this doc was merged back from.',
+  ],
+  [
+    'docs/modules/inventory.md::docs/build-sequence.md',
+    'Superseded-docs table: 3,910 lines deleted, listed with what was wrong in them.',
+  ],
+  [
+    'docs/modules/inventory.md::docs/modules/inventory-locations.md',
+    'Superseded-docs table: promised by PR #414, never written, folded in here.',
+  ],
+  [
+    'docs/modules/operator-view.md::docs/operator-paperless-flow.md',
+    'Records the doc folded into this one and deleted, with its word count.',
+  ],
+  [
+    'docs/modules/operator-view.md::docs/modules/partial-operation-completion-design.md',
+    'Records a design doc folded into this one and deleted.',
+  ],
+]);
+
+// ============== Fences ==============
+
+/**
+ * Blank out fenced code blocks, preserving line numbering (every removed line
+ * becomes empty). Handles ``` and ~~~ fences of any length, and the info
+ * string on the opening fence.
+ */
+export function stripFencedBlocks(source: string): string {
+  const lines = source.split('\n');
+  let fence: string | null = null;
+  return lines
+    .map((line) => {
+      const m = /^\s{0,3}(`{3,}|~{3,})/.exec(line);
+      if (fence === null) {
+        if (m) {
+          fence = m[1][0].repeat(m[1].length);
+          return '';
+        }
+        return line;
+      }
+      // Inside a fence: only a closer of the same char and >= length ends it.
+      if (m && m[1][0] === fence[0] && m[1].length >= fence.length) fence = null;
+      return '';
+    })
+    .join('\n');
+}
+
+// ============== GitHub heading slugs ==============
+
+/**
+ * GitHub's anchor slug, and the rule people get wrong: lowercase, strip every
+ * character that is not a letter, number, mark, hyphen or underscore
+ * (UNDERSCORES ARE KEPT), then replace EACH space with ONE hyphen.
+ *
+ * Do NOT collapse runs of whitespace. An em dash surrounded by spaces is
+ * stripped and leaves the two spaces behind, so `## Foo — bar` really does
+ * anchor at `#foo--bar` — a DOUBLE hyphen. Collapsing produces a slug that
+ * looks right and 404s, which cost real time during #634.
+ *
+ * Known divergence: github-slugger keeps a handful of Latin-1 symbols this
+ * drops (`£`, `¢`, …). No heading in this repo uses one; widen the keep-set if
+ * that ever changes.
+ */
+export function slugify(heading: string): string {
+  return (
+    heading
+      // `[text](url)` contributes only `text` — the URL is not part of the slug.
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      // Inline HTML (<br>, <sup>…) is markup, not text.
+      .replace(/<[^>]*>/g, '')
+      .toLowerCase()
+      .trim()
+      .replace(/[^\p{L}\p{N}\p{M}\- _]/gu, '')
+      .replace(/ /g, '-')
+  );
+}
+
+/**
+ * Every anchor a markdown file exposes, in GitHub's duplicate-heading scheme:
+ * the first `## Foo` is `#foo`, the second `#foo-1`, the third `#foo-2`.
+ */
+export function headingSlugs(source: string): Set<string> {
+  const out = new Set<string>();
+  const seen = new Map<string, number>();
+  for (const line of stripFencedBlocks(source).split('\n')) {
+    const m = /^ {0,3}(#{1,6})\s+(.*?)\s*#*\s*$/.exec(line);
+    if (!m) continue;
+    const base = slugify(m[2]);
+    if (!base) continue;
+    const n = seen.get(base) ?? 0;
+    seen.set(base, n + 1);
+    out.add(n === 0 ? base : `${base}-${n}`);
+  }
+  return out;
+}
+
+// ============== Citation extraction ==============
+
+export interface Citation {
+  /** Exactly as written — this is the allowlist key's snippet half. */
+  raw: string;
+  /** Path portion: percent-decoded, `#anchor` / `::nodeid` stripped. */
+  target: string;
+  /** `#…` fragment on a markdown link, or null. */
+  anchor: string | null;
+  line: number;
+  /** Which resolution base applies (see the file header). */
+  base: 'doc-dir' | 'repo-root';
+}
+
+/**
+ * Directory prefixes that make an inline-code span a repo path. Everything
+ * else in backticks is a column name, a flag, an env var or prose.
+ */
+const CODE_PATH_PREFIXES = [
+  '__tests__/',
+  'e2e/',
+  'api/',
+  'utils/',
+  'components/',
+  'app/',
+  'scripts/',
+  'supabase/',
+  'lib/',
+  'types/',
+  'hooks/',
+  'docs/',
+  '.github/',
+];
+
+/**
+ * Characters that mean "this is a pattern, not a path": globs (`utils/*.ts`),
+ * brace expansions (`__tests__/…/{A,B}.test.tsx`) and placeholders
+ * (`utils/<entity>Access.ts`). `[` and `]` are NOT here — Next.js route
+ * segments (`app/dashboard/[companyId]/`) are real directory names.
+ */
+const NOT_A_LITERAL_PATH = /[*{}<>|$…"']/;
+
+/** Strip `#anchor`, `#L12-L20` and a pytest `::node_id` from a cited path. */
+function splitFragment(raw: string): { target: string; anchor: string | null } {
+  const noNodeId = raw.split('::')[0];
+  const hash = noNodeId.indexOf('#');
+  if (hash === -1) return { target: noNodeId, anchor: null };
+  return { target: noNodeId.slice(0, hash), anchor: noNodeId.slice(hash + 1) || null };
+}
+
+function lineOf(source: string, index: number): number {
+  return source.slice(0, index).split('\n').length;
+}
+
+/**
+ * Markdown links to something in this repo. External URLs, `mailto:` and
+ * site-absolute (`/foo`) targets are skipped — the first two are not ours to
+ * check and the third has no defined base here.
+ *
+ * A bare `#anchor` link is kept, with an empty target, so it is checked against
+ * the doc's own headings.
+ */
+export function extractLinkCitations(source: string, _docRelPath: string): Citation[] {
+  const out: Citation[] = [];
+  const body = stripFencedBlocks(source);
+  // [label](target) or [label](target "title").
+  //
+  // The label allows one level of nested brackets, because the labels here are
+  // routinely inline-code paths carrying Next.js route segments —
+  // [`app/operator/[companyId]/layout.tsx`](…). A plain `[^\]]*` label stops at
+  // the first inner `]` and silently matches nothing, so those links (the ones
+  // most likely to rot, since route folders get renamed) went unchecked.
+  const re = /\[(?:[^[\]]|\[[^[\]]*\])*\]\(\s*([^)\s]+)(?:\s+"[^"]*")?\s*\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    const rawTarget = m[1];
+    if (/^[a-z][a-z0-9+.-]*:/i.test(rawTarget)) continue; // http:, https:, mailto:, …
+    if (rawTarget.startsWith('//') || rawTarget.startsWith('/')) continue;
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(rawTarget);
+    } catch {
+      decoded = rawTarget; // malformed escape — check what was written
+    }
+    const { target, anchor } = splitFragment(decoded);
+    out.push({
+      raw: rawTarget,
+      target,
+      anchor,
+      line: lineOf(body, m.index),
+      base: 'doc-dir',
+    });
+  }
+  return out;
+}
+
+/** Inline-code spans that name a repo file, e.g. `` `utils/jobsAccess.ts` ``. */
+export function extractCodePathCitations(source: string, _docRelPath: string): Citation[] {
+  const out: Citation[] = [];
+  const body = stripFencedBlocks(source);
+  const re = /`([^`\n]+)`/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    // A citation may carry a trailing test name (`file.ts > describe`) or a
+    // pytest node id; the path is the first whitespace-delimited token.
+    const first = m[1].trim().split(/\s+/)[0];
+    if (!CODE_PATH_PREFIXES.some((p) => first.startsWith(p))) continue;
+    if (NOT_A_LITERAL_PATH.test(first)) continue;
+    const { target } = splitFragment(first);
+    if (!target.includes('/')) continue;
+    out.push({
+      raw: first,
+      target,
+      anchor: null, // `utils/jobsAccess.ts#deleteJob` names a symbol, not a heading
+      line: lineOf(body, m.index),
+      base: 'repo-root',
+    });
+  }
+  return out;
+}
+
+export function extractCitations(source: string, docRelPath: string): Citation[] {
+  return [
+    ...extractLinkCitations(source, docRelPath),
+    ...extractCodePathCitations(source, docRelPath),
+  ];
+}
+
+// ============== Resolution ==============
+
+/**
+ * Extensions tried for an inline-code citation that names a MODULE rather than
+ * a file — `components/common/DeleteIconButton`, `lib/unitPresets` — the same
+ * extensionless form the imports use. Deliberately NOT applied to markdown
+ * links: a link is a URL, and a URL that needs a guessed suffix is a 404.
+ */
+const MODULE_EXTENSIONS = ['.ts', '.tsx', '.py', '.sql', '.md'];
+
+export function resolveCitation(repoRoot: string, docRelPath: string, c: Citation): string | null {
+  if (c.target === '') return path.join(repoRoot, docRelPath); // bare `#anchor`
+  const baseDir =
+    c.base === 'doc-dir' ? path.dirname(path.join(repoRoot, docRelPath)) : repoRoot;
+  const abs = path.resolve(baseDir, c.target);
+  if (existsSync(abs)) return abs;
+  if (c.base === 'repo-root') {
+    for (const ext of MODULE_EXTENSIONS) {
+      if (existsSync(abs + ext)) return abs + ext;
+    }
+  }
+  return null;
+}
+
+// ============== Validation ==============
+
+/** `#L12` / `#L12-L20` is a GitHub line range, not a heading. */
+function isLineRef(anchor: string): boolean {
+  return /^L\d+(-L\d+)?$/.test(anchor);
+}
+
+export interface DocScanResult {
+  docsScanned: number;
+  citationsChecked: number;
+  /** Cross-doc + same-doc `#anchor`s actually resolved against a heading set. */
+  anchorsChecked: number;
+  issues: DocIssue[];
+}
+
+export interface ScanOptions {
+  /** Set false to see what the allowlist is hiding — see unusedAllowlistEntries. */
+  applyAllowlist?: boolean;
+}
+
+export function validateDoc(
+  repoRoot: string,
+  docRelPath: string,
+  slugCache: Map<string, Set<string>> = new Map(),
+  { applyAllowlist = true }: ScanOptions = {},
+): { citationsChecked: number; anchorsChecked: number; issues: DocIssue[] } {
+  const source = readFileSync(path.join(repoRoot, docRelPath), 'utf8');
+  const issues: DocIssue[] = [];
+  const citations = extractCitations(source, docRelPath);
+  let anchorsChecked = 0;
+
+  for (const c of citations) {
+    if (applyAllowlist && ALLOWLIST.has(`${docRelPath}::${c.raw}`)) continue;
+
+    const resolved = resolveCitation(repoRoot, docRelPath, c);
+    if (resolved === null) {
+      issues.push({
+        file: docRelPath,
+        line: c.line,
+        kind: 'missing-path',
+        target: c.raw,
+        message: `cites "${c.raw}", which does not exist (resolved against ${
+          c.base === 'doc-dir' ? path.dirname(docRelPath) || '.' : 'the repo root'
+        })`,
+      });
+      continue;
+    }
+
+    if (!c.anchor || isLineRef(c.anchor)) continue;
+    if (!resolved.endsWith('.md')) continue; // #fragment on a non-doc is a symbol/line hint
+
+    let slugs = slugCache.get(resolved);
+    if (!slugs) {
+      slugs = headingSlugs(readFileSync(resolved, 'utf8'));
+      slugCache.set(resolved, slugs);
+    }
+    anchorsChecked++;
+    if (!slugs.has(c.anchor)) {
+      issues.push({
+        file: docRelPath,
+        line: c.line,
+        kind: 'missing-anchor',
+        target: c.raw,
+        message: `links to #${c.anchor} in ${path.relative(
+          repoRoot,
+          resolved,
+        )}, which has no heading with that slug`,
+      });
+    }
+  }
+
+  return { citationsChecked: citations.length, anchorsChecked, issues };
+}
+
+// ============== File walking ==============
+
+function walkMarkdown(dir: string, out: string[]): void {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name.startsWith('.')) continue;
+    const full = path.join(dir, name);
+    if (statSync(full).isDirectory()) walkMarkdown(full, out);
+    else if (name.endsWith('.md')) out.push(full);
+  }
+}
+
+/** Every doc this check owns: `docs/**` plus the always-loaded CLAUDE.md. */
+export function docFiles(repoRoot: string): string[] {
+  const abs: string[] = [];
+  try {
+    walkMarkdown(path.join(repoRoot, 'docs'), abs);
+  } catch {
+    /* docs/ may be absent in a partial checkout */
+  }
+  const rel = abs.map((f) => path.relative(repoRoot, f)).sort();
+  if (existsSync(path.join(repoRoot, 'CLAUDE.md'))) rel.unshift('CLAUDE.md');
+  return rel;
+}
+
+export function scanProject(repoRoot: string, opts: ScanOptions = {}): DocScanResult {
+  const docs = docFiles(repoRoot);
+  const slugCache = new Map<string, Set<string>>();
+  const issues: DocIssue[] = [];
+  let citationsChecked = 0;
+  let anchorsChecked = 0;
+  for (const doc of docs) {
+    const r = validateDoc(repoRoot, doc, slugCache, opts);
+    citationsChecked += r.citationsChecked;
+    anchorsChecked += r.anchorsChecked;
+    issues.push(...r.issues);
+  }
+  return { docsScanned: docs.length, citationsChecked, anchorsChecked, issues };
+}
+
+/**
+ * Allowlist entries that no longer suppress anything — the file they excuse has
+ * come back, or the doc stopped citing it. A stale entry is not harmless: it is
+ * a standing licence to break that exact citation again without a red build.
+ * Asserted empty by __tests__/standards/docLinkCheck.test.ts, which is also
+ * what proves the missing-path check fires on the real tree rather than being
+ * trivially green.
+ */
+export function unusedAllowlistEntries(repoRoot: string): string[] {
+  const raised = new Set(
+    scanProject(repoRoot, { applyAllowlist: false }).issues.map((i) => `${i.file}::${i.target}`),
+  );
+  return [...ALLOWLIST.keys()].filter((k) => !raised.has(k));
+}
+
+// ============== CLI ==============
+
+function main(): void {
+  const repoRoot = path.resolve(__dirname, '..');
+  const result = scanProject(repoRoot);
+
+  console.log(
+    `[doc-link-check] ${result.docsScanned} docs, ${result.citationsChecked} citations checked`,
+  );
+
+  if (result.issues.length === 0) {
+    console.log('[doc-link-check] OK — every cited path and anchor resolves.');
+    return;
+  }
+
+  console.error(`\n[doc-link-check] ${result.issues.length} dangling reference(s):\n`);
+  for (const i of result.issues) {
+    console.error(`  ${i.file}:${i.line} [${i.kind}] ${i.message}`);
+  }
+  console.error(
+    '\nFix the doc. Only add an ALLOWLIST entry (scripts/docLinkCheck.ts) when the doc ' +
+      'deliberately names a file that no longer exists — and give it a reason.\n',
+  );
+  process.exit(1);
+}
+
+// Run only when invoked directly (not when imported by the test).
+if (require.main === module) main();


### PR DESCRIPTION
Three things the user asked to land together: correct CLAUDE.md's false claims, condense it, and build the #686 docs guard. Bundling is coherent here — the guard is what protects the pointer inversions this PR makes.

## CLAUDE.md: 637 → 258 lines, 6,002 → 2,231 words

It is loaded into every session, so derivable content in it is pure cost.

### The delegation plan was void — checking it first is why this works

Our #634 plan proposed moving rules into `.claude/rules/` with `paths:` frontmatter. Verified against the Claude Code docs before building anything:

| Mechanism | Verdict |
|---|---|
| `@path` imports | **Zero savings** — imported files load at launch |
| `.claude/rules/` without `paths:` | **Zero savings** — always-loaded, same priority |
| `.claude/rules/` with `paths:` | **Blocked**: `.gitignore:80` excludes `.claude/*`. And its trigger is *reading* a matching file, while the migration/GRANT rules bite at **creation** — the rule would be absent exactly when the mistake is made |
| Nested `CLAUDE.md` | Lazy, **and not re-injected after `/compact`** |

So the reduction is deletion of derivable text plus pointers into ordinary `docs/` files — the boring mechanism, and the only one that actually reduces always-loaded context.

### 20 false claims removed

| Claim | Reality |
|---|---|
| Vercel git auto-deploy off via `git.deploymentEnabled` in `vercel.json`, "the only path to production" | `vercel.json` has only `functions` and `rewrites`. The **only** `deploymentEnabled` in the repo was that sentence describing itself |
| Three criteria for when FastAPI is allowed | `architecture.md` §8.1 has **four**. An agent applying the short list judges shipped correct code to be in violation |
| "`getSupabase()` — existing `utils/*Access.ts` files use this" | No `utils` file imports the untyped getter any more |
| Operators land on `/dashboard/{companyId}` | `homePathForRole` sends them to `/operator/{companyId}` |
| "Touch targets 48px (theme enforces this)" | `minHeight: 48` is set on three components |
| "Body text minimum 16px" | `body2` is 14px in the same theme it describes |
| `/dashboard/{companyId}/operations` | Route does not exist |
| Multi-tenancy SQL block | Stale on all three tables |

Plus my own: the concision standard mis-stated the docs word count. **Deleted rather than corrected** — it is an unenforced count sitting in the paragraph that forbids them.

### Kept longer than the plan wanted, deliberately

The plan targeted ~175 lines by cutting the two grant sections to a few lines each. I didn't. They are security boundaries with an **inverted default** — a new function is browser-callable unless you revoke it, and `SECURITY DEFINER` bypasses RLS — and the CI guard for it is an *allowlist*, so the cheapest way to green a violation is to add your function to it. **258 with those intact beats 175 without.**

## Moved, not lost

`docs/runbooks/database-migrations.md` (new) · `docs/writing-docs.md` (new) · Sentry → `observability.md` · soft-delete → `architecture.md` §16 · design system → `design-system.md` · pre-PR + shell hygiene → the local-dev runbook.

**Three docs pointed *into* the moved sections and were inverted in the same commit**, or they'd have gone circular.

### Two saves found while inverting

- **`architecture.md` §9 had been cut citing "CLAUDE.md owns it"** — but that section had been deleted the same day, leaving `ALLOWED_ORIGINS` (real: `api/index.py:81`) and the backend `SUPABASE_URL` documented **nowhere in the repo**. Restored.
- **`design-system.md` had delegated six topics *to* CLAUDE.md**, parking derivable content in the expensive place. Four of the six arrived wrong.

## The guard (closes #686)

`scripts/docLinkCheck.ts` asserts every cited code path exists and every relative link and cross-doc anchor resolves, over `docs/` **and** `CLAUDE.md`. Built in the idiom of `interactionStandardsCheck.ts` / `schemaEmbedCheck.ts`.

Measured on this tree: **32 docs, 1,072 citations, 143 anchors.** **Zero real dangling references.** 13 allowlisted entries, every one a doc deliberately naming a deleted file, each with a reason and keyed `path::snippet` so line moves don't break them. A test asserts the allowlist has **no unused entries**, so a stale exception fails the build — and that test is also what proves the check fires on the real tree rather than being trivially green.

Anchor slugs implement GitHub's rules exactly, including that **each** space becomes one hyphen, so an em dash yields a double hyphen — tested against the live `#who-uses-what-on-what--the-device-model`. A collapsing regex produces false positives; that bug cost real time during #634.

**It caught me writing a dangling anchor into CLAUDE.md while I was writing the rule against them.**

### Verified, not assumed

I injected three deliberate breaks (missing repo-root path, missing relative link, bad anchor) and confirmed the guard fails on all three with precise messages, then goes green again on revert.

```
tsc --noEmit          clean
pnpm lint             16 warnings (cap 17, unchanged)
vitest standards+schema  4 files / 62 tests passed
```

### Known scope limit, stated in the file header

Citations inside `COMMENT ON FUNCTION` bodies and pytest docstrings are invisible to it — that's #685. The Markdown pass is the cheap 80%.

Closes #686. Refs #634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)