### PR TITLE
fix(billing): pin the Stripe webhook to www, stop reporting bad signatures

### DIFF
--- a/api/routes/stripe_routes.py
+++ b/api/routes/stripe_routes.py
@@ -512,10 +512,18 @@ async def webhook(request: Request):
     try:
         event = s.Webhook.construct_event(payload, sig, _webhook_secret())
     except ValueError as e:  # malformed payload
+        # Reportable: construct_event verifies the signature BEFORE json.loads, so
+        # a ValueError can only follow a payload Stripe itself signed. That is our
+        # bug (or Stripe's), never a stranger's.
         sentry_sdk.capture_exception(e)
         raise HTTPException(status_code=400, detail="Invalid payload")
-    except stripe.error.SignatureVerificationError as e:
-        sentry_sdk.capture_exception(e)
+    except stripe.error.SignatureVerificationError:
+        # Deliberately NOT captured to Sentry. This route is public and
+        # unauthenticated, so anyone who finds the URL can drive this branch at
+        # will — reporting it hands a stranger our Sentry quota and buries real
+        # issues. Genuine signature mismatches (e.g. a rolled secret) show up in
+        # Stripe's own delivery log, which is the authority on them anyway.
+        logger.warning("Stripe webhook rejected: invalid signature")
         raise HTTPException(status_code=400, detail="Invalid signature")
 
     try:

--- a/docs/modules/billing.md
+++ b/docs/modules/billing.md
@@ -202,6 +202,28 @@ the Stripe Dashboard / Vercel label (so the unused `STRIPE_SECRET_KEY` /
 backend loads env at startup — restart `python api/index.py` after changing them
 (`--reload` watches `.py`, not `.env.local`).
 
+### The production webhook URL must be `www.jigged.app` (verified 2026-08-03)
+
+Register the live endpoint as `https://www.jigged.app/api/stripe/webhook` — **on `www`, not the
+apex**. Vercel serves `www` as primary and answers `https://jigged.app/…` with a `307` from its
+edge router, and **Stripe does not follow redirects**: only `2xx` counts as delivered.
+
+This is as-built, not preference. The endpoint was registered on the apex on 2026-07-26 and
+**every live event failed for five days** until Stripe's auto-disable warning surfaced it. Sentry
+saw nothing and could not have — the `307` is issued before the function is invoked, so there is
+no exception to report. `/checkout/sync` and `/reconcile` (§ above) kept the cache correct
+throughout, which is *why* it went unnoticed; treat reconciliation as a safety net, never as
+delivery.
+
+**Enforced by** a Sentry uptime monitor asserting `GET …/api/stripe/webhook` returns `405`
+(route reachable, method not allowed). `405` = healthy, `307` = this bug returning, `404` =
+backend not deployed, `401` = Vercel deployment protection. `GET` is deliberate: it never reaches
+the signature path, so the probe generates no Sentry events.
+
+The apex is still what the code advertises as canonical (`metadataBase`, `og:url`, email
+`SITE_URL`) — that inconsistency is tracked separately. If it is ever resolved by making the apex
+primary in Vercel, **this URL must move back in the same change.**
+
 ## 11. Testing
 
 - **DB-only (CI, no Stripe):** `api/tests/integration/test_billing_enforcement.py` —


### PR DESCRIPTION
## What broke

Stripe emailed that `https://jigged.app/api/stripe/webhook` had failed **29 times since 2026-07-30 05:00:01 UTC**, and would be auto-disabled on 2026-08-08.

**Root cause: the endpoint was registered on the apex domain, which Vercel `307`s to `www`. Stripe does not follow redirects — only `2xx` counts as delivered.**

Verified live:

| Probe | Result |
|---|---|
| `POST https://jigged.app/api/stripe/webhook` | `307 → www.jigged.app` |
| `POST https://www.jigged.app/api/stripe/webhook` | `400 {"detail":"Invalid signature"}` — handler healthy |

The apex response carries no `x-matched-path` and a single-hop `x-vercel-id`; `www` returns `x-matched-path: /api/index` and two hops. The redirect comes from Vercel's edge router — **the Python function is never invoked.** No code or env was at fault.

The timeline is unambiguous: the first live subscription was created `2026-07-30 04:59:13 UTC` and cancelled at `05:00:00`; Stripe's reported first failure is `05:00:01`. Stripe's delivery log showed `307 ERR` on **every** attempt — **no webhook had ever been delivered to production.**

## Status: fixed and confirmed

The URL was corrected in the Stripe Dashboard (not a code change). A real live `customer.subscription.updated` then delivered **`200 OK`**, and `company_billing` picked up the change — `cancel_at` and `canceled_at` went from set to `null`, matching Stripe. Confirmed end to end.

## Why nothing caught it

Sentry instruments code that *runs*. A request answered by the edge produces no exception, no transaction, no event. **A request that never arrives is invisible to an error tracker** — this is the boundary between error monitoring and availability monitoring, not a gap in our Sentry setup.

It was also masked: `/checkout/sync` and `/reconcile` re-sync from Stripe, so `company_billing` stayed *correct* the whole time. Treat reconciliation as a safety net, never as evidence of delivery.

No customer was mis-gated (both companies are `billing_exempt`), and no data repair was needed.

## What this PR changes

The URL fix itself is a Dashboard change. This PR stops it regressing:

1. **`docs/modules/billing.md`** — records that the production endpoint lives on `www` because Stripe doesn't follow redirects, with as-built framing and a verification date, citing the enforcing guard rather than asserting a claim no build can falsify. Notes that if the apex ever becomes canonical, the URL must move back **in the same change**.

2. **`api/routes/stripe_routes.py`** — stop `capture_exception` on `SignatureVerificationError`. The route is public and unauthenticated, so anyone who finds the URL can drive that branch at will and burn our Sentry quota, burying real issues. Genuine mismatches (e.g. a rolled secret) appear in Stripe's own delivery log, which is the authority on them.

   The `ValueError` branch **keeps** its capture, and the asymmetry is deliberate: `construct_event` calls `verify_header` *before* `json.loads`, so a malformed payload can only follow a payload Stripe itself signed. That one is our bug; a bad signature is a stranger's.

## Guard (configured out-of-band)

Sentry uptime monitor `6785095`, active: `GET https://www.jigged.app/api/stripe/webhook` asserting **`405`**, hourly.

| Result | Meaning |
|---|---|
| `405` | route reachable — healthy |
| `307` | this bug returning |
| `404` | backend not deployed |
| `401` | Vercel deployment protection |

All four verified live. `GET` is deliberate: it hits FastAPI's method-not-allowed path and never reaches signature verification, so the probe itself generates zero Sentry events — unlike a bogus-signature `POST`, which would flood the queue in exactly the way `CLAUDE.md` warns about. Hourly rather than 60s because each check invokes the FastAPI lambda.

## Testing

`cd api && conda run -n jigged pytest tests/unit/test_stripe_routes.py` — 15 passed. `test_webhook_rejects_bad_signature` asserts the `400`, which is unchanged.

## Follow-ups

- **#698** — corrects a separate false claim in `billing.md` (that webhooks stamp `event.created`; they don't — every path stamps `now()`). That work was written while this PR was open but pushed after it merged, so it is **not** in this PR.
- **#695** — apex/`www` canonicalisation: the code advertises the apex as canonical (`metadataBase`, `og:url`, email `SITE_URL`) while Vercel serves `www`, so every canonical URL we publish points at a redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)