### PR TITLE
chore(api): drop bcrypt, and record why psycopg2-binary looks unused but is not

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,7 +8,6 @@ email-validator>=2.0.0
 
 # Authentication (for operator JWT tokens)
 PyJWT>=2.8.0
-bcrypt>=4.0.0
 
 # AI providers (for CSV import mapping)
 # >=0.40.0 guarantees client.models.list() for the model deprecation check
@@ -33,5 +32,9 @@ httpx>=0.27.0
 python-multipart>=0.0.9
 
 # Database
+# psycopg2-binary is NOT imported anywhere under api/ — grep it and you will find
+# nothing, which is exactly why it keeps looking removable. It is used by
+# scripts/sync_demo_template.py, which lives outside this directory but installs
+# from this file. Removing it breaks that script with an ImportError at line 26.
 psycopg2-binary>=2.9.0
 asyncpg>=0.29.0


### PR DESCRIPTION
I told you there were three unused dependencies. **There was one.** Correcting that here, and leaving evidence so the same mistake isn't made again.

| Dependency | Verdict | Why |
|---|---|---|
| `bcrypt` | ✅ **removed** | Zero imports repo-wide. Operator auth uses PyJWT; nothing ever hashed a password. |
| `google-genai` | ❌ **live** | `GeminiProvider` is exported from `services/ai/__init__.py` and registered in the provider factory. |
| `psycopg2-binary` | ❌ **needed** | Used by `scripts/sync_demo_template.py`, which installs from this file. |

## How I got it wrong

I grepped `import google.genai` and `from google_genai`. The actual import is:

```python
from google import genai      # namespace package
```

Both greps miss it. Had I acted on that, the AI import-mapping feature would have broken at module load — `services/ai/__init__.py` imports `GeminiProvider` unconditionally, so it's an import-time failure across the whole provider factory, not a lazy one.

`psycopg2-binary` is the inverse trap: genuinely absent from `api/`, so it reads as dead, but a script one directory up depends on it. It now carries a comment at the line saying exactly that, because the next person to grep will reach the same wrong conclusion I did.

**Not deleting two of them is as much the point of this PR as deleting the one.**

## Verification

233 backend unit tests pass.