### PR TITLE
docs(billing): correct the monotonic-guard stamp claim

### DIFF
--- a/docs/modules/billing.md
+++ b/docs/modules/billing.md
@@ -137,9 +137,16 @@ subscription at all). Everything calls it, so behaviour is identical everywhere 
 no code parses event payloads.
 
 Writes go through the `apply_stripe_subscription(...)` RPC (guarded upsert):
-- **Monotonic guard** on `subscription_event_at` (webhooks stamp `event.created`;
-  `/checkout/sync` and reconcile stamp `now()`) — concurrent/out-of-order Vercel
-  lambdas can't lose-update each other.
+- **Monotonic guard** on `subscription_event_at` — **every** path stamps `now()`, because
+  `_sync_customer` is the sole writer and it always passes `_now_iso()`
+  ([`stripe_routes.py`](../../api/routes/stripe_routes.py) `_sync_customer`). Concurrent /
+  out-of-order Vercel lambdas therefore can't lose-update each other, and a redelivered old
+  event still writes, because what it writes is a *fresh refetch*, not the payload.
+  **Withdrawn:** "webhooks stamp `event.created`" — never true in code, and stamping the
+  event time would be wrong here: it would let a stale guard value discard a current read.
+  The `COMMENT ON COLUMN company_billing.subscription_event_at` in
+  [`20260725205821`](../../supabase/migrations/20260725205821_stripe_billing_cache.sql) still
+  carries the old wording and needs a follow-up `COMMENT ON` migration.
 - **Grandfather auto-clear:** `billing_exempt` clears only on `active`/`past_due`
   (a real paying relationship), **never on `trialing`** — so a grandfathered shop
   that starts a trial and cancels mid-trial keeps its free access.


### PR DESCRIPTION
Follow-up to #694. This commit was written while #694 was open but pushed after it merged, so it never landed — re-submitted here on current `main`. Docs only, no migration.

## The false claim

`docs/modules/billing.md` said:

> **Monotonic guard** on `subscription_event_at` (webhooks stamp `event.created`; `/checkout/sync` and reconcile stamp `now()`)

**The code has never done that.** `_sync_customer` is the sole writer and always passes `_now_iso()` — for the webhook and every reconcile path alike. Its own docstring says so: *"The webhook and every reconcile path call this, so behaviour is identical everywhere."*

## Why it matters

`subscription_event_at` cannot distinguish a webhook write from a reconcile write. During the #694 investigation I used the doc's claim as a verification step — "a real webhook write will carry a whole-second `event.created` stamp" — and it is untestable, because no such write exists. Only Stripe's delivery log proves delivery.

The same reasoning also produced a wrong (if harmless) conclusion: that replaying failed events would be a no-op because the guard rejects older stamps. Replays stamp `now()`, so they write. The outcome was unaffected — a replay just re-syncs current truth — but the stated mechanism was wrong.

## `now()` is correct — this is a doc bug, not a code bug

Not something to "fix" in the other direction. The handler never parses the event payload; it refetches the subscription from Stripe. Stamping the older `event.created` would let a stale guard value discard a **fresher** read on redelivery. `now()` is right; the doc was wrong.

## Form

Recorded as `**Withdrawn:**` rather than deleted, per the docs standard — *"recording that a reason was wrong is what stops the next person rebuilding on it."*

## Known follow-up, deliberately not bundled

The `COMMENT ON COLUMN company_billing.subscription_event_at` in the **applied** migration [`20260725205821`](https://github.com/debola31/Jigged/blob/main/supabase/migrations/20260725205821_stripe_billing_cache.sql) still carries the old wording (twice — the inline comment and the `COMMENT ON`). Correcting it needs a *new* `COMMENT ON` migration; editing an applied migration is not an option. Noted inline in the doc so the drift is recorded rather than silently half-fixed, and kept out of this PR so it stays migration-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)