### PR TITLE
chore(analytics): make PostHog production-only

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -57,13 +57,21 @@ import posthog from "posthog-js";
 // NEXT_PUBLIC_POSTHOG_HOST is deliberately not read: ingestion goes through our
 // own origin via the `next.config.ts` rewrites, so `api_host` is the fixed "/ingest"
 // path below. The wizard emitted a variable for it that nothing consumed.
+//
+// THE TOKEN IS THE ENVIRONMENT SWITCH, AND ITS ABSENCE IS THE NORMAL STATE.
+// It is set in Vercel Production only — not Preview, not Development, and commented
+// out in `.env.local` — so `pnpm dev`, the Playwright suite and preview deployments
+// all no-op below. Same reasoning as SENTRY_ENABLED above, but it deliberately does
+// NOT reuse `NODE_ENV`: Vercel builds previews with NODE_ENV=production, which is
+// right for Sentry (a preview crash is a real crash) and wrong here (a preview
+// pageview against seeded data is not a real user). PostHog's free plan caps you at
+// one project, so there is no dev project to send this noise to instead.
+//
+// The wizard's console.error for a missing token is deliberately gone. It fired on
+// every local page load, and it told you to configure the one thing we now leave
+// unconfigured on purpose — an alert that is wrong by construction trains you to
+// ignore the console, which is how the Sentry queue above went bad in the first place.
 const posthogToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
-
-if (!posthogToken && process.env.NODE_ENV !== "production") {
-  console.error(
-    "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN is configured"
-  );
-}
 
 if (posthogToken) {
   posthog.init(posthogToken, {


### PR DESCRIPTION
## What this fixes

PostHog has collected **156 events** since the setup wizard ran on 2026-07-30. Every single one came from `localhost:3000` — the `dev@jigged.test` seed login. There are **zero production events**, because `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` was never set in Vercel and `posthog.init()` is gated on the token being present. The deployed app has never initialised the SDK.

Only 4 of the 12 instrumented custom events have ever fired (`user_signed_in`, `user_signed_out`, `quote_created`, `quote_converted_to_job`). The 13 wizard insights and 2 dashboards are all reading that dev noise.

## The approach

The token's **presence is the environment switch**. It is now set in Vercel Production only — not Preview, not Development, and commented out in `.env.local` — so `pnpm dev`, the Playwright suite and preview deployments all no-op.

That left the wizard's `console.error` for a missing token firing on every local page load, telling you to configure the one thing we now deliberately leave unconfigured. This PR drops it and documents the switch in its place.

**Why not a `NODE_ENV` guard like `SENTRY_ENABLED`?** Vercel builds previews with `NODE_ENV=production`. That is correct for Sentry — a preview crash is a real crash — and wrong for analytics, where a preview pageview against seeded data is not a real user. PostHog's free plan caps at one project, so there is no dev project to send that noise to instead.

## Changes outside this diff

Both already applied, neither is code:

- **Vercel:** `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` added to Production only. `NEXT_PUBLIC_*` is inlined at build time, so this takes effect on the next production deploy through the gate.
- **PostHog project settings:** `test_account_filters` extended (the existing cohort filter was preserved) to also exclude `$host` containing `localhost`, `127.0.0.1` and `vercel.app`, with `test_account_filters_default_checked` on.

## Known gap

`test_account_filters_default_checked` only applies to **newly created** insights. The 13 existing wizard insights predate it and will not pick it up retroactively. Since they are all reading empty or single-digit data, the better fix is to rebuild them against real production events rather than repair them — not done here.

## Not in scope

Autocapture stays on. It will be the highest-volume production event and captures element text across admin screens (quote line items, part names, customer fields). Left deliberately while we work out what is worth capturing.

## Verification

- `pnpm lint` — passes, 16 warnings against the 17 threshold, all pre-existing
- `npx tsc --noEmit` — clean
- No schema, migration, or runtime behaviour change in production beyond the SDK now initialising there for the first time

🤖 Generated with [Claude Code](https://claude.com/claude-code)