### PR TITLE
fix(operator): upload photos before committing the note, and bound the upload

### DIFF
--- a/__tests__/app/operator/OperationActionPage.test.tsx
+++ b/__tests__/app/operator/OperationActionPage.test.tsx
@@ -62,7 +62,9 @@ vi.mock('@/utils/operatorAccess', () => ({
 // which creates its client at MODULE scope — so without a mock the whole test
 // file throws on import rather than on use.
 vi.mock('@/utils/jobNoteMediaAccess', () => ({
-  addJobNoteMedia: vi.fn(async () => ({ id: 'media1' })),
+  uploadJobNoteMediaFile: vi.fn(async () => 'company/jobs/job1/abcd_p.jpg'),
+  insertNoteMedia: vi.fn(async () => ({ id: 'media1' })),
+  discardNoteMediaUploads: vi.fn(async () => undefined),
   getJobNoteMediaUrl: vi.fn(async () => 'blob:x'),
 }));
 vi.mock('@/utils/imageCompression', () => ({

--- a/__tests__/components/maintenance/MachineLogPanel.test.tsx
+++ b/__tests__/components/maintenance/MachineLogPanel.test.tsx
@@ -14,7 +14,7 @@ vi.mock('@/utils/machineMaintenanceAccess', () => ({
   getMachineLog: (...a: unknown[]) => mockGetMachineLog(...a),
   getMachineDetails: (...a: unknown[]) => mockGetMachineDetails(...a),
   addMachineNote: (...a: unknown[]) => mockAddMachineNote(...a),
-  addMachineNoteMedia: vi.fn(),
+  uploadMachineNoteMediaFile: vi.fn(async () => 'c1/work-centers/wc1/abcd_p.jpg'),
 }));
 vi.mock('@/utils/operatorEventsAccess', () => ({
   logOperatorEvent: (...a: unknown[]) => mockLogOperatorEvent(...a),
@@ -31,7 +31,8 @@ vi.mock('@/hooks/useNoteDwell', () => ({
 // creates its client at MODULE scope — without this the file throws on import
 // rather than on use. Same reason as OperationActionPage.test.tsx.
 vi.mock('@/utils/jobNoteMediaAccess', () => ({
-  addNoteMedia: vi.fn(),
+  insertNoteMedia: vi.fn(async () => ({ id: 'm1' })),
+  discardNoteMediaUploads: vi.fn(async () => undefined),
   getJobNoteMediaUrl: vi.fn(async () => 'blob:x'),
 }));
 vi.mock('@/utils/imageCompression', () => ({

--- a/__tests__/components/operator/JobFeed.test.tsx
+++ b/__tests__/components/operator/JobFeed.test.tsx
@@ -4,7 +4,11 @@ import userEvent from '@testing-library/user-event';
 
 import JobFeed from '@/components/operator/JobFeed';
 import { getJobNotes, addJobNote, getCurrentMember } from '@/utils/operatorAccess';
-import { addJobNoteMedia, getJobNoteMediaUrl } from '@/utils/jobNoteMediaAccess';
+import {
+  getJobNoteMediaUrl,
+  insertNoteMedia,
+  uploadJobNoteMediaFile,
+} from '@/utils/jobNoteMediaAccess';
 import { compressPhoto } from '@/utils/imageCompression';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import type { JobNote } from '@/types/operator';
@@ -16,12 +20,16 @@ vi.mock('@/utils/operatorAccess', () => ({
   updateNoteBody: vi.fn(),
 }));
 vi.mock('@/utils/jobNoteMediaAccess', () => ({
-  addJobNoteMedia: vi.fn(),
+  uploadJobNoteMediaFile: vi.fn(async () => 'company/jobs/job-1/abcd_photo.jpg'),
+  insertNoteMedia: vi.fn(async () => ({ id: 'media1' })),
+  discardNoteMediaUploads: vi.fn(async () => undefined),
   getJobNoteMediaUrl: vi.fn(),
   deleteJobNote: vi.fn(),
   deleteJobNoteMedia: vi.fn(),
 }));
-vi.mock('@/utils/imageCompression', () => ({ compressPhoto: vi.fn() }));
+vi.mock('@/utils/imageCompression', () => ({
+  compressPhoto: vi.fn(async (f: File) => ({ file: f, dims: { width: 10, height: 10 } })),
+}));
 // Dwell tracking imports the Supabase client at module scope; it has its own
 // suite in __tests__/hooks/useNoteDwell.test.tsx.
 vi.mock('@/hooks/useNoteDwell', () => ({ useNoteDwell: () => ({ observe: () => () => {} }) }));
@@ -109,7 +117,8 @@ beforeEach(() => {
   mock(getJobNotes).mockResolvedValue([]);
   mock(getJobNoteMediaUrl).mockResolvedValue('blob:thumb');
   mock(compressPhoto).mockResolvedValue({ file: new File(['x'], 'p.jpg', { type: 'image/jpeg' }) });
-  mock(addJobNoteMedia).mockResolvedValue({ id: 'm1' });
+  mock(uploadJobNoteMediaFile).mockResolvedValue('company/jobs/job1/abcd_p.jpg');
+  mock(insertNoteMedia).mockResolvedValue({ id: 'm1' });
   // Pre-dismiss the mic hint by default so it doesn't collide with offer assertions.
   window.localStorage.setItem('jigged:composer-mic-hint', JSON.stringify({ shows: 0, dismissed: true }));
 });
@@ -233,6 +242,32 @@ describe('JobFeed — capture funnel events', () => {
         (c: unknown[]) => c[1] === 'note_saved' || c[1] === 'note_saved_with_photo',
       ),
     ).toBe(false);
+  });
+
+  it('posts nothing to the feed when the photo upload fails (#624)', async () => {
+    // The shop-floor case: an operator photographs a problem on dropping wifi and
+    // the upload stalls. It used to post a photo-less note anyway, which is the
+    // one outcome that reads as "saved" while losing the thing it was taken for.
+    const user = userEvent.setup();
+    mock(uploadJobNoteMediaFile).mockRejectedValue(new Error('The upload timed out'));
+    mock(addJobNote).mockResolvedValue(makeNote({ id: 'new', body: 'cracked insert' }));
+    renderComposer();
+    await waitFor(() => expect(getJobNotes).toHaveBeenCalled());
+
+    await user.type(
+      screen.getByPlaceholderText('Add a note or photo for this step…'),
+      'cracked insert',
+    );
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(input, new File(['x'], 'p.jpg', { type: 'image/jpeg' }));
+    await user.click(screen.getByRole('button', { name: 'Post' }));
+
+    await screen.findByRole('alert');
+    expect(addJobNote).not.toHaveBeenCalled();
+    // The feed is still empty — no photo-less note was prepended.
+    expect(screen.getByText('No activity yet.')).toBeInTheDocument();
+    // Still in hand, so tapping Post again is a retry rather than a second note.
+    expect(screen.getByDisplayValue('cracked insert')).toBeInTheDocument();
   });
 
   it('records composer_abandoned when they open it and leave without saving', async () => {

--- a/__tests__/hooks/useNoteCapture.test.tsx
+++ b/__tests__/hooks/useNoteCapture.test.tsx
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { ChangeEvent } from 'react';
+
+/**
+ * The composer's write order (#624).
+ *
+ * The bug this suite exists for: `submit()` used to create the note row first and
+ * upload into it afterwards. Uploading is the slow half, so a shop-floor phone on
+ * dropping wifi stalled with the note already committed — leaving a note that
+ * claimed to be saved without the photo it was taken for, and nothing saying so.
+ *
+ * Every assertion here is about ORDER. Photos go up first; nothing is committed
+ * until they are all there; a failure leaves the operator exactly what they had.
+ */
+
+vi.mock('@/utils/operatorAccess', () => ({ addJobNote: vi.fn() }));
+vi.mock('@/utils/jobNoteMediaAccess', () => ({
+  uploadJobNoteMediaFile: vi.fn(),
+  insertNoteMedia: vi.fn(),
+  discardNoteMediaUploads: vi.fn(async () => undefined),
+}));
+vi.mock('@/utils/imageCompression', () => ({
+  compressPhoto: vi.fn(async (f: File) => ({ file: f, dims: { width: 10, height: 10 } })),
+}));
+vi.mock('@/utils/operatorEventsAccess', () => ({ logOperatorEvent: vi.fn() }));
+
+import { useNoteCapture, type NoteWriter, type UploadedPhoto } from '@/hooks/useNoteCapture';
+import { discardNoteMediaUploads } from '@/utils/jobNoteMediaAccess';
+import { logOperatorEvent } from '@/utils/operatorEventsAccess';
+
+type TestNote = { id: string; body: string | null; media?: unknown[] };
+
+const mock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
+/** Records the order calls arrive in, which is the whole point of the suite. */
+function makeWriter(overrides: Partial<NoteWriter<TestNote>> = {}) {
+  const calls: string[] = [];
+  const writer: NoteWriter<TestNote> = {
+    createNote: vi.fn(async (body: string | null) => {
+      calls.push('createNote');
+      return { id: 'note-1', body };
+    }),
+    uploadMedia: vi.fn(async (file: File) => {
+      calls.push(`uploadMedia:${file.name}`);
+      return `company/jobs/job-1/abcd_${file.name}`;
+    }),
+    linkMedia: vi.fn(async (_note: TestNote, upload: UploadedPhoto) => {
+      calls.push('linkMedia');
+      return { id: `media-${upload.file.name}` } as never;
+    }),
+    withMedia: (note, media) => ({ ...note, media }),
+    ...overrides,
+  };
+  return { writer, calls };
+}
+
+function renderCapture(writer: NoteWriter<TestNote>) {
+  return renderHook(() =>
+    useNoteCapture<TestNote>({
+      companyId: 'company-1',
+      operatorId: 'operator-1',
+      writer,
+      enabled: true,
+    }),
+  );
+}
+
+/** Drive `pickPhotos` the way the hidden file input does. */
+function photoPick(...names: string[]) {
+  const files = names.map((n) => new File([new Uint8Array(8)], n, { type: 'image/jpeg' }));
+  return { target: { files, value: '' } } as unknown as ChangeEvent<HTMLInputElement>;
+}
+
+describe('useNoteCapture', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:preview'),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uploads every photo BEFORE it creates the note', async () => {
+    const { writer, calls } = makeWriter();
+    const { result } = renderCapture(writer);
+
+    await act(async () => {
+      await result.current.pickPhotos(photoPick('a.jpg', 'b.jpg'));
+    });
+    act(() => result.current.setDraft('coolant low'));
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(calls).toEqual([
+      'uploadMedia:a.jpg',
+      'uploadMedia:b.jpg',
+      'createNote',
+      'linkMedia',
+      'linkMedia',
+    ]);
+  });
+
+  it('never creates the note when a photo upload fails', async () => {
+    // THE HEADLINE INVARIANT. Before the fix this left a committed, photo-less note.
+    const { writer } = makeWriter({
+      uploadMedia: vi.fn().mockRejectedValue(new Error('Network request failed')),
+    });
+    const { result } = renderCapture(writer);
+
+    await act(async () => {
+      await result.current.pickPhotos(photoPick('a.jpg'));
+    });
+    act(() => result.current.setDraft('spindle noise'));
+    await act(async () => {
+      await expect(result.current.submit()).rejects.toThrow();
+    });
+
+    expect(writer.createNote).not.toHaveBeenCalled();
+    expect(writer.linkMedia).not.toHaveBeenCalled();
+  });
+
+  it('leaves the draft and the photo staged so a retry is clean', async () => {
+    const { writer } = makeWriter({
+      uploadMedia: vi.fn().mockRejectedValue(new Error('Network request failed')),
+    });
+    const { result } = renderCapture(writer);
+
+    await act(async () => {
+      await result.current.pickPhotos(photoPick('a.jpg'));
+    });
+    act(() => result.current.setDraft('spindle noise'));
+    await act(async () => {
+      await expect(result.current.submit()).rejects.toThrow();
+    });
+
+    expect(result.current.draft).toBe('spindle noise');
+    expect(result.current.pending).toHaveLength(1);
+    expect(result.current.hasContent).toBe(true);
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.saving).toBe(false);
+  });
+
+  it('records no save in the funnel when the upload fails', async () => {
+    const { writer } = makeWriter({
+      uploadMedia: vi.fn().mockRejectedValue(new Error('Network request failed')),
+    });
+    const { result } = renderCapture(writer);
+
+    await act(async () => {
+      await result.current.pickPhotos(photoPick('a.jpg'));
+    });
+    await act(async () => {
+      await expect(result.current.submit()).rejects.toThrow();
+    });
+
+    const kinds = mock(logOperatorEvent).mock.calls.map((c) => c[1]);
+    expect(kinds).not.toContain('note_saved');
+    expect(kinds).not.toContain('note_saved_with_photo');
+  });
+
+  it('sweeps photos already in the bucket when the note write fails', async () => {
+    // Uploading first moves the orphan risk here, so it has to be cleaned up.
+    const { writer } = makeWriter({
+      createNote: vi.fn().mockRejectedValue(new Error('insert failed')),
+    });
+    const { result } = renderCapture(writer);
+
+    await act(async () => {
+      await result.current.pickPhotos(photoPick('a.jpg', 'b.jpg'));
+    });
+    await act(async () => {
+      await expect(result.current.submit()).rejects.toThrow();
+    });
+
+    expect(discardNoteMediaUploads).toHaveBeenCalledWith([
+      'company/jobs/job-1/abcd_a.jpg',
+      'company/jobs/job-1/abcd_b.jpg',
+    ]);
+  });
+
+  it('sweeps the photos that did land when a later one fails mid-loop', async () => {
+    const uploadMedia = vi
+      .fn()
+      .mockResolvedValueOnce('company/jobs/job-1/abcd_a.jpg')
+      .mockRejectedValueOnce(new Error('Network request failed'));
+    const { writer } = makeWriter({ uploadMedia });
+    const { result } = renderCapture(writer);
+
+    await act(async () => {
+      await result.current.pickPhotos(photoPick('a.jpg', 'b.jpg'));
+    });
+    await act(async () => {
+      await expect(result.current.submit()).rejects.toThrow();
+    });
+
+    expect(discardNoteMediaUploads).toHaveBeenCalledWith(['company/jobs/job-1/abcd_a.jpg']);
+    expect(writer.createNote).not.toHaveBeenCalled();
+  });
+
+  it('clears the composer and records the save once everything lands', async () => {
+    const { writer } = makeWriter();
+    const { result } = renderCapture(writer);
+
+    await act(async () => {
+      await result.current.pickPhotos(photoPick('a.jpg'));
+    });
+    act(() => result.current.setDraft('replaced the filter'));
+
+    let saved: TestNote | null = null;
+    await act(async () => {
+      saved = await result.current.submit();
+    });
+
+    expect(saved).toMatchObject({ id: 'note-1', body: 'replaced the filter' });
+    expect(result.current.draft).toBe('');
+    expect(result.current.pending).toHaveLength(0);
+    expect(result.current.error).toBeNull();
+    expect(logOperatorEvent).toHaveBeenCalledWith(
+      'company-1',
+      'note_saved_with_photo',
+      expect.objectContaining({ photoCount: 1, bodyLength: 'replaced the filter'.length }),
+    );
+  });
+
+  it('writes a text-only note without touching storage', async () => {
+    const { writer, calls } = makeWriter();
+    const { result } = renderCapture(writer);
+
+    act(() => result.current.setDraft('just a note'));
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(calls).toEqual(['createNote']);
+    expect(logOperatorEvent).toHaveBeenCalledWith(
+      'company-1',
+      'note_saved',
+      expect.objectContaining({ photoCount: 0 }),
+    );
+  });
+});

--- a/__tests__/utils/storageHelpers.test.ts
+++ b/__tests__/utils/storageHelpers.test.ts
@@ -41,6 +41,8 @@ import {
   generateStoragePath,
   generateTempStoragePath,
   uploadFileToStorage,
+  uploadTimeoutMs,
+  UploadTimeoutError,
   deleteFileFromStorage,
   getSignedUrl,
   getSignedUrls,
@@ -189,6 +191,74 @@ describe('storageHelpers', () => {
       await uploadFileToStorage('path/to/file.pdf', mockBlob);
 
       expect(mockStorage.upload).toHaveBeenCalled();
+    });
+  });
+
+  // ============== Upload deadline (#624) Tests ==============
+
+  describe('uploadTimeoutMs', () => {
+    // Pinned rather than recomputed, so a change to the constants has to be a
+    // deliberate edit here rather than a silent one. The sizes are the real range
+    // this choke point carries.
+    it('scales the budget with payload size', () => {
+      expect(uploadTimeoutMs(16 * 1024)).toBe(20_274); // the issue's control, observed <5s
+      expect(uploadTimeoutMs(1.5 * 1024 * 1024)).toBe(46_215); // compressed operator photo
+      expect(uploadTimeoutMs(25 * 1024 * 1024)).toBe(456_907); // job / part attachment PDF
+    });
+
+    it('caps the budget so no single request can pin a tab indefinitely', () => {
+      expect(uploadTimeoutMs(100 * 1024 * 1024)).toBe(900_000); // 100MB part model
+      expect(uploadTimeoutMs(5 * 1024 * 1024 * 1024)).toBe(900_000);
+    });
+  });
+
+  describe('uploadFileToStorage deadline', () => {
+    // #624: a stalled upload used to hang forever — no timeout, no error, no way
+    // out — and the composer sat on "Saving…" until the tab was killed.
+    it('rejects an upload that never settles once its budget elapses', async () => {
+      vi.useFakeTimers();
+      try {
+        mockStorage.upload.mockReturnValue(new Promise(() => {}));
+        const photo = new File([new Uint8Array(1024)], 'photo.jpg', { type: 'image/jpeg' });
+
+        const pending = uploadFileToStorage('a/b/photo.jpg', photo);
+        const assertion = expect(pending).rejects.toBeInstanceOf(UploadTimeoutError);
+
+        await vi.advanceTimersByTimeAsync(uploadTimeoutMs(photo.size) + 1);
+        await assertion;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('says the upload timed out rather than that the server refused it', async () => {
+      vi.useFakeTimers();
+      try {
+        mockStorage.upload.mockReturnValue(new Promise(() => {}));
+        const photo = new File([new Uint8Array(1024)], 'photo.jpg', { type: 'image/jpeg' });
+
+        const pending = uploadFileToStorage('a/b/photo.jpg', photo);
+        const assertion = expect(pending).rejects.toThrow(/timed out — check your connection/);
+
+        await vi.advanceTimersByTimeAsync(uploadTimeoutMs(photo.size) + 1);
+        await assertion;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('leaves no timer armed when the upload lands inside its budget', async () => {
+      vi.useFakeTimers();
+      try {
+        mockStorage.upload.mockResolvedValue({ data: {}, error: null });
+        const photo = new File([new Uint8Array(1024)], 'photo.jpg', { type: 'image/jpeg' });
+
+        await uploadFileToStorage('a/b/photo.jpg', photo);
+
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/components/maintenance/MachineLogPanel.tsx
+++ b/components/maintenance/MachineLogPanel.tsx
@@ -15,12 +15,12 @@ import { useNoteDwell } from '@/hooks/useNoteDwell';
 import { useNoteCapture } from '@/hooks/useNoteCapture';
 import type { NoteWriter } from '@/hooks/useNoteCapture';
 import { getCurrentMember, updateNoteBody } from '@/utils/operatorAccess';
-import { deleteJobNote, deleteJobNoteMedia } from '@/utils/jobNoteMediaAccess';
+import { deleteJobNote, deleteJobNoteMedia, insertNoteMedia } from '@/utils/jobNoteMediaAccess';
 import {
   addMachineNote,
-  addMachineNoteMedia,
   getMachineDetails,
   getMachineLog,
+  uploadMachineNoteMediaFile,
 } from '@/utils/machineMaintenanceAccess';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import { countWorkCenterAttachments } from '@/utils/workCenterAttachmentsAccess';
@@ -125,8 +125,9 @@ export default function MachineLogPanel({
           // The main composer never resolves anything — that is the reply's job.
           resolvesNoteId: null,
         }),
-      attachMedia: (note, file, dims) =>
-        addMachineNoteMedia(companyId, workCenterId, note.id, file, { dims }),
+      uploadMedia: (file) => uploadMachineNoteMediaFile(companyId, workCenterId, file),
+      linkMedia: (note, upload) =>
+        insertNoteMedia(companyId, note.id, upload.storagePath, upload.file, upload.dims),
       withMedia: (note, media) => ({ ...note, media }),
       eventContext: { workCenterId, maintenanceKind: kind },
     };

--- a/components/maintenance/MachineReplyComposer.tsx
+++ b/components/maintenance/MachineReplyComposer.tsx
@@ -3,7 +3,8 @@
 import { useMemo } from 'react';
 import MachineComposer from '@/components/maintenance/MachineComposer';
 import { useNoteCapture, type NoteWriter } from '@/hooks/useNoteCapture';
-import { addMachineNote, addMachineNoteMedia } from '@/utils/machineMaintenanceAccess';
+import { addMachineNote, uploadMachineNoteMediaFile } from '@/utils/machineMaintenanceAccess';
+import { insertNoteMedia } from '@/utils/jobNoteMediaAccess';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import type { MachineNote } from '@/types/machineMaintenance';
 
@@ -59,8 +60,9 @@ export default function MachineReplyComposer({
           maintenanceKind: null,
           resolvesNoteId: target.id,
         }),
-      attachMedia: (note, file, dims) =>
-        addMachineNoteMedia(companyId, workCenterId, note.id, file, { dims }),
+      uploadMedia: (file) => uploadMachineNoteMediaFile(companyId, workCenterId, file),
+      linkMedia: (note, upload) =>
+        insertNoteMedia(companyId, note.id, upload.storagePath, upload.file, upload.dims),
       withMedia: (note, media) => ({ ...note, media }),
       eventContext: { workCenterId, resolving: true },
     }),

--- a/docs/modules/operator-view.md
+++ b/docs/modules/operator-view.md
@@ -521,10 +521,26 @@ no draft persistence, so the only real fix was to stop having two commits. **The
 offer is deleted, not relocated.**
 
 **Submit order is load-bearing and deliberately NOT atomic:** `createOperationCompletion` lands
-first and durably, then `addJobNote` if there is text or a photo, then `addJobNoteMedia` per photo.
-A transaction would be *worse* — it would roll back real finished work because an image failed to
-upload on shop wifi. So if the note fails the completion stands, and the note error surfaces on
-its own next to the text the operator still has.
+first and durably, then the note. A transaction across the two would be *worse* — it would roll back
+real finished work because an image failed to upload on shop wifi. So if the note fails the
+completion stands, and the note error surfaces on its own next to the text the operator still has.
+
+**Within the note, photos upload BEFORE the note row is written** — `uploadJobNoteMediaFile` for
+every photo, then `addJobNote`, then `insertNoteMedia` per photo. Corrected 2026-08-04 from
+[#624](https://github.com/debola31/Jigged/issues/624); it used to be the other way round. Uploading
+is the slow, failure-prone half, so a phone on dropping wifi stalled with the note *already
+committed*: backing out left a note claiming to be saved without the photo it was taken for, and
+nothing said so. Inverted, a failed or timed-out upload leaves **nothing** behind — which is why
+this needs no partial-save state and no second kind of error message. The draft and the photos are
+still in the composer, and tapping save again is a clean retry rather than a second note. It is the
+rule [`OperatorLocationActionModal`](../../components/operator/OperatorLocationActionModal.tsx)
+already states: *upload before the write, never after.* It was reachable here only because the
+storage path keys on the job or the machine and never on the note.
+
+The cost moves rather than vanishing: photos that land before a later step fails are orphans, swept
+best-effort by `discardNoteMediaUploads` and otherwise invisible. A `insertNoteMedia` failure *after*
+the note lands can still leave a text-only note, but that is a fast local write rather than a
+transfer, so it is a far smaller exposure than the one it replaced.
 
 **Capture is always optional.** Completion works with the field empty.
 
@@ -611,6 +627,15 @@ renders them and deliberately owns **no** submit button, because the surface it 
 what "save" means. The photo pipeline copies bytes into a stable `File` **immediately**, because a
 camera-origin `File` on iOS can become unreadable by compress-and-upload time and yield a
 zero-byte blob; unreadable picks are **reported per file**, never dropped silently.
+
+The write side now holds the same line. Both slow steps are **bounded**, because an unbounded one
+reads as a working app rather than a broken one and the operator waits, gives up, and loses the
+photo: compression carries a real `AbortSignal` (30 s, CPU-bound so it only fires when something is
+wrong), and the upload carries a size-aware deadline in
+[`storageHelpers`](../../utils/storageHelpers.ts) — roughly 46 s for a compressed photo, minutes for
+a 100 MB part model, since one choke point serves both. Supabase Storage exposes no cancel or
+progress hook for uploads, so that deadline abandons the request rather than stopping it; if photo
+uploads ever fail often enough to matter, the escalation is TUS resumable uploads, not a longer wait.
 
 ### Triangularity (B5)
 
@@ -812,6 +837,8 @@ Convention (Given/When/Then + a checkable verification clause) is stated once in
 
 - [ ] **Given** a step WITH a `routing_operation_id`, **when** a note is saved, **then** it is written as a **durable `part` subject** with the job recorded only as provenance; **given** an ad-hoc step with no routing link, **then** it falls back to a `job` subject — a genuine subject difference, not a silent fallback — *verified by `__tests__/utils/operatorNoteSubject.test.ts` (6 `it`s) and `__tests__/utils/operatorAccess.test.ts` > `addJobNote`*.
 - [ ] **Given** a blank-text note with a photo, **when** it is saved, **then** `body` is stored as null so a media-only note is valid — *verified by `__tests__/utils/operatorAccess.test.ts` > `addJobNote`*.
+- [ ] **Given** a note with a photo, **when** it is saved, **then** every photo reaches storage **before** the note row is written; **given** an upload that fails or times out, **then** no note is created at all, the draft and photos stay in the composer so saving again is a retry rather than a second note, and the photos that did land are swept — *verified by `__tests__/hooks/useNoteCapture.test.tsx` (8 `it`s) and `__tests__/components/operator/JobFeed.test.tsx`*.
+- [ ] **Given** a stalled upload, **when** its size-aware deadline expires, **then** it fails rather than hanging on "Saving…" forever — *verified by `__tests__/utils/storageHelpers.test.ts` > `uploadFileToStorage deadline`*.
 - [ ] **Given** the job feed, **when** it loads, **then** job-subject notes AND durable part-subject notes captured on this job roll up together, newest first — *verified by `__tests__/utils/operatorAccess.test.ts` > `getJobNotes`*.
 - [ ] **Given** an author editing their own note, **when** it saves, **then** only `body` changes, `edited_at` is stamped by the trigger, a "· edited" marker renders, and **the view count does not reset** — *verified by `__tests__/components/notes/NoteEditDialog.test.tsx` (12 `it`s), `__tests__/components/operator/JobFeed.test.tsx` (17 `it`s) and `__tests__/utils/operatorAccess.test.ts` > `updateNoteBody`*.
 - [ ] **Given** an author deleting their own note, **when** it is removed, **then** it disappears from the feed, the Playbook and My work — *verified by `__tests__/components/operator/JobFeed.test.tsx` and `__tests__/app/operator/MyWorkPage.test.tsx` (31 `it`s)*.

--- a/hooks/useNoteCapture.ts
+++ b/hooks/useNoteCapture.ts
@@ -2,7 +2,11 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { addJobNote } from '@/utils/operatorAccess';
-import { addJobNoteMedia } from '@/utils/jobNoteMediaAccess';
+import {
+  discardNoteMediaUploads,
+  insertNoteMedia,
+  uploadJobNoteMediaFile,
+} from '@/utils/jobNoteMediaAccess';
 import { compressPhoto } from '@/utils/imageCompression';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 import type { OperatorEventContext } from '@/utils/operatorEventsAccess';
@@ -82,15 +86,25 @@ export interface NoteCaptureContext {
  */
 export interface NoteWriter<TNote> {
   createNote: (body: string | null) => Promise<TNote>;
-  attachMedia: (
-    note: TNote,
-    file: File,
-    dims?: { width: number; height: number },
-  ) => Promise<JobNoteMedia>;
+  /**
+   * Put the bytes in the bucket and return where they landed. Takes NO note, because the storage
+   * path keys on the job or the machine and never on the note — which is what lets `submit` get
+   * every photo up before it commits anything. See the ordering comment there.
+   */
+  uploadMedia: (file: File) => Promise<string>;
+  /** Record an already-uploaded file against the note. A fast local write, not a transfer. */
+  linkMedia: (note: TNote, upload: UploadedPhoto) => Promise<JobNoteMedia>;
   /** Merge saved media onto the note for the optimistic prepend. */
   withMedia: (note: TNote, media: JobNoteMedia[]) => TNote;
   /** Merged into every funnel event this composer emits. */
   eventContext?: OperatorEventContext;
+}
+
+/** A compressed photo that is already in the bucket, waiting for a note to belong to. */
+export interface UploadedPhoto {
+  storagePath: string;
+  file: File;
+  dims?: { width: number; height: number };
 }
 
 /**
@@ -124,9 +138,13 @@ export interface NoteCapture<TNote = JobNote> extends NoteCaptureFieldsState {
    * Write the note and its media. Returns the note (with media) so an optimistic
    * list can prepend it, or null when there was nothing to write.
    *
-   * THROWS on failure, deliberately: the caller decides what a partial failure
-   * means. On the completion path the completion has already landed and must
-   * stand, so the error is surfaced on its own rather than rolled back.
+   * THROWS on failure, deliberately: the caller decides what a failure means. On
+   * the completion path the completion has already landed and must stand, so the
+   * error is surfaced on its own rather than rolled back.
+   *
+   * A throw means NOTHING WAS WRITTEN in the overwhelmingly common case — see the
+   * ordering comment in the implementation — so the draft and photos the operator
+   * still has are the whole of what is unsaved, and retrying is safe.
    */
   submit: () => Promise<TNote | null>;
 }
@@ -304,12 +322,47 @@ export function useNoteCapture<TNote = JobNote>(opts: {
     setSaving(true);
     setError(null);
     try {
-      const note = await writer.createNote(body || null);
+      /**
+       * UPLOAD EVERY PHOTO FIRST, COMMIT SECOND. The order is the fix for #624.
+       *
+       * It used to be the other way round: create the note, then upload into it. Uploading is the
+       * slow, failure-prone half — a shop-floor phone on dropping wifi can stall on it for minutes
+       * — and by the time it stalled the note row was already committed. Backing out left a note
+       * that claimed to be saved with the photo it was taken for missing, and nothing said so.
+       *
+       * Inverted, a failed or timed-out upload leaves NOTHING behind. The catch below then tells
+       * the truth with no extra machinery: the draft and the photos are still staged, the error is
+       * accurate, and tapping save again is a clean retry rather than a second note.
+       *
+       * This is the rule OperatorLocationActionModal already states — "upload BEFORE the write,
+       * never after" — and the reason it was reachable here is that the storage path keys on the
+       * job or the machine, never on the note, so it needs nothing the note provides.
+       *
+       * The cost is symmetrical and much smaller: if a later step fails, the photos already in the
+       * bucket are orphans. They are invisible and cheap, and we make a best-effort sweep below.
+       */
+      const uploads: UploadedPhoto[] = [];
+      let note: TNote;
+      try {
+        for (const p of photos) {
+          const prepared = await compressPhoto(p.file);
+          uploads.push({
+            storagePath: await writer.uploadMedia(prepared.file),
+            file: prepared.file,
+            dims: prepared.dims,
+          });
+        }
+        note = await writer.createNote(body || null);
+      } catch (err) {
+        // Everything up to and including the note write is still reversible, so sweep the bytes
+        // that did land rather than leaving them unreferenced.
+        await discardNoteMediaUploads(uploads.map((u) => u.storagePath));
+        throw err;
+      }
 
       const media: JobNoteMedia[] = [];
-      for (const p of photos) {
-        const prepared = await compressPhoto(p.file);
-        media.push(await writer.attachMedia(note, prepared.file, prepared.dims));
+      for (const u of uploads) {
+        media.push(await writer.linkMedia(note, u));
       }
 
       photos.forEach((p) => URL.revokeObjectURL(p.previewUrl));
@@ -374,8 +427,9 @@ export function useStepNoteWriter(args: {
           jobPartId: context.jobPartId,
           jobOperationId: context.jobOperationId,
         }),
-      attachMedia: (note, file, dims) =>
-        addJobNoteMedia(companyId, jobId, note.id, file, { dims }),
+      uploadMedia: (file) => uploadJobNoteMediaFile(companyId, jobId, file),
+      linkMedia: (note, upload) =>
+        insertNoteMedia(companyId, note.id, upload.storagePath, upload.file, upload.dims),
       withMedia: (note, media) => ({ ...note, media }),
       eventContext: { jobOperationId: context.jobOperationId },
     };

--- a/utils/imageCompression.ts
+++ b/utils/imageCompression.ts
@@ -21,6 +21,28 @@ const PHOTO_COMPRESSION_OPTIONS = {
   fileType: 'image/jpeg' as const,
 };
 
+/**
+ * Compression is the OTHER way the composer can hang: it precedes every upload, and a worker that
+ * never reports back leaves the same endless "Saving…" as a stalled request. Unlike the upload,
+ * this one cancels for real — browser-image-compression takes an AbortSignal.
+ *
+ * Generous, because the budget is CPU rather than network: a 12 MP photo on an old phone is a few
+ * seconds, so 30 s only fires when something is genuinely wrong.
+ */
+const COMPRESSION_TIMEOUT_MS = 30_000;
+
+/**
+ * Fresh per call — a module-level signal would start its clock at import and be shared by every
+ * photo. Guarded because `AbortSignal.timeout` needs Safari 16+, and operators are on their own
+ * phones of unknown vintage: on an older one we lose the deadline, which is where we already are,
+ * rather than losing the ability to attach a photo at all.
+ */
+function compressionSignal(): AbortSignal | undefined {
+  return typeof AbortSignal.timeout === 'function'
+    ? AbortSignal.timeout(COMPRESSION_TIMEOUT_MS)
+    : undefined;
+}
+
 export interface PreparedPhoto {
   file: File;
   dims?: { width: number; height: number };
@@ -34,7 +56,10 @@ function renameToJpg(name: string): string {
 
 /** Compress + downscale a captured image and read its final pixel dimensions. */
 export async function compressPhoto(input: File): Promise<PreparedPhoto> {
-  const compressed = await imageCompression(input, PHOTO_COMPRESSION_OPTIONS);
+  const compressed = await imageCompression(input, {
+    ...PHOTO_COMPRESSION_OPTIONS,
+    signal: compressionSignal(),
+  });
 
   // Normalize to a File with a .jpg name and image/jpeg type regardless of what
   // the library returns (File or Blob, original extension).

--- a/utils/jobNoteMediaAccess.ts
+++ b/utils/jobNoteMediaAccess.ts
@@ -58,32 +58,66 @@ function rowToMedia(row: MediaRow): JobNoteMedia {
 }
 
 /**
- * Attach one (already-compressed) photo to a note of ANY subject. Uploads to
- * {companyId}/{entityType}/{entityId}/... then records the metadata row. Rolls
- * back the storage object if the row insert fails so a failed attach never leaks
- * an orphaned file. `dims` (the compressed image's pixel size) is optional.
+ * Put one (already-compressed) photo in the bucket and return where it landed.
  *
- * The folder is a caller decision because a machine-subject note has no job to
- * file under — its photos live beside the machine. The company segment, which is
- * the only one the bucket RLS reads, is unchanged either way.
+ * SPLIT FROM THE ROW INSERT ON PURPOSE, and the split is the whole point of #624. The bytes are
+ * the slow, failure-prone half; the row is a fast local write. Keeping them in one function forced
+ * every caller to have a note row already, so a stalled upload on shop wifi left a note claiming
+ * to be saved with the photo it was taken for missing. Callers now upload first and commit second.
+ *
+ * NOTE THAT THE PATH NEVER CONTAINED THE NOTE ID — it keys on the job or the work center — so this
+ * needs nothing that does not exist before the note does. That is what made the reorder possible.
+ *
+ * The folder is a caller decision because a machine-subject note has no job to file under; its
+ * photos live beside the machine. The company segment, which is the only one the bucket RLS reads,
+ * is unchanged either way.
  */
-export async function addNoteMedia(
+export async function uploadNoteMediaFile(
   companyId: string,
-  noteId: string,
   file: File,
-  opts: {
-    folder: { entityType: StorageEntityType; entityId: string };
-    dims?: { width: number; height: number };
-  },
-): Promise<JobNoteMedia> {
-  const supabase = getSupabase();
+  folder: { entityType: StorageEntityType; entityId: string },
+): Promise<string> {
   const storagePath = generateStoragePath(
     companyId,
-    opts.folder.entityType,
-    opts.folder.entityId,
+    folder.entityType,
+    folder.entityId,
     file.name,
   );
   await uploadFileToStorage(storagePath, file);
+  return storagePath;
+}
+
+/**
+ * Drop photos that reached the bucket before a later step of the same save failed.
+ *
+ * The counterpart to uploading before committing: if the note write or a row insert fails, the
+ * bytes already up would otherwise be orphans. Best-effort and NEVER THROWS — the caller is already
+ * on its way to reporting a real failure, and replacing that message with "cleanup failed" would
+ * tell the operator about our problem instead of theirs. A missed sweep leaves an unreferenced
+ * object, which is invisible and cheap — the same trade `deleteJobNoteMedia` already makes.
+ */
+export async function discardNoteMediaUploads(storagePaths: string[]): Promise<void> {
+  await Promise.all(
+    storagePaths.map((path) =>
+      deleteFileFromStorage(path).catch((err) =>
+        console.warn('Failed to discard an uploaded photo after a failed save:', err),
+      ),
+    ),
+  );
+}
+
+/**
+ * Record the metadata row for a file already in the bucket. Rolls the object back if the insert
+ * fails, so a failed attach never leaks an orphan.
+ */
+export async function insertNoteMedia(
+  companyId: string,
+  noteId: string,
+  storagePath: string,
+  file: File,
+  dims?: { width: number; height: number },
+): Promise<JobNoteMedia> {
+  const supabase = getSupabase();
 
   const { data, error } = await supabase
     .from('note_media')
@@ -94,8 +128,8 @@ export async function addNoteMedia(
       kind: 'photo',
       mime_type: file.type || null,
       size_bytes: file.size,
-      width: opts?.dims?.width ?? null,
-      height: opts?.dims?.height ?? null,
+      width: dims?.width ?? null,
+      height: dims?.height ?? null,
     })
     .select(MEDIA_SELECT)
     .single();
@@ -108,6 +142,36 @@ export async function addNoteMedia(
   }
 
   return rowToMedia(data as unknown as MediaRow);
+}
+
+/**
+ * Upload and record in one step, for callers that already hold a note row and are not carrying the
+ * two halves themselves. The composer deliberately does NOT use this — see `uploadNoteMediaFile`.
+ */
+export async function addNoteMedia(
+  companyId: string,
+  noteId: string,
+  file: File,
+  opts: {
+    folder: { entityType: StorageEntityType; entityId: string };
+    dims?: { width: number; height: number };
+  },
+): Promise<JobNoteMedia> {
+  const storagePath = await uploadNoteMediaFile(companyId, file, opts.folder);
+  return insertNoteMedia(companyId, noteId, storagePath, file, opts.dims);
+}
+
+/**
+ * Upload half of `addJobNoteMedia`, for the composer's upload-then-commit order. Only the folder
+ * choice differs between a job photo and a machine photo, so that is all the two halves split on —
+ * `insertNoteMedia` is shared.
+ */
+export function uploadJobNoteMediaFile(
+  companyId: string,
+  jobId: string,
+  file: File,
+): Promise<string> {
+  return uploadNoteMediaFile(companyId, file, { entityType: 'jobs', entityId: jobId });
 }
 
 /**

--- a/utils/machineMaintenanceAccess.ts
+++ b/utils/machineMaintenanceAccess.ts
@@ -2,7 +2,7 @@ import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import { mapReactions } from '@/utils/operatorAccess';
 import type { ReactionRel } from '@/utils/operatorAccess';
-import { addNoteMedia } from '@/utils/jobNoteMediaAccess';
+import { addNoteMedia, uploadNoteMediaFile } from '@/utils/jobNoteMediaAccess';
 import type { JobNoteMedia } from '@/types/operator';
 import type {
   MachineDetails,
@@ -194,6 +194,22 @@ export async function addMachineNote(
   }
 
   return rowToNote(data as unknown as MachineNoteRow);
+}
+
+/**
+ * Upload half of `addMachineNoteMedia`, for the composer's upload-then-commit order. A machine
+ * photo files beside the machine rather than under a job — that folder choice is the only thing
+ * that differs from the job path, which is why it is all the split covers.
+ */
+export function uploadMachineNoteMediaFile(
+  companyId: string,
+  workCenterId: string,
+  file: File,
+): Promise<string> {
+  return uploadNoteMediaFile(companyId, file, {
+    entityType: 'work-centers',
+    entityId: workCenterId,
+  });
 }
 
 /** Attach one already-compressed photo to a machine entry. */

--- a/utils/storageHelpers.ts
+++ b/utils/storageHelpers.ts
@@ -67,6 +67,66 @@ export function generateCompanyLogoPath(
   return `${companyId}/company/logo_${uuid}_${sanitized}`;
 }
 
+/** A storage request that ran past its deadline. Distinct so callers can word it as a network
+ *  condition rather than as a rejection by the server. */
+export class UploadTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UploadTimeoutError';
+  }
+}
+
+/**
+ * Deadlines for storage requests, because a stalled one otherwise hangs forever.
+ *
+ * Supabase's `.upload()` accepts no AbortSignal (still true in storage-js 2.112) and there is no
+ * progress event to hang a stall detector off, so this RACES rather than CANCELS: the request is
+ * abandoned, not stopped. The cost is that a stalled upload whose bytes later land leaves an
+ * orphaned object with no row — invisible, and a category this module already tolerates by design
+ * (see deleteJobNoteMedia). It can never block a retry, because generateStoragePath mints a fresh
+ * uuid per call. If uploads on shop wifi turn out to fail often enough to care, the escalation is
+ * TUS resumable uploads (which Supabase recommends above 6 MB), not a bigger timeout.
+ */
+const UPLOAD_TIMEOUT_BASE_MS = 20_000;
+/**
+ * ≈480 kbit/s sustained — deliberately BELOW any link a phone can meaningfully use, so failing this
+ * budget means the transfer stalled rather than that it was slow. A marginal LTE signal inside a
+ * steel building still sustains around 1 Mbit/s up when it is working at all.
+ */
+const UPLOAD_MIN_BYTES_PER_MS = 60;
+/** Only binds above ~51 MB. No single request should be able to pin a tab for half an hour. */
+const UPLOAD_TIMEOUT_MAX_MS = 15 * 60_000;
+/** A delete carries no payload, so it needs no size term. */
+const DELETE_TIMEOUT_MS = 20_000;
+
+/**
+ * How long an upload of `bytes` may take before it counts as stalled.
+ *
+ * ONE FORMULA CANNOT SERVE BOTH ENDS OF THIS WELL, and the linear term is the compromise: the same
+ * choke point carries 1.5 MB operator photos taken on a phone (~46 s) and 100 MB part model files
+ * uploaded from an office desk (capped at 15 min). If the phone number proves wrong in the pilot,
+ * add a per-call override rather than changing the shared rate.
+ */
+export function uploadTimeoutMs(bytes: number): number {
+  return Math.min(
+    UPLOAD_TIMEOUT_BASE_MS + Math.ceil(bytes / UPLOAD_MIN_BYTES_PER_MS),
+    UPLOAD_TIMEOUT_MAX_MS,
+  );
+}
+
+/** Reject after `ms` if `work` has not settled. Clears its timer either way. */
+async function withDeadline<T>(work: Promise<T>, ms: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new UploadTimeoutError(message)), ms);
+  });
+  try {
+    return await Promise.race([work, deadline]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /**
  * Upload file to Supabase Storage
  */
@@ -77,12 +137,16 @@ export async function uploadFileToStorage(
   const supabase = getSupabase();
   const bucket = getStorageBucket();
 
-  const { error } = await supabase.storage
-    .from(bucket)
-    .upload(path, file, {
-      cacheControl: '3600',
-      upsert: false
-    });
+  const { error } = await withDeadline(
+    supabase.storage
+      .from(bucket)
+      .upload(path, file, {
+        cacheControl: '3600',
+        upsert: false
+      }),
+    uploadTimeoutMs(file.size),
+    'The upload timed out — check your connection and try again.',
+  );
 
   if (error) {
     console.error('Storage upload error:', error);
@@ -99,9 +163,14 @@ export async function deleteFileFromStorage(
   const supabase = getSupabase();
   const bucket = getStorageBucket();
 
-  const { error } = await supabase.storage
-    .from(bucket)
-    .remove([path]);
+  // Bounded for the same reason as the upload, and it is not hypothetical: the media rollback path
+  // awaits this after a failed insert, so a hung remove would hang the composer one branch below
+  // the failure it is cleaning up after.
+  const { error } = await withDeadline(
+    supabase.storage.from(bucket).remove([path]),
+    DELETE_TIMEOUT_MS,
+    'Removing the file timed out — check your connection and try again.',
+  );
 
   if (error) {
     console.error('Storage delete error:', error);


### PR DESCRIPTION
Closes #624.

## What was wrong

Both halves of the issue reproduced exactly as filed, and neither had been touched since:

- `uploadFileToStorage` was a bare `await …upload(…)` — no timeout, no abort, no retry. A repo-wide grep for `AbortController|AbortSignal|Promise.race` returned zero hits outside comments.
- `useNoteCapture.submit()` created the note row **first**, then uploaded into it. So by the time an upload stalled, the note was already committed; backing out left a text-only note with nothing saying the photo was lost. `setSaving(false)` lives in `finally`, which cannot run while the upload is pending — hence the endless "Saving…".

**On the issue's scope:** it lists quote attachments, but there is no quote-attachment upload path — and that follows from the domain rather than being a gap. A quote *becomes* a job when the PO arrives, so by the time there is a PDF to attach there is a job to attach it to; the PO PDF goes to the job that conversion just created, via `uploadJobAttachment`. The six real paths (note media, job attachments, part attachments, work-center manuals, location photos, operator stock-move evidence) all funnel through `uploadFileToStorage`, which is why one deadline covers them.

## The fix

**1. Upload before commit** — `submit()` now puts every photo in the bucket, then writes the note, then records the rows. A failed or timed-out upload leaves **nothing** behind, so the existing `catch`/`finally` becomes correct for free: the draft and photos stay staged, the error is accurate, and saving again is a clean retry rather than a second note.

This deletes the problem rather than describing it. An earlier draft of this fix carried partial-save state, a warning Alert, a retry action and a feed dedupe — none of it is needed once nothing can be committed without its photos. **No UI changed in this PR.**

It is also the rule the repo already wrote down, in `OperatorLocationActionModal`: *"Upload BEFORE the write, never after… saving silently without the photo the operator just attached would be a lie about what was recorded."* It was reachable here only because the storage path keys on the job or work-center and **never on the note**.

**2. A deadline** — size-aware, because one choke point carries 1.5 MB phone photos and 100 MB part models:

| Payload | Budget |
|---|---|
| 16 KB (the issue's own control, observed <5 s) | 20.3 s |
| 1.5 MB compressed operator photo | 46.2 s |
| 25 MB job/part PDF | 7 m 17 s |
| 100 MB part model | 15 m (capped) |

**3. `compressPhoto`** — the other hang vector in the same `submit()` — gets a real `AbortSignal` (30 s), guarded for older Safari.

## Why not something more first-party

I looked before building. Storage `.upload()` accepts **no** `AbortSignal` even in the latest `@supabase/storage-js@2.112.0` (we're on 2.105.1 — a bump buys nothing), and the [upload progress/cancel request](https://github.com/supabase/storage/issues/23) has been open since 2021. Supabase's only documented reliability guidance is [TUS resumable uploads above 6 MB](https://supabase.com/docs/guides/storage/uploads/resumable-uploads) — our compressed photos are 1.5 MB, well under that, and `tus-js-client` would be a new dependency on the one surface where CLAUDE.md calls bundle weight expensive. Rejected for now; it's the escalation if the pilot shows photo uploads failing often.

So the deadline **races rather than cancels**. The cost is a possibly-orphaned storage object — invisible, already a tolerated category (`deleteJobNoteMedia` leaves them by design), and it can never block a retry because `generateStoragePath` mints a fresh uuid per call.

## Verification

`pnpm build` clean · lint clean (16 pre-existing warnings, cap 17) · `docLinkCheck` clean (32 docs, 1080 citations) · **2000 tests / 147 files green**.

New coverage, 14 tests:
- `__tests__/hooks/useNoteCapture.test.tsx` (new, 8 `it`s — the hook had none) asserts the recorded call order is `uploadMedia → uploadMedia → createNote → linkMedia → linkMedia`, that a failed upload means `createNote` is **never called**, that the draft and photo stay staged, that no `note_saved` is logged, and that photos already in the bucket are swept when a later step fails. These are call-order assertions; they cannot pass under the old ordering.
- `storageHelpers.test.ts` pins the budget table and asserts an upload that never settles rejects with `UploadTimeoutError` and leaves no timer armed.
- `JobFeed.test.tsx` gets the case the feed never had: a failing photo upload posts **nothing** to the feed. Previously it posted a photo-less note.

Also repaired three test mocks (`JobFeed`, `OperationActionPage`, `MachineLogPanel`) that were passing vacuously — none of them ever attached a photo, so their media mocks were never exercised.

**Manual check** (local Supabase, operator login): DevTools → Network → ~10 kbit/s up, attach a photo to a machine log entry, save. Button leaves "Saving…" at the deadline with an error, **no entry appears in the log**, draft and photo still staged; restore the connection, save again, exactly one entry appears with its photo.

No E2E: a 46 s budget exceeds Playwright's default timeout, and shrinking it needs an env override that would exist only for the test.

## Known limits

- `insertNoteMedia` failing *after* the note lands can still leave a text-only note. That is a fast local write rather than a transfer, so it is a far smaller exposure than the one it replaces; closing it fully needs an RPC that writes note + media together.
- Worst case "Saving…" for one photo is now ~76 s (30 s compress + 46 s upload), and photos upload serially. If that's too long in the pilot, the next move is progress text or parallel uploads.
- `moveFileInStorage` is dead code (zero production callers, only its own tests). Left alone and unbounded — flagging rather than deleting.
- **Coverage floors left alone deliberately.** They're 17 points stale (50/45/47/51 vs actual 67/61/66/68, last ratcheted 2026-05-28). Bumping them here would claim three months of other people's work and jump the floor for every in-flight PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

