### PR TITLE
fix(hooks): pass primitive useLoad deps, so the guard means something again

### DIFF
--- a/app/dashboard/[companyId]/jobs/page.tsx
+++ b/app/dashboard/[companyId]/jobs/page.tsx
@@ -222,6 +222,7 @@ export default function JobsPage() {
   // cancelled), then filter to the exact selected stages client-side via
   // getJobLifecycleStage (see visibleJobs). Closed jobs are fetched only when a
   // closed stage is selected — the default (open stages only) hides them.
+  const statusFilterKey = [...statusFilter].sort().join(',');
   const {
     data: jobsData,
     loading,
@@ -241,12 +242,16 @@ export default function JobsPage() {
       };
       return getAllJobs(companyId, filters, sortModel.field, sortModel.sort);
     },
+    // Primitive deps only (see the warning in hooks/useLoad.ts): the selected
+    // stages collapse to a sorted key, and sortModel spreads into its two
+    // fields. Sorted, so merely reordering the multi-select can't refetch.
     [
       companyId,
-      statusFilter,
+      statusFilterKey,
       customerId,
       searchDebounced,
-      sortModel,
+      sortModel.field,
+      sortModel.sort,
       overdueOnly,
     ],
     {

--- a/app/dashboard/[companyId]/parts/page.tsx
+++ b/app/dashboard/[companyId]/parts/page.tsx
@@ -175,7 +175,9 @@ export default function PartsPage() {
           return new Set<string>();
         }),
       ]),
-    [companyId, searchDebounced, sortModel],
+    // Spread sortModel into its two primitives rather than passing the object —
+    // useLoad wants primitive deps (see the warning in hooks/useLoad.ts).
+    [companyId, searchDebounced, sortModel.field, sortModel.sort],
     {
       onError: (error) => {
         console.error('Error fetching parts:', error);

--- a/components/notes/NoteEditDialog.tsx
+++ b/components/notes/NoteEditDialog.tsx
@@ -135,6 +135,12 @@ export default function NoteEditDialog({
   const changed = trimmed !== (initialBody ?? '').trim() || removed.length > 0;
   const canSave = changed && !emptyBlocked && !saving;
 
+  // Keyed on the ids, not the array — same reason as NoteMediaGallery. NO_MEDIA
+  // above already gives the omitted-prop case a stable identity; this covers a
+  // caller that rebuilds a real media array each render, and keeps useLoad's
+  // non-primitive-dep warning meaningful by not firing it here every render.
+  const mediaKey = media.map((m) => m.id).join(',');
+
   // Batch-load thumbnails once per media set, mirroring NoteMediaGallery.
   const { data: urls } = useLoad(async () => {
     const pairs = await Promise.all(
@@ -149,7 +155,7 @@ export default function NoteEditDialog({
     const map: Record<string, string> = {};
     for (const p of pairs) if (p) map[p[0]] = p[1];
     return map;
-  }, [media]);
+  }, [mediaKey]);
 
   return (
     <Dialog open={open} onClose={saving ? undefined : onClose} fullWidth maxWidth="sm">

--- a/components/operator/NoteMediaGallery.tsx
+++ b/components/operator/NoteMediaGallery.tsx
@@ -26,6 +26,11 @@ const THUMB = 72;
 export default function NoteMediaGallery({ media }: { media: JobNoteMedia[] }) {
   const [viewerUrl, setViewerUrl] = useState<string | null>(null);
 
+  // Keyed on the ids, not the array — useLoad wants a primitive dep, and the
+  // URLs resolve off thumbnail_path/storage_path, which are fixed per id. So a
+  // parent re-rendering with a new array of the same photos costs nothing.
+  const mediaKey = media.map((m) => m.id).join(',');
+
   // Batch-load this note's thumbnail URLs once.
   const { data: urls, loading } = useLoad(async () => {
     const pairs = await Promise.all(
@@ -40,7 +45,7 @@ export default function NoteMediaGallery({ media }: { media: JobNoteMedia[] }) {
     const map: Record<string, string> = {};
     for (const p of pairs) if (p) map[p[0]] = p[1];
     return map;
-  }, [media]);
+  }, [mediaKey]);
 
   const openViewer = async (m: JobNoteMedia) => {
     try {

--- a/hooks/useCompanies.ts
+++ b/hooks/useCompanies.ts
@@ -8,13 +8,17 @@ const EMPTY_COMPANIES: UserCompanyAccess[] = [];
 
 export function useCompanies() {
   const { user } = useAuth();
+  // Key on the id, NOT the `user` object — see the same note in useUserRole.
+  // AuthProvider hands down a fresh User object on every auth event, so [user]
+  // re-ran getUserCompanies for an answer that cannot have changed.
+  const userId = user?.id;
   // The no-user guard lives inside the loader (returning []) rather than a
   // synchronous setState in the effect body — keeps set-state-in-effect quiet.
   // When signed-out, `loading` is briefly true before resolving to []; that
   // state is a redirect-to-login transient, so the flash isn't user-visible.
   const { data, loading, error } = useLoad(
-    async () => (user ? getUserCompanies(user.id) : EMPTY_COMPANIES),
-    [user],
+    async () => (userId ? getUserCompanies(userId) : EMPTY_COMPANIES),
+    [userId],
   );
   return {
     companies: data ?? EMPTY_COMPANIES,

--- a/hooks/useUserRole.ts
+++ b/hooks/useUserRole.ts
@@ -11,6 +11,12 @@ export function useUserRole() {
   const { user } = useAuth();
   const params = useParams();
   const companyId = params.companyId as string | undefined;
+  // Key on the id, NOT the `user` object. AuthProvider calls setUser on every
+  // auth event (INITIAL_SESSION, SIGNED_IN, each TOKEN_REFRESHED), each time
+  // with a fresh User object carrying the same id — keying on the object
+  // re-ran getUserRole on all of them, and tripped useLoad's non-primitive-dep
+  // warning on every render. Don't widen this back to [user].
+  const userId = user?.id;
 
   // The no-user / no-company guard lives inside the loader (returning null)
   // rather than a synchronous setState in the effect body — keeps
@@ -18,14 +24,14 @@ export function useUserRole() {
   // redirect transient, not user-visible.
   const { data: role, loading } = useLoad<UserRole>(
     async () => {
-      if (!user || !companyId) return null;
+      if (!userId || !companyId) return null;
       try {
-        return (await getUserRole(user.id, companyId)) as UserRole;
+        return (await getUserRole(userId, companyId)) as UserRole;
       } catch {
         return null;
       }
     },
-    [user, companyId],
+    [userId, companyId],
   );
 
   const isAdmin = role === 'admin';


### PR DESCRIPTION
## What

Six `useLoad` call sites keyed on an object or array instead of a primitive, so every dashboard page load flooded the dev console with `useLoad: received a non-primitive dependency`.

| File | Was | Now |
|---|---|---|
| `hooks/useUserRole.ts` | `[user, companyId]` | `[userId, companyId]` |
| `hooks/useCompanies.ts` | `[user]` | `[userId]` |
| `components/operator/NoteMediaGallery.tsx` | `[media]` | `[mediaKey]` (joined ids) |
| `components/notes/NoteEditDialog.tsx` | `[media]` | `[mediaKey]` |
| `app/dashboard/[companyId]/parts/page.tsx` | `[…, sortModel]` | `[…, sortModel.field, sortModel.sort]` |
| `app/dashboard/[companyId]/jobs/page.tsx` | `[…, statusFilter, sortModel, …]` | `[…, statusFilterKey, sortModel.field, sortModel.sort, …]` |

## Why

**None of these was the infinite loop the message warns about.** Every offending dep was a `useState` value or React context state, so identity churn is bounded and the render settles — which is why the app looked fine. Two things were real, though:

1. **Redundant queries.** `AuthProvider` calls `setUser(newSession?.user ?? null)` unconditionally on every auth event — `INITIAL_SESSION`, `SIGNED_IN`, each `TOKEN_REFRESHED` — handing down a fresh `User` object carrying the same `id`. Keying on the object meant every one of those re-ran `getUserRole` and `getUserCompanies` for an answer that cannot have changed.

2. **The guard was being trained away.** It exists precisely because this failure mode is silent in every channel you would normally check: the setState happens in a promise callback so React's "Maximum update depth" guard never fires, a short-circuiting loader makes no network traffic, and every iteration is sub-millisecond so a longtask observer sees nothing. The only symptom is a pegged core — which is how `NoteEditDialog`'s `media = []` default went unnoticed while it made the operator "Me" tab feel frozen. A warning that fires on every page load for a benign reason is a warning nobody reads the day it is real.

Hence: fix the call sites, don't soften the check.

## Notes for review

- **The two page-level fixes weren't found by grep.** `sortModel` and `statusFilter` read as plain identifiers in their dep lists, so a search for object literals misses them — they surfaced only by driving the running app. Worth knowing if you go looking for more.
- `jobs/page.tsx` uses a **sorted** stage key (`[...statusFilter].sort().join(',')`) so merely reordering the multi-select can't trigger a refetch. Same shape as the existing `partIdsKey` pattern in `components/jobs/OperationsPanel.tsx`.
- **`NO_MEDIA` in `NoteEditDialog` is deliberately untouched.** The module-level stable default is the fix for the original pegged-core bug and must stay — the new `mediaKey` covers the separate case of a caller rebuilding a real media array each render.
- Deliberately **not** changing `AuthProvider` to skip `setUser` when the id is unchanged: consumers read `user.email` and `user.user_metadata`, so suppressing the update would trade a cheap dep fix for a staleness risk.

No schema changes, no migration, no user-visible behaviour change.

## Verification

Drove a dev server against the local Supabase stack as both `dev@jigged.test` and `operator1@jigged.test`, across dashboard home, quotes, customers, vendors, work-centers, parts, jobs, settings, select-company, a part-detail and job-detail drill-in, and operator home / my-work / inventory.

**28 warnings before → 0 after**, across all of it.

- `vitest run` — 2000 tests / 147 files pass
- `pnpm lint` — 0 errors, 16 warnings (under the 17 cap; all pre-existing in `RoutingOperationRowEditor`)
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)