### PR TITLE
feat(demo): mirror source feature flags, and make every seeded part priceable

### DIFF
--- a/api/tests/integration/test_demo_lifecycle.py
+++ b/api/tests/integration/test_demo_lifecycle.py
@@ -111,6 +111,49 @@ def _wipe_company(supabase_admin, company_id: str) -> None:
     wipe_company("inventory_locations")
 
 
+# A source flag set chosen to cover the case that is easy to get wrong: an opt-IN flag turned on
+# AND an opt-OUT flag explicitly turned off. `readFeatureFlag` resolves an omitted key to the
+# descriptor's default, so squashing "absent" into "false" would silently re-enable ai_insights
+# for a tenant that had killed it.
+SOURCE_SETTINGS = {
+    "features": {
+        "inventory_locations": True,
+        "machine_maintenance": True,
+        "ai_insights": False,
+    },
+    "ai_limits": {"chat_per_hour": 100},
+}
+
+
+def _make_demo(supabase_admin, billing_user, source_settings=None):
+    source_id = billing_user["company_id"]
+    if source_settings is not None:
+        supabase_admin.table("companies").update({"settings": source_settings}).eq(
+            "id", source_id
+        ).execute()
+    billing_user["client"].rpc(
+        "create_demo_company",
+        {"p_source_company_id": source_id, "p_user_id": billing_user["user_id"]},
+    ).execute()
+    return {
+        "source_id": source_id,
+        "demo_id": _demo_id(supabase_admin, source_id),
+        "user": billing_user,
+        "client": billing_user["client"],
+    }
+
+
+def _drop_demo(supabase_admin, made):
+    # The demo company is not the fixture's own company, so _teardown_seeded_user will not
+    # reach it.
+    if made["demo_id"]:
+        _wipe_company(supabase_admin, made["demo_id"])
+        supabase_admin.table("companies").update({"demo_company_id": None}).eq(
+            "id", made["source_id"]
+        ).execute()
+        supabase_admin.table("companies").delete().eq("id", made["demo_id"]).execute()
+
+
 @pytest.fixture
 def demo(supabase_admin, billing_user):
     """A company whose demo has been created through the real RPC, as the real user.
@@ -120,25 +163,29 @@ def demo(supabase_admin, billing_user):
     (`auth.uid()` must equal p_user_id, and the caller must be an admin of the source company).
     Nothing here touches billing.
     """
-    source_id = billing_user["company_id"]
-    client = billing_user["client"]
+    made = _make_demo(supabase_admin, billing_user)
+    yield made
+    _drop_demo(supabase_admin, made)
 
-    client.rpc(
-        "create_demo_company",
-        {"p_source_company_id": source_id, "p_user_id": billing_user["user_id"]},
-    ).execute()
 
-    demo_id = _demo_id(supabase_admin, source_id)
-    yield {"source_id": source_id, "demo_id": demo_id, "user": billing_user, "client": client}
+@pytest.fixture
+def flagged_demo(supabase_admin, billing_user):
+    """Same, but the source company carries SOURCE_SETTINGS *before* the demo is created — so
+    these tests see what `create_demo_company` copied rather than what a later sync fixed up."""
+    made = _make_demo(supabase_admin, billing_user, SOURCE_SETTINGS)
+    yield made
+    _drop_demo(supabase_admin, made)
 
-    # The demo company is not the fixture's own company, so _teardown_seeded_user will not
-    # reach it.
-    if demo_id:
-        _wipe_company(supabase_admin, demo_id)
-        supabase_admin.table("companies").update({"demo_company_id": None}).eq(
-            "id", source_id
-        ).execute()
-        supabase_admin.table("companies").delete().eq("id", demo_id).execute()
+
+def _settings(supabase_admin, company_id: str) -> dict:
+    row = (
+        supabase_admin.table("companies")
+        .select("settings")
+        .eq("id", company_id)
+        .single()
+        .execute()
+    )
+    return row.data["settings"] or {}
 
 
 def test_create_demo_company_seeds_the_graph(supabase_admin, demo):
@@ -376,3 +423,111 @@ def test_reset_rejects_a_caller_who_is_not_the_user(supabase_admin, demo):
             },
         ).execute()
     assert "Access denied" in str(exc.value)
+
+
+# ===========================================================================
+# Feature-flag mirroring
+#
+# A demo company is invisible to /admin/companies — admin_routes.py lists with
+# .eq("is_demo", False) — so its `settings.features` block cannot be edited
+# anywhere. Before mirroring it sat at `{}` forever, meaning every opt-in flag
+# read off no matter what the real company had enabled.
+# ===========================================================================
+
+
+def test_create_mirrors_source_feature_flags(supabase_admin, flagged_demo):
+    """The demo stands in for the user's own company, so it must show the same product
+    surface. Copied verbatim: an explicit `false` has to survive as `false`, because an
+    absent key resolves to the descriptor default and ai_insights defaults to ON."""
+    demo_features = _settings(supabase_admin, flagged_demo["demo_id"]).get("features")
+    assert demo_features == SOURCE_SETTINGS["features"]
+
+
+def test_ai_limits_are_deliberately_not_mirrored(supabase_admin, flagged_demo):
+    """`ai_limits` is admin-only like `features`, and is withheld on purpose: it caps Anthropic
+    spend per company, so copying a raised cap onto a second company_id doubles the exposure.
+    The demo keeps the default (20/hour) instead."""
+    assert "ai_limits" not in _settings(supabase_admin, flagged_demo["demo_id"])
+
+
+def test_entry_sync_propagates_a_flag_flipped_after_creation(supabase_admin, flagged_demo):
+    """Flags change after a demo exists. `sync_demo_access` is what DemoModeProvider calls on
+    every entry, which makes it the one place that convergence can happen."""
+    source_id, demo_id = flagged_demo["source_id"], flagged_demo["demo_id"]
+
+    changed = dict(SOURCE_SETTINGS["features"])
+    changed["data_import"] = True            # newly enabled
+    changed["inventory_locations"] = False   # newly disabled
+    supabase_admin.table("companies").update(
+        {"settings": {**SOURCE_SETTINGS, "features": changed}}
+    ).eq("id", source_id).execute()
+
+    flagged_demo["client"].rpc(
+        "sync_demo_access",
+        {"p_source_company_id": source_id, "p_demo_company_id": demo_id},
+    ).execute()
+
+    assert _settings(supabase_admin, demo_id)["features"] == changed
+
+
+def test_mirror_leaves_the_demo_editable_settings_blocks_alone(supabase_admin, flagged_demo):
+    """Settings is reachable *inside* demo mode — full CRUD is the point — so `defaults` and
+    `default_payment_terms` can be edited there. Mirroring the whole `settings` object on every
+    entry would silently revert whatever the user had just changed."""
+    source_id, demo_id = flagged_demo["source_id"], flagged_demo["demo_id"]
+
+    demo_settings = _settings(supabase_admin, demo_id)
+    supabase_admin.table("companies").update(
+        {
+            "settings": {
+                **demo_settings,
+                "defaults": {"quote_validity_days": 30},
+                "default_payment_terms": "Net 15",
+            }
+        }
+    ).eq("id", demo_id).execute()
+
+    # An admin flips a flag on the source; entry re-syncs.
+    supabase_admin.table("companies").update(
+        {"settings": {**SOURCE_SETTINGS, "features": {"data_import": True}}}
+    ).eq("id", source_id).execute()
+    flagged_demo["client"].rpc(
+        "sync_demo_access",
+        {"p_source_company_id": source_id, "p_demo_company_id": demo_id},
+    ).execute()
+
+    after = _settings(supabase_admin, demo_id)
+    assert after["features"] == {"data_import": True}, "the flag change should land"
+    assert after["defaults"] == {"quote_validity_days": 30}, "demo-side edit was reverted"
+    assert after["default_payment_terms"] == "Net 15", "demo-side edit was reverted"
+
+
+def test_reset_re_mirrors_flags(supabase_admin, flagged_demo):
+    """Reset restores the demo's product surface as well as its rows, so it does not depend on
+    when the user last entered."""
+    source_id, demo_id = flagged_demo["source_id"], flagged_demo["demo_id"]
+
+    supabase_admin.table("companies").update(
+        {"settings": {"features": {"machine_maintenance": True}}}
+    ).eq("id", source_id).execute()
+
+    flagged_demo["client"].rpc(
+        "reset_demo_company",
+        {"p_source_company_id": source_id, "p_user_id": flagged_demo["user"]["user_id"]},
+    ).execute()
+
+    assert _settings(supabase_admin, demo_id)["features"] == {"machine_maintenance": True}
+
+
+def test_sync_demo_features_is_not_reachable_from_the_browser(demo):
+    """It is SECURITY DEFINER and writes companies.settings, so an exposed EXECUTE grant would
+    let any signed-in user rewrite any company's feature block."""
+    with pytest.raises(Exception) as exc:
+        demo["client"].rpc(
+            "sync_demo_features",
+            {
+                "p_source_company_id": demo["source_id"],
+                "p_demo_company_id": demo["demo_id"],
+            },
+        ).execute()
+    assert "sync_demo_features" in str(exc.value) or "permission denied" in str(exc.value).lower()

--- a/docs/modules/demo-mode.md
+++ b/docs/modules/demo-mode.md
@@ -58,8 +58,8 @@ Entered from Settings or the onboarding card; exited from Settings or the banner
 page while in demo mode.
 
 - **First entry** creates the hidden demo company, seeds it from the active template, mirrors
-  every `user_company_access` row, and navigates to it. **Later entries** go straight there,
-  lazy-syncing access for team members added since.
+  every `user_company_access` row and the source's feature flags, and navigates to it. **Later
+  entries** go straight there, lazy-syncing both for changes made since.
 - Navigation **preserves page context** both ways — on `/parts` in real, land on `/parts` in
   demo, and back again. Browser history works normally.
 - **Full CRUD.** It is a real company that happens to be pre-populated; users can quote, convert,
@@ -144,10 +144,43 @@ are for.
 | `seed_demo_data(company_id, template)` | The shared seeding helper — resolves `_ref` keys to UUIDs and inserts the graph |
 | `create_demo_company(source_company_id, user_id)` | Creates the hidden company, seeds it, mirrors `user_company_access`, sets `demo_company_id` on the real company. Raises **"No active demo template found"** when none is active |
 | `reset_demo_company(source_company_id, user_id)` | Deletes the demo company's data and re-seeds |
-| `sync_demo_access(source_company_id, demo_company_id)` | Lazy role mirroring on entry |
+| `sync_demo_access(source_company_id, demo_company_id)` | Lazy convergence on entry — roles **and** feature flags |
+| `sync_demo_features(source_company_id, demo_company_id)` | Copies `settings.features` onto the demo. Backend-only; called by the three above |
 
 `sync_demo_access` inserts missing members copying both `role` **and** `name`, then `UPDATE`s
-only the roles that changed — so it stays correct without triggers.
+only the roles that changed — so it stays correct without triggers. Its name still says "access"
+only; broadening it beat renaming, which would churn the RPC, `utils/demoAccess.ts`, the provider
+and the `function_execute_leaks()` allowlist for no behavioural gain.
+
+### Feature flags mirror the source company
+
+**A demo company shows the same product surface as the company it stands in for**, copied from
+`settings.features` at creation, on every entry, and on reset.
+
+It has to come from somewhere, because it cannot be set: the flag editor is `/admin/companies`,
+and [`admin_routes.py`](../../api/routes/admin_routes.py) lists companies with
+`.eq("is_demo", False)` — demo companies are invisible there, as they are to the company switcher
+and the login redirect. Before mirroring, every demo sat at `settings = '{}'`, so **every opt-in
+flag read off regardless of what the real company had enabled**, with no way to change it.
+
+**Withdrawn — turning every flag on in demos.** It would make the demo a sales showcase, which is
+a different product from an onboarding sandbox presented as *your* company. Three concrete
+failures: entering and leaving preserves page context, so a feature on in demo and off in real is
+a page that vanishes on exit; `machine_maintenance` is a one-pilot-shop-at-a-time experiment with
+a written kill criterion, and all-on puts it in front of shops outside the pilot and pollutes the
+measurement; and `ai_insights` is opt-**out**, so all-on re-exposes to a tenant exactly the thing
+they turned off.
+
+The block is copied **verbatim**, not key-by-key: an omitted key resolves to the descriptor's
+`defaultEnabled` while a stored `false` does not, and squashing that distinction is how an
+opt-out kill switch quietly stops killing.
+
+Two deliberate exclusions:
+
+| Not mirrored | Why |
+|---|---|
+| `settings.ai_limits` | Admin-only like `features`, but it caps Anthropic spend per company — copying a raised cap onto a second `company_id` doubles the exposure. Demos keep the default 20/hour |
+| `settings.defaults`, `default_payment_terms`, `custom_payment_terms` | Editable from the Settings page **inside** demo mode, where full CRUD is the point. Re-mirroring on every entry would silently revert the user's own edits |
 
 Access layer is Supabase-first, no FastAPI: `getDemoStatus`, `createDemoCompany`,
 `resetDemoCompany`, `syncDemoAccess` in [`utils/demoAccess.ts`](../../utils/demoAccess.ts),
@@ -220,6 +253,12 @@ had **no** coverage at all before 2026-08-05, which is why both failures above s
 | Reset clears the tables that used to be out of scope | `test_reset_clears_the_tables_that_were_out_of_scope` |
 | Reset keeps membership and never reaches the real company | `test_reset_preserves_membership_and_leaves_the_real_company_alone` |
 | `auth.uid()` check rejects resetting someone else's demo | `test_reset_rejects_a_caller_who_is_not_the_user` |
+| Creation copies the source's flags verbatim, explicit `false` included | `test_create_mirrors_source_feature_flags` |
+| `ai_limits` is *not* copied | `test_ai_limits_are_deliberately_not_mirrored` |
+| A flag flipped after creation converges on the next entry | `test_entry_sync_propagates_a_flag_flipped_after_creation` |
+| Mirroring never reverts settings edited inside demo mode | `test_mirror_leaves_the_demo_editable_settings_blocks_alone` |
+| Reset re-mirrors flags | `test_reset_re_mirrors_flags` |
+| `sync_demo_features` is unreachable from the browser | `test_sync_demo_features_is_not_reachable_from_the_browser` |
 
 The tests assert **derived** state and **lower-bound** counts, not the template's own numbers —
 asserting the template back at itself would pass with every trigger broken, and equalities would
@@ -232,8 +271,8 @@ Separately covered, and the part with money attached:
 | A demo company short-circuits the entitlement check regardless of billing state | `__tests__/lib/entitlement.test.ts` > `demo short-circuits regardless of billing state` |
 | Stripe checkout refuses a demo company | `api/tests/unit/test_stripe_routes.py` > `test_checkout_rejects_demo_company` |
 
-Still untested and worth naming: `sync_demo_access` role mirroring on re-entry, and the
-frontend enter/exit navigation.
+Still untested and worth naming: `sync_demo_access`'s *role* mirroring on re-entry (its flag
+mirroring is covered), and the frontend enter/exit navigation.
 
 ## Resolved questions
 

--- a/supabase/migrations/20260805041203_demo_mirrors_source_feature_flags.sql
+++ b/supabase/migrations/20260805041203_demo_mirrors_source_feature_flags.sql
@@ -1,0 +1,325 @@
+-- A demo company mirrors its source company's feature flags.
+--
+-- WHY. `create_demo_company` inserts the demo with no `settings` at all, so every
+-- demo sits at `{}` — meaning every opt-IN flag reads off. A shop with Storage,
+-- Data import and Machine Maintenance enabled entered its demo and found none of
+-- them. Both demo companies in production were in exactly that state.
+--
+-- **And there is no other way to set them.** The feature-flag editor is
+-- `/admin/companies`, which lists companies through `admin_routes.py` filtering
+-- `.eq("is_demo", False)` — demo companies are deliberately invisible there, as
+-- they are to the company switcher and the login redirect. So the flags on a demo
+-- company were not merely wrong by default, they were unreachable.
+--
+-- WHY MIRROR RATHER THAN TURN EVERYTHING ON. The demo presents as the user's own
+-- company with a DEMO badge, and entering/leaving preserves page context both
+-- ways — so a flag on in the demo and off in the real company is a page that
+-- vanishes on exit. Beyond that: `machine_maintenance` is a one-pilot-shop-at-a-
+-- time experiment with a written kill criterion, and all-on would put it in front
+-- of shops outside the pilot and pollute the measurement; `ai_insights` is opt-OUT
+-- with a per-tenant kill switch, so all-on would re-expose to a tenant precisely
+-- the thing they turned off. An always-on demo is a *sales showcase*, which is a
+-- different product from this one.
+--
+-- SCOPE — `settings.features` ONLY, and the rest of `settings` is left alone:
+--   * `defaults`, `default_payment_terms`, `custom_payment_terms` are editable
+--     from the Settings page, which IS reachable inside demo mode (full CRUD is
+--     the point). Mirroring them on every entry would silently revert whatever
+--     the user had just changed in there.
+--   * `ai_limits` is admin-only like `features`, but is deliberately NOT mirrored:
+--     it caps Anthropic spend per company, and copying a raised limit onto a
+--     second company_id doubles the exposure. Demos keep the default of 20/hour.
+--
+-- The whole `features` object is copied verbatim rather than key-by-key, so an
+-- explicit `false` on an opt-out flag survives as a `false` — an omitted key and
+-- a stored `false` resolve differently in `readFeatureFlag`, and squashing that
+-- distinction is how a kill switch quietly stops killing.
+
+-- ---------------------------------------------------------------------------
+-- 1. The mirror itself
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.sync_demo_features(p_source_company_id uuid, p_demo_company_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+    UPDATE companies d
+       SET settings = jsonb_set(COALESCE(d.settings, '{}'::jsonb), '{features}',
+                                COALESCE(s.settings->'features', '{}'::jsonb), true),
+           updated_at = now()
+      FROM companies s
+     WHERE d.id = p_demo_company_id
+       AND s.id = p_source_company_id
+       -- Only when it actually differs. This runs on every demo entry, and an
+       -- unconditional write would touch the row (and updated_at) every time.
+       AND (d.settings->'features')
+           IS DISTINCT FROM COALESCE(s.settings->'features', '{}'::jsonb);
+END;
+$function$;
+
+-- Backend-only: every caller is a SECURITY DEFINER function in this file. A
+-- browser role reaching this directly could rewrite any company's feature block,
+-- since SECURITY DEFINER bypasses the RLS on `companies`.
+REVOKE EXECUTE ON FUNCTION public.sync_demo_features(uuid, uuid) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.sync_demo_features(uuid, uuid) TO service_role;
+
+COMMENT ON FUNCTION public.sync_demo_features(uuid, uuid) IS
+'Copies companies.settings.features verbatim from a source company onto its demo company, and nothing else in settings — the sibling blocks (defaults, default_payment_terms, custom_payment_terms) are editable from inside demo mode and must not be reverted, and ai_limits is withheld on purpose so a raised Anthropic cap is not duplicated onto a second company_id. No-ops when the two already match. Called by create_demo_company, sync_demo_access and reset_demo_company; not reachable from the browser.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Mirror at creation
+-- ---------------------------------------------------------------------------
+-- Verbatim from the live definition, plus the sync_demo_features call. Placed
+-- BEFORE seed_demo_data because seeding reads nothing from settings today, but a
+-- future seeder branching on a flag should see the mirrored value, not '{}'.
+
+CREATE OR REPLACE FUNCTION public.create_demo_company(p_source_company_id uuid, p_user_id uuid, p_template_name character varying DEFAULT 'default'::character varying)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+    v_source_name TEXT;
+    v_demo_company_id UUID;
+    v_existing_demo_id UUID;
+BEGIN
+    IF p_user_id != auth.uid() THEN
+        RAISE EXCEPTION 'Access denied: cannot create demo company for another user';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM user_company_access
+        WHERE user_id = p_user_id
+          AND company_id = p_source_company_id
+          AND role = 'admin'
+    ) THEN
+        RAISE EXCEPTION 'Access denied: must be admin of source company';
+    END IF;
+
+    -- Idempotency: return existing demo if linked
+    SELECT demo_company_id INTO v_existing_demo_id
+    FROM companies
+    WHERE id = p_source_company_id;
+
+    IF v_existing_demo_id IS NOT NULL THEN
+        RETURN v_existing_demo_id;
+    END IF;
+
+    SELECT name INTO v_source_name FROM companies WHERE id = p_source_company_id;
+    IF v_source_name IS NULL THEN
+        RAISE EXCEPTION 'Source company not found: %', p_source_company_id;
+    END IF;
+
+    INSERT INTO companies (name, is_demo)
+    VALUES (v_source_name || ' - Demo', TRUE)
+    RETURNING id INTO v_demo_company_id;
+
+    UPDATE companies SET demo_company_id = v_demo_company_id
+    WHERE id = p_source_company_id;
+
+    -- Mirror access (operator/user/admin all preserved)
+    INSERT INTO user_company_access (user_id, company_id, role, name)
+    SELECT uca.user_id, v_demo_company_id, uca.role, uca.name
+    FROM user_company_access uca
+    WHERE uca.company_id = p_source_company_id;
+
+    -- Mirror feature flags, so the demo shows the same product surface as the
+    -- company it is standing in for.
+    PERFORM sync_demo_features(p_source_company_id, v_demo_company_id);
+
+    PERFORM seed_demo_data(v_demo_company_id, p_user_id, p_template_name::text);
+
+    RETURN v_demo_company_id;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.create_demo_company(uuid, uuid, character varying) IS
+'Creates (or returns existing) demo company for the source company, mirrors user_company_access and settings.features, and seeds via seed_demo_data. Idempotent: returns existing demo_company_id if companies.demo_company_id is already set. Caller must be admin of source company.';
+
+-- ---------------------------------------------------------------------------
+-- 3. Re-mirror on every entry
+-- ---------------------------------------------------------------------------
+-- This is the function DemoModeProvider already calls on each entry to a demo
+-- that exists, which makes it the one place a flag flipped AFTER the demo was
+-- created can converge. Its name still says "access"; it now also syncs the
+-- feature block, and the COMMENT says so rather than the name being quietly
+-- wrong. Renaming would churn the RPC, utils/demoAccess.ts, the provider and the
+-- function_execute_leaks() allowlist for no behavioural gain.
+
+CREATE OR REPLACE FUNCTION public.sync_demo_access(p_source_company_id uuid, p_demo_company_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+    -- Add any missing access entries (new team members since demo was created)
+    INSERT INTO user_company_access (user_id, company_id, role, name)
+    SELECT uca.user_id, p_demo_company_id, uca.role, uca.name
+    FROM user_company_access uca
+    WHERE uca.company_id = p_source_company_id
+      AND NOT EXISTS (
+        SELECT 1 FROM user_company_access
+        WHERE user_id = uca.user_id AND company_id = p_demo_company_id
+      );
+
+    -- Update roles that changed in the source company
+    UPDATE user_company_access demo_uca
+    SET role = source_uca.role
+    FROM user_company_access source_uca
+    WHERE demo_uca.company_id = p_demo_company_id
+      AND source_uca.company_id = p_source_company_id
+      AND demo_uca.user_id = source_uca.user_id
+      AND demo_uca.role != source_uca.role;
+
+    -- Feature flags the admin has changed on the source since the demo was made.
+    PERFORM sync_demo_features(p_source_company_id, p_demo_company_id);
+END;
+$function$;
+
+COMMENT ON FUNCTION public.sync_demo_access(uuid, uuid) IS
+'Lazy convergence of a demo company on its source, called on every entry to an existing demo. Despite the name it syncs two things: user_company_access (adds members added since, updates changed roles) and settings.features via sync_demo_features. Does not remove members dropped from the source, and does not touch any other settings block.';
+
+-- ---------------------------------------------------------------------------
+-- 4. Re-mirror on reset
+-- ---------------------------------------------------------------------------
+-- Reset runs from inside demo mode, so entry-sync has already happened and the
+-- flags are usually right. It is here so that "Reset" means the demo is fully
+-- back to its intended state without depending on when the user last entered.
+
+CREATE OR REPLACE FUNCTION public.reset_demo_company(p_source_company_id uuid, p_user_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+    v_demo_company_id uuid;
+BEGIN
+    IF p_user_id != auth.uid() THEN
+        RAISE EXCEPTION 'Access denied';
+    END IF;
+
+    SELECT demo_company_id INTO v_demo_company_id
+    FROM companies WHERE id = p_source_company_id;
+
+    IF v_demo_company_id IS NULL THEN
+        RAISE EXCEPTION 'No demo company exists for company: %', p_source_company_id;
+    END IF;
+
+    -- Delete leaves-first. The order is not cosmetic: six of these are RESTRICT
+    -- parents (shipment_line_items -> job_parts, part_location_stock -> parts,
+    -- work_center_attachments -> work_centers, quickbooks_invoice_line_items ->
+    -- job_parts, notes -> work_centers, job_materials -> parts), and because the
+    -- whole body is one transaction a single RESTRICT violation rolled the
+    -- entire reset back — deleting nothing, permanently, for any demo that had
+    -- shipped something. That was #675.
+
+    -- notes and their children (notes RESTRICTs work_centers; note_* CASCADE
+    -- from notes, but explicit beats relying on it)
+    DELETE FROM note_reactions WHERE company_id = v_demo_company_id;
+    DELETE FROM note_views     WHERE company_id = v_demo_company_id;
+    DELETE FROM note_media     WHERE company_id = v_demo_company_id;
+    DELETE FROM notes          WHERE company_id = v_demo_company_id;
+
+    -- fulfillment + invoicing edges, above job_parts
+    DELETE FROM job_fulfillment_audit WHERE company_id = v_demo_company_id;
+    DELETE FROM shipment_line_items
+        WHERE shipment_id IN (SELECT id FROM shipments WHERE company_id = v_demo_company_id);
+    DELETE FROM shipments      WHERE company_id = v_demo_company_id;
+    DELETE FROM quickbooks_invoice_line_items WHERE company_id = v_demo_company_id;
+    DELETE FROM quickbooks_invoice_links      WHERE company_id = v_demo_company_id;
+
+    -- inventory ledger and balances (part_location_stock RESTRICTs parts)
+    DELETE FROM inventory_transactions WHERE company_id = v_demo_company_id;
+    DELETE FROM part_location_stock    WHERE company_id = v_demo_company_id;
+
+    -- jobs
+    DELETE FROM job_operation_completions WHERE company_id = v_demo_company_id;
+    DELETE FROM job_materials  WHERE job_id IN (SELECT id FROM jobs WHERE company_id = v_demo_company_id);
+    DELETE FROM job_operations WHERE job_id IN (SELECT id FROM jobs WHERE company_id = v_demo_company_id);
+    DELETE FROM job_attachments WHERE company_id = v_demo_company_id;
+    DELETE FROM job_parts      WHERE company_id = v_demo_company_id;
+    DELETE FROM jobs           WHERE company_id = v_demo_company_id;
+
+    -- quotes
+    DELETE FROM quote_line_items WHERE company_id = v_demo_company_id;
+    DELETE FROM quote_materials  WHERE company_id = v_demo_company_id;
+    DELETE FROM quote_operations WHERE company_id = v_demo_company_id;
+    DELETE FROM quotes           WHERE company_id = v_demo_company_id;
+
+    -- routings, then parts and their children
+    DELETE FROM routing_operations
+        WHERE routing_id IN (SELECT id FROM routings WHERE company_id = v_demo_company_id);
+    DELETE FROM routings WHERE company_id = v_demo_company_id;
+    DELETE FROM parts_bom
+        WHERE parent_part_id IN (SELECT id FROM parts WHERE company_id = v_demo_company_id)
+           OR child_part_id  IN (SELECT id FROM parts WHERE company_id = v_demo_company_id);
+    DELETE FROM part_procurement_tiers
+        WHERE part_id IN (SELECT id FROM parts WHERE company_id = v_demo_company_id);
+    DELETE FROM part_pricing_tiers WHERE company_id = v_demo_company_id;
+    DELETE FROM parts_unit_conversions
+        WHERE part_id IN (SELECT id FROM parts WHERE company_id = v_demo_company_id);
+    DELETE FROM part_attachments WHERE company_id = v_demo_company_id;
+    DELETE FROM part_comments    WHERE company_id = v_demo_company_id;
+    DELETE FROM parts            WHERE company_id = v_demo_company_id;
+
+    -- storage locations, now that nothing holds a balance in one
+    DELETE FROM inventory_locations WHERE company_id = v_demo_company_id;
+
+    -- work centers (work_center_attachments RESTRICTs them)
+    DELETE FROM work_center_attachments WHERE company_id = v_demo_company_id;
+    DELETE FROM work_centers            WHERE company_id = v_demo_company_id;
+
+    -- parties
+    DELETE FROM customer_carrier_accounts WHERE company_id = v_demo_company_id;
+    DELETE FROM customers WHERE company_id = v_demo_company_id;  -- contacts/addresses CASCADE
+    DELETE FROM vendors   WHERE company_id = v_demo_company_id;  -- vendor_contacts CASCADE
+
+    -- odds and ends the demo owns
+    DELETE FROM operator_events  WHERE company_id = v_demo_company_id;
+    DELETE FROM ai_chat_queries  WHERE company_id = v_demo_company_id;
+    DELETE FROM saved_insights   WHERE company_id = v_demo_company_id;
+    DELETE FROM company_custom_units WHERE company_id = v_demo_company_id;
+
+    -- Reset the shared Q-/J- counter so the re-seeded demo reads Q-0001 / J-0009
+    -- again rather than climbing on every reset.
+    DELETE FROM company_order_counters WHERE company_id = v_demo_company_id;
+
+    -- Deliberately KEPT: user_company_access (the membership Reset is documented
+    -- to preserve), company_billing, invitations, quickbooks_connections,
+    -- ai_config, auth_audit_log, feedback.
+
+    -- Flags are not data the reset wipes — they are re-mirrored from the source,
+    -- so Reset restores the demo's product surface as well as its rows.
+    PERFORM sync_demo_features(p_source_company_id, v_demo_company_id);
+
+    PERFORM seed_demo_data(v_demo_company_id, p_user_id);
+END;
+$function$;
+
+COMMENT ON FUNCTION public.reset_demo_company(uuid, uuid) IS
+'Wipes every table the demo company owns, re-mirrors settings.features from the source, then re-seeds from the active template. Caller must be the requesting user (auth.uid() check). Deletion is leaves-first because six child tables are ON DELETE RESTRICT against parts/job_parts/work_centers; the body is one transaction, so a single violation rolls the whole reset back (#675). Keeps user_company_access, company_billing, invitations, quickbooks_connections, ai_config, auth_audit_log and feedback; clears company_order_counters so quote/job numbering restarts.';
+
+-- ---------------------------------------------------------------------------
+-- 5. Backfill the demos that already exist
+-- ---------------------------------------------------------------------------
+-- Every existing demo company satisfies the invariant by the time this migration
+-- finishes — no "if empty, read the source instead" fallback in the access layer.
+-- Both production demos are at settings = '{}' today while their sources have
+-- three opt-in flags on between them, so this is the statement that actually
+-- fixes what was reported.
+
+UPDATE public.companies d
+   SET settings = jsonb_set(COALESCE(d.settings, '{}'::jsonb), '{features}',
+                            COALESCE(s.settings->'features', '{}'::jsonb), true),
+       updated_at = now()
+  FROM public.companies s
+ WHERE s.demo_company_id = d.id
+   AND d.is_demo
+   AND (d.settings->'features')
+       IS DISTINCT FROM COALESCE(s.settings->'features', '{}'::jsonb);

--- a/types/database.ts
+++ b/types/database.ts
@@ -3853,6 +3853,10 @@ export type Database = {
         Args: { p_demo_company_id: string; p_source_company_id: string }
         Returns: undefined
       }
+      sync_demo_features: {
+        Args: { p_demo_company_id: string; p_source_company_id: string }
+        Returns: undefined
+      }
       tenant_tables_missing_write_gate: {
         Args: never
         Returns: {

--- a/utils/demoAccess.ts
+++ b/utils/demoAccess.ts
@@ -96,8 +96,20 @@ export async function resetDemoCompany(sourceCompanyId: string, userId: string):
 }
 
 /**
- * Sync team member access from source company to demo company.
- * Adds missing members and updates changed roles.
+ * Converge a demo company on its source. Called on every entry to an existing
+ * demo (see DemoModeProvider), which is what makes it the place lazy syncing
+ * happens.
+ *
+ * Despite the name it syncs two things: team member access (adds members added
+ * since, updates changed roles) and `settings.features`. Flags are mirrored
+ * because a demo company is filtered out of /admin/companies — the only
+ * feature-flag editor — so there is otherwise no way to set them, and a demo
+ * showing a different product surface than the company it stands in for is a
+ * page that vanishes when you exit demo mode.
+ *
+ * Other `settings` blocks are deliberately left alone: `defaults` and
+ * `default_payment_terms` are editable from the Settings page *inside* demo
+ * mode, and re-mirroring them here would revert the user's own edits.
  */
 export async function syncDemoAccess(sourceCompanyId: string, demoCompanyId: string): Promise<void> {
   const supabase = getSupabase();


### PR DESCRIPTION
## The problem

`create_demo_company` inserted the demo with no `settings` at all, so every demo company sat at
`{}` — and every opt-**in** flag therefore read off. A shop with Storage, Data import and Machine
Maintenance enabled entered its demo and found none of them.

Both production demos were in exactly that state:

| Company | `settings.features` |
|---|---|
| Contour Tool & Machine | `inventory_locations`, `data_import`, `machine_maintenance`, `ai_insights` all true |
| Contour Tool & Machine **- Demo** | `{}` |
| Jigged Usability Sandbox | `inventory_locations`, `machine_maintenance`, `ai_insights` true; `data_import` false |
| Jigged Usability Sandbox **- Demo** | `{}` |

**And there was no other way to set them.** The flag editor is `/admin/companies`, which lists
companies through [`admin_routes.py`](api/routes/admin_routes.py) filtering `.eq("is_demo", False)`
— demo companies are deliberately invisible there, as they are to the company switcher and the
login redirect. So the flags weren't merely wrong by default, they were *unreachable*.

## Mirror, not all-on

The alternative — every flag on in every demo — was considered and rejected. Three concrete
failures:

- **The round-trip breaks.** Entering and leaving demo mode preserves page context both ways, so a
  feature on in demo and off in real is a page that vanishes on exit.
- **It corrupts the pilots the flags exist to run.** `machine_maintenance` is explicitly "one pilot
  shop at a time" with a written kill criterion; all-on puts it in front of shops outside the pilot
  and pollutes the measurement.
- **`ai_insights` is opt-OUT with a kill switch.** All-on re-exposes to a tenant precisely the thing
  they turned off.

An always-on demo is a *sales showcase*. This feature is an onboarding sandbox presented as the
user's own company — a different product. If the showcase is ever wanted it should be built as its
own thing rather than by redefining this one.

## What changed

New `sync_demo_features(source, demo)` copies `settings.features` **verbatim**, called from three
places:

| Caller | When |
|---|---|
| `create_demo_company` | at creation |
| `sync_demo_access` | every entry — so a flag flipped *after* the demo existed converges |
| `reset_demo_company` | so Reset restores the product surface, not just the rows |

Verbatim matters: an omitted key resolves to the descriptor's `defaultEnabled` while a stored
`false` does not, so squashing "absent" into "false" is how an opt-out kill switch quietly stops
killing.

**Backend-only.** It is `SECURITY DEFINER` and writes `companies.settings`, so a browser-reachable
grant would let any signed-in user rewrite any company's feature block. `EXECUTE` is revoked from
`PUBLIC`/`anon`/`authenticated`; `function_execute_leaks()` stays empty.

### Scope — `settings.features` only, deliberately

| Not mirrored | Why |
|---|---|
| `ai_limits` | Admin-only too, but it caps Anthropic spend per company. Copying a raised cap onto a second `company_id` doubles the exposure — demos keep the default 20/hour |
| `defaults`, `default_payment_terms`, `custom_payment_terms` | Editable from the Settings page **inside** demo mode, where full CRUD is the point. Re-mirroring on every entry would silently revert the user's own edits |

### Backfill

Every existing demo company is updated in the migration, so the invariant holds by the time it
finishes rather than through an "if empty, read the source instead" fallback in the access layer.
That statement is what actually fixes the two production demos — no user action needed.

## Tests

Six added to `test_demo_lifecycle.py` (13 total in the file):

- creation copies the flags verbatim, explicit `false` included
- `ai_limits` is *not* copied
- a flag flipped after creation converges on the next entry
- mirroring never reverts settings edited inside demo mode
- reset re-mirrors
- `sync_demo_features` is unreachable from the browser

**Verified failing** with `sync_demo_features` stubbed to a no-op: 4 of the 5 mirroring tests fail.
The 5th (`ai_limits` not mirrored) passes trivially when nothing mirrors at all — it guards against
over-mirroring, so that is correct.

## Verification

- `supabase db reset` — clean replay, 102 migrations
- Manual: flags land at create; a later flip lands on entry sync; demo-side `defaults` +
  `default_payment_terms` survive; `ai_limits` absent from the demo
- `function_execute_leaks()` — empty
- `pnpm exec tsc --noEmit` clean · `pnpm lint` clean (16 warnings, limit 17, all pre-existing)
- `docLinkCheck` — 32 docs, 1078 citations resolve; `vitest run __tests__/standards/` 38 passed
- `api/tests` — **522 passed**, 3 skipped, 12 xfailed, 1 xpassed (pre-existing, unrelated)
- `pnpm test --run --coverage` — **147 files, 2000 tests passed**

## Note for review

`sync_demo_access` now syncs more than access. I broadened it rather than renaming: it is already
the function `DemoModeProvider` calls on every entry, and a rename would churn the RPC,
`utils/demoAccess.ts`, the provider and the `function_execute_leaks()` allowlist for no
behavioural gain. Its `COMMENT` and the docs both say what it actually does now rather than
leaving the name quietly wrong — but say the word and I'll rename it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)