### PR TITLE
fix(operator): scope the selected station to its company

### DIFF
--- a/__tests__/components/operator/OperatorStationContext.test.tsx
+++ b/__tests__/components/operator/OperatorStationContext.test.tsx
@@ -2,8 +2,13 @@ import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 
 vi.mock('@/utils/operatorEventsAccess', () => ({ logOperatorEvent: vi.fn() }));
+
+// Mutable, because the bug this file now guards IS a company change: with a
+// fixed arrow there is no way to express "the same device, a different company"
+// at all, which is why the original five cases all passed while the leak shipped.
+const params = { companyId: 'c1' };
 vi.mock('next/navigation', () => ({
-  useParams: () => ({ companyId: 'c1' }),
+  useParams: () => params,
 }));
 
 vi.mock('@/utils/operatorAccess', () => ({
@@ -20,7 +25,11 @@ import {
 
 const mockGetStationName = vi.mocked(getStationName);
 
-const KEY = 'jigged_operator_station';
+// The station is stored PER COMPANY. `LEGACY_KEY` is the flat key devices wrote
+// before that, kept here because retiring it is behaviour with its own test.
+const keyFor = (companyId: string) => `jigged_operator_station:${companyId}`;
+const KEY = keyFor('c1');
+const LEGACY_KEY = 'jigged_operator_station';
 
 // This jsdom env has no origin, so it ships no Storage — polyfill a minimal
 // in-memory one on `window` (the context reads window.localStorage).
@@ -56,6 +65,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   window.localStorage.clear();
+  params.companyId = 'c1';
   vi.clearAllMocks();
 });
 
@@ -114,5 +124,118 @@ describe('OperatorStationProvider', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.stationId).toBe('st-anca');
     expect(window.localStorage.getItem(KEY)).toBe('st-anca');
+  });
+});
+
+// The August-2026 bug: one flat localStorage key held the station for the whole
+// DEVICE, so a user with access to two companies (demo mode hands out two
+// routinely) carried company A's machine into company B. The header named a
+// station absent from the picker, My Station went silently empty WITHOUT
+// offering the picker — `showStationSelector` requires `!stationId` — and the
+// first maintenance note was rejected by notes_validate_subject() as
+// "Could not save that."
+//
+// Nothing here needs a live param flip: the App Router keys the `[companyId]`
+// segment subtree by the param value, so a company change remounts the provider.
+// Remounting under a different companyId IS the real scenario.
+describe('OperatorStationProvider — station is per company', () => {
+  // Drives the selection through setStation rather than seeding localStorage
+  // directly, so the assertion does not depend on the key format. Seeding a
+  // company-scoped key by hand would pass vacuously against the flat-key bug
+  // this exists to catch — the old code simply would not find that key.
+  it('does not inherit the other company\'s station on a company switch', async () => {
+    const inC1 = renderHook(() => useStationContext(), { wrapper: OperatorStationProvider });
+    await waitFor(() => expect(inC1.result.current.initializing).toBe(false));
+    act(() => inC1.result.current.setStation('st-haas'));
+    inC1.unmount();
+
+    params.companyId = 'c2';
+    const inC2 = renderHook(() => useStationContext(), { wrapper: OperatorStationProvider });
+
+    await waitFor(() => expect(inC2.result.current.initializing).toBe(false));
+    expect(inC2.result.current.stationId).toBeNull();
+    // Not merely cleared afterwards — never adopted under c2. Resolving it there
+    // would mean a paint with the wrong machine named in the header, off a lookup
+    // that (with genuine access to both companies) would have SUCCEEDED.
+    expect(mockGetStationName).not.toHaveBeenCalledWith('st-haas', 'c2');
+  });
+
+  it('keeps each company\'s station, so switching back still remembers it', async () => {
+    const inC1 = renderHook(() => useStationContext(), { wrapper: OperatorStationProvider });
+    await waitFor(() => expect(inC1.result.current.initializing).toBe(false));
+    act(() => inC1.result.current.setStation('st-anca'));
+    inC1.unmount();
+
+    params.companyId = 'c2';
+    const inC2 = renderHook(() => useStationContext(), { wrapper: OperatorStationProvider });
+    await waitFor(() => expect(inC2.result.current.initializing).toBe(false));
+    act(() => inC2.result.current.setStation('st-edm'));
+    inC2.unmount();
+
+    params.companyId = 'c1';
+    const backInC1 = renderHook(() => useStationContext(), { wrapper: OperatorStationProvider });
+    await waitFor(() => expect(backInC1.result.current.initializing).toBe(false));
+
+    // Under one flat key, c2's choice would have clobbered c1's.
+    expect(backInC1.result.current.stationId).toBe('st-anca');
+  });
+
+  // Company-scoping alone would leave a station the user genuinely CAN read —
+  // RLS admits every company they belong to — so the lookup has to reject it too.
+  it('forgets a station the company lookup rejects, dropping back to the picker', async () => {
+    window.localStorage.setItem(KEY, 'st-foreign');
+    mockGetStationName.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() => useStationContext(), { wrapper: OperatorStationProvider });
+
+    await waitFor(() => expect(result.current.stationId).toBeNull());
+    expect(mockGetStationName).toHaveBeenCalledWith('st-foreign', 'c1');
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+
+  // Devices already out on floors hold the flat key. Dropping it outright would
+  // put every operator in front of the picker one morning for a bug they never
+  // hit, so it is adopted once by whichever company opens first.
+  it('migrates the legacy flat key into the current company, exactly once', async () => {
+    window.localStorage.setItem(LEGACY_KEY, 'st-anca');
+
+    const first = renderHook(() => useStationContext(), { wrapper: OperatorStationProvider });
+    await waitFor(() => expect(first.result.current.stationId).toBe('st-anca'));
+
+    expect(window.localStorage.getItem(keyFor('c1'))).toBe('st-anca');
+    // Consumed, not copied: leaving it would re-seed every other company in turn
+    // with the same wrong machine.
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull();
+
+    params.companyId = 'c2';
+    const second = renderHook(() => useStationContext(), { wrapper: OperatorStationProvider });
+    await waitFor(() => expect(second.result.current.initializing).toBe(false));
+    expect(second.result.current.stationId).toBeNull();
+  });
+
+  // A shop phone that changes hands must not hand the next person a station in
+  // ANY company — Supabase's own sign-out never touches device-local state.
+  it('clearStoredStation() with no company wipes every company, and the legacy key', () => {
+    window.localStorage.setItem(keyFor('c1'), 'st-anca');
+    window.localStorage.setItem(keyFor('c2'), 'st-edm');
+    window.localStorage.setItem(LEGACY_KEY, 'st-old');
+    window.localStorage.setItem('jigged_unrelated', 'keep-me');
+
+    clearStoredStation();
+
+    expect(window.localStorage.getItem(keyFor('c1'))).toBeNull();
+    expect(window.localStorage.getItem(keyFor('c2'))).toBeNull();
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBeNull();
+    expect(window.localStorage.getItem('jigged_unrelated')).toBe('keep-me');
+  });
+
+  it('clearStoredStation(companyId) forgets only that company', () => {
+    window.localStorage.setItem(keyFor('c1'), 'st-anca');
+    window.localStorage.setItem(keyFor('c2'), 'st-edm');
+
+    clearStoredStation('c1');
+
+    expect(window.localStorage.getItem(keyFor('c1'))).toBeNull();
+    expect(window.localStorage.getItem(keyFor('c2'))).toBe('st-edm');
   });
 });

--- a/__tests__/components/providers/AuthProvider.test.tsx
+++ b/__tests__/components/providers/AuthProvider.test.tsx
@@ -23,6 +23,11 @@ vi.mock('@sentry/nextjs', () => ({
   setUser: vi.fn(),
 }));
 
+const mockClearStoredStation = vi.fn();
+vi.mock('@/lib/operatorStationStorage', () => ({
+  clearStoredStation: (...a: unknown[]) => mockClearStoredStation(...a),
+}));
+
 // Minimal consumer that exercises the context signOut with each scope.
 function SignOutHarness() {
   const { signOut } = useAuth();
@@ -72,5 +77,39 @@ describe('AuthProvider signOut scope', () => {
       expect(sharedSupabase.auth.signOut).toHaveBeenCalledWith({ scope: 'global' });
       expect(sharedSupabase.auth.signOut).toHaveBeenCalledWith({ scope: 'others' });
     });
+  });
+
+  // The selected station is device-local, so Supabase's own sign-out does not
+  // touch it. Left behind, the next person to sign in on a shared shop phone
+  // inherits whatever machine the last person was standing at, and their notes
+  // get filed against it with nothing on screen to say so.
+  it('forgets the station on every company when a session ends on this device', async () => {
+    render(
+      <AuthProvider>
+        <SignOutHarness />
+      </AuthProvider>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'default' }));
+
+    // No argument — every company, not just whichever one was on screen.
+    await waitFor(() => expect(mockClearStoredStation).toHaveBeenCalledWith());
+  });
+
+  it("leaves the station alone for scope 'others', which keeps THIS device signed in", async () => {
+    // No handover happens, so stripping a working station would just put the
+    // operator in front of the picker for nothing.
+    render(
+      <AuthProvider>
+        <SignOutHarness />
+      </AuthProvider>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'others' }));
+
+    await waitFor(() => {
+      expect(sharedSupabase.auth.signOut).toHaveBeenCalledWith({ scope: 'others' });
+    });
+    expect(mockClearStoredStation).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/utils/machineMaintenanceAccess.test.ts
+++ b/__tests__/utils/machineMaintenanceAccess.test.ts
@@ -33,6 +33,7 @@ import {
   addMachineNote,
   addMachineNoteMedia,
   deriveOpenItems,
+  getMachineDetails,
   getMachineLog,
 } from '@/utils/machineMaintenanceAccess';
 import type { MachineNote } from '@/types/machineMaintenance';
@@ -170,6 +171,38 @@ describe('getMachineLog', () => {
   it('surfaces a query failure instead of showing an empty machine', async () => {
     mockQueryBuilder.error = { message: 'boom' };
     await expect(getMachineLog('wc1', 'c1')).rejects.toThrow('boom');
+  });
+});
+
+describe('getMachineDetails', () => {
+  // RLS admits every company the caller belongs to, so `id` alone is not
+  // tenancy. Unscoped, this rendered one company's make/model/SERIAL as another
+  // company's machine — and in demo mode, where the demo tenant is seeded from a
+  // real shop, that put a real customer's machine inside the demo.
+  it('scopes to the company, not just the machine id', async () => {
+    mockQueryBuilder.data = { make: 'Haas', model: 'VF-4SS', serial_number: 'HS-VF4-8804' };
+
+    await getMachineDetails('wc1', 'c1');
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('work_centers');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'wc1');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'c1');
+  });
+
+  it('still ignores deleted_at, because archiving hides a machine and not its history', async () => {
+    // Company and archival are different axes (§9): an archived machine's page
+    // stays readable by direct link, but only inside its own company.
+    mockQueryBuilder.data = { make: 'Haas' };
+
+    await getMachineDetails('wc-archived', 'c1');
+
+    expect(mockQueryBuilder.is).not.toHaveBeenCalledWith('deleted_at', null);
+  });
+
+  it('answers null when the machine is not in this company', async () => {
+    mockQueryBuilder.data = null;
+
+    await expect(getMachineDetails('wc-foreign', 'c1')).resolves.toBeNull();
   });
 });
 

--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -733,16 +733,34 @@ describe('station selection', () => {
   it('resolves a live station to its name', async () => {
     mockQueryBuilder.data = { name: 'Anca Grinder' };
 
-    await expect(getStationName('wc1')).resolves.toBe('Anca Grinder');
+    await expect(getStationName('wc1', 'c1')).resolves.toBe('Anca Grinder');
     expect(mockQueryBuilder.is).toHaveBeenCalledWith('deleted_at', null);
+  });
+
+  // The company filter is the whole reason a stale station can no longer survive
+  // a company switch. RLS admits every company the user belongs to, so a machine
+  // in the company they were in a minute ago reads back perfectly well — this
+  // filter is the only thing that turns "a machine you may read" into "a machine
+  // you are standing at HERE". Without it the header named a station missing from
+  // the picker, the job list went silently empty, and the first maintenance note
+  // died in notes_validate_subject() as "Could not save that."
+  it('scopes the lookup to the company, so another company\'s machine is not "yours"', async () => {
+    mockQueryBuilder.data = { name: 'Anca Grinder' };
+
+    await getStationName('wc1', 'c1');
+
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'wc1');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'c1');
   });
 
   it('answers null for an archived machine, which is what tells the caller to forget it', async () => {
     // maybeSingle, not single: "no live row" is an expected answer here, not an
-    // error. The provider clears the stored station on exactly this null.
+    // error. The provider clears the stored station on exactly this null — and
+    // on the null a foreign company_id now produces, which wants identical
+    // handling and so deliberately shares this answer.
     mockQueryBuilder.data = null;
 
-    await expect(getStationName('wc-archived')).resolves.toBeNull();
+    await expect(getStationName('wc-archived', 'c1')).resolves.toBeNull();
     expect(mockQueryBuilder.maybeSingle).toHaveBeenCalled();
   });
 
@@ -751,7 +769,7 @@ describe('station selection', () => {
     // would wipe a valid station off the device every time the wifi blinked.
     mockQueryBuilder.error = { message: 'network down' };
 
-    await expect(getStationName('wc1')).rejects.toThrow('network down');
+    await expect(getStationName('wc1', 'c1')).rejects.toThrow('network down');
   });
 });
 

--- a/__tests__/utils/workCenterAttachmentsAccess.test.ts
+++ b/__tests__/utils/workCenterAttachmentsAccess.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Chainable Supabase mock (same shape as machineMaintenanceAccess.test.ts) ---
+const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
+  const builder: Record<string, ReturnType<typeof vi.fn> | unknown> = {};
+  const chainMethods = ['from', 'select', 'insert', 'delete', 'eq', 'is', 'order', 'single', 'maybeSingle'];
+  chainMethods.forEach((m) => {
+    builder[m] = vi.fn().mockImplementation(() => builder);
+  });
+  builder.data = null;
+  builder.error = null;
+  builder.count = 0;
+  return {
+    mockQueryBuilder: builder,
+    mockSupabase: { from: vi.fn().mockImplementation(() => builder) },
+  };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => mockSupabase,
+  getTypedSupabase: () => mockSupabase,
+}));
+
+vi.mock('@/utils/storageHelpers', () => ({
+  generateStoragePath: vi.fn(),
+  uploadFileToStorage: vi.fn(),
+  deleteFileFromStorage: vi.fn(),
+  getSignedUrl: vi.fn(),
+}));
+
+vi.mock('@/utils/operatorAccess', () => ({ getCurrentMember: vi.fn() }));
+
+import {
+  listWorkCenterAttachments,
+  countWorkCenterAttachments,
+} from '@/utils/workCenterAttachmentsAccess';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockQueryBuilder.data = null;
+  mockQueryBuilder.error = null;
+  mockQueryBuilder.count = 0;
+});
+
+/**
+ * A manual carries part numbers, tooling and process notes, so listing the wrong
+ * company's is a real disclosure rather than a cosmetic mix-up.
+ *
+ * RLS on `work_center_attachments` admits every company the caller belongs to,
+ * so `work_center_id` alone is NOT tenancy. A stale cross-company station
+ * selection reached both of these with a foreign machine id, and the result was
+ * another company's manuals counted on the button and opened from the sheet with
+ * working signed URLs.
+ */
+describe('work center attachments are company-scoped', () => {
+  it('listWorkCenterAttachments filters on the company as well as the machine', async () => {
+    mockQueryBuilder.data = [];
+
+    await listWorkCenterAttachments('wc1', 'c1');
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('work_center_attachments');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('work_center_id', 'wc1');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'c1');
+  });
+
+  it('countWorkCenterAttachments filters on the company as well as the machine', async () => {
+    // This count renders the "Manuals · N" button that opens the list, so an
+    // unscoped count advertises another company's documents before anyone taps.
+    mockQueryBuilder.count = 3;
+
+    await expect(countWorkCenterAttachments('wc1', 'c1')).resolves.toBe(3);
+
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('work_center_id', 'wc1');
+    expect(mockQueryBuilder.eq).toHaveBeenCalledWith('company_id', 'c1');
+  });
+
+  it('countWorkCenterAttachments still degrades to 0 on error rather than throwing', async () => {
+    // It only decides whether an affordance renders, and "no manuals" is what a
+    // machine with none looks like anyway — a broken screen would be worse.
+    mockQueryBuilder.error = { message: 'network down' };
+
+    await expect(countWorkCenterAttachments('wc1', 'c1')).resolves.toBe(0);
+  });
+});

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -29,6 +29,7 @@ import { getSupabase } from '@/lib/supabase';
 import AppAmbientBackdrop from '@/components/layout/AppAmbientBackdrop';
 import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 import { OperatorStationProvider, useStationContext } from '@/components/operator/OperatorStationContext';
+import { clearStoredStation } from '@/lib/operatorStationStorage';
 import { OperatorChromeProvider, useOperatorChrome, useOperatorNav } from '@/components/operator/OperatorChromeContext';
 import JiggedIcon from '@/components/branding/JiggedIcon';
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
@@ -117,7 +118,9 @@ export default function OperatorLayout({
 
       if (!operatorAccess) {
         // Local scope — only clear this device's bad session; don't revoke the
-        // user's sessions on other devices.
+        // user's sessions on other devices. The station goes with it: the
+        // session that chose it is over (see AuthProvider.signOut).
+        clearStoredStation();
         await supabase.auth.signOut({ scope: 'local' });
         router.push(`/operator/${companyId}/login`);
         return;

--- a/app/operator/[companyId]/login/page.tsx
+++ b/app/operator/[companyId]/login/page.tsx
@@ -18,6 +18,7 @@ import { JiggedLogo } from '@/components/branding';
 import EmailIcon from '@mui/icons-material/Email';
 import LockIcon from '@mui/icons-material/Lock';
 import { getSupabase } from '@/lib/supabase';
+import { clearStoredStation } from '@/lib/operatorStationStorage';
 import { getCompany } from '@/utils/companyAccess';
 
 /**
@@ -140,7 +141,9 @@ export default function OperatorLoginPage() {
 
       if (opError || !operatorAccess) {
         // Local scope — only clear this device's session; don't revoke the
-        // user's sessions on other devices.
+        // user's sessions on other devices. The station goes with it: the
+        // session that chose it is over (see AuthProvider.signOut).
+        clearStoredStation();
         await supabase.auth.signOut({ scope: 'local' });
         throw new Error('You do not have access to this company');
       }

--- a/components/maintenance/MachineLogPanel.tsx
+++ b/components/maintenance/MachineLogPanel.tsx
@@ -82,14 +82,17 @@ export default function MachineLogPanel({
     onError: (err) => setError(err instanceof Error ? err.message : 'Could not load the log.'),
   });
 
-  const { data: details } = useLoad(() => getMachineDetails(workCenterId), [workCenterId]);
+  const { data: details } = useLoad(
+    () => getMachineDetails(workCenterId, companyId),
+    [workCenterId, companyId],
+  );
 
   // Only decides whether an affordance renders, and returns 0 rather than
   // throwing — so a failure degrades to "this machine has no manuals", which is
   // also what it looks like when it genuinely has none.
   const { data: manualCount } = useLoad(
-    () => countWorkCenterAttachments(workCenterId),
-    [workCenterId],
+    () => countWorkCenterAttachments(workCenterId, companyId),
+    [workCenterId, companyId],
   );
 
   // The precondition for reading any result at all: a container nobody filled
@@ -324,6 +327,7 @@ export default function MachineLogPanel({
         open={manualsOpen}
         onClose={() => setManualsOpen(false)}
         workCenterId={workCenterId}
+        companyId={companyId}
         machineName={machineName}
       />
 

--- a/components/maintenance/MachineManualsManager.tsx
+++ b/components/maintenance/MachineManualsManager.tsx
@@ -57,7 +57,7 @@ export default function MachineManualsManager({
     data: files,
     loading,
     reload,
-  } = useLoad(() => listWorkCenterAttachments(workCenterId), [workCenterId], {
+  } = useLoad(() => listWorkCenterAttachments(workCenterId, companyId), [workCenterId, companyId], {
     onError: (err) => setError(err instanceof Error ? err.message : 'Could not load manuals.'),
   });
 

--- a/components/maintenance/MachineManualsSheet.tsx
+++ b/components/maintenance/MachineManualsSheet.tsx
@@ -52,18 +52,20 @@ export default function MachineManualsSheet({
   open,
   onClose,
   workCenterId,
+  companyId,
   machineName,
 }: {
   open: boolean;
   onClose: () => void;
   workCenterId: string;
+  companyId: string;
   machineName?: string | null;
 }) {
   const [error, setError] = useState<string | null>(null);
 
   const { data: files, loading } = useLoad(
-    () => (open ? listWorkCenterAttachments(workCenterId) : Promise.resolve([])),
-    [open, workCenterId],
+    () => (open ? listWorkCenterAttachments(workCenterId, companyId) : Promise.resolve([])),
+    [open, workCenterId, companyId],
     { onError: (err) => setError(err instanceof Error ? err.message : 'Could not load manuals.') },
   );
 

--- a/components/operator/OperatorAccountBlock.tsx
+++ b/components/operator/OperatorAccountBlock.tsx
@@ -113,8 +113,8 @@ export function OperatorIdentityRow({
   const [feedbackSuccess, setFeedbackSuccess] = useState(false);
 
   const handleLogout = async () => {
-    // Clears the persisted station (localStorage) on explicit logout — same store
-    // OperatorStationContext uses.
+    // Clears the persisted station (localStorage) on explicit logout — for every
+    // company, not just this one, since the device may change hands.
     clearStoredStation();
     const supabase = getTypedSupabase();
     // Local scope — sign out ONLY this device. An operator logging out here must not revoke

--- a/components/operator/OperatorStationContext.tsx
+++ b/components/operator/OperatorStationContext.tsx
@@ -6,45 +6,19 @@ import { useParams } from 'next/navigation';
 import { getStationOperationTypes, getStationName } from '@/utils/operatorAccess';
 import type { Station } from '@/types/operator';
 
-// The operator's selected station is a device-local "where am I right now"
-// default. We persist it in localStorage (NOT sessionStorage) so it survives a
-// backgrounded-tab eviction / browser restart — the shop-floor reality that had
-// operators landing on a job with the station picker stacked underneath it every
-// morning.
 import { logOperatorEvent } from '@/utils/operatorEventsAccess';
 
-const STORAGE_KEY = 'jigged_operator_station';
+// The persistence itself lives in lib/ because sign-out paths outside the
+// operator tree need to clear it — see the note at the top of that module.
+import {
+  readStoredStation,
+  writeStoredStation,
+  clearStoredStation,
+} from '@/lib/operatorStationStorage';
 
-// localStorage access can throw (Safari private mode throws on setItem; access
-// can be blocked entirely). A fallback station default must never white-screen
-// the whole operator app, so every access is guarded and degrades to in-memory.
-function readStoredStation(): string | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    return window.localStorage.getItem(STORAGE_KEY);
-  } catch {
-    return null;
-  }
-}
-
-function writeStoredStation(id: string): void {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(STORAGE_KEY, id);
-  } catch {
-    /* storage unavailable — keep the value in memory only */
-  }
-}
-
-/** Clear the persisted station (used on explicit logout). */
-export function clearStoredStation(): void {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.removeItem(STORAGE_KEY);
-  } catch {
-    /* ignore */
-  }
-}
+// Re-exported so existing importers (and the provider's own callers) keep one
+// obvious place to reach for it.
+export { clearStoredStation };
 
 interface StationContextValue {
   stationId: string | null;
@@ -85,15 +59,16 @@ export function OperatorStationProvider({ children }: { children: ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [initializing, setInitializing] = useState(true);
 
-  // Seed the station from the stored default, exactly once on mount (the effect
-  // has no reactive inputs — localStorage is read, not subscribed).
+  // Seed the station from THIS COMPANY's stored default. Runs once per mounted
+  // company: the App Router keys the `[companyId]` segment subtree by the param
+  // value, so a company switch remounts this provider rather than re-running the
+  // effect under a live instance. localStorage is read, not subscribed.
   // `initializing` flips false here so consumers know the "no station" decision
   // is now trustworthy.
   useEffect(() => {
-    const storedStation = readStoredStation();
-    if (storedStation) setStationId(storedStation);
+    setStationId(readStoredStation(companyId));
     setInitializing(false);
-  }, []);
+  }, [companyId]);
 
   // Fetch all stations for the company
   useEffect(() => {
@@ -125,16 +100,18 @@ export function OperatorStationProvider({ children }: { children: ReactNode }) {
         return;
       }
 
-      // Otherwise fetch it directly.
+      // Otherwise fetch it directly, scoped to this company.
       try {
-        const name = await getStationName(stationId);
+        const name = await getStationName(stationId, companyId);
         if (name === null) {
-          // The stored station names a machine that has been archived (or was
-          // never in this company). Forget it rather than sitting on a station
-          // with no name: the header would read "Select Station" while every
+          // The stored station names a machine that has been archived, or one
+          // that lives in a DIFFERENT company. Both want the same handling, so
+          // getStationName answers null for both rather than making this branch
+          // tell them apart. Forget it rather than sitting on a station with no
+          // name: the header would read "Select Station" while every
           // station-gated surface still believed one was chosen, and nothing on
           // the floor offers a way out of that.
-          clearStoredStation();
+          clearStoredStation(companyId);
           setStationId(null);
           setStationName(null);
         } else {
@@ -149,14 +126,14 @@ export function OperatorStationProvider({ children }: { children: ReactNode }) {
       setLoading(false);
     }
     resolveName();
-  }, [stationId, stations]);
+  }, [stationId, stations, companyId]);
 
   // One call site covers every route in: the station picker and the header
   // dropdown both land here.
   const setStation = useCallback(
     (id: string) => {
       setStationId(id);
-      writeStoredStation(id);
+      writeStoredStation(companyId, id);
       logOperatorEvent(companyId, 'station_selected', { workCenterId: id });
     },
     [companyId],

--- a/components/providers/AuthProvider.tsx
+++ b/components/providers/AuthProvider.tsx
@@ -6,6 +6,7 @@ import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import type { Session, User, AuthChangeEvent } from '@supabase/supabase-js';
 import { getSupabase } from '@/lib/supabase';
 import { redirectToSessionExpiry } from '@/lib/supabaseErrors';
+import { clearStoredStation } from '@/lib/operatorStationStorage';
 
 /**
  * Sign-out scope. `local` (default) ends only this device's session; `others`
@@ -124,6 +125,15 @@ export default function AuthProvider({ children }: AuthProviderProps) {
     // flow (ResetPassword) passes 'global' to kill lost/old devices, and the
     // change-password flow calls supabase.auth.signOut({ scope: 'others' })
     // directly. Do NOT change this default without revisiting those two flows.
+    //
+    // Forget the selected station for EVERY company on the way out. It is
+    // device-local, not account-local, so Supabase's own sign-out does not touch
+    // it: without this, the next person to sign in on a shared shop phone
+    // inherits whatever machine the last person was standing at, and their notes
+    // get filed against it with nothing on screen to say so. Skipped for
+    // `others` on purpose — that scope deliberately keeps THIS device signed in,
+    // so there is no handover and no reason to strip a working station.
+    if (scope !== 'others') clearStoredStation();
     await supabase.auth.signOut({ scope });
   };
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -177,6 +177,64 @@ Both workflows are scoped to production so local and CI runs can't page anyone. 
 scoped to an environment nothing emits is silent** — only scope after the code that emits
 that tag has actually deployed.
 
+### What actually alerts, and who receives it
+
+The section above is mechanics. This is the state, and it is recorded here because none of it
+lives in the repo — **all alerting config is server-side only**, which is exactly why the two
+holes below went unnoticed for months. Re-measure with `sentry api` before trusting it.
+
+| | `javascript-nextjs` | `python-fastapi` |
+|---|---|---|
+| Workflow id | 3138841 | 3174587 |
+| Environment | `vercel-production` | `production` |
+| Detector | 6744903 (Issue Stream) | 6806071 (Issue Stream) |
+| Triggers (`any-short`) | `new_high_priority_issue`, `existing_high_priority_issue` | same |
+| Action | `email` → `issue_owners` | same |
+| Frequency | 30 min | 30 min |
+
+Ownership on both projects is `{"raw": null, "fallthrough": true}` — **no CODEOWNERS**, so
+`issue_owners` always falls through to ActiveMembers, which is the org's single member. In
+practice: *every alert goes to the one account email, and nothing routes by area.*
+
+**Trap 1 — the account email is the whole delivery path, and it is not validated by anything.**
+Until 2026-08-05 the org's sole member was an address that did not exist, so five months of alert
+email went nowhere while the workflows reported themselves healthy and `lastTriggered` kept
+advancing. Nothing in Sentry surfaces this. Check it directly, and check it after any account
+change:
+
+```bash
+sentry api '/api/0/organizations/jigged/members/' | jq -r '.[] | "\(.email) active=\(.user.isActive)"'
+```
+
+Sentry also does not deliver to an **unverified** primary address, and the org-scoped CLI token is
+denied on `/users/{id}/emails/` — so verification can only be confirmed in
+Settings → Account → Emails. A green workflow is not evidence anyone was told.
+
+**Trap 2 — a detector with no workflow notifies nobody.** The uptime monitor is live and
+unrouted:
+
+```bash
+sentry api '/api/0/organizations/jigged/detectors/' \
+  | jq -r '.[] | "\(.name) → workflowIds=\(.workflowIds)"'
+# Stripe webhook reachable (405 = healthy) → workflowIds=[]
+```
+
+An empty `workflowIds`, with no workflow listing it in `detectorIds`, means downtime is detected
+and then dropped. Its `intervalSeconds: 3600 × downtimeThreshold: 3` also puts detection ~3 hours
+behind the event. **Any new detector is silent until a workflow claims it** — the uptime UI does
+not warn about this.
+
+**What is deliberately not alerted.** Only *high* priority fires, and Sentry derives priority from
+level: `error`/`fatal` → high, `warning` → medium, `info`/`debug` → low. So the repo's deliberate
+`captureException(…, { level: 'warning' })` sites raise nothing, by construction. That is the
+intended trade — see [why any of this matters](#why-any-of-this-matters) — but it means **lowering
+a capture to `warning` silently opts it out of alerting**, which is easy to do by accident.
+
+**The real ceiling is capture, not routing.** 4 of 34 `utils/*Access.ts` modules import Sentry, so
+most write failures never become an issue at all and no rule can reach them —
+[#708](https://github.com/debola31/Jigged/issues/708). Tuning alerts on a queue that is nearly
+empty because reporting is thin is motion without progress.
+
 ### Inbound filters: what's free and what isn't
 
 Free, per-project, at `/api/0/projects/jigged/<project>/filters/`:

--- a/lib/operatorStationStorage.ts
+++ b/lib/operatorStationStorage.ts
@@ -1,0 +1,114 @@
+/**
+ * Device-local persistence for the operator's selected station.
+ *
+ * The operator's selected station is a "where am I standing right now" default.
+ * It lives in localStorage (NOT sessionStorage) so it survives a backgrounded-tab
+ * eviction or a browser restart — the shop-floor reality that had operators
+ * landing on a job with the station picker stacked underneath it every morning.
+ *
+ * Split out of OperatorStationContext so that sign-out paths OUTSIDE the operator
+ * tree (AuthProvider, which every dashboard page mounts) can clear the station
+ * without importing the React context and dragging the operator access layer into
+ * their bundle. Nothing here touches React or Supabase — it is localStorage and
+ * string keys.
+ */
+
+// A station IS a work center, and a work center belongs to exactly ONE company —
+// so the stored selection is PER COMPANY, not per device. One user can hold
+// access to several companies (demo mode hands out two routinely), and under the
+// single flat key this used to use, switching company carried the previous
+// company's machine along: the header named a station that was absent from the
+// station dropdown, the job list went permanently empty WITHOUT offering the
+// picker, and the first maintenance note saved against it was rejected by the
+// `notes_validate_subject()` trigger with "work center … is not in company …",
+// surfacing on the floor as "Could not save that."
+//
+// Matches the convention the rest of the app already uses for device-local
+// company state — `jigged.jobs.statusFilter.${companyId}` on the dashboard jobs
+// page, and the companyId-keyed dismissal in components/demo/OnboardingCard.tsx.
+const STORAGE_PREFIX = 'jigged_operator_station';
+
+// The flat key devices wrote before that fix. It names a machine in SOME company
+// and cannot say which — see readStoredStation for how it is retired.
+const LEGACY_STORAGE_KEY = STORAGE_PREFIX;
+
+function storageKey(companyId: string): string {
+  return `${STORAGE_PREFIX}:${companyId}`;
+}
+
+/**
+ * The station stored for this company, or null.
+ *
+ * localStorage access can throw (Safari private mode throws on setItem; access
+ * can be blocked entirely). A remembered station default must never white-screen
+ * the whole operator app, so every access is guarded and degrades to in-memory.
+ */
+export function readStoredStation(companyId: string): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const scoped = window.localStorage.getItem(storageKey(companyId));
+    if (scoped) return scoped;
+
+    // One-shot migration off the flat key, so this fix does not put every
+    // operator already out on a floor back in front of the picker one morning
+    // for a bug they never hit. The old value carries no company, so it is
+    // adopted by whichever company opens first and CONSUMED — copying it to
+    // every company would re-seed each one in turn with the same wrong machine.
+    // A wrong guess costs exactly one re-pick, because `getStationName` now
+    // validates by company and the provider clears what it rejects.
+    const legacy = window.localStorage.getItem(LEGACY_STORAGE_KEY);
+    if (!legacy) return null;
+    try {
+      window.localStorage.setItem(storageKey(companyId), legacy);
+      window.localStorage.removeItem(LEGACY_STORAGE_KEY);
+    } catch {
+      /* storage is read-only — the value still seeds this session */
+    }
+    return legacy;
+  } catch {
+    return null;
+  }
+}
+
+/** Remember `stationId` as this company's station on this device. */
+export function writeStoredStation(companyId: string, stationId: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(storageKey(companyId), stationId);
+  } catch {
+    /* storage unavailable — keep the value in memory only */
+  }
+}
+
+/**
+ * Clear the persisted station.
+ *
+ * With a `companyId`, forgets only that company's station — what the provider
+ * does when the stored machine turns out to be archived, or to belong to a
+ * different company.
+ *
+ * Without one, forgets EVERY company's station plus the legacy key, which is
+ * what ending a session on this device means: a phone that changes hands must
+ * not hand the next person a station, in any company.
+ */
+export function clearStoredStation(companyId?: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (companyId) {
+      window.localStorage.removeItem(storageKey(companyId));
+      return;
+    }
+    // Collect before removing — removing while iterating by index reindexes the
+    // store underneath the loop and silently skips entries.
+    const doomed: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (key === LEGACY_STORAGE_KEY || key?.startsWith(`${STORAGE_PREFIX}:`)) {
+        doomed.push(key);
+      }
+    }
+    doomed.forEach((key) => window.localStorage.removeItem(key));
+  } catch {
+    /* ignore */
+  }
+}

--- a/utils/machineMaintenanceAccess.ts
+++ b/utils/machineMaintenanceAccess.ts
@@ -232,14 +232,26 @@ export function addMachineNoteMedia(
  * A by-id read, so it does NOT filter deleted_at: an archived machine's page
  * stays reachable by direct link and its knowledge stays readable — archiving
  * hides a machine from pickers, not its history (§9).
+ *
+ * `companyId` is a DIFFERENT axis from archival and is required. RLS lets a user
+ * read work centers in every company they belong to, so without this filter a
+ * machine id from another company resolves and its make/model/serial render as
+ * though they belonged to the company on screen. That is not hypothetical: a
+ * stale cross-company station selection did exactly that, and in demo mode —
+ * where the demo tenant is seeded from a real shop — it put a real customer's
+ * machine serial inside the demo. Matches `getMachineLog` below.
  */
-export async function getMachineDetails(workCenterId: string): Promise<MachineDetails | null> {
+export async function getMachineDetails(
+  workCenterId: string,
+  companyId: string,
+): Promise<MachineDetails | null> {
   const supabase = getSupabase();
 
   const { data, error } = await supabase
     .from('work_centers')
     .select(MACHINE_DETAIL_COLUMNS)
     .eq('id', workCenterId)
+    .eq('company_id', companyId)
     .maybeSingle();
 
   if (error) throw new Error(error.message);

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -1156,8 +1156,8 @@ export async function getStationOperationTypes(
 }
 
 /**
- * Resolve a station's display name, or null when there is no live machine with
- * that id.
+ * Resolve a station's display name within a company, or null when that company
+ * has no live machine with that id.
  *
  * Filters `deleted_at` even though it is a by-id read, which is the opposite of
  * the usual rule. The distinction is what the read is FOR: a detail page or a
@@ -1166,12 +1166,22 @@ export async function getStationOperationTypes(
  * stored station no longer names anywhere an operator can stand, and the caller
  * drops them back to the picker rather than leaving them on a ghost machine.
  *
- * Throws on a query failure so the caller can tell "this machine is gone" (null)
- * apart from "the network is down" (throw) — the first should clear the stored
- * station, the second must never touch it.
+ * `companyId` is REQUIRED, and RLS is not a substitute for it. One user can hold
+ * access to several companies, so a work center from the company they were in a
+ * minute ago reads back perfectly well — this filter is the only thing that
+ * turns "a machine you may read" into "a machine you are standing at HERE". Not
+ * having it is how a station selected in one company survived a company switch:
+ * the name resolved, so the stale selection looked healthy, and the first note
+ * saved against it died in the `notes_validate_subject()` trigger with
+ * "work center … is not in company …".
+ *
+ * Throws on a query failure so the caller can tell "this machine is not here"
+ * (null) apart from "the network is down" (throw) — the first should clear the
+ * stored station, the second must never touch it.
  */
 export async function getStationName(
   stationId: string,
+  companyId: string,
 ): Promise<string | null> {
   const supabase = getSupabase();
 
@@ -1179,6 +1189,7 @@ export async function getStationName(
     .from('work_centers')
     .select('name')
     .eq('id', stationId)
+    .eq('company_id', companyId)
     .is('deleted_at', null)
     .maybeSingle();
 

--- a/utils/workCenterAttachmentsAccess.ts
+++ b/utils/workCenterAttachmentsAccess.ts
@@ -113,15 +113,25 @@ export async function uploadWorkCenterAttachment(
   return rowToAttachment(data as unknown as AttachmentRow);
 }
 
-/** A machine's manuals, newest first. */
+/**
+ * A machine's manuals, newest first.
+ *
+ * `companyId` is required, and RLS is not a substitute for it: the policy admits
+ * every company the caller belongs to, so filtering on `work_center_id` alone
+ * lists another company's manuals — with signed URLs that open — whenever a
+ * foreign machine id reaches this call. A manual carries part numbers, tooling
+ * and process notes, so that is a real disclosure and not a cosmetic one.
+ */
 export async function listWorkCenterAttachments(
   workCenterId: string,
+  companyId: string,
 ): Promise<WorkCenterAttachment[]> {
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('work_center_attachments')
     .select(ATTACHMENT_SELECT)
     .eq('work_center_id', workCenterId)
+    .eq('company_id', companyId)
     .order('created_at', { ascending: false });
 
   if (error) {
@@ -136,13 +146,21 @@ export async function listWorkCenterAttachments(
  * count only decides whether an affordance renders, and a machine with no
  * manuals shows nothing — so a failure degrades to the same thing as an empty
  * machine rather than to a broken screen.
+ *
+ * Company-scoped for the same reason as `listWorkCenterAttachments` — this count
+ * is what renders the "Manuals · N" button that opens that list, so an unscoped
+ * count advertises another company's documents before anyone taps.
  */
-export async function countWorkCenterAttachments(workCenterId: string): Promise<number> {
+export async function countWorkCenterAttachments(
+  workCenterId: string,
+  companyId: string,
+): Promise<number> {
   const supabase = getSupabase();
   const { count, error } = await supabase
     .from('work_center_attachments')
     .select('id', { count: 'exact', head: true })
-    .eq('work_center_id', workCenterId);
+    .eq('work_center_id', workCenterId)
+    .eq('company_id', companyId);
   if (error) {
     console.error('Error counting work center attachments:', error);
     return 0;


### PR DESCRIPTION
## The bug

In demo mode with access to two companies, switching company kept the **previous** company's
machine selected. The header named a station absent from the station dropdown, and saving a
maintenance note failed with "Could not save that." The Postgres log had the real answer:

```
work center 853e003b-… is not in company 752325ba-…
PL/pgSQL function notes_validate_subject() line 24 at RAISE   (SQLSTATE P0001)
```

**That trigger was the only guard in the entire blast radius that fired.** Everything else failed
silently. The bug is entirely client-side.

## Root cause

Two defects compound:

1. **The persisted station was not company-scoped.** One flat `jigged_operator_station` key for the
   whole device, so every company read and wrote the same slot. The rest of the app already had the
   convention — `jigged.jobs.statusFilter.${companyId}`, and the companyId-keyed dismissal in
   `OnboardingCard`.

2. **The self-heal was company-blind.** The provider already clears a station when `getStationName`
   returns `null`, but that function filtered on `id` + `deleted_at` and **not `company_id`** —
   while its own doc comment says it exists to "validate a persisted selection." Because the user
   genuinely holds RLS access to *both* companies, the lookup **succeeded** and returned a real
   name, so the stale station looked healthy.

RLS was never going to catch this. RLS answers "may this user read this row" — legitimately *yes*.
The missing question was "is this machine in the company I am standing in".

## What else was broken

| Surface | Behaviour with a stale cross-company station |
|---|---|
| My Station | Zero rows, **no error** — and `showStationSelector` requires `!stationId`, so the picker stayed suppressed. A permanent "No jobs available" indistinguishable from an idle station, with no way out from the floor. |
| Operation page | The wrong-station banner fired on **every** step, destroying the one signal that catches a mis-scan. |
| Maintenance | `getMachineDetails` had no company filter at all — one company's make/model/**serial** rendered as another's. `list`/`countWorkCenterAttachments` likewise, so its manuals were counted and openable via working signed URLs. In demo mode, where the demo tenant is seeded from a real shop, that put a real customer's machine inside the demo. |
| Note save | The only path that actually failed. |

**Not corrupted:** `createOperationCompletion` never touches `stationId` and step notes write no
`work_center_id`, so job completions and step notes stayed correct. That bounds the incident.

## The fix

Three independent layers, so no single regression re-opens it.

- **`getStationName(stationId, companyId)`** — the load-bearing change. Makes a cross-company
  station impossible to *hold*, however it got into state. "Archived" and "in another company" want
  identical handling, so both answer `null` and share the existing branch.
- **Per-company storage key**, extracted to `lib/operatorStationStorage.ts` so sign-out paths
  outside the operator tree can clear it without pulling the operator access layer into their
  bundle.
- **Company filters** on `getMachineDetails`, `listWorkCenterAttachments`,
  `countWorkCenterAttachments`. `getMachineLog` in the same module already took a `companyId` —
  this was an inconsistency inside one file. `getMachineDetails` still ignores `deleted_at` on
  purpose: archiving hides a machine from pickers, not its history (§9), and company is a different
  axis.

**Legacy key is migrated, not dropped**, so operators already out on a floor are not put in front
of the picker one morning for a bug they never hit. It names a machine in *some* company and cannot
say which, so it is adopted by whichever company opens first and **consumed** — copying it would
re-seed every company in turn with the same wrong machine. A wrong guess costs one re-pick, because
the company-scoped validation clears it.

**Shared-device hygiene.** `clearStoredStation()` had one caller; six other session-ending paths
left the key behind, so a shared phone handed the next operator the previous one's machine *within
the same company* — notes filed against the wrong machine with no error surface. Now cleared in
`AuthProvider.signOut()` plus the two direct operator call sites. Skipped for `scope: 'others'`,
which deliberately keeps *this* device signed in.

## Deliberately not done

- **`key={companyId}` on the provider.** Verified against the installed Next 16.2.11 router: the
  `[companyId]` subtree is already keyed by `createRouterCacheKey` → `companyId|<uuid>|d`, so it
  would be a no-op.
- **A `stations`-membership guard.** `getStationOperationTypes` swallows its failure with
  `catch {}`, so an empty list cannot be read as "loaded and empty" — it would clear a valid station
  whenever shop wifi drops, breaking behaviour an existing test deliberately asserts.

## Testing

6 new station cases, plus company-filter assertions for all four newly-scoped reads and two
`AuthProvider` sign-out cases.

The station test's `useParams` mock was a fixed arrow, so a company change could not be *expressed*
— which is why the original five cases all passed while the leak shipped.

**All six new station tests were checked against pre-fix behaviour and fail there.** The first
version of the switch test passed vacuously (seeding a company-scoped key by hand is invisible to
flat-key code), so it now drives the selection through `setStation` and asserts on behaviour rather
than key format.

- `2015 tests / 148 files` pass · `pnpm lint` clean · `pnpm build` green
- `docLinkCheck` and `interactionStandardsCheck` pass

## Sentry

This never reached Sentry, and **no alert configuration could have helped** — nothing captures it.
`addMachineNote` throws a friendly `Error`, `useNoteCapture` re-throws, and `MachineComposer.submit()`
catches it with an **empty block**, so not even an unhandled rejection fires. Only 4 of 34
`utils/*Access.ts` modules import Sentry. Tracked separately in #708.

`docs/observability.md` gains a section recording what the two alert workflows trigger on and who
receives them — it previously covered only API mechanics, which is why two silent-delivery traps
went unnoticed: alert email was routed to a nonexistent address for five months while the workflows
reported healthy, and the uptime detector has `workflowIds: []` so downtime notifies nobody.

## Verifying by hand

Needs genuine multi-company access, against a local stack:

1. Pick a station in `/operator/{A}`, then switch to `/operator/{B}`.
2. Expect no station, nav collapsed, **picker offered** — not A's machine and not a silent
   "No jobs available".
3. Pick a station in B, open Maintenance: machine card and manuals count are **B's**. Add a note —
   it saves.
4. Back to `/operator/{A}` — A's station is still remembered independently.
5. Log out from **Me**, and separately via the dashboard header — both companies' keys are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
