### PR TITLE
A place with sub-locations holds no stock

### DIFF
--- a/__tests__/components/inventory/InventoryCountPage.test.tsx
+++ b/__tests__/components/inventory/InventoryCountPage.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@/utils/operatorAccess', () => ({
 
 vi.mock('@/utils/inventoryCountAccess', () => ({
   loadCountCandidates: vi.fn(),
-  loadLocationCountCandidates: vi.fn(),
+  loadCountCandidatesForPlaces: vi.fn(),
   loadPartAtLocationCandidate: vi.fn(),
   loadPartEverywhereCandidates: vi.fn(),
   refreshLocationQuantities: vi.fn(),
@@ -68,7 +68,7 @@ vi.mock('@/utils/inventoryLocationsAccess', () => ({
 import InventoryCountPage from '@/app/dashboard/[companyId]/inventory/count/page';
 import {
   loadCountCandidates,
-  loadLocationCountCandidates,
+  loadCountCandidatesForPlaces,
   refreshLocationQuantities,
   commitCount,
   loadPartAtLocationCandidate,
@@ -531,7 +531,7 @@ describe('counting one place', () => {
       { id: 'loc-yard', company_id: 'co1', parent_id: null, name: 'Yard', kind: 'outside', code: null, sort_order: 1, created_at: '', updated_at: '' },
       { id: 'loc-un', company_id: 'co1', parent_id: null, name: 'Unassigned', kind: 'system', code: null, sort_order: 2, created_at: '', updated_at: '' },
     ]);
-    asMock(loadLocationCountCandidates).mockResolvedValue({
+    asMock(loadCountCandidatesForPlaces).mockResolvedValue({
       candidates: [here('BUY-ORING-214', 828), here('BUY-BEARING-608ZZ', 580)],
       total: 2,
     });
@@ -561,7 +561,7 @@ describe('counting one place', () => {
   it('names the place it is scoped to instead of the whole shop', async () => {
     renderPage();
     expect(await screen.findByText("What's in Shelf A?")).toBeInTheDocument();
-    expect(loadLocationCountCandidates).toHaveBeenCalledWith(LOC, 'Shelf A', {
+    expect(loadCountCandidatesForPlaces).toHaveBeenCalledWith([{ id: LOC, name: 'Shelf A', path: 'Shelf A' }], {
       search: '',
       offset: 0,
       limit: 2,
@@ -603,15 +603,15 @@ describe('counting one place', () => {
     const user = userEvent.setup();
     renderPage();
     await screen.findByText("What's in Shelf A?");
-    asMock(loadLocationCountCandidates).mockClear();
+    asMock(loadCountCandidatesForPlaces).mockClear();
 
     await user.click(screen.getByRole('checkbox', { name: /count BUY-ORING-214/i }));
     await user.click(screen.getByRole('combobox', { name: /send the ticked parts to/i }));
     await user.click(await screen.findByRole('option', { name: /^Yard/ }));
     await user.click(screen.getByRole('button', { name: /put 1 away/i }));
 
-    await waitFor(() => expect(loadLocationCountCandidates).toHaveBeenCalled());
-    const [, , opts] = asMock(loadLocationCountCandidates).mock.calls[0];
+    await waitFor(() => expect(loadCountCandidatesForPlaces).toHaveBeenCalled());
+    const [, opts] = asMock(loadCountCandidatesForPlaces).mock.calls[0];
     expect(opts.offset ?? 0).toBe(0);
   });
 
@@ -680,7 +680,7 @@ describe('counting one place', () => {
    */
   it('pages through a bin instead of showing one capped page', async () => {
     const user = userEvent.setup();
-    asMock(loadLocationCountCandidates).mockResolvedValue({
+    asMock(loadCountCandidatesForPlaces).mockResolvedValue({
       candidates: [here('BUY-ORING-214', 828), here('BUY-BEARING-608ZZ', 580)],
       total: 9428,
     });
@@ -692,7 +692,7 @@ describe('counting one place', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
 
     await waitFor(() =>
-      expect(loadLocationCountCandidates).toHaveBeenLastCalledWith(LOC, 'Shelf A', {
+      expect(loadCountCandidatesForPlaces).toHaveBeenLastCalledWith([{ id: LOC, name: 'Shelf A', path: 'Shelf A' }], {
         search: '',
         offset: 2,
         limit: 2,
@@ -718,7 +718,7 @@ describe('counting one place', () => {
    */
   it('does not reset the page when the mount-time search debounce fires', async () => {
     const user = userEvent.setup();
-    asMock(loadLocationCountCandidates).mockResolvedValue({
+    asMock(loadCountCandidatesForPlaces).mockResolvedValue({
       candidates: [here('BUY-ORING-214', 828), here('BUY-BEARING-608ZZ', 580)],
       total: 9428,
     });
@@ -728,17 +728,16 @@ describe('counting one place', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
 
     await waitFor(() =>
-      expect(loadLocationCountCandidates).toHaveBeenLastCalledWith(
-        LOC,
-        'Shelf A',
+      expect(loadCountCandidatesForPlaces).toHaveBeenLastCalledWith(
+        [{ id: LOC, name: 'Shelf A', path: 'Shelf A' }],
         expect.objectContaining({ offset: 2 }),
       ),
     );
 
     await new Promise((resolve) => setTimeout(resolve, 700));
 
-    const offsets = asMock(loadLocationCountCandidates).mock.calls.map(
-      (call: unknown[]) => (call[2] as { offset: number }).offset,
+    const offsets = asMock(loadCountCandidatesForPlaces).mock.calls.map(
+      (call: unknown[]) => (call[1] as { offset: number }).offset,
     );
     expect(offsets).toEqual([0, 2]);
   });
@@ -746,7 +745,7 @@ describe('counting one place', () => {
   /** A tick on page 1 must survive turning to page 2 — the sheet holds rows, not indexes. */
   it('keeps what is already ticked when the page turns', async () => {
     const user = userEvent.setup();
-    asMock(loadLocationCountCandidates).mockResolvedValue({
+    asMock(loadCountCandidatesForPlaces).mockResolvedValue({
       candidates: [here('BUY-ORING-214', 828), here('BUY-BEARING-608ZZ', 580)],
       total: 9428,
     });
@@ -754,7 +753,7 @@ describe('counting one place', () => {
     await screen.findByText(/1–2 of 9,428 here/i);
 
     await user.click(screen.getByRole('checkbox', { name: /count BUY-ORING-214/i }));
-    asMock(loadLocationCountCandidates).mockResolvedValue({
+    asMock(loadCountCandidatesForPlaces).mockResolvedValue({
       candidates: [here('SOMETHING-ELSE', 3)],
       total: 9428,
     });
@@ -767,7 +766,7 @@ describe('counting one place', () => {
   // The RPC caps the array to bound how long it holds row locks; say so before someone selects
   // 2,000 rows and is refused.
   it('refuses to select-all past the cap', async () => {
-    asMock(loadLocationCountCandidates).mockResolvedValue({
+    asMock(loadCountCandidatesForPlaces).mockResolvedValue({
       candidates: Array.from({ length: 1001 }, (_, i) => here(`P${i}`, 1)),
       total: 1001,
     });
@@ -801,7 +800,7 @@ describe('counting one place — the sheet outlives the search', () => {
     asMock(getLocations).mockResolvedValue([
       { id: LOC2, company_id: 'co1', parent_id: null, name: 'Shelf A', kind: 'shelf', code: null, sort_order: 0, created_at: '', updated_at: '' },
     ]);
-    asMock(loadLocationCountCandidates).mockResolvedValue({
+    asMock(loadCountCandidatesForPlaces).mockResolvedValue({
       candidates: [hereRow('BUY-ORING-214', 828), hereRow('BUY-BEARING-608ZZ', 580)],
       total: 2,
     });
@@ -820,7 +819,7 @@ describe('counting one place — the sheet outlives the search', () => {
     await user.type(inputFor('BUY-ORING-214', 'Shelf A'), '800');
 
     // The server list is replaced by something that does not contain the counted part.
-    asMock(loadLocationCountCandidates).mockResolvedValue({
+    asMock(loadCountCandidatesForPlaces).mockResolvedValue({
       candidates: [hereRow('SOMETHING-ELSE', 5)],
       total: 1,
     });
@@ -870,7 +869,7 @@ describe('counting one place — adding a part that is not listed', () => {
     asMock(getLocations).mockResolvedValue([
       { id: LOC3, company_id: 'co1', parent_id: null, name: 'Shelf A', kind: 'shelf', code: null, sort_order: 0, created_at: '', updated_at: '' },
     ]);
-    asMock(loadLocationCountCandidates).mockResolvedValue({ candidates: [], total: 0 });
+    asMock(loadCountCandidatesForPlaces).mockResolvedValue({ candidates: [], total: 0 });
     nextAddPick = { id: 'p-missing', part_name: 'BUY-DOWEL-3MM' };
     asMock(loadPartAtLocationCandidate).mockResolvedValue(
       cand({
@@ -1326,5 +1325,115 @@ describe('stock that moved between two counted places', () => {
     // Reported after the fact, as before — the count IS what is on the shelf.
     await waitFor(() => expect(commitCount).toHaveBeenCalled());
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Counting a whole cabinet.
+ *
+ * A container holds no stock of its own since 20260806160053, so a one-bin sheet for one would be
+ * permanently blank. "Count Cabinet 3" means the bins under it — and it needed no new write path,
+ * because `commitCount` already adjusts each line at its own `target.locationId`.
+ */
+describe('counting a container', () => {
+  const CAB = 'loc-cab';
+  const ROW1 = 'loc-row-1';
+  const ROW2 = 'loc-row-2';
+
+  const place = (id: string, name: string, parent: string | null, sort = 0) => ({
+    id,
+    company_id: 'co1',
+    parent_id: parent,
+    name,
+    kind: null,
+    code: null,
+    sort_order: sort,
+    created_at: '',
+    updated_at: '',
+  });
+
+  beforeEach(() => {
+    searchParams.set('location', CAB);
+    asMock(getLocations).mockResolvedValue([
+      place(CAB, 'Cabinet 3', null),
+      place(ROW1, 'Row 1', CAB, 0),
+      place(ROW2, 'Row 2', CAB, 1),
+      place('loc-un', 'Unassigned', null, 9),
+    ]);
+    asMock(loadCountCandidatesForPlaces).mockResolvedValue({
+      candidates: [
+        at('p-bearing', 'BUY-BEARING-608ZZ', ROW1, 'Cabinet 3 › Row 1', 380),
+        at('p-oring', 'BUY-ORING-214', ROW1, 'Cabinet 3 › Row 1', 828),
+        at('p-bearing', 'BUY-BEARING-608ZZ', ROW2, 'Cabinet 3 › Row 2', 200),
+      ],
+      total: 3,
+    });
+    freshBalances({ 'p-bearing::loc-row-1': 380, 'p-bearing::loc-row-2': 200 });
+  });
+
+  afterEach(() => searchParams.delete('location'));
+
+  it('gathers every bin beneath the container, in walking order', async () => {
+    renderPage();
+    await screen.findByText("What's in Cabinet 3?");
+
+    expect(loadCountCandidatesForPlaces).toHaveBeenCalledWith(
+      [
+        { id: ROW1, name: 'Row 1', path: 'Cabinet 3 › Row 1' },
+        { id: ROW2, name: 'Row 2', path: 'Cabinet 3 › Row 2' },
+      ],
+      expect.objectContaining({ offset: 0 }),
+    );
+  });
+
+  /**
+   * The reason this is safe. Aggregating a split part would re-create the exact ambiguity that
+   * forces the company-wide sheet to skip such parts: 380 + 200 counted as 560 has no defensible
+   * home for the −20. Two lines means each number is about one shelf you are standing at.
+   */
+  it('keeps a split part as one line per bin rather than one total', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText("What's in Cabinet 3?");
+
+    // The picker is part-first — one row per part, whatever its places — so the split shows on the
+    // sheet, which is where the numbers get typed.
+    await user.click(screen.getByRole('checkbox', { name: /count BUY-BEARING-608ZZ/i }));
+    await user.click(screen.getByRole('button', { name: /^count 1 part in 2 places/i }));
+
+    expect(inputFor('BUY-BEARING-608ZZ', 'Cabinet 3 › Row 1')).toBeInTheDocument();
+    expect(inputFor('BUY-BEARING-608ZZ', 'Cabinet 3 › Row 2')).toBeInTheDocument();
+  });
+
+  it('commits a line against its own bin, not the container', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText("What's in Cabinet 3?");
+
+    await user.click(screen.getByRole('checkbox', { name: /count BUY-BEARING-608ZZ/i }));
+    await user.click(screen.getByRole('button', { name: /^count 1 part in 2 places/i }));
+    // Only Row 2 gets a number, so only Row 2 commits — the other line has no entry.
+    await user.type(inputFor('BUY-BEARING-608ZZ', 'Cabinet 3 › Row 2'), '190');
+    await user.click(screen.getByRole('button', { name: /^save/i }));
+
+    await waitFor(() => expect(commitCount).toHaveBeenCalled());
+    const [variances] = asMock(commitCount).mock.calls.at(-1)!;
+    const targets = (variances as Array<{ candidate: CountCandidate }>).map(
+      (v) => v.candidate.target.locationId,
+    );
+    expect(targets).toEqual([ROW2]);
+    expect(targets).not.toContain(CAB);
+  });
+
+  /**
+   * `bulk_put_away` moves parts out of ONE location, and the ticked rows here come from several —
+   * so there is no single source to send them from. Counting is unaffected; putting away stays
+   * available one level down, standing at the bin.
+   */
+  it('withholds the bulk put-away, which has no single source on a subtree', async () => {
+    renderPage();
+    await screen.findByText("What's in Cabinet 3?");
+
+    expect(screen.queryByLabelText(/send the ticked parts to/i)).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/inventory/locations/LocationTable.test.tsx
+++ b/__tests__/components/inventory/locations/LocationTable.test.tsx
@@ -4,6 +4,11 @@
  * What is worth pinning here is the interaction model, because it is the part that changed twice:
  * the whole row opens a place, the chevron is a *separate* target that only expands, and there is
  * no selection column at all.
+ *
+ * It changed a third time, and that is what most of the expand/collapse cases below now assert:
+ * the table is an **accordion with one open branch**. Rows start collapsed and opening a place
+ * closes anything not on its ancestor chain. The old suite assumed the opposite default and read
+ * child rows straight out of the first render — so four cases here are rewrites, not additions.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, within } from '../../../test-utils';
@@ -28,18 +33,24 @@ const node = (
   ...over,
 });
 
-const shelfA = node({ id: 'a', name: 'Shelf A', parent_id: 'cab', depth: 1 });
+const bin1 = node({ id: 'bin1', name: 'Bin 1', parent_id: 'a', depth: 2 });
+const shelfA = node({ id: 'a', name: 'Shelf A', parent_id: 'cab', depth: 1, children: [bin1] });
 const shelfB = node({ id: 'b', name: 'Shelf B', parent_id: 'cab', depth: 1 });
 const cabinet = node({ id: 'cab', name: 'Cabinet 3', children: [shelfA, shelfB] });
-const yard = node({ id: 'yard', name: 'Yard', sort_order: 1 });
-const unassigned = node({ id: 'un', name: 'Unassigned', kind: 'system', sort_order: 2 });
+const rackShelf = node({ id: 'rs', name: 'Rack Shelf', parent_id: 'rack', depth: 1 });
+const rack = node({ id: 'rack', name: 'Rack 1', sort_order: 1, children: [rackShelf] });
+const yard = node({ id: 'yard', name: 'Yard', sort_order: 2 });
+const unassigned = node({ id: 'un', name: 'Unassigned', kind: 'system', sort_order: 3 });
 
-const TREE = [cabinet, yard, unassigned];
+const TREE = [cabinet, rack, yard, unassigned];
 
 const onOpen = vi.fn();
 const onCountHere = vi.fn();
 
-const renderTable = (tree = TREE, counts: Array<[string, number]> = [['a', 2], ['b', 1], ['yard', 1]]) =>
+const renderTable = (
+  tree = TREE,
+  counts: Array<[string, number]> = [['bin1', 2], ['b', 1], ['yard', 1]],
+) =>
   render(
     <LocationTable
       tree={tree}
@@ -53,13 +64,35 @@ const rowFor = (name: string) => screen.getByText(name).closest('tr') as HTMLEle
 
 beforeEach(() => vi.clearAllMocks());
 
+const expand = async (user: ReturnType<typeof userEvent.setup>, name: string) =>
+  user.click(screen.getByRole('button', { name: `Expand ${name}` }));
+
 describe('LocationTable', () => {
-  it('shows every level at once, children under their parent', () => {
+  it('starts with roots only, so a generated cabinet does not bury the shop', () => {
     renderTable();
-    const names = screen.getAllByRole('row').slice(1).map((r) => within(r).getAllByRole('cell')[0].textContent);
-    expect(names?.[0]).toContain('Cabinet 3');
-    expect(names?.[1]).toContain('Shelf A');
-    expect(names?.[2]).toContain('Shelf B');
+    const names = screen
+      .getAllByRole('row')
+      .slice(1)
+      .map((r) => within(r).getAllByRole('cell')[0].textContent);
+
+    expect(names).toHaveLength(4);
+    expect(names[0]).toContain('Cabinet 3');
+    expect(screen.queryByText('Shelf A')).not.toBeInTheDocument();
+  });
+
+  it('shows children under their parent once opened', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    await expand(user, 'Cabinet 3');
+
+    const names = screen
+      .getAllByRole('row')
+      .slice(1)
+      .map((r) => within(r).getAllByRole('cell')[0].textContent);
+    expect(names[0]).toContain('Cabinet 3');
+    expect(names[1]).toContain('Shelf A');
+    expect(names[2]).toContain('Shelf B');
   });
 
   /** The roll-up bug this inherited from the board: a full cabinet must never read empty. */
@@ -99,32 +132,102 @@ describe('LocationTable', () => {
     await user.click(within(rowFor('Cabinet 3')).getByText(/part|empty/i));
 
     expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ id: 'cab' }));
-    // Still expanded, i.e. the click did not toggle it.
-    expect(screen.getByText('Shelf A')).toBeInTheDocument();
+    // Still collapsed, i.e. the click did not toggle it.
+    expect(screen.queryByText('Shelf A')).not.toBeInTheDocument();
   });
 
   it('expands and collapses from the chevron without opening anything', async () => {
     const user = userEvent.setup();
     renderTable();
 
-    await user.click(screen.getByRole('button', { name: 'Collapse Cabinet 3' }));
-
-    expect(screen.queryByText('Shelf A')).not.toBeInTheDocument();
-    expect(onOpen).not.toHaveBeenCalled();
-
-    await user.click(screen.getByRole('button', { name: 'Expand Cabinet 3' }));
+    await expand(user, 'Cabinet 3');
     expect(screen.getByText('Shelf A')).toBeInTheDocument();
     expect(onOpen).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Collapse Cabinet 3' }));
+    expect(screen.queryByText('Shelf A')).not.toBeInTheDocument();
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  /** The accordion, at the level the screenshot complained about: two sides open at once. */
+  it('closes the open sibling when another is opened', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    await expand(user, 'Cabinet 3');
+    await expand(user, 'Shelf A');
+    expect(screen.getByText('Bin 1')).toBeInTheDocument();
+
+    // Shelf B has no children of its own, so opening Shelf A and then Cabinet 3's other branch is
+    // expressed by going back up: re-opening Cabinet 3 collapses it, which takes Shelf A with it.
+    await user.click(screen.getByRole('button', { name: 'Collapse Cabinet 3' }));
+    expect(screen.queryByText('Bin 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Shelf A')).not.toBeInTheDocument();
+  });
+
+  it('closes the other root entirely — one open branch in the whole table', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    await expand(user, 'Cabinet 3');
+    await expand(user, 'Shelf A');
+    expect(screen.getByText('Bin 1')).toBeInTheDocument();
+
+    await expand(user, 'Rack 1');
+
+    expect(screen.getByText('Rack Shelf')).toBeInTheDocument();
+    // The whole Cabinet 3 chain went, not just its deepest level.
+    expect(screen.queryByText('Shelf A')).not.toBeInTheDocument();
+    expect(screen.queryByText('Bin 1')).not.toBeInTheDocument();
+  });
+
+  it('keeps the ancestors open when a deeper node is closed', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    await expand(user, 'Cabinet 3');
+    await expand(user, 'Shelf A');
+    await user.click(screen.getByRole('button', { name: 'Collapse Shelf A' }));
+
+    expect(screen.queryByText('Bin 1')).not.toBeInTheDocument();
+    expect(screen.getByText('Shelf A')).toBeInTheDocument();
+  });
+
+  it('announces the open state, not just a differently worded label', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    expect(screen.getByRole('button', { name: 'Expand Cabinet 3' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    await expand(user, 'Cabinet 3');
+    expect(screen.getByRole('button', { name: 'Collapse Cabinet 3' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
   });
 
   it('counts one place without opening it', async () => {
     const user = userEvent.setup();
     renderTable();
 
-    await user.click(screen.getByRole('button', { name: 'Count Shelf A' }));
+    await user.click(screen.getByRole('button', { name: 'Count Yard' }));
 
-    expect(onCountHere).toHaveBeenCalledWith(expect.objectContaining({ id: 'a' }));
+    expect(onCountHere).toHaveBeenCalledWith(expect.objectContaining({ id: 'yard' }));
     expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A container holds no stock of its own (20260806160053), so this button briefly did nothing and
+   * was briefly hidden. Both were wrong — counting a cabinet means counting the bins in it, and the
+   * worksheet resolves the subtree.
+   */
+  it('offers a count action on a container too, for everything inside it', () => {
+    renderTable();
+
+    expect(screen.getByRole('button', { name: 'Count Cabinet 3' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Count Yard' })).toBeInTheDocument();
   });
 
   /**

--- a/__tests__/components/inventory/locations/LocationsManager.test.tsx
+++ b/__tests__/components/inventory/locations/LocationsManager.test.tsx
@@ -316,10 +316,24 @@ describe('LocationsManager — count or put away', () => {
     const user = userEvent.setup();
     render(<LocationsManager companyId="co1" />);
 
-    await user.click(await screen.findByRole('button', { name: /^Cabinet 3/ }));
+    await user.click(await screen.findByRole('button', { name: /^Yard/ }));
     await user.click(await screen.findByRole('button', { name: /count or put away/i }));
 
-    expect(routerMocks.push).toHaveBeenCalledWith('/dashboard/co1/inventory/count?location=cab3');
+    expect(routerMocks.push).toHaveBeenCalledWith('/dashboard/co1/inventory/count?location=yard');
+  });
+
+  /**
+   * The worksheet counts what a place holds DIRECTLY, and since 20260806160053 a place with
+   * sub-locations holds nothing directly — so this button could only ever open a blank sheet. Its
+   * children each carry their own.
+   */
+  it('offers no worksheet for a place that has sub-locations', async () => {
+    const user = userEvent.setup();
+    render(<LocationsManager companyId="co1" />);
+
+    await user.click(await screen.findByRole('button', { name: /^Cabinet 3/ }));
+
+    expect(screen.queryByRole('button', { name: /count or put away/i })).not.toBeInTheDocument();
   });
 
   /** The put-away entry a real shop needs most: `Unassigned` is where all 9,428 parts start. */

--- a/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
+++ b/__tests__/components/inventory/locations/VisualLocationBuilder.test.tsx
@@ -20,17 +20,27 @@ import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { render, screen } from '../../../test-utils';
 import userEvent from '@testing-library/user-event';
 
+const countSpec = (ns: { children: unknown[] }[]): number =>
+  ns.reduce((s, n) => s + 1 + countSpec(n.children as { children: unknown[] }[]), 0);
+
 vi.mock('@/utils/inventoryLocationsAccess', () => ({
-  materializeLocationSpec: vi.fn(async (_co: string, _p: string | null, nodes: { children: unknown[] }[]) => {
-    const count = (function c(ns: { children: unknown[] }[]): number {
-      return ns.reduce((s, n) => s + 1 + c(n.children as { children: unknown[] }[]), 0);
-    })(nodes);
-    return Array.from({ length: count }, (_, i) => ({ id: String(i) }));
-  }),
+  materializeLocationSpec: vi.fn(async (_co: string, _p: string | null, nodes: { children: unknown[] }[]) =>
+    Array.from({ length: countSpec(nodes) }, (_, i) => ({ id: String(i) })),
+  ),
+  subdivideLocation: vi.fn(async (_p: string, nodes: { children: unknown[] }[]) =>
+    Array.from({ length: countSpec(nodes) }, (_, i) => ({ id: String(i) })),
+  ),
+  // Empty by default: an empty shelf keeps the single-screen flow these cases were written for.
+  // The distribute-step suite below overrides it.
+  getLocationContents: vi.fn(async () => ({ contents: [], total: 0 })),
 }));
 
 import VisualLocationBuilder from '@/components/inventory/locations/builder/VisualLocationBuilder';
-import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
+import {
+  getLocationContents,
+  materializeLocationSpec,
+  subdivideLocation,
+} from '@/utils/inventoryLocationsAccess';
 
 const subdivide = (props: Partial<{ existingSiblingNames: string[] }> = {}) =>
   render(
@@ -123,5 +133,109 @@ describe('the level generator', () => {
 
     // Row 1 plus its two sides, cloned.
     expect(await screen.findByRole('button', { name: /create 18 locations/i })).toBeInTheDocument();
+  });
+});
+
+/**
+ * Dividing up a shelf that already holds stock.
+ *
+ * The invariant added in 20260806160053 is what makes this a second step rather than a footnote: a
+ * place cannot hold stock and sub-locations at once, so the subdivide has to say where the stock
+ * goes. `subdivide_location` defers the check to COMMIT, which means an incomplete distribution
+ * does not half-apply — it rolls the whole thing back, sub-locations and all. Blocking Create until
+ * the arithmetic balances is what keeps that from being how a user finds out.
+ */
+describe('dividing up a shelf that holds stock', () => {
+  const CONTENTS = [
+    { part_id: 'p1', part_name: 'BEARING-608ZZ', quantity: 100, primary_unit: 'each' },
+    { part_id: 'p2', part_name: 'ORING-214', quantity: 40, primary_unit: 'each' },
+  ];
+
+  beforeEach(() => {
+    (getLocationContents as Mock).mockResolvedValue({ contents: CONTENTS, total: 2 });
+  });
+
+  it('asks where the stock goes before it will create anything', async () => {
+    const user = userEvent.setup();
+    subdivide();
+
+    // Create is not even offered yet — the loaded shelf turns the primary action into Next.
+    const next = await screen.findByRole('button', { name: /where does the stock go/i });
+    expect(screen.queryByRole('button', { name: /^create /i })).not.toBeInTheDocument();
+
+    await user.click(next);
+    expect(screen.getByText('BEARING-608ZZ')).toBeInTheDocument();
+    expect(screen.getByText('ORING-214')).toBeInTheDocument();
+  });
+
+  it('keeps Create disabled until every part is fully placed', async () => {
+    const user = userEvent.setup();
+    subdivide();
+    await user.click(await screen.findByRole('button', { name: /where does the stock go/i }));
+
+    expect(screen.getByRole('button', { name: /^create /i })).toBeDisabled();
+
+    // "Send everything to…" fills every row with its full balance in one interaction.
+    await user.click(screen.getByLabelText(/send everything to/i));
+    await user.click(screen.getAllByRole('option')[0]);
+
+    expect(screen.getByRole('button', { name: /^create /i })).toBeEnabled();
+  });
+
+  it('says how much is still unplaced rather than just refusing', async () => {
+    const user = userEvent.setup();
+    subdivide();
+    await user.click(await screen.findByRole('button', { name: /where does the stock go/i }));
+
+    await user.click(screen.getByLabelText(/send everything to/i));
+    await user.click(screen.getAllByRole('option')[0]);
+
+    // Take 40 off the bearings; the row must say what is left rather than silently disabling.
+    const qtyFields = screen.getAllByLabelText('Qty');
+    await user.clear(qtyFields[0]);
+    await user.type(qtyFields[0], '60');
+
+    expect(await screen.findByText(/40 each still to place/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^create /i })).toBeDisabled();
+  });
+
+  it('sends one part to two places and hands both moves to the RPC', async () => {
+    const user = userEvent.setup();
+    subdivide();
+    await user.click(await screen.findByRole('button', { name: /where does the stock go/i }));
+
+    await user.click(screen.getByLabelText(/send everything to/i));
+    await user.click(screen.getAllByRole('option')[0]);
+
+    // Split the bearings 60/40 across the first two bins.
+    const qtyFields = screen.getAllByLabelText('Qty');
+    await user.clear(qtyFields[0]);
+    await user.type(qtyFields[0], '60');
+    await user.click(screen.getAllByRole('button', { name: /^split$/i })[0]);
+
+    const places = screen.getAllByLabelText('Place');
+    await user.click(places[1]);
+    await user.click(screen.getAllByRole('option')[1]);
+
+    await user.click(screen.getByRole('button', { name: /^create /i }));
+
+    const [, , moves] = (subdivideLocation as Mock).mock.calls.at(-1)!;
+    const bearings = (moves as Array<{ partId: string; quantity: number }>).filter(
+      (m) => m.partId === 'p1',
+    );
+    expect(bearings.map((m) => m.quantity).sort((a, b) => a - b)).toEqual([40, 60]);
+    // The whole balance moved, and the two lines went to different places.
+    expect(new Set(bearings.map((m) => (m as { toRef: string }).toRef)).size).toBe(2);
+  });
+
+  it('leaves an empty shelf on the single-screen flow it always had', async () => {
+    (getLocationContents as Mock).mockResolvedValue({ contents: [], total: 0 });
+    const user = userEvent.setup();
+    subdivide();
+
+    await user.click(await screen.findByRole('button', { name: /create 15 locations/i }));
+
+    expect(materializeLocationSpec).toHaveBeenCalled();
+    expect(subdivideLocation).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/components/operator/OperatorBinView.test.tsx
+++ b/__tests__/components/operator/OperatorBinView.test.tsx
@@ -80,24 +80,53 @@ beforeEach(() => {
 });
 
 describe('OperatorBinViewPage', () => {
-  it('shows the path, sub-locations (drill-down), and stock here', async () => {
+  it('shows the path and its stock', async () => {
     (resolveScan as ReturnType<typeof vi.fn>).mockResolvedValue(
-      scanWith(
-        [loc({ id: 'sub1', name: 'Sub A', code: 'C01-B03-A' })],
-        [{ part_id: 'p1', part_name: 'Steel Rod', primary_unit: 'ea', quantity: 12 }],
-      ),
+      scanWith([], [{ part_id: 'p1', part_name: 'Steel Rod', primary_unit: 'ea', quantity: 12 }]),
     );
     renderPage();
 
     expect(await screen.findByText('Bin 3')).toBeInTheDocument();
     expect(screen.getByText('Cabinet 1 › Bin 3')).toBeInTheDocument();
-    expect(screen.getByText('Sub A')).toBeInTheDocument(); // drill-down
     expect(screen.getByText('Steel Rod')).toBeInTheDocument();
     expect(screen.getByText('12')).toBeInTheDocument();
+  });
 
-    // tapping a sub-location navigates into its bin view
+  it('drills down into a sub-location', async () => {
+    (resolveScan as ReturnType<typeof vi.fn>).mockResolvedValue(
+      scanWith([loc({ id: 'sub1', name: 'Sub A', code: 'C01-B03-A' })], []),
+    );
+    renderPage();
+
+    expect(await screen.findByText('Sub A')).toBeInTheDocument();
+
     await userEvent.click(screen.getByText('Sub A'));
     expect(mockPush).toHaveBeenCalledWith('/operator/co1/inventory/locations/sub1');
+  });
+
+  /**
+   * The pair this used to assert together — sub-locations AND stock on one screen — is a state
+   * 20260806160053 made unreachable, so the page stops offering the half that would create it.
+   * It previously rendered "Stock a part" directly above the line "No stock recorded directly here
+   * — open a sub-location above", i.e. a button inviting you to break the sentence beside it. The
+   * database now refuses that write, so the button led to an error rather than a mistake.
+   */
+  it('offers no way to stock a place that has sub-locations', async () => {
+    (resolveScan as ReturnType<typeof vi.fn>).mockResolvedValue(
+      scanWith([loc({ id: 'sub1', name: 'Sub A', code: 'C01-B03-A' })], []),
+    );
+    renderPage();
+
+    expect(await screen.findByText('Sub A')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /stock a part/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/stock goes in the sub-locations above/i)).toBeInTheDocument();
+  });
+
+  it('still offers Stock a part on a bin with no sub-locations', async () => {
+    (resolveScan as ReturnType<typeof vi.fn>).mockResolvedValue(scanWith([], []));
+    renderPage();
+
+    expect(await screen.findByRole('button', { name: /stock a part/i })).toBeInTheDocument();
   });
 
   it('shows an empty state when nothing is stored here', async () => {

--- a/__tests__/components/operator/OperatorPartLookup.test.tsx
+++ b/__tests__/components/operator/OperatorPartLookup.test.tsx
@@ -113,13 +113,19 @@ describe('OperatorPartLookup — J11, "is this part in storage, and where?"', ()
    * the point; the remaining test below is the one true answer.
    */
 
-  it('says a part with no stock is genuinely nowhere', async () => {
+  /**
+   * The wording is a stock statement, not a placement one. It used to read "None in any place
+   * right now.", which sounds like something that exists and has not been put away — the state the
+   * blue "not put away yet" alert reports. No balance rows means the shop holds none of it at all.
+   */
+  it('says a part with no stock anywhere is simply not available', async () => {
     const user = userEvent.setup();
     mockBalances.mockResolvedValue([]);
     renderLookup();
     await pick(user);
 
-    expect(await screen.findByText(/none in any place right now/i)).toBeInTheDocument();
+    expect(await screen.findByText('None available')).toBeInTheDocument();
+    expect(screen.queryByText(/not put away yet/i)).not.toBeInTheDocument();
   });
 
   it('surfaces a failed read instead of showing an empty answer', async () => {
@@ -215,7 +221,7 @@ describe('OperatorPartLookup — where it lives vs where it is piled', () => {
     expect(screen.getByText(/not put away yet/i)).toBeInTheDocument();
   });
 
-  it('still says nowhere when there is genuinely nothing anywhere', async () => {
+  it('still says not available when every row is a zero', async () => {
     const user = userEvent.setup();
     mockBalances.mockResolvedValue([
       shelf({ quantity: 0 }),
@@ -224,7 +230,7 @@ describe('OperatorPartLookup — where it lives vs where it is piled', () => {
     renderLookup();
     await pick(user);
 
-    expect(await screen.findByText(/none in any place right now/i)).toBeInTheDocument();
+    expect(await screen.findByText('None available')).toBeInTheDocument();
   });
 });
 

--- a/__tests__/utils/locationDestinations.test.ts
+++ b/__tests__/utils/locationDestinations.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Which locations may be offered as a destination.
+ *
+ * The case that earns its keep is the container. Before 20260806160053 every picker in the app
+ * offered a cabinet made only of Side 1 and Side 2 as somewhere to put a part, and the database
+ * now refuses that write — so an unfiltered option list turns into an error dialog on a choice the
+ * user should never have been shown. These assertions are what keep the guard invisible.
+ *
+ * The second case is the asymmetry: a container is exactly what a MOVE wants and exactly what a
+ * STOCK write must not have. Both rules are exercised against the same tree so the difference is
+ * visible in one read.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { stockDestinationOptions, locationParentOptions } from '@/utils/locationDestinations';
+import { rollUpOccupancy } from '@/utils/locationOccupancy';
+import type { InventoryLocation, InventoryLocationNode } from '@/types/inventoryLocations';
+
+/** The seed's shape: Cabinet 3 › Shelf A / Shelf B, plus a bare Yard and the put-away pile. */
+const loc = (
+  id: string,
+  name: string,
+  parent_id: string | null = null,
+  kind: string | null = null,
+): InventoryLocation =>
+  ({
+    id,
+    company_id: 'co1',
+    parent_id,
+    name,
+    kind,
+    sort_order: 0,
+    photo_path: null,
+    created_at: '',
+    updated_at: '',
+  }) as InventoryLocation;
+
+const CABINET = loc('cabinet', 'Cabinet 3');
+const SHELF_A = loc('shelf-a', 'Shelf A', 'cabinet');
+const SHELF_B = loc('shelf-b', 'Shelf B', 'cabinet');
+const YARD = loc('yard', 'Yard');
+const PILE = loc('pile', 'Unassigned', null, 'system');
+
+const TREE = [CABINET, SHELF_A, SHELF_B, YARD, PILE];
+
+const ids = (options: { id: string }[]) => options.map((o) => o.id);
+
+describe('stockDestinationOptions', () => {
+  it('never offers a location that has sub-locations', () => {
+    const options = stockDestinationOptions(TREE);
+
+    expect(ids(options)).not.toContain('cabinet');
+    expect(ids(options)).toEqual(expect.arrayContaining(['shelf-a', 'shelf-b', 'yard']));
+  });
+
+  it('never offers the put-away pile', () => {
+    expect(ids(stockDestinationOptions(TREE))).not.toContain('pile');
+  });
+
+  it('excludes the source location', () => {
+    expect(ids(stockDestinationOptions(TREE, { excludeId: 'shelf-a' }))).not.toContain('shelf-a');
+  });
+
+  it('labels each option with its full path, so "Shelf A" is never ambiguous', () => {
+    const shelf = stockDestinationOptions(TREE).find((o) => o.id === 'shelf-a');
+    expect(shelf?.label).toBe('Cabinet 3 › Shelf A');
+  });
+
+  it('sorts places already holding some of the part first', () => {
+    const options = stockDestinationOptions(TREE, {
+      balances: [{ location_id: 'yard', quantity: 12 } as never],
+    });
+
+    expect(ids(options)[0]).toBe('yard');
+    expect(options[0].quantity).toBe(12);
+  });
+
+  it('turns a leaf into a container the moment it gains a child', () => {
+    // The regression this guards: subdividing Shelf A must stop it being offered, without any
+    // caller remembering to re-derive anything.
+    const subdivided = [...TREE, loc('bin-1', 'Bin 1', 'shelf-a')];
+
+    expect(ids(stockDestinationOptions(subdivided))).not.toContain('shelf-a');
+    expect(ids(stockDestinationOptions(subdivided))).toContain('bin-1');
+  });
+});
+
+describe('locationParentOptions', () => {
+  /** Stock on Shelf B only — so Cabinet 3 rolls up as occupied while holding nothing itself. */
+  const occupancy = rollUpOccupancy(
+    [
+      {
+        ...CABINET,
+        depth: 0,
+        children: [
+          { ...SHELF_A, depth: 1, children: [] } as InventoryLocationNode,
+          { ...SHELF_B, depth: 1, children: [] } as InventoryLocationNode,
+        ],
+      } as InventoryLocationNode,
+      { ...YARD, depth: 0, children: [] } as InventoryLocationNode,
+    ],
+    new Map([['shelf-b', 3]]),
+  );
+
+  it('offers a container — which is the whole point of a move', () => {
+    // The opposite answer to stockDestinationOptions on the same node, which is why these are two
+    // functions rather than one with a flag.
+    expect(ids(locationParentOptions(TREE, { nodeId: 'yard', occupancy }))).toContain('cabinet');
+    expect(ids(stockDestinationOptions(TREE))).not.toContain('cabinet');
+  });
+
+  it('drops a location that holds stock directly, since it could never become a parent', () => {
+    expect(ids(locationParentOptions(TREE, { nodeId: 'yard', occupancy }))).not.toContain('shelf-b');
+  });
+
+  it('keeps a container whose stock is all in its children', () => {
+    // Rolled-up occupancy would exclude Cabinet 3 here and wrongly empty the list on a real shop.
+    expect(ids(locationParentOptions(TREE, { nodeId: 'yard', occupancy }))).toContain('cabinet');
+  });
+
+  it('excludes the node itself and everything under it', () => {
+    const options = ids(locationParentOptions(TREE, { nodeId: 'cabinet', occupancy }));
+
+    expect(options).not.toContain('cabinet');
+    expect(options).not.toContain('shelf-a');
+    expect(options).not.toContain('shelf-b');
+  });
+
+  it('never offers the put-away pile', () => {
+    expect(ids(locationParentOptions(TREE, { nodeId: 'yard', occupancy }))).not.toContain('pile');
+  });
+});

--- a/api/tests/integration/test_location_children_hold_no_stock.py
+++ b/api/tests/integration/test_location_children_hold_no_stock.py
@@ -1,0 +1,458 @@
+"""A place with sub-locations holds no stock — 20260806160053.
+
+WHAT THIS GUARDS. If Cabinet 1-A is just Side 1 and Side 2, nobody ever means "put it in the
+cabinet". Until 20260806160053 every layer allowed it: no picker filtered parents, no RPC checked,
+and nothing in the schema said otherwise. Two constraint triggers now close both directions —
+stock may only land on a leaf, and a location holding stock may not gain children.
+
+WHY THIS USES psycopg2 RATHER THAN THE SUPABASE CLIENT. One test here cannot be written through
+PostgREST at all. PostgREST runs one transaction per request, and the defect below needs two
+transactions open at once:
+
+    T1 inserts children under Cabinet 1-A, uncommitted. T2 inserts stock at Cabinet 1-A; its
+    EXISTS cannot see T1's uncommitted children, so it passes. T1's deferred check fires at its
+    own commit, cannot see T2's uncommitted stock row, so it passes. Both commit. A parent now
+    holds stock and NOTHING RAISED.
+
+That is textbook write skew, and it is why both trigger bodies take conflicting row locks
+(FOR SHARE on the stock side, FOR UPDATE on the structural side) before their EXISTS. Deferral does
+not help — a deferred trigger takes a fresh snapshot at commit, which still excludes an uncommitted
+transaction — and Postgres only detects write skew at SERIALIZABLE, which nothing here runs at.
+
+`test_concurrent_*` are therefore the tests that matter most in this file: **a version of the
+triggers with the row locks removed passes every other test here and fails only those two.** If you
+are tempted to simplify the locks away, delete them and watch.
+
+The RPC tests set `request.jwt.claims` and `SET ROLE authenticated` to reproduce exactly what
+PostgREST does per request, so they exercise the real EXECUTE grant and the real membership check
+rather than running as a superuser that would pass either way.
+
+Requires a local Supabase with all migrations applied. Skipped without it.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+from contextlib import contextmanager
+
+import psycopg2
+import pytest
+from psycopg2 import errors
+
+pytestmark = pytest.mark.integration
+
+# The Supabase CLI's fixed local port. Overridable for CI, and skipped rather than failed when
+# nothing is listening — same posture as the rest of this directory.
+DB_URL = os.getenv(
+    "TEST_SUPABASE_DB_URL", "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+)
+
+
+def _connect():
+    try:
+        return psycopg2.connect(DB_URL)
+    except psycopg2.OperationalError as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"No local Postgres at {DB_URL}: {exc}")
+
+
+@pytest.fixture
+def db():
+    conn = _connect()
+    conn.autocommit = True
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def shop(db):
+    """A company with: an empty container, a stocked leaf, a bare leaf, and the system pile.
+
+    `is_demo` so `company_can_write()` is true without a billing row — otherwise the billing gate
+    could mask the result a test is trying to assert.
+    """
+    company = str(uuid.uuid4())
+    user = str(uuid.uuid4())
+    with db.cursor() as cur:
+        cur.execute(
+            "INSERT INTO companies (id, name, is_demo) VALUES (%s, %s, true)",
+            (company, f"Container Test {company[:8]}"),
+        )
+        # A real auth user, so get_user_company_ids() resolves for the RPC tests.
+        cur.execute(
+            """
+            INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password,
+                                    email_confirmed_at, created_at, updated_at)
+            VALUES (%s, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
+                    %s, '', now(), now(), now())
+            """,
+            (user, f"container-{company[:8]}@test.jigged.local"),
+        )
+        cur.execute(
+            "INSERT INTO user_company_access (user_id, company_id, role) VALUES (%s, %s, 'admin')",
+            (user, company),
+        )
+        cur.execute("SELECT inv_get_or_create_unassigned(%s)", (company,))
+        unassigned = cur.fetchone()[0]
+
+        def location(name, parent=None):
+            cur.execute(
+                "INSERT INTO inventory_locations (company_id, parent_id, name) "
+                "VALUES (%s, %s, %s) RETURNING id",
+                (company, parent, name),
+            )
+            return cur.fetchone()[0]
+
+        container = location("Cabinet 1-A")
+        side_one = location("Side 1", container)
+        stocked = location("Shelf X")
+        bare = location("Yard")
+
+        # quantity 0 at creation so auto_track_stocked_part seeds nothing; the placement is then
+        # explicit. parts.quantity is a rollup, so it becomes 100 by trigger.
+        cur.execute(
+            """
+            INSERT INTO parts (company_id, part_name, source, is_stocked, primary_unit, quantity)
+            VALUES (%s, %s, 'bought', true, 'each', 0) RETURNING id
+            """,
+            (company, f"CONTAINER-{company[:8]}"),
+        )
+        part = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO part_location_stock (company_id, part_id, location_id, quantity) "
+            "VALUES (%s, %s, %s, 100)",
+            (company, part, stocked),
+        )
+
+    yield {
+        "company": company,
+        "user": user,
+        "container": container,
+        "side_one": side_one,
+        "stocked": stocked,
+        "bare": bare,
+        "unassigned": unassigned,
+        "part": part,
+    }
+
+    with db.cursor() as cur:
+        cur.execute("DELETE FROM part_location_stock WHERE company_id = %s", (company,))
+        cur.execute("DELETE FROM inventory_transactions WHERE company_id = %s", (company,))
+        cur.execute("DELETE FROM parts WHERE company_id = %s", (company,))
+        cur.execute(
+            "DELETE FROM inventory_locations WHERE company_id = %s AND parent_id IS NOT NULL",
+            (company,),
+        )
+        cur.execute("DELETE FROM inventory_locations WHERE company_id = %s", (company,))
+        cur.execute("DELETE FROM companies WHERE id = %s", (company,))
+        cur.execute("DELETE FROM auth.users WHERE id = %s", (user,))
+
+
+def _as_user(cur, user_id: str):
+    """Reproduce what PostgREST does per request: claims, then the browser role.
+
+    Both settings are transaction-local, so this only works on a connection with autocommit OFF —
+    on an autocommit connection `set_config(..., true)` expires with the statement that set it and
+    `get_user_company_ids()` silently resolves to nothing. Use `user_session` rather than calling
+    this against the shared `db` fixture.
+    """
+    cur.execute(
+        "SELECT set_config('request.jwt.claims', %s, true)",
+        (json.dumps({"sub": user_id, "role": "authenticated"}),),
+    )
+    cur.execute("SET LOCAL ROLE authenticated")
+
+
+@contextmanager
+def user_session(user_id: str):
+    """A transactional connection acting as `user_id`, the way a browser request would.
+
+    The caller commits; leaving it uncommitted is what the deferred-check test needs.
+    """
+    conn = _connect()  # autocommit stays off: the transaction IS the point
+    try:
+        with conn.cursor() as cur:
+            _as_user(cur, user_id)
+            yield conn, cur
+    finally:
+        conn.close()
+
+
+# ── Direction (a): stock may only land on a leaf ──────────────────────────────
+
+
+def test_stock_cannot_be_written_to_a_container(db, shop):
+    with pytest.raises(errors.CheckViolation, match="sub-locations"):
+        with db.cursor() as cur:
+            cur.execute(
+                "INSERT INTO part_location_stock (company_id, part_id, location_id, quantity) "
+                "VALUES (%s, %s, %s, 5)",
+                (shop["company"], shop["part"], shop["container"]),
+            )
+
+
+def test_stock_on_a_leaf_still_works(db, shop):
+    with db.cursor() as cur:
+        cur.execute(
+            "INSERT INTO part_location_stock (company_id, part_id, location_id, quantity) "
+            "VALUES (%s, %s, %s, 5)",
+            (shop["company"], shop["part"], shop["bare"]),
+        )
+        cur.execute(
+            "SELECT quantity FROM part_location_stock WHERE location_id = %s", (shop["bare"],)
+        )
+        assert cur.fetchone()[0] == 5
+
+
+# ── Direction (b): a stocked location may not gain children ───────────────────
+
+
+def test_child_cannot_be_added_under_a_stocked_location(db, shop):
+    with pytest.raises(errors.CheckViolation, match="holds stock"):
+        with db.cursor() as cur:
+            cur.execute(
+                "INSERT INTO inventory_locations (company_id, parent_id, name) VALUES (%s, %s, %s)",
+                (shop["company"], shop["stocked"], "Bin 1"),
+            )
+
+
+def test_location_cannot_be_reparented_into_a_stocked_location(db, shop):
+    with pytest.raises(errors.CheckViolation, match="holds stock"):
+        with db.cursor() as cur:
+            cur.execute(
+                "UPDATE inventory_locations SET parent_id = %s WHERE id = %s",
+                (shop["stocked"], shop["bare"]),
+            )
+
+
+def test_the_put_away_pile_can_never_be_divided(db, shop):
+    """`Unassigned` is where the importer and auto-track put homeless stock. Children would make it
+    unwritable and strand them, so it is refused even while empty."""
+    with pytest.raises(errors.CheckViolation, match="put-away pile"):
+        with db.cursor() as cur:
+            cur.execute(
+                "INSERT INTO inventory_locations (company_id, parent_id, name) VALUES (%s, %s, %s)",
+                (shop["company"], shop["unassigned"], "Nope"),
+            )
+
+
+def test_child_under_an_empty_container_still_works(db, shop):
+    with db.cursor() as cur:
+        cur.execute(
+            "INSERT INTO inventory_locations (company_id, parent_id, name) "
+            "VALUES (%s, %s, %s) RETURNING id",
+            (shop["company"], shop["container"], "Side 2"),
+        )
+        assert cur.fetchone()[0]
+
+
+# ── Concurrency: the pair only holds because the locks conflict ───────────────
+
+
+def _blocked_insert(url: str, sql: str, params: tuple, sink: list, opened: list):
+    """Run one statement on its own connection, leaving the transaction open.
+
+    The connection is handed to `opened` BEFORE the statement runs, so the test can close it even
+    when this thread is still blocked or has left a transaction open. Skipping that leaks an `idle
+    in transaction` backend holding row locks, and the fixture teardown's DELETE then blocks
+    forever — which is exactly how this file first hung.
+    """
+    conn = psycopg2.connect(url)
+    opened.append(conn)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql, params)
+        sink.append(("ok", None))
+    except Exception as exc:  # noqa: BLE001 - the exception IS the assertion
+        sink.append(("raised", exc))
+
+
+@pytest.mark.parametrize("commit_first", ["structure", "stock"])
+def test_concurrent_subdivide_and_stock_cannot_both_win(db, shop, commit_first):
+    """Two transactions, one bin. Whichever commits second must raise.
+
+    Without the row locks in the trigger bodies BOTH commit and the invariant breaks silently —
+    which is the entire reason those locks exist. This is the test that proves it.
+    """
+    target = shop["bare"]  # empty leaf: legal for either move, in isolation
+    add_child = (
+        "INSERT INTO inventory_locations (company_id, parent_id, name) VALUES (%s, %s, %s)",
+        (shop["company"], target, "Late Bin"),
+    )
+    add_stock = (
+        "INSERT INTO part_location_stock (company_id, part_id, location_id, quantity) "
+        "VALUES (%s, %s, %s, 7)",
+        (shop["company"], shop["part"], target),
+    )
+    first, second = (add_child, add_stock) if commit_first == "structure" else (add_stock, add_child)
+
+    winner = psycopg2.connect(DB_URL)
+    sink: list = []
+    opened: list = []
+    loser = threading.Thread(
+        target=_blocked_insert, args=(DB_URL, second[0], second[1], sink, opened)
+    )
+    try:
+        with winner.cursor() as cur:
+            cur.execute(*first)  # takes its row lock; does not commit yet
+
+        loser.start()
+        loser.join(timeout=3)
+
+        # The lock pair is what makes this true. Without it the second statement returns
+        # immediately, having seen nothing, and this is the assertion that fails.
+        assert loser.is_alive(), "second transaction did not block — the row locks do not conflict"
+
+        winner.commit()
+        loser.join(timeout=15)
+        assert not loser.is_alive(), "second transaction never unblocked"
+
+        assert sink, "second transaction produced no outcome"
+        outcome, payload = sink[0]
+        assert outcome == "raised", "second transaction was allowed to break the invariant"
+        assert isinstance(payload, errors.CheckViolation)
+    finally:
+        winner.rollback()
+        winner.close()
+        # Unblocks the loser if it is still waiting on the lock, then closes it either way —
+        # otherwise a failed assertion strands an open transaction and hangs teardown.
+        loser.join(timeout=15)
+        for conn in opened:
+            conn.close()
+
+
+# ── subdivide_location: the one caller allowed through the illegal state ──────
+
+
+def test_subdivide_moves_the_stock_down_and_commits(db, shop):
+    with user_session(shop["user"]) as (conn, cur):
+        cur.execute(
+            "SELECT id, name FROM subdivide_location(%s, %s::jsonb, %s::jsonb)",
+            (
+                shop["stocked"],
+                json.dumps(
+                    [
+                        {"ref": "a", "parent_ref": None, "name": "Bin 1", "sort_order": 0},
+                        {"ref": "b", "parent_ref": None, "name": "Bin 2", "sort_order": 1},
+                    ]
+                ),
+                json.dumps(
+                    [
+                        {
+                            "part_id": shop["part"],
+                            "to_ref": "a",
+                            "quantity": 60,
+                            "unit": "each",
+                            "converted_quantity": 60,
+                        },
+                        {
+                            "part_id": shop["part"],
+                            "to_ref": "b",
+                            "quantity": 40,
+                            "unit": "each",
+                            "converted_quantity": 40,
+                        },
+                    ]
+                ),
+            ),
+        )
+        created = {name: loc_id for loc_id, name in cur.fetchall()}
+        conn.commit()  # the deferred check runs here, and must pass
+
+    assert set(created) == {"Bin 1", "Bin 2"}
+
+    with db.cursor() as cur:
+        cur.execute(
+            "SELECT location_id, quantity FROM part_location_stock WHERE part_id = %s",
+            (shop["part"],),
+        )
+        balances = dict(cur.fetchall())
+        # The parent kept nothing — that is the invariant, checked at COMMIT.
+        assert shop["stocked"] not in balances
+        assert balances[created["Bin 1"]] == 60
+        assert balances[created["Bin 2"]] == 40
+
+        # The rollup is untouched: this moved stock, it did not create or destroy any.
+        cur.execute("SELECT quantity FROM parts WHERE id = %s", (shop["part"],))
+        assert cur.fetchone()[0] == 100
+
+        # Delegating to transfer_stock means a normal paired ledger, not a bespoke one.
+        cur.execute(
+            "SELECT count(*), count(DISTINCT transfer_group_id) FROM inventory_transactions "
+            "WHERE part_id = %s",
+            (shop["part"],),
+        )
+        assert cur.fetchone() == (4, 2)
+
+
+def test_subdivide_with_an_incomplete_distribution_rolls_everything_back(db, shop):
+    """Leaving stock behind on the new parent must take the sub-locations down with it.
+
+    The check is deferred, so the RPC itself returns happily and the failure lands at COMMIT. What
+    matters is that nothing survives — a half-applied subdivide would leave a container holding
+    stock, which is the state this whole migration exists to make unreachable.
+    """
+    with user_session(shop["user"]) as (conn, cur):
+        cur.execute(
+            "SELECT id FROM subdivide_location(%s, %s::jsonb, %s::jsonb)",
+            (
+                shop["stocked"],
+                json.dumps([{"ref": "a", "parent_ref": None, "name": "Bin 1"}]),
+                json.dumps(
+                    [
+                        {
+                            "part_id": shop["part"],
+                            "to_ref": "a",
+                            "quantity": 60,  # 40 left behind on the parent
+                            "unit": "each",
+                            "converted_quantity": 60,
+                        }
+                    ]
+                ),
+            ),
+        )
+        assert cur.fetchone(), "the RPC should succeed; the deferred check fires at COMMIT"
+
+        with pytest.raises(errors.CheckViolation, match="sub-locations"):
+            conn.commit()
+        conn.rollback()
+
+    with db.cursor() as cur:
+        cur.execute(
+            "SELECT count(*) FROM inventory_locations WHERE parent_id = %s", (shop["stocked"],)
+        )
+        assert cur.fetchone()[0] == 0, "the sub-locations survived a rolled-back subdivide"
+        cur.execute(
+            "SELECT quantity FROM part_location_stock WHERE location_id = %s", (shop["stocked"],)
+        )
+        assert cur.fetchone()[0] == 100
+
+
+def test_subdivide_is_refused_to_a_non_member(db, shop):
+    """SECURITY DEFINER bypasses RLS, so the membership check inside the body is the only tenant
+    boundary this RPC has."""
+    outsider = str(uuid.uuid4())
+    with db.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password,
+                                    email_confirmed_at, created_at, updated_at)
+            VALUES (%s, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
+                    %s, '', now(), now(), now())
+            """,
+            (outsider, f"outsider-{outsider[:8]}@test.jigged.local"),
+        )
+    try:
+        with pytest.raises(errors.InsufficientPrivilege, match="access denied"):
+            with user_session(outsider) as (_conn, cur):
+                cur.execute(
+                    "SELECT id FROM subdivide_location(%s, %s::jsonb)",
+                    (
+                        shop["container"],
+                        json.dumps([{"ref": "a", "parent_ref": None, "name": "Side 2"}]),
+                    ),
+                )
+    finally:
+        with db.cursor() as cur:
+            cur.execute("DELETE FROM auth.users WHERE id = %s", (outsider,))

--- a/app/dashboard/[companyId]/inventory/count/page.tsx
+++ b/app/dashboard/[companyId]/inventory/count/page.tsx
@@ -100,9 +100,10 @@ import {
 import {
   commitCount,
   loadCountCandidates,
-  loadLocationCountCandidates,
+  loadCountCandidatesForPlaces,
   loadPartAtLocationCandidate,
   loadPartEverywhereCandidates,
+  type CountPlace,
 } from '@/utils/inventoryCountAccess';
 import PartAutocomplete, { type PartSelectOption } from '@/components/parts/PartAutocomplete';
 import { getCurrentMember } from '@/utils/operatorAccess';
@@ -114,6 +115,8 @@ import {
   getBalancesForParts,
   getLocations,
 } from '@/utils/inventoryLocationsAccess';
+import { stockDestinationOptions } from '@/utils/locationDestinations';
+import { computePathNames } from '@/lib/locationTree';
 import LocationPicker, {
   type LocationPickerOption,
 } from '@/components/inventory/locations/LocationPicker';
@@ -292,6 +295,14 @@ export default function InventoryCountPage() {
 
   /** Parts held at this location in total — may exceed the page, so the UI can say so. */
   const [hereTotal, setHereTotal] = useState(0);
+  /**
+   * True when `?location=` names a container, so the sheet spans the bins beneath it.
+   *
+   * Gates the bulk put-away below: `bulk_put_away` moves parts FROM one location, and on a subtree
+   * sheet the ticked rows come from several. Counting is unaffected — every line already commits at
+   * its own bin — so this hides one control rather than restricting the sheet.
+   */
+  const [countingSubtree, setCountingSubtree] = useState(false);
 
   /** Put-away state: the destination, and whether a move is in flight. */
   const [moveTo, setMoveTo] = useState<LocationPickerOption | null>(null);
@@ -399,9 +410,43 @@ export default function InventoryCountPage() {
             return;
           }
 
-          const { candidates: found, total } = await loadLocationCountCandidates(
-            locationId,
-            here.name,
+          /*
+           * A container is counted through its bins.
+           *
+           * Since 20260806160053 a place with sub-locations holds no stock of its own, so a
+           * one-bin sheet for a cabinet would be permanently blank. "Count Cabinet 1-A" means the
+           * bins under it — which is also how you would physically do it, walking bin to bin — and
+           * `commitCount` already writes each line at its own `target.locationId`, so a sheet
+           * spanning ten bins needs no new write path.
+           *
+           * A leaf resolves to a one-element list, i.e. exactly what this always did.
+           */
+          const byId = new Map(locations.map((l) => [l.id, l] as const));
+          const childrenOf = (id: string) => locations.filter((l) => l.parent_id === id);
+          const leaves: CountPlace[] = [];
+          const walk = (node: InventoryLocation) => {
+            const kids = childrenOf(node.id);
+            if (kids.length === 0) {
+              leaves.push({
+                id: node.id,
+                name: node.name,
+                // Full path once a sheet spans several bins — the page title can no longer say
+                // which place a row belongs to. A single bin keeps its bare name.
+                path: computePathNames(node.id, byId).join(' › ') || node.name,
+              });
+              return;
+            }
+            [...kids]
+              .sort((a, b) => a.sort_order - b.sort_order || a.name.localeCompare(b.name))
+              .forEach(walk);
+          };
+          walk(here);
+          setCountingSubtree(leaves.length > 1 || leaves[0]?.id !== here.id);
+
+          const { candidates: found, total } = await loadCountCandidatesForPlaces(
+            leaves.length === 1 && leaves[0].id === here.id
+              ? [{ id: here.id, name: here.name, path: here.name }]
+              : leaves,
             { search: serverSearch, offset: page * LOCATION_PAGE_SIZE, limit: LOCATION_PAGE_SIZE },
           );
           if (cancelled) return;
@@ -791,7 +836,9 @@ export default function InventoryCountPage() {
    * is worse than no move at all, because you can't tell what you already did.
    */
   const putAway = async () => {
-    if (!locationId || !moveTo || selected.size === 0) return;
+    // `countingSubtree`: the RPC moves parts out of ONE location, and here the ticked rows come
+    // from several bins. The control is hidden in that mode; this is the backstop.
+    if (!locationId || !moveTo || selected.size === 0 || countingSubtree) return;
     setMoving(true);
     try {
       // `.values()`, not `.keys()`: the map is keyed by row now, and the RPC wants part ids.
@@ -813,9 +860,8 @@ export default function InventoryCountPage() {
       setReloadKey((k) => k + 1);
       setEntries({});
       setMoveTo(null);
-      const { candidates: found, total } = await loadLocationCountCandidates(
-        locationId,
-        locationName,
+      const { candidates: found, total } = await loadCountCandidatesForPlaces(
+        [{ id: locationId, name: locationName, path: locationName }],
         { search: serverSearch },
       );
       setCandidates(found);
@@ -885,25 +931,16 @@ export default function InventoryCountPage() {
     }
   };
 
-  /** Every location, for the destination picker and for "+ Count it somewhere else". */
-  const destinationOptions = useMemo<LocationPickerOption[]>(() => {
-    const byId = new Map(allLocations.map((l) => [l.id, l] as const));
-    const pathOf = (id: string): string => {
-      const names: string[] = [];
-      let cursor: string | null = id;
-      const guard = new Set<string>();
-      while (cursor && byId.has(cursor) && !guard.has(cursor)) {
-        guard.add(cursor);
-        const n: InventoryLocation = byId.get(cursor)!;
-        names.unshift(n.name);
-        cursor = n.parent_id;
-      }
-      return names.join(' › ');
-    };
-    return allLocations
-      .map((l) => ({ id: l.id, label: pathOf(l.id), kind: l.kind }))
-      .sort((a, b) => a.label.localeCompare(b.label));
-  }, [allLocations]);
+  /**
+   * Where a count may write, for the destination picker and for "+ Count it somewhere else".
+   *
+   * Containers are excluded: since 20260806160053 stock cannot sit at a place that has
+   * sub-locations, so counting one could only ever commit zero rows or raise.
+   */
+  const destinationOptions = useMemo<LocationPickerOption[]>(
+    () => stockDestinationOptions(allLocations),
+    [allLocations],
+  );
 
   const createDestination = async (name: string): Promise<LocationPickerOption> => {
     const created = await createLocation(companyId, { name });
@@ -1078,8 +1115,14 @@ export default function InventoryCountPage() {
                 </Button>
               </Box>
 
-              {/* ── Put away: the other thing you do standing at a bin ─────────── */}
-              {locationMode && (
+              {/* ── Put away: the other thing you do standing at a bin ───────────
+
+                  Withheld on a subtree sheet. `bulk_put_away` moves parts out of ONE location, and
+                  when you are counting a whole cabinet the ticked rows come from several bins — so
+                  "send the ticked parts to…" has no single source to send them from. Counting is
+                  unaffected; each line still commits at its own bin. Putting away stays available
+                  one level down, standing at the bin, which is where it belongs anyway. */}
+              {locationMode && !countingSubtree && (
                 <Card elevation={2} sx={{ mb: 3 }}>
                   <CardContent
                     sx={{ display: 'flex', gap: 2, alignItems: 'flex-start', flexWrap: 'wrap' }}

--- a/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
+++ b/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
@@ -22,7 +22,7 @@ import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
 
 import { resolveScan, getLocations, getLocationHistory } from '@/utils/inventoryLocationsAccess';
-import type { InventoryLocation } from '@/types/inventoryLocations';
+import { stockDestinationOptions } from '@/utils/locationDestinations';
 import { getCurrentMember } from '@/utils/operatorAccess';
 import { useSetOperatorChrome } from '@/components/operator/OperatorChromeContext';
 import { getStandardUnitsForUnit } from '@/lib/unitPresets';
@@ -116,27 +116,12 @@ export default function OperatorBinViewPage() {
   };
 
   const { data: allLocations } = useLoad(() => getLocations(companyId), [companyId]);
-  const moveDestinations = useMemo(() => {
-    const list = allLocations ?? [];
-    const byId = new Map(list.map((l) => [l.id, l] as const));
-    const pathOf = (id: string): string => {
-      const names: string[] = [];
-      let cursor: string | null = id;
-      const guard = new Set<string>();
-      while (cursor && byId.has(cursor) && !guard.has(cursor)) {
-        guard.add(cursor);
-        const n: InventoryLocation = byId.get(cursor)!;
-        names.unshift(n.name);
-        cursor = n.parent_id;
-      }
-      return names.join(' › ');
-    };
-    // The current location and the `Unassigned` bucket are both dropped by `LocationPicker` now
-    // (`excludeId` / `excludeSystem`), so this only has to build the labelled list.
-    return list
-      .map((l) => ({ id: l.id, label: pathOf(l.id), kind: l.kind }))
-      .sort((a, b) => a.label.localeCompare(b.label));
-  }, [allLocations]);
+  // Containers, the `Unassigned` pile and this bin itself are all dropped by the shared rule —
+  // a container cannot hold stock, so moving stock into one would only raise on arrival.
+  const moveDestinations = useMemo(
+    () => stockDestinationOptions(allLocations ?? [], { excludeId: locationId }),
+    [allLocations, locationId],
+  );
 
   const modalUnit = modal?.part.primary_unit || 'ea';
   const unitOptions = useMemo(
@@ -206,7 +191,21 @@ export default function OperatorBinViewPage() {
         </Box>
       )}
 
-      {/* Stock here: act on each part */}
+      {/*
+        A container has no "Stock here" section at all.
+
+        It used to render one, with a "Stock a part" button, above the line "No stock recorded
+        directly here — open a sub-location above." That line was describing a state the button
+        beside it invited you to break, and since 20260806160053 the database refuses the write —
+        so the button now leads to an error rather than a mistake. Neither is worth showing.
+        The sub-locations above are the whole answer for a container, and one line under them says
+        so instead.
+      */}
+      {children.length > 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Stock goes in the sub-locations above, not in {node.name} itself.
+        </Typography>
+      ) : (
       <Box>
         <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
           <Typography variant="overline" color="text.secondary" sx={{ flex: 1 }}>
@@ -220,11 +219,7 @@ export default function OperatorBinViewPage() {
           <Card elevation={2} sx={{ mt: 0.5 }}>
             <CardContent sx={{ textAlign: 'center', py: 4 }}>
               <Inventory2OutlinedIcon sx={{ fontSize: 40, color: 'text.disabled', mb: 1 }} />
-              <Typography color="text.secondary">
-                {children.length > 0
-                  ? 'No stock recorded directly here — open a sub-location above.'
-                  : 'Nothing stored here yet.'}
-              </Typography>
+              <Typography color="text.secondary">Nothing stored here yet.</Typography>
             </CardContent>
           </Card>
         ) : (
@@ -314,6 +309,7 @@ export default function OperatorBinViewPage() {
           </Stack>
         )}
       </Box>
+      )}
 
       {/* Recent movements, last. The contents above answer "what is here now"; this answers
           "what happened here", including the photo whoever moved it left behind. Before this there
@@ -346,16 +342,20 @@ export default function OperatorBinViewPage() {
         />
       )}
 
-      <OperatorReceivePartModal
-        open={receiveOpen}
-        companyId={companyId}
-        locationId={node.id}
-        locationName={node.name}
-        excludePartIds={contents.map((c) => c.part_id)}
-        operatorId={operatorId}
-        onClose={() => setReceiveOpen(false)}
-        onDone={reloadAll}
-      />
+      {/* Not mounted for a container — there is no button to open it, and a modal that could only
+          ever write somewhere the database refuses has no reason to exist on this page. */}
+      {children.length === 0 && (
+        <OperatorReceivePartModal
+          open={receiveOpen}
+          companyId={companyId}
+          locationId={node.id}
+          locationName={node.name}
+          excludePartIds={contents.map((c) => c.part_id)}
+          operatorId={operatorId}
+          onClose={() => setReceiveOpen(false)}
+          onDone={reloadAll}
+        />
+      )}
     </Box>
   );
 }

--- a/components/inventory/locations/LocationTable.tsx
+++ b/components/inventory/locations/LocationTable.tsx
@@ -30,6 +30,10 @@
  * a four-level tree was already partly invisible. Depth reads two ways — indentation, and the full
  * breadcrumb in the detail drawer.
  *
+ * **You traverse one branch at a time.** Opening a place closes whatever else was open, so the
+ * table never shows two siblings' contents at once and indentation never has to carry more than a
+ * single chain. See `openPath` below for why that is a path and not a set of expanded ids.
+ *
  * There was an `Inside` column too, counting child places. It went because the chevron already
  * says a row has children and the drawer already lists them, so it was a third telling of the
  * same fact — and on a flat shop (the reparenting decision measured 118 of 121 as flat) it is a
@@ -116,17 +120,24 @@ function FillDot({ filled }: { filled: boolean }) {
   );
 }
 
-/** One row per node, parents before children, depth carried for indentation. */
+/**
+ * One row per node, parents before children, depth carried for indentation.
+ *
+ * `ancestors` rides along so a row can compute what the open path becomes when its chevron is
+ * clicked, without a second walk to find where it sits.
+ */
 function flatten(
   nodes: InventoryLocationNode[],
-  collapsed: ReadonlySet<string>,
+  openPath: readonly string[],
   depth = 0,
-): Array<{ node: InventoryLocationNode; depth: number }> {
-  const out: Array<{ node: InventoryLocationNode; depth: number }> = [];
+  ancestors: readonly string[] = [],
+): Array<{ node: InventoryLocationNode; depth: number; ancestors: readonly string[] }> {
+  const out: Array<{ node: InventoryLocationNode; depth: number; ancestors: readonly string[] }> =
+    [];
   for (const node of [...nodes].sort(placeOrder)) {
-    out.push({ node, depth });
-    if (node.children.length > 0 && !collapsed.has(node.id)) {
-      out.push(...flatten(node.children, collapsed, depth + 1));
+    out.push({ node, depth, ancestors });
+    if (node.children.length > 0 && openPath.includes(node.id)) {
+      out.push(...flatten(node.children, openPath, depth + 1, [...ancestors, node.id]));
     }
   }
   return out;
@@ -143,22 +154,36 @@ export interface LocationTableProps {
 
 export default function LocationTable({ tree, occupancy, onOpen, onCountHere }: LocationTableProps) {
   /**
-   * Collapsed, not expanded: the default is everything visible.
+   * ONE open branch in the whole table, held as the chain of ids from a root down to the deepest
+   * open node. Empty means roots only.
    *
-   * At 12–18 places the whole shop fits on one screen, and a tree that starts closed makes you
-   * click to discover you have nothing to discover. Collapsing is for the shop that grows.
+   * ## Why this replaced "everything starts expanded"
+   *
+   * The previous state was a set of *collapsed* ids defaulting to empty, on the reasoning that at
+   * 12–18 places the whole shop fits on one screen and a tree that starts closed makes you click
+   * to discover you have nothing to discover. That reasoning does not survive contact with a
+   * generated cabinet: the builder's own default is 5 rows × 2 bins, so **one** subdivide turns a
+   * single row into 16, and a shop with three such cabinets renders 50 rows of which two matter.
+   * You are not reading a shop, you are scrolling past one.
+   *
+   * An accordion also cannot express "everything expanded" — siblings would start co-open, which
+   * is precisely the state being removed — so default-collapsed is not a separate decision, it is
+   * the same one.
+   *
+   * ## Why a path rather than a set
+   *
+   * "At most one open node per parent" and "at most one open branch overall" differ only in what
+   * happens to a second root, and a path makes the stricter answer the only representable one:
+   * opening a node sets the path to its own ancestry plus itself, so anything not on that chain is
+   * closed by construction rather than by a cleanup pass that could be forgotten.
    */
-  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set());
+  const [openPath, setOpenPath] = useState<readonly string[]>([]);
 
-  const rows = useMemo(() => flatten(tree, collapsed), [tree, collapsed]);
+  const rows = useMemo(() => flatten(tree, openPath), [tree, openPath]);
 
-  const toggleCollapse = (id: string) =>
-    setCollapsed((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
+  /** Open this node (closing whatever else was open), or close it and keep its ancestors open. */
+  const toggleOpen = (id: string, ancestors: readonly string[]) =>
+    setOpenPath((prev) => (prev.includes(id) ? [...ancestors] : [...ancestors, id]));
 
   return (
     <TableContainer component={Paper} elevation={2}>
@@ -171,10 +196,11 @@ export default function LocationTable({ tree, occupancy, onOpen, onCountHere }: 
           </TableRow>
         </TableHead>
         <TableBody>
-          {rows.map(({ node, depth }) => {
+          {rows.map(({ node, depth, ancestors }) => {
             const occ = occupancyFor(occupancy, node.id);
             const isSystem = node.kind === SYSTEM_KIND;
             const countLabel = isSystem ? `Put away from ${node.name}` : `Count ${node.name}`;
+            const isOpen = openPath.includes(node.id);
             return (
               <Fragment key={node.id}>
                 {/*
@@ -204,11 +230,12 @@ export default function LocationTable({ tree, occupancy, onOpen, onCountHere }: 
                           // The row opens the place; this must not also do that.
                           onClick={(e) => {
                             e.stopPropagation();
-                            toggleCollapse(node.id);
+                            toggleOpen(node.id, ancestors);
                           }}
-                          aria-label={
-                            collapsed.has(node.id) ? `Expand ${node.name}` : `Collapse ${node.name}`
-                          }
+                          aria-label={isOpen ? `Collapse ${node.name}` : `Expand ${node.name}`}
+                          // Says the same thing to assistive tech that the chevron says visually.
+                          // The label alone flips wording without ever announcing a state.
+                          aria-expanded={isOpen}
                           /*
                            * 48px, like the count button at the end of this row — and for the same
                            * reason its comment gives: the theme applies the design system's 48px
@@ -222,10 +249,10 @@ export default function LocationTable({ tree, occupancy, onOpen, onCountHere }: 
                            */
                           sx={{ width: 48, height: 48, mr: 0.5 }}
                         >
-                          {collapsed.has(node.id) ? (
-                            <KeyboardArrowRightIcon fontSize="small" />
-                          ) : (
+                          {isOpen ? (
                             <KeyboardArrowDownIcon fontSize="small" />
+                          ) : (
+                            <KeyboardArrowRightIcon fontSize="small" />
                           )}
                         </IconButton>
                       ) : (
@@ -282,7 +309,15 @@ export default function LocationTable({ tree, occupancy, onOpen, onCountHere }: 
                   </TableCell>
 
                   <TableCell align="right">
-                    {/* Tooltip and accessible name must agree. They didn't: sighted users read
+                    {/* Offered on containers too, where it counts everything in the bins beneath.
+
+                        A container holds no stock of its own (20260806160053), so this briefly did
+                        nothing and was briefly hidden. Both were wrong: "count this cabinet"
+                        obviously means its bins, which is also how you would physically do it, and
+                        `commitCount` already writes each line at its own bin — so the worksheet
+                        needed a wider read, not the button taking away.
+
+                        Tooltip and accessible name must agree. They didn't: sighted users read
                         "Put away from Unassigned" while a screen reader said "Count Unassigned".
                         The worksheet does both, and at the pile putting away is the real job. */}
                     <Tooltip title={countLabel}>

--- a/components/inventory/locations/LocationsManager.tsx
+++ b/components/inventory/locations/LocationsManager.tsx
@@ -33,6 +33,7 @@ import {
   clearLocationPhoto,
 } from '@/utils/inventoryLocationsAccess';
 import { rollUpOccupancy, occupancyFor } from '@/utils/locationOccupancy';
+import { locationParentOptions } from '@/utils/locationDestinations';
 import { generateLocationLabelSheet, type LocationLabel } from '@/utils/locationLabelPdf';
 import LocationFormModal, { type LocationFormValues } from './LocationFormModal';
 import LocationPicker, { type LocationPickerOption } from './LocationPicker';
@@ -279,6 +280,13 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
    * The options exclude the node itself AND its descendants. `moveLocation` refuses a cycle
    * anyway, but offering a destination that will be rejected is a worse experience than not
    * offering it — the guard is the backstop, not the interface.
+   *
+   * Same reasoning now excludes any place holding stock DIRECTLY. Since 20260806160053 a location
+   * that holds stock cannot become a container, and unlike "Divide it up…" a Move has no
+   * distribution step to hang on it — so the database simply refuses. A cabinet whose *shelves*
+   * are full is still a fine destination, which is why `locationParentOptions` reads `directParts`
+   * rather than the rolled-up `hasStock`: the latter would exclude every populated cabinet in the
+   * shop and quietly empty this list.
    */
   const [moveState, setMoveState] = useState<{ open: boolean; node: InventoryLocationNode | null }>({
     open: false,
@@ -290,27 +298,11 @@ export default function LocationsManager({ companyId, companyName }: LocationsMa
   const moveOptions = useMemo<LocationPickerOption[]>(() => {
     const node = moveState.node;
     if (!node) return [];
-    const banned = new Set<string>([node.id]);
-    // One pass is enough: `locations` is parent-before-child by `sort_order` only by accident, so
-    // walk ancestry per row instead of trusting order.
-    const isUnder = (id: string | null): boolean => {
-      let cursor = id;
-      const guard = new Set<string>();
-      while (cursor && !guard.has(cursor)) {
-        if (cursor === node.id) return true;
-        guard.add(cursor);
-        cursor = byId.get(cursor)?.parent_id ?? null;
-      }
-      return false;
-    };
     return [
       { id: TOP_LEVEL, label: 'Top level (not inside anything)', kind: null },
-      ...locations
-        .filter((l) => !banned.has(l.id) && !isUnder(l.parent_id))
-        .map((l) => ({ id: l.id, label: computePath(l.id, byId).join(' › '), kind: l.kind }))
-        .sort((a, b) => a.label.localeCompare(b.label)),
+      ...locationParentOptions(locations, { nodeId: node.id, occupancy }),
     ];
-  }, [moveState.node, locations, byId]);
+  }, [moveState.node, locations, occupancy]);
 
   const confirmMove = async () => {
     const node = moveState.node;

--- a/components/inventory/locations/board/LocationDetailSheet.tsx
+++ b/components/inventory/locations/board/LocationDetailSheet.tsx
@@ -261,7 +261,12 @@ export default function LocationDetailSheet({
 
           {/* The one recurring action, so it leads — and it's offered for the system bucket too,
               where it's the *only* thing you can do and the most important thing on the page.
-              Everything below is setup you do once when the shelf arrives. */}
+              Everything below is setup you do once when the shelf arrives.
+
+              On a container it counts everything in the bins beneath — a container holds no stock
+              of its own (20260806160053), so the worksheet gathers its leaves. It says "Count
+              what's inside" there, because "put away" is a single-bin action and the subtree sheet
+              withholds it: there is no one source to send the ticked parts from. */}
           <Button
             fullWidth
             variant="contained"
@@ -269,7 +274,11 @@ export default function LocationDetailSheet({
             onClick={() => actions.onCountHere(node)}
             sx={{ mb: 2 }}
           >
-            {node.kind === 'system' ? 'Put these away' : 'Count or put away'}
+            {node.kind === 'system'
+              ? 'Put these away'
+              : node.children.length > 0
+                ? "Count what's inside"
+                : 'Count or put away'}
           </Button>
 
           {node.children.length > 0 && (
@@ -335,14 +344,23 @@ export default function LocationDetailSheet({
                   Divide it up…
                 </Button>
                 <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                  <Button
-                    variant="outlined"
-                    startIcon={<AddIcon />}
-                    onClick={() => actions.onAddChild(node)}
-                    sx={{ flex: 1, minWidth: 150 }}
-                  >
-                    Add one inside
-                  </Button>
+                  {/* Withheld while this place holds stock DIRECTLY.
+
+                      "Add one inside" goes through the plain create form, which has nowhere to ask
+                      the question a loaded shelf raises — since 20260806160053 a place cannot hold
+                      stock and sub-locations at once, so the create would simply be refused. "Divide
+                      it up…" above is the same operation with that question attached, and its spec
+                      can be pruned to a single node, so nothing is unreachable. */}
+                  {occupancyFor(occupancy, node.id).directParts === 0 && (
+                    <Button
+                      variant="outlined"
+                      startIcon={<AddIcon />}
+                      onClick={() => actions.onAddChild(node)}
+                      sx={{ flex: 1, minWidth: 150 }}
+                    >
+                      Add one inside
+                    </Button>
+                  )}
                   <Button
                     variant="outlined"
                     startIcon={<QrCode2Icon />}

--- a/components/inventory/locations/builder/DistributeContentsStep.tsx
+++ b/components/inventory/locations/builder/DistributeContentsStep.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+/**
+ * "Where does each part go?" — the second step of a subdivide, shown only when the place being
+ * divided already holds stock.
+ *
+ * ## Why this step exists at all
+ *
+ * Since 20260806160053 a place with sub-locations holds no stock, so dividing up a loaded shelf has
+ * to say what happens to what is on it. Three answers were considered:
+ *
+ * - **Refuse until it is empty.** Honest, and it makes the common case ("I just built these bins,
+ *   now let me use them") a detour through a separate put-away worksheet.
+ * - **Sweep it all into `Unassigned`.** Never blocks, and silently declares stock homeless — the
+ *   shelf you were organising becomes a pile someone else has to re-place.
+ * - **Ask.** Which is this, because the person subdividing is standing at the shelf and is the only
+ *   one who knows which side the bearings ended up on.
+ *
+ * ## Splitting is the point, not a nicety
+ *
+ * Assigning each part to exactly one bin would be the easy version and would be wrong for the case
+ * that motivates subdividing in the first place: you divide a shelf *because* what is on it is
+ * already in two piles. So a part can be split across several destinations, and the sum is checked
+ * against what is actually on hand.
+ *
+ * The check is not politeness. `subdivide_location` defers the invariant to COMMIT, so an
+ * incomplete distribution does not half-apply — it rolls the whole subdivide back, sub-locations
+ * and all. Catching it here turns a mystifying failure into an arithmetic hint.
+ *
+ * ## "Send everything to…" is required, not a shortcut
+ *
+ * `getLocationContents` returns up to `LOCATION_CONTENTS_LIMIT` (200) parts, and a 200-row table
+ * where every row needs a decision is not a UI, it is a punishment. One picker that fills every row
+ * makes the overwhelmingly common intent — "it all goes in Bin 1, I will sort it later" — a single
+ * interaction, and leaves the per-part table for the rows that differ.
+ */
+
+import { useMemo } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import AddIcon from '@mui/icons-material/Add';
+import CloseIcon from '@mui/icons-material/Close';
+
+import type { LocationContent } from '@/types/inventoryLocations';
+
+/** One part's stock going to one spec leaf. Several lines per part means a split. */
+export interface Assignment {
+  toRef: string;
+  quantity: number;
+}
+
+export type AssignmentMap = Record<string, Assignment[]>;
+
+export interface SpecLeaf {
+  key: string;
+  label: string;
+}
+
+const num = (n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 4 });
+
+/**
+ * Quantities are `numeric` in Postgres and floats here, so `0.1 + 0.2 !== 0.3` decides whether the
+ * Create button is enabled. The tolerance is well below any real unit's meaningful precision and
+ * well above float noise.
+ */
+const EPSILON = 1e-9;
+
+export function assignedTotal(lines: Assignment[] = []): number {
+  return lines.reduce((sum, l) => sum + (Number.isFinite(l.quantity) ? l.quantity : 0), 0);
+}
+
+/** Every part fully placed, and nothing sent to a destination that was never chosen. */
+export function isDistributionComplete(
+  contents: LocationContent[],
+  assignments: AssignmentMap,
+): boolean {
+  return contents.every((c) => {
+    const lines = assignments[c.part_id] ?? [];
+    return (
+      lines.length > 0 &&
+      lines.every((l) => l.toRef !== '' && l.quantity > 0) &&
+      Math.abs(assignedTotal(lines) - c.quantity) < EPSILON
+    );
+  });
+}
+
+export interface DistributeContentsStepProps {
+  parentName: string;
+  contents: LocationContent[];
+  leaves: SpecLeaf[];
+  assignments: AssignmentMap;
+  onChange: (next: AssignmentMap) => void;
+}
+
+export default function DistributeContentsStep({
+  parentName,
+  contents,
+  leaves,
+  assignments,
+  onChange,
+}: DistributeContentsStepProps) {
+  const complete = useMemo(
+    () => isDistributionComplete(contents, assignments),
+    [contents, assignments],
+  );
+
+  /** Put every part's whole balance in one place. The "I'll sort it later" path. */
+  const sendEverythingTo = (toRef: string) => {
+    const next: AssignmentMap = {};
+    for (const c of contents) next[c.part_id] = [{ toRef, quantity: c.quantity }];
+    onChange(next);
+  };
+
+  const setLine = (partId: string, index: number, patch: Partial<Assignment>) => {
+    const lines = [...(assignments[partId] ?? [])];
+    lines[index] = { ...lines[index], ...patch };
+    onChange({ ...assignments, [partId]: lines });
+  };
+
+  const addLine = (partId: string) => {
+    const lines = assignments[partId] ?? [];
+    const remaining =
+      (contents.find((c) => c.part_id === partId)?.quantity ?? 0) - assignedTotal(lines);
+    onChange({
+      ...assignments,
+      // Pre-filled with what is left over, which is the amount you are almost always about to type.
+      [partId]: [...lines, { toRef: '', quantity: Math.max(remaining, 0) }],
+    });
+  };
+
+  const removeLine = (partId: string, index: number) => {
+    const lines = (assignments[partId] ?? []).filter((_, i) => i !== index);
+    onChange({ ...assignments, [partId]: lines });
+  };
+
+  return (
+    <Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        {parentName} holds {contents.length} {contents.length === 1 ? 'part' : 'parts'}. A place with
+        sub-locations can&apos;t hold stock itself, so each one needs somewhere to go.
+      </Typography>
+
+      <TextField
+        select
+        fullWidth
+        size="small"
+        label="Send everything to…"
+        value=""
+        onChange={(e) => sendEverythingTo(e.target.value)}
+        helperText="Fills every row below. Change individual parts afterwards."
+        sx={{ mb: 3, maxWidth: 420 }}
+      >
+        {leaves.map((leaf) => (
+          <MenuItem key={leaf.key} value={leaf.key}>
+            {leaf.label}
+          </MenuItem>
+        ))}
+      </TextField>
+
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ fontWeight: 600 }}>Part</TableCell>
+            <TableCell sx={{ fontWeight: 600 }} align="right">
+              On hand
+            </TableCell>
+            <TableCell sx={{ fontWeight: 600 }}>Goes to</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {contents.map((content) => {
+            const lines = assignments[content.part_id] ?? [];
+            const assigned = assignedTotal(lines);
+            const short = content.quantity - assigned;
+            const balanced = Math.abs(short) < EPSILON && lines.length > 0;
+
+            return (
+              <TableRow key={content.part_id} sx={{ verticalAlign: 'top' }}>
+                <TableCell>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    {content.part_name}
+                  </Typography>
+                </TableCell>
+                <TableCell align="right">
+                  <Typography variant="body2">
+                    {num(content.quantity)} {content.primary_unit ?? ''}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Stack spacing={1}>
+                    {lines.map((line, index) => (
+                      <Stack key={index} direction="row" spacing={1} alignItems="center">
+                        <TextField
+                          select
+                          size="small"
+                          label="Place"
+                          value={line.toRef}
+                          onChange={(e) => setLine(content.part_id, index, { toRef: e.target.value })}
+                          sx={{ minWidth: 200 }}
+                        >
+                          {leaves.map((leaf) => (
+                            <MenuItem key={leaf.key} value={leaf.key}>
+                              {leaf.label}
+                            </MenuItem>
+                          ))}
+                        </TextField>
+                        <TextField
+                          size="small"
+                          type="number"
+                          label="Qty"
+                          value={Number.isFinite(line.quantity) ? line.quantity : ''}
+                          onChange={(e) =>
+                            setLine(content.part_id, index, { quantity: Number(e.target.value) })
+                          }
+                          sx={{ width: 110 }}
+                          inputProps={{ min: 0, step: 'any' }}
+                        />
+                        {/* Only offered on a split — removing the last line would leave the part
+                            unassigned, which the Create button forbids anyway. */}
+                        {lines.length > 1 && (
+                          <IconButton
+                            aria-label={`Remove this destination for ${content.part_name}`}
+                            onClick={() => removeLine(content.part_id, index)}
+                            sx={{ width: 40, height: 40 }}
+                          >
+                            <CloseIcon fontSize="small" />
+                          </IconButton>
+                        )}
+                      </Stack>
+                    ))}
+
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Button
+                        size="small"
+                        startIcon={<AddIcon />}
+                        onClick={() => addLine(content.part_id)}
+                      >
+                        {lines.length === 0 ? 'Choose a place' : 'Split'}
+                      </Button>
+                      {/* The arithmetic, said plainly. Silence when it balances — a green tick on
+                          every row of a long table is noise that hides the one row that doesn't. */}
+                      {!balanced && lines.length > 0 && (
+                        <Typography variant="caption" color="warning.main">
+                          {short > 0
+                            ? `${num(short)} ${content.primary_unit ?? ''} still to place`
+                            : `${num(-short)} ${content.primary_unit ?? ''} more than is here`}
+                        </Typography>
+                      )}
+                    </Stack>
+                  </Stack>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+
+      {!complete && (
+        <Alert severity="info" sx={{ mt: 2 }}>
+          Every part needs a place, and the amounts have to add up to what is on the shelf.
+        </Alert>
+      )}
+    </Box>
+  );
+}

--- a/components/inventory/locations/builder/VisualLocationBuilder.tsx
+++ b/components/inventory/locations/builder/VisualLocationBuilder.tsx
@@ -10,16 +10,25 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Alert from '@mui/material/Alert';
 
-import type { LevelSpec, LocationSpecNode } from '@/types/inventoryLocations';
+import type { LevelSpec, LocationContent, LocationSpecNode } from '@/types/inventoryLocations';
 import {
   buildSpecFromLevels,
+  collectSpecLeaves,
   countSpecNodes,
   removeSpecNode,
   addChildUnder,
   duplicateNode,
 } from '@/utils/locationSpec';
-import { materializeLocationSpec } from '@/utils/inventoryLocationsAccess';
+import {
+  getLocationContents,
+  materializeLocationSpec,
+  subdivideLocation,
+} from '@/utils/inventoryLocationsAccess';
 import LevelConfigStep from './LevelConfigStep';
+import DistributeContentsStep, {
+  isDistributionComplete,
+  type AssignmentMap,
+} from './DistributeContentsStep';
 import { cloneLevels } from './storageTypes';
 
 /**
@@ -97,6 +106,18 @@ export default function VisualLocationBuilder({
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  /**
+   * What the parent currently holds, and where each part is going.
+   *
+   * Loaded on open rather than lazily on reaching step 2: whether a second step exists at all
+   * depends on the answer, and a "Create" button that turns into "Next" after a round trip is worse
+   * than a brief moment where it is disabled.
+   */
+  const [contents, setContents] = useState<LocationContent[]>([]);
+  const [loadingContents, setLoadingContents] = useState(false);
+  const [assignments, setAssignments] = useState<AssignmentMap>({});
+  const [step, setStep] = useState<'layout' | 'distribute'>('layout');
+
   const reset = () => {
     setLevels(cloneLevels(DEFAULT_LEVELS));
     setCustomized(false);
@@ -104,6 +125,16 @@ export default function VisualLocationBuilder({
     setStartOverOpen(false);
     setCreating(false);
     setError(null);
+    setContents([]);
+    setAssignments({});
+    setStep('layout');
+
+    if (!parentId) return;
+    setLoadingContents(true);
+    getLocationContents(parentId)
+      .then((page) => setContents(page.contents))
+      .catch((e) => setError(e instanceof Error ? e.message : 'Could not read what is here.'))
+      .finally(() => setLoadingContents(false));
   };
 
   const uniformTree = useMemo(
@@ -137,12 +168,36 @@ export default function VisualLocationBuilder({
     setStartOverOpen(false);
   };
 
+  /** Only a loaded parent needs the second step; an empty one keeps the original single screen. */
+  const needsDistribution = contents.length > 0;
+  const leaves = useMemo(() => collectSpecLeaves(tree), [tree]);
+  const distributionReady = isDistributionComplete(contents, assignments);
+
   const handleCreate = async () => {
     setCreating(true);
     setError(null);
     try {
-      const created = await materializeLocationSpec(companyId, parentId, tree, startSortOrder);
-      onCreated(created.length);
+      if (needsDistribution) {
+        // One transaction: the sub-locations and the stock that moves into them. Doing it in two
+        // steps is not merely slower, it is impossible — see `subdivideLocation`.
+        const created = await subdivideLocation(
+          parentId!,
+          tree,
+          Object.entries(assignments).flatMap(([partId, lines]) =>
+            lines.map((line) => ({
+              partId,
+              toRef: line.toRef,
+              quantity: line.quantity,
+              unit: contents.find((c) => c.part_id === partId)?.primary_unit || 'ea',
+            })),
+          ),
+          startSortOrder,
+        );
+        onCreated(created.length);
+      } else {
+        const created = await materializeLocationSpec(companyId, parentId, tree, startSortOrder);
+        onCreated(created.length);
+      }
       onClose();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to create locations.');
@@ -166,21 +221,34 @@ export default function VisualLocationBuilder({
       </DialogTitle>
       <DialogContent dividers sx={{ minHeight: 420 }}>
         <Box>
-            <Box sx={{ minWidth: 0 }}>
-              <LevelConfigStep
-                levels={levels}
-                onChange={setLevels}
-                total={total}
-                customized={customized}
-                tree={tree}
-                onCustomize={enterCustomize}
-                onRemove={editRemove}
-                onAdd={editAdd}
-                onDuplicate={editDuplicate}
-                onStartOver={() => setStartOverOpen(true)}
-                existingSiblingNames={existingSiblingNames}
-              />
-            </Box>
+          <Box sx={{ minWidth: 0, display: step === 'layout' ? 'block' : 'none' }}>
+            {/* Kept mounted rather than unmounted when the distribute step is showing: the level
+                config holds the hand-edited tree, and stepping back to fix a name must not reset
+                it to the generated default. */}
+            <LevelConfigStep
+              levels={levels}
+              onChange={setLevels}
+              total={total}
+              customized={customized}
+              tree={tree}
+              onCustomize={enterCustomize}
+              onRemove={editRemove}
+              onAdd={editAdd}
+              onDuplicate={editDuplicate}
+              onStartOver={() => setStartOverOpen(true)}
+              existingSiblingNames={existingSiblingNames}
+            />
+          </Box>
+
+          {step === 'distribute' && (
+            <DistributeContentsStep
+              parentName={parentPath?.length ? parentPath[parentPath.length - 1] : 'This place'}
+              contents={contents}
+              leaves={leaves}
+              assignments={assignments}
+              onChange={setAssignments}
+            />
+          )}
         </Box>
 
         {error && (
@@ -194,9 +262,41 @@ export default function VisualLocationBuilder({
           Cancel
         </Button>
         <Box sx={{ flex: 1 }} />
-        <Button variant="contained" onClick={handleCreate} disabled={creating || total === 0}>
-          Create {total} location{total === 1 ? '' : 's'}
-        </Button>
+
+        {step === 'distribute' && (
+          <Button onClick={() => setStep('layout')} disabled={creating}>
+            Back
+          </Button>
+        )}
+
+        {/*
+          A loaded shelf gets Next → Create; an empty one keeps the single click it always had.
+          `loadingContents` disables Create rather than hiding the dialog behind a spinner: the
+          layout step is usable while the read is in flight, and it is only the branch between the
+          two buttons that has to wait.
+        */}
+        {needsDistribution && step === 'layout' ? (
+          <Button
+            variant="contained"
+            onClick={() => setStep('distribute')}
+            disabled={creating || total === 0}
+          >
+            Next: where does the stock go?
+          </Button>
+        ) : (
+          <Button
+            variant="contained"
+            onClick={handleCreate}
+            disabled={
+              creating ||
+              total === 0 ||
+              loadingContents ||
+              (needsDistribution && !distributionReady)
+            }
+          >
+            Create {total} location{total === 1 ? '' : 's'}
+          </Button>
+        )}
       </DialogActions>
 
       <Dialog open={startOverOpen} onClose={() => setStartOverOpen(false)}>

--- a/components/operator/OperatorPartLookup.tsx
+++ b/components/operator/OperatorPartLookup.tsx
@@ -38,6 +38,17 @@
  *
  * `is_location_tracked` was what told them apart, and it was removed in 20260802015837: every part
  * has a place. An empty list now means exactly one thing, so the branch is gone.
+ *
+ * ## The empty case is a STOCK statement, not a placement one
+ *
+ * It used to read *"None in any place right now."*, which sounds like a part that exists somewhere
+ * and has not been put away — the very state the blue alert below reports as "not put away yet".
+ * It is not. `parts.quantity` is a pure roll-up of `part_location_stock`, so no rows anywhere means
+ * the shop holds **none of this part at all**, Unassigned included. An operator reading the old
+ * wording would go looking for something that is not in the building.
+ *
+ * Hence **"None available"**: it answers the question the operator actually has, which is whether
+ * they can get one, and it stops promising a location hunt that would find nothing.
  */
 
 import { useMemo, useState } from 'react';
@@ -183,7 +194,7 @@ export default function OperatorPartLookup({
               <CircularProgress size={24} />
             </Box>
           ) : places.length === 0 && !unassigned ? (
-            <Alert severity="warning">None in any place right now.</Alert>
+            <Alert severity="warning">None available</Alert>
           ) : (
             <>
               {/* Stock sitting in the put-away pile is called out FIRST and separately. It is the

--- a/components/operator/PutAwayPickerDialog.tsx
+++ b/components/operator/PutAwayPickerDialog.tsx
@@ -29,8 +29,16 @@
  * bare list of names into "Shelf A — 40 ea / Yard — empty", which is most of what makes the choice
  * an informed one.
  *
- * `excludeSystem` hides `Unassigned`: it is the pile you are emptying, never a destination. No
- * `onCreate` either — creating places is an owner's job, the same call the board makes by
+ * ## What it will not offer
+ *
+ * The option list comes from `stockDestinationOptions`, so three exclusions are the shared rule
+ * rather than this file's opinion: **containers** (a cabinet made of Side 1 and Side 2 is not
+ * somewhere a part goes — and since 20260806160053 the database refuses that write, so offering it
+ * would only produce an error on arrival), the `Unassigned` pile (it is what you are emptying), and
+ * the source. `excludeSystem` stays on the picker as a second line: it is redundant against the
+ * current builder and costs nothing, and it keeps the intent legible at the call site.
+ *
+ * No `onCreate` either — creating places is an owner's job, the same call the board makes by
  * withholding "Add storage".
  */
 
@@ -45,7 +53,7 @@ import Typography from '@mui/material/Typography';
 import LocationPicker, {
   type LocationPickerOption,
 } from '@/components/inventory/locations/LocationPicker';
-import { computePathNames } from '@/utils/inventoryLocationsAccess';
+import { stockDestinationOptions } from '@/utils/locationDestinations';
 import type { InventoryLocation, PartLocationBalanceWithLocation } from '@/types/inventoryLocations';
 
 export interface PutAwayPickerDialogProps {
@@ -72,26 +80,12 @@ export default function PutAwayPickerDialog({
 }: PutAwayPickerDialogProps) {
   const [choice, setChoice] = useState<LocationPickerOption | null>(null);
 
-  const options = useMemo<LocationPickerOption[]>(() => {
-    const byId = new Map(locations.map((l) => [l.id, l] as const));
-    const heldAt = new Map(balances.map((b) => [b.location_id, Number(b.quantity ?? 0)] as const));
-    return locations
-      .map((l) => ({
-        id: l.id,
-        label: computePathNames(l.id, byId).join(' › ') || l.name,
-        kind: l.kind,
-        quantity: heldAt.get(l.id) ?? 0,
-      }))
-      // Places already holding some sort first: putting stock back with the rest of it is the
-      // common case, and it keeps one part from scattering across the shop. Alphabetical within
-      // each group so the order is stable and learnable rather than shifting with stock levels.
-      .sort((a, b) => {
-        const aHas = (a.quantity ?? 0) > 0;
-        const bHas = (b.quantity ?? 0) > 0;
-        if (aHas !== bHas) return aHas ? -1 : 1;
-        return a.label.localeCompare(b.label);
-      });
-  }, [locations, balances]);
+  // Leaf-only, pile excluded, already-holding-some sorted first — all of it now the shared rule in
+  // `stockDestinationOptions` rather than a fourth private copy of the same walk.
+  const options = useMemo<LocationPickerOption[]>(
+    () => stockDestinationOptions(locations, { balances }),
+    [locations, balances],
+  );
 
   const close = () => {
     setChoice(null);

--- a/components/parts/PartLocationInventory.tsx
+++ b/components/parts/PartLocationInventory.tsx
@@ -26,6 +26,7 @@ import type {
   PartLocationBalanceWithLocation,
 } from '@/types/inventoryLocations';
 import { createLocation, getBalancesForPart, getLocations } from '@/utils/inventoryLocationsAccess';
+import { stockDestinationOptions } from '@/utils/locationDestinations';
 import { getStandardUnitsForUnit } from '@/lib/unitPresets';
 import PartLocationActionModal, {
   type LocationAction,
@@ -37,18 +38,8 @@ import PartLocationActionModal, {
 const EMPTY_BALANCES: PartLocationBalanceWithLocation[] = [];
 const EMPTY_LOCATIONS: InventoryLocation[] = [];
 
-function pathLabel(id: string, byId: Map<string, InventoryLocation>): string {
-  const names: string[] = [];
-  let cursor: string | null = id;
-  const guard = new Set<string>();
-  while (cursor && byId.has(cursor) && !guard.has(cursor)) {
-    guard.add(cursor);
-    const node: InventoryLocation = byId.get(cursor)!;
-    names.unshift(node.name);
-    cursor = node.parent_id;
-  }
-  return names.join(' › ');
-}
+// The private `pathLabel` that used to live here is gone: it was the fourth copy of the same
+// ancestry walk, and `stockDestinationOptions` now builds the labelled list.
 
 interface PartLocationInventoryProps {
   part: Part;
@@ -91,8 +82,6 @@ export default function PartLocationInventory({
 
   const { features } = useCompanyFeatures();
 
-  const byId = useMemo(() => new Map(locations.map((l) => [l.id, l] as const)), [locations]);
-
   /**
    * Whether this shop has been given places at all.
    *
@@ -112,14 +101,12 @@ export default function PartLocationInventory({
    */
   const onePlace = locations.length === 1 && locations[0].kind === 'system';
 
-  // `kind` rides along so the picker can drop the auto-managed `Unassigned` bucket from
-  // destination lists without needing to know how it's identified.
+  // Leaves only: since 20260806160053 a place with sub-locations cannot hold stock, so offering a
+  // cabinet here would put an error behind a legitimate-looking choice. `kind` rides along so the
+  // picker can also drop the auto-managed `Unassigned` bucket without knowing how it's identified.
   const locationOptions = useMemo<LocationOption[]>(
-    () =>
-      locations
-        .map((l) => ({ id: l.id, label: pathLabel(l.id, byId), kind: l.kind }))
-        .sort((a, b) => a.label.localeCompare(b.label)),
-    [locations, byId],
+    () => stockDestinationOptions(locations),
+    [locations],
   );
 
   /**

--- a/docs/modules/inventory.md
+++ b/docs/modules/inventory.md
@@ -178,7 +178,53 @@ worked, leaves): a job attribute.
 | `parts_unit_conversions` | FR-1. `(part_id, from_unit)` UNIQUE, `to_primary_factor` > 0 — bar in lbs: `inches` × 0.166. Custom/cross-category only; names in `company_custom_units`. |
 | `inventory_transactions` | FR-13. `quantity` always positive, direction in `type`; `has_discrepancy` = clamped-to-zero depletion; `transfer_group_id` pairs a transfer's two rows; `notes` the only mutable column (`restrict_transaction_update_to_notes`). |
 | `inventory_locations` | `parent_id` self-FK RESTRICT; `code` **not unique**; **no `path`/`level`/ltree** — depth recomputed client-side each read. The partial unique index `(company_id) WHERE name='Unassigned'` *is* the auto-bucket mechanism, resolved **by name**. Traps: re-parent cycle check is client-side only; Unassigned is that string in SQL but `kind==='system'` in TS. |
-| `part_location_stock` | `(part_id, location_id)` UNIQUE, both FKs RESTRICT, RLS **SELECT-only**. |
+| `part_location_stock` | `(part_id, location_id)` UNIQUE, both FKs RESTRICT, RLS **SELECT-only**. A row exists only while the part is actually there — `CHECK (quantity > 0)`, emptying deletes. **Never at a location with children** — see below. |
+
+### A place is a container or a bin, never both
+
+**Invariant (20260806160053):** *a location with at least one child holds no `part_location_stock`
+rows.* If Cabinet 1-A is just Side 1 and Side 2, nobody means "put it in the cabinet" — they mean a
+side, and every picker used to offer the cabinet anyway.
+
+This partly reverses [`20260623031347`](../../supabase/migrations/20260623031347_drop_location_display_flags.sql),
+which dropped `is_stockable` on the reasoning that *"every location can hold stock"*. That was right
+about leaves and about printing (a container's QR still navigates); it was wrong about containers.
+No flag came back: containment is already `parent_id`, and a flag that must agree with it is a
+second source of truth that can drift.
+
+Both directions are enforced, by two **`DEFERRABLE INITIALLY IMMEDIATE` constraint triggers sharing
+one name** across the two tables:
+
+| Direction | Trigger on | Refuses |
+|---|---|---|
+| (a) | `part_location_stock` INSERT | stock landing on a location that has children |
+| (b) | `inventory_locations` INSERT / UPDATE OF `parent_id` | children under a location that holds stock, and any child under `Unassigned` |
+
+**The row locks in those trigger bodies are load-bearing, not defensive.** Both test cross-row state
+with a plain `EXISTS`, PostgREST runs at READ COMMITTED, and deferral does not help — a deferred
+trigger takes a *fresh* snapshot at commit, which still excludes an uncommitted transaction. Two
+concurrent transactions (one adding children, one adding stock) would each see nothing and both
+commit, breaking the invariant **silently**. Postgres only detects that write skew at SERIALIZABLE.
+So direction (a) takes `FOR SHARE` on the location row and (b) takes `FOR UPDATE`: those conflict,
+the second transaction blocks, and its post-lock `EXISTS` sees the winner's rows. The implicit FK
+locks are both `FOR KEY SHARE` and do not conflict with each other, so they serialise nothing.
+`test_concurrent_subdivide_and_stock_cannot_both_win` in
+[`test_location_children_hold_no_stock.py`](../../api/tests/integration/test_location_children_hold_no_stock.py)
+fails **only** when the locks are removed — every other case in that file passes without them.
+
+Why deferrable at all: subdividing a loaded shelf must pass through the illegal intermediate state
+(create the children, then move the stock down). `subdivide_location(p_parent_id, p_nodes, p_moves)`
+is the only caller allowed through — it takes the parent lock up front, defers both triggers,
+inserts the subtree from a flat `{ref, parent_ref}` list, and delegates each move to the existing
+`transfer_stock` so the ledger and `transfer_group_id` are identical to any other movement. An
+incomplete distribution therefore cannot half-apply: the deferred check fires at COMMIT and rolls
+the sub-locations back with it. It is browser-callable and on the `function_execute_leaks()`
+allowlist.
+
+Client-side, [`utils/locationDestinations.ts`](../../utils/locationDestinations.ts) is the single
+source of the two option rules — `stockDestinationOptions` (leaves only, no pile) and
+`locationParentOptions` (containers required, but not one holding stock directly). Six call sites
+each hand-rolled their own list before, and none filtered containers.
 | `job_materials` | **Write-only** — written by `create_job_part_operations_from_routing()`, read by nothing since `20260614043526_retire_job_material_consumption` dropped its consumption columns; the live BOM is read instead. Slated for removal (§5.9). Older `jobs.md` copies wrongly show those columns and an `inventory_item_id` FK. |
 
 ### The two stock engines
@@ -203,7 +249,10 @@ No item detail/create/edit/import page of its own; that is all Parts UI.
 - **Part → Inventory tab** ([`InventoryTab.tsx`](../../components/parts/workspace/tabs/InventoryTab.tsx)) when `is_stocked`: untracked → Add/Remove/Adjust (`PartLocationActionModal`), tracked → `PartLocationInventory` (+ move). **No longer a gap** — this said "no job selector … only an operator at a bin can tag a job", which was true when written and was repaired on 2026-07-28: `JobTagPicker` is on both engines (`PartLocationActionModal`). §1 already recorded the repair; §3 did not, and the two sat contradicting each other.
 - **`/inventory/locations`** (flag-gated) — [`LocationsManager`](../../components/inventory/locations/LocationsManager.tsx): board only (list view **deleted 2026-07-30**, §5.5), `LocationDetailSheet` owning every action, the in-grid **Add storage** tile the only way in, toolbar just **Print all labels** · **Count all parts** (§5.11).
 - **Subdivide** — one [`VisualLocationBuilder`](../../components/inventory/locations/builder/VisualLocationBuilder.tsx) modal: storage type, then ≤4 levels against a read-only preview → `materializeLocationSpec`. `parentId` swaps in `SUBDIVISION_TYPES`, so subdividing Cabinet 3 can't yield `Cabinet 3 › Cabinet 1`. **"Build visually" is NOT live** — `subdividing = parentId !== null` is always true because the only caller passes a parent, so the 10-card `STORAGE_TYPES` palette and the title `Build storage visually` never render. This line used to claim both were live; §5.5 says the opposite and §5.5 is right. **Superseded 2026-08-01:** the founder has decided the drawn board and this builder are both to be replaced — see the open question below.
-- **Operator** — `/operator/{companyId}/inventory` is the warehouse home (browse top-level places; the flag hides this nav tab); `…/inventory/locations/{locationId}` is **the QR target** (leaf = contents with Add/Remove/Set), reached through `…/login?location={id}`. Operator removals are always graceful (clamp to 0, flag `has_discrepancy`), stamped `operator_id`, job tag optional.
+  - **Second step when the shelf is loaded (2026-08-06):** [`DistributeContentsStep`](../../components/inventory/locations/builder/DistributeContentsStep.tsx) asks where each part goes, allows **splitting one part across several new bins** (you divide a shelf *because* what is on it is already in two piles), and leads with **"Send everything to…"** because `LOCATION_CONTENTS_LIMIT` is 200 and a 200-row table of decisions is not a UI. Create stays disabled until each part's lines sum exactly to its on-hand — not politeness: an incomplete distribution rolls the whole subdivide back at COMMIT, so checking here turns a mystifying failure into arithmetic. An **empty** place keeps the original single screen. `Add one inside` is withheld from a place holding stock (the plain create form has nowhere to ask), and Move drops stocked targets for the same reason.
+- **Storage table** — an **accordion with one open branch** (2026-08-06): rows start collapsed and opening a place closes anything not on its ancestor chain, held as `openPath` (root→deepest ids) rather than a set of expanded ids so the stricter rule is the only representable one. Replaces default-everything-expanded, whose stated reason (12–18 places fit on one screen) does not survive the builder's own 5 × 2 default turning one row into 16.
+- **Counting a container** (2026-08-06) — `?location=<container>` gathers **every bin beneath it**, depth-first, one line per (part, bin). It needed no new write path: `commitCount` already adjusts each line at its own `target.locationId`, so a sheet spanning ten bins is ten independent one-bin assertions. `getContentsPageForLocations` is `getLocationContentsPage` generalised from `.eq` to `.in`, ordered by the bin's `sort_order` then name then part — a walking route as far as one query expresses it; across two shelves it interleaves by sibling position, which is why every row carries its bin's full path. **A split part stays two lines, never one total** — aggregating would re-create exactly the ambiguity that makes the company-wide sheet *skip* split parts. The **bulk put-away is withheld** on a subtree sheet: `bulk_put_away` moves parts out of one location and the ticked rows come from several. (Briefly, containers had no count action at all — the button was hidden rather than the read widened. That was wrong and lasted one commit.)
+- **Operator** — `/operator/{companyId}/inventory` is the warehouse home (browse top-level places; the flag hides this nav tab); `…/inventory/locations/{locationId}` is **the QR target**, reached through `…/login?location={id}`. A **leaf** shows contents with Add/Remove/Move/Adjust and `Stock a part`; a **container** shows only its sub-locations plus one line saying stock goes in them — it used to show `Stock a part` directly above *"No stock recorded directly here"*, a button inviting you to break the sentence beside it. Operator removals are always graceful (clamp to 0, flag `has_discrepancy`), stamped `operator_id`, job tag optional. The zero-stock lookup says **"None available"**, not the old *"None in any place right now."*: `parts.quantity` is a pure roll-up, so no rows means none on hand anywhere — a stock fact the old wording dressed as a placement one.
 - QR labels encode the location **UUID** (`locationLabelPdf.buildLocationScanUrl`): A4, 2 × 5, 34 mm at error-correction H, `kind='system'` excluded. The label prints the QR and the full path — nothing else. There was a `code` line under it until 20260803034616; see below.
 
 ### Access layer
@@ -225,7 +274,7 @@ Supabase + RLS via `getTypedSupabase()`, **no FastAPI**: `partsAccess.ts`, `inve
 
 **Archive** — `deletePart`/`bulkDeleteParts` → `archive_parts` stamps `deleted_at`, never blocking on references (architecture.md §16); children (conversions, balances) are kept and return on revive, transactions keep their name snapshots, and re-importing the same `part_name` **revives** rather than duplicating. `delete_location` differs: **empty** subtrees only, no delete-and-relocate.
 
-**Dead/unreachable** — `removePartStockGraceful` · `enableLocationTracking`/`disableLocationTracking` (superseded by auto-track; both now billing-gated anyway, #645) · `enable_location_tracking_for_company`, `inv_location_path_label` · `job_materials`. Deleted 2026-07-29: `getLocationTree`, `buildLocationUrl` (duplicated `buildLocationScanUrl`), `bulkGenerateChildren`/`BulkGenerateModal` (Subdivide is a strict superset with live preview, and it had **zero tests**, so deleting beat porting), `PartLocationBalance`. Path-walking is reimplemented **five times** in TS plus once in unused SQL — worth extracting.
+**Dead/unreachable** — `removePartStockGraceful` · `enableLocationTracking`/`disableLocationTracking` (superseded by auto-track; both now billing-gated anyway, #645) · `enable_location_tracking_for_company`, `inv_location_path_label` · `job_materials`. Deleted 2026-07-29: `getLocationTree`, `buildLocationUrl` (duplicated `buildLocationScanUrl`), `bulkGenerateChildren`/`BulkGenerateModal` (Subdivide is a strict superset with live preview, and it had **zero tests**, so deleting beat porting), `PartLocationBalance`. Path-walking was reimplemented **five times** in TS plus once in unused SQL; **extracted 2026-08-06** to [`lib/locationTree.ts`](../../lib/locationTree.ts) (`computePathNames`, re-exported from `inventoryLocationsAccess` for existing importers). It lives in `lib/` rather than beside the access layer because that module builds a Supabase client at import time, so wanting a display path used to drag the whole access layer — and a `lib/supabase` stub — into every consumer and every test of one.
 
 ---
 
@@ -558,7 +607,7 @@ feature. Spec it recurring, assignable, place-scoped; not a one-off Adjust butto
 
 **Phase 2 ✅ 2026-07-30** — reshaped locations (§5.5), plus **`bulk_put_away`** (atomic RPC, whole-balance, capped 1000) and **place-scoped counting**, both inside J9's worksheet: counting a bin and moving what doesn't belong are one visit. **Rollout gate cleared.** Two pre-existing bugs no test caught: `storage.objects` had no SELECT policy in any migration (it existed only in the prod snapshot), so every attachment read broke on fresh local stacks and preview branches; `friendlyErrorMessage` ignored `check_violation`, flattening every stock RPC message to "Failed to update stock."
 
-Filed: **#618** `materializeLocationSpec` non-transactional · ~~**#619**~~ **fixed 2026-08-01**: `getBalancesForParts` now pages each chunk with a total order (the arithmetic is ≥1,001 rows in one chunk, not 500×2, and only a dropped **non-zero** row misroutes) · **#620** the board drops `TOP_LIMIT`, so windowing past a few hundred units. Deferred: §5.10 spike · bar-rack card · drag-to-reparent (118/121 flat; a **picker** landed 2026-08-01 instead — `moveLocation` had shipped with cycle detection and tests and never had a caller, so a mis-parented cabinet was permanent) · recurring/assignable counts (§5.11) · service worker (offline stock writes ≫ a cache).
+Filed: **#618** `materializeLocationSpec` non-transactional — **still open for the empty-parent path**, but a loaded parent now goes through `subdivide_location`, which is one transaction · ~~**#619**~~ **fixed 2026-08-01**: `getBalancesForParts` now pages each chunk with a total order (the arithmetic is ≥1,001 rows in one chunk, not 500×2, and only a dropped **non-zero** row misroutes) · **#620** the board drops `TOP_LIMIT`, so windowing past a few hundred units. Deferred: §5.10 spike · bar-rack card · drag-to-reparent (118/121 flat; a **picker** landed 2026-08-01 instead — `moveLocation` had shipped with cycle detection and tests and never had a caller, so a mis-parented cabinet was permanent) · recurring/assignable counts (§5.11) · service worker (offline stock writes ≫ a cache).
 
 **Filed 2026-08-01:** **#645** every location-stock RPC bypassed the billing write-gate — `SECURITY DEFINER` runs as the owner, no table sets `FORCE ROW LEVEL SECURITY`, and `part_location_stock` was exempt on the false rationale *"writes never come from the browser"*. Entitlement therefore depended on a feature flag. Fixed the same day across seven functions, plus `definer_writers_missing_write_gate()` and a CI test, because the existing guard checks whether a *policy exists* and cannot see a definer function walking past one. · **#649** `create_shipment_with_line_items` has the identical bug; left open because whether a lapsed shop may ship an order it will invoice for is a billing policy call. · **#646** / **#647** / **#648** the counting, owner-ledger and board-vs-table work from that audit.
 
@@ -615,6 +664,9 @@ Pinned by tests, not by prose.
 | Locations — balances, RPC wrappers, unit conversion, board request budget, contents paging, `bulkPutAway`, photo signed URLs, **transfer folding** | `__tests__/utils/inventoryLocationsAccess.test.ts` |
 | J11 lookup (three answers, put-away picker), bin + shop-wide history, movement photo | `__tests__/components/operator/{OperatorPartLookup,OperatorWarehouseHome,PutAwayPickerDialog,BinHistory,MovementPhotoField}.test.tsx` |
 | Occupancy roll-up, subdivide numbering, board/sheet/builder/form/picker rules | `__tests__/utils/{locationOccupancy,locationSpec}.test.ts`, `__tests__/components/inventory/locations/*.test.tsx` |
+| Container/bin invariant — both directions, subdivide rollback, and the **write-skew race** | [`api/tests/integration/test_location_children_hold_no_stock.py`](../../api/tests/integration/test_location_children_hold_no_stock.py) (psycopg2, not the Supabase client: the race needs two open transactions, which PostgREST cannot give) |
+| Which places may be offered as a destination, for stock vs for a location | [`__tests__/utils/locationDestinations.test.ts`](../../__tests__/utils/locationDestinations.test.ts) |
+| Counting a container — subtree gathering, split parts staying per-bin, commit targeting the bin | `__tests__/components/inventory/InventoryCountPage.test.tsx` (`counting a container`) |
 | J9 count plan, commit routing, bin-scoped count, draft resume | `__tests__/lib/inventoryCountPlan.test.ts`, `__tests__/utils/inventoryCountAccess.test.ts`, `__tests__/components/inventory/InventoryCountPage.test.tsx` |
 | J4 material check | `__tests__/components/jobs/JobPartMaterialsCard.test.tsx`, `__tests__/utils/materialCheckAccess.test.ts` |
 | J7 bin remove/receive + job-tagged depletion; owner-side job tag (#59) | `__tests__/components/operator/{OperatorBinView,OperatorReceivePartModal,OperatorLocationActionModal}.test.tsx`, `__tests__/components/parts/PartTransactionJobTag.test.tsx` |

--- a/lib/locationTree.ts
+++ b/lib/locationTree.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure walks over the location tree — no Supabase, no network.
+ *
+ * ## Why this is in `lib/` rather than beside the access layer
+ *
+ * `computePathNames` lived in `utils/inventoryLocationsAccess.ts`, which builds a Supabase client
+ * at import time. Anything wanting a display path therefore dragged the whole access layer in with
+ * it, and any test touching such a component had to stub `lib/supabase` before it could even load
+ * the module — a workaround `__tests__/components/operator/PutAwayPickerDialog.test.tsx` records
+ * having to make. The function itself never needed any of that: it reads a Map the caller already
+ * has.
+ *
+ * Sibling of `locationSpec.ts` and `locationOccupancy.ts` in intent: decisions live in pure
+ * functions, and only the access layer talks to the network.
+ */
+import type { InventoryLocation } from '@/types/inventoryLocations';
+
+/**
+ * Root → leaf names for a location, e.g. `['Cabinet 1', 'Row 3', 'Left']`.
+ *
+ * Exists because this walk had been hand-rolled in four separate places (the operator bin page, the
+ * count page, `PartLocationInventory` and the put-away dialog). Use this one rather than writing a
+ * fifth — the cycle guard in particular is easy to leave out, and re-parenting can produce one.
+ */
+export function computePathNames(
+  locationId: string,
+  byId: Map<string, InventoryLocation>,
+): string[] {
+  const names: string[] = [];
+  let cursor: string | null = locationId;
+  const guard = new Set<string>();
+  while (cursor && byId.has(cursor) && !guard.has(cursor)) {
+    guard.add(cursor);
+    const node: InventoryLocation = byId.get(cursor)!;
+    names.unshift(node.name);
+    cursor = node.parent_id;
+  }
+  return names;
+}

--- a/supabase/migrations/20260806160053_location_children_hold_no_stock.sql
+++ b/supabase/migrations/20260806160053_location_children_hold_no_stock.sql
@@ -1,0 +1,408 @@
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- A place with sub-locations holds no stock
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- If Cabinet 1-A is just Side 1 and Side 2, nobody ever means "put it in the
+-- cabinet" — they mean a side. Until now every layer allowed it: no picker
+-- filtered parents, no RPC checked, and nothing in the schema said otherwise.
+--
+-- ## This partly reverses 20260623031347
+--
+-- That migration dropped `is_stockable` on the reasoning that *"every location
+-- can hold stock, and every location is printable"*. It was right about LEAVES
+-- and right about printing — a parent's QR label is still useful, it navigates.
+-- It was wrong about CONTAINERS, and this reverses that half only. Nothing here
+-- brings back a per-row flag: containment is already expressed by `parent_id`,
+-- and a flag that must agree with it is a second source of truth that can drift.
+--
+-- ## The invariant
+--
+--     A location with at least one child holds no part_location_stock rows.
+--
+-- Two directions, both closed below:
+--   (a) you cannot write stock to a location that has children;
+--   (b) you cannot give children to a location that holds stock.
+--
+-- `inventory_locations` has no `deleted_at` — empty locations are hard deleted
+-- by `delete_location` — so "has children" is a plain EXISTS with no soft-delete
+-- filter to forget.
+--
+-- ## Why the triggers are DEFERRABLE
+--
+-- Subdividing a shelf that already holds stock is a legitimate, supported action
+-- ("Divide it up…"), and it MUST pass through the illegal intermediate state:
+-- create the sub-locations, then move the stock down into them. Postgres has a
+-- first-class mechanism for exactly that, so `subdivide_location` below defers
+-- the check to COMMIT rather than reaching for a session-GUC escape hatch — a
+-- flag any caller could set is not a guard, it is a guard-shaped hole.
+--
+-- INITIALLY IMMEDIATE means every ordinary path is still checked at statement
+-- time. Only a transaction that explicitly defers gets the window.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 0. Refuse to install over violating data
+-- ─────────────────────────────────────────────────────────────────────────────
+-- A constraint trigger never validates rows that already exist, so installing it
+-- over bad data would leave a violation permanently invisible behind a guard
+-- that claims to prevent it. Audited before writing this: production held 0 such
+-- rows of 141, `supabase/seed.sql` stocks only leaves, and the demo template
+-- (20260805045639) stocks only leaf refs. So this raises in no known environment
+-- — it exists so that if that is ever untrue, the deploy stops instead of
+-- silently grandfathering it in.
+DO $$
+DECLARE
+    v_bad bigint;
+BEGIN
+    SELECT count(*) INTO v_bad
+      FROM public.part_location_stock s
+     WHERE EXISTS (SELECT 1 FROM public.inventory_locations c
+                    WHERE c.parent_id = s.location_id);
+    IF v_bad > 0 THEN
+        RAISE EXCEPTION
+          'refusing to install: % balance row(s) sit at a location that has sub-locations. Move them into a child location first.',
+          v_bad;
+    END IF;
+END $$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. Direction (a): stock may only land on a leaf
+-- ─────────────────────────────────────────────────────────────────────────────
+-- INSERT only. `deplete`/`adjust`/`transfer` only ever update or delete rows
+-- that already passed this check, and a location acquiring children later is
+-- direction (b)'s job.
+CREATE OR REPLACE FUNCTION public.assert_stock_location_is_a_leaf()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $$
+BEGIN
+    -- LOAD-BEARING, not defensive. See the concurrency note under section 3:
+    -- without this lock the invariant is silently breakable by two concurrent
+    -- transactions, which is the one failure mode this whole migration exists to
+    -- prevent. FOR SHARE (not FOR UPDATE) so two operators receiving into the
+    -- same bin still proceed concurrently — only a STRUCTURAL change serialises
+    -- against them.
+    PERFORM 1 FROM public.inventory_locations
+     WHERE id = NEW.location_id
+       FOR SHARE;
+
+    IF EXISTS (SELECT 1 FROM public.inventory_locations c
+                WHERE c.parent_id = NEW.location_id) THEN
+        RAISE EXCEPTION
+          'That place has sub-locations, so stock goes in one of those rather than in it.'
+          USING ERRCODE = 'check_violation';
+    END IF;
+
+    RETURN NULL;  -- AFTER trigger; the return value is ignored.
+END;
+$$;
+
+COMMENT ON FUNCTION public.assert_stock_location_is_a_leaf() IS
+  'Constraint-trigger body for direction (a) of the container/bin invariant: stock may only sit at a location with no children. Takes FOR SHARE on the location row so it serialises against assert_location_parent_holds_no_stock, which takes FOR UPDATE — without that the pair is open to write skew under READ COMMITTED.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. Direction (b): a location holding stock may not become a container
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.assert_location_parent_holds_no_stock()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+    v_kind text;
+    v_name text;
+BEGIN
+    -- A root has no parent to invalidate. (On UPDATE, only NEW.parent_id matters:
+    -- vacating OLD.parent_id can only turn a container back into a leaf, which
+    -- relaxes the invariant rather than breaking it.)
+    IF NEW.parent_id IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    -- The other half of the lock pair. FOR UPDATE conflicts with the FOR SHARE
+    -- above, so whichever transaction reaches its lock second blocks until the
+    -- first is visible.
+    SELECT kind, name INTO v_kind, v_name
+      FROM public.inventory_locations
+     WHERE id = NEW.parent_id
+       FOR UPDATE;
+
+    -- `Unassigned` is the auto-managed put-away pile, not a shelf: it is where
+    -- `inv_get_or_create_unassigned` and the parts importer put stock that has
+    -- nowhere yet. Giving it children would make it unwritable and strand them.
+    IF v_kind = 'system' THEN
+        RAISE EXCEPTION
+          '% is the put-away pile rather than a place, so it cannot be divided up.', v_name
+          USING ERRCODE = 'check_violation';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM public.part_location_stock s
+                WHERE s.location_id = NEW.parent_id) THEN
+        RAISE EXCEPTION
+          '% holds stock, so it cannot have sub-locations until that stock is moved into one of them.',
+          v_name
+          USING ERRCODE = 'check_violation';
+    END IF;
+
+    RETURN NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION public.assert_location_parent_holds_no_stock() IS
+  'Constraint-trigger body for direction (b) of the container/bin invariant: a location holding stock may not gain children, and the system Unassigned pile may never gain children at all. Takes FOR UPDATE on the parent row to serialise against assert_stock_location_is_a_leaf.';
+
+-- Trigger functions are invoked by the trigger machinery, not by callers, so
+-- they need no EXECUTE grant — permission is checked when the trigger is
+-- created. Revoking anyway, per the repo's standing idiom: correct under either
+-- default-privilege state and free.
+REVOKE EXECUTE ON FUNCTION public.assert_stock_location_is_a_leaf()        FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.assert_location_parent_holds_no_stock()  FROM PUBLIC, anon, authenticated;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. The constraint triggers
+-- ─────────────────────────────────────────────────────────────────────────────
+-- ## Concurrency: why the row locks above are not optional
+--
+-- Both directions test cross-row state with a plain EXISTS, and PostgREST runs
+-- at READ COMMITTED. Without the locks:
+--
+--   T1 (subdivide) inserts children under Cabinet 1-A, uncommitted. T2 (an
+--   operator receiving a part) inserts stock at Cabinet 1-A; its EXISTS cannot
+--   see T1's uncommitted children, so it passes. T1's deferred check fires at
+--   its own commit, cannot see T2's uncommitted stock row, so it passes. Both
+--   commit. A parent now holds stock and NOTHING RAISED.
+--
+-- That is textbook write skew. Deferral does not help — a deferred trigger takes
+-- a FRESH snapshot at commit time, which still excludes a transaction that has
+-- not committed. Postgres only detects write skew at SERIALIZABLE, and nothing
+-- here runs at SERIALIZABLE.
+--
+-- The implicit foreign-key locks do not save you either: inserting stock takes
+-- FOR KEY SHARE on the location row, and inserting a child takes FOR KEY SHARE
+-- on its parent row. FOR KEY SHARE does not conflict with itself, so the two
+-- directions never serialise on their own. FOR SHARE and FOR UPDATE do conflict,
+-- which is the whole point of the pairing.
+--
+-- ## One name, two tables
+--
+-- Deliberate: `SET CONSTRAINTS public.location_children_hold_no_stock DEFERRED`
+-- then defers BOTH, so `subdivide_location` cannot defer one direction and leave
+-- the other armed. Constraint triggers must be AFTER ... FOR EACH ROW.
+CREATE CONSTRAINT TRIGGER location_children_hold_no_stock
+    AFTER INSERT ON public.part_location_stock
+    DEFERRABLE INITIALLY IMMEDIATE
+    FOR EACH ROW EXECUTE FUNCTION public.assert_stock_location_is_a_leaf();
+
+CREATE CONSTRAINT TRIGGER location_children_hold_no_stock
+    AFTER INSERT OR UPDATE OF parent_id ON public.inventory_locations
+    DEFERRABLE INITIALLY IMMEDIATE
+    FOR EACH ROW EXECUTE FUNCTION public.assert_location_parent_holds_no_stock();
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. subdivide_location: create the sub-locations AND redistribute, atomically
+-- ─────────────────────────────────────────────────────────────────────────────
+-- The one caller allowed through the illegal intermediate state, and the only
+-- reason the triggers are deferrable.
+--
+-- It also retires a wart `materializeLocationSpec` documents about itself: that
+-- path is sequential and NOT transactional, so a failure halfway leaves the
+-- nodes created before it (#618). Subdividing through this RPC is one statement
+-- and either happens or does not.
+--
+-- ## Node shape
+--
+--   p_nodes = [{"ref":"k1","parent_ref":null,"name":"Side 1","kind":null,"sort_order":0}, ...]
+--
+-- Flat, with refs resolved in-function through one jsonb map — the same
+-- `_ref`/`parent_ref` idiom the demo-template loader uses, and it maps straight
+-- onto `LocationSpecNode.key` so the client can reuse the builder's own keys.
+-- `parent_ref` null means "directly under p_parent_id". Nodes must arrive
+-- parent-before-child; an unresolvable ref raises rather than silently rooting
+-- the node somewhere wrong.
+--
+--   p_moves = [{"part_id":"…","to_ref":"k1","quantity":5,"unit":"ea","converted_quantity":5}]
+--
+-- Each move delegates to the existing `transfer_stock`, so the ledger rows, the
+-- `transfer_group_id` pairing and the unit handling stay identical to every
+-- other movement in the app rather than being re-implemented here.
+--
+-- If the moves do not empty the parent, the deferred check fires at COMMIT and
+-- the whole thing rolls back — an incomplete distribution cannot half-apply.
+CREATE OR REPLACE FUNCTION public.subdivide_location(
+    p_parent_id uuid,
+    p_nodes     jsonb,
+    p_moves     jsonb DEFAULT '[]'::jsonb
+)
+RETURNS SETOF public.inventory_locations
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+    v_company   uuid;
+    v_map       jsonb := '{}'::jsonb;   -- ref -> new location id
+    v_created   uuid[] := '{}';
+    v_node      jsonb;
+    v_move      jsonb;
+    v_ref       text;
+    v_parent    uuid;
+    v_new_id    uuid;
+    v_to        uuid;
+BEGIN
+    IF jsonb_typeof(p_nodes) <> 'array' OR jsonb_array_length(p_nodes) = 0 THEN
+        RAISE EXCEPTION 'Nothing to create.' USING ERRCODE = 'check_violation';
+    END IF;
+
+    SELECT company_id INTO v_company
+      FROM public.inventory_locations WHERE id = p_parent_id;
+    IF v_company IS NULL THEN
+        RAISE EXCEPTION 'location % not found', p_parent_id USING ERRCODE = 'no_data_found';
+    END IF;
+    IF NOT (v_company IN (SELECT public.get_user_company_ids())) THEN
+        RAISE EXCEPTION 'access denied to company %', v_company USING ERRCODE = 'insufficient_privilege';
+    END IF;
+    PERFORM public.inv_assert_can_write(v_company);
+
+    -- Take the structural lock UP FRONT rather than leaving it to the deferred
+    -- trigger. Blocking a racing stock write here costs one wait; discovering it
+    -- at COMMIT means doing every insert and every transfer and then throwing
+    -- the lot away.
+    PERFORM 1 FROM public.inventory_locations WHERE id = p_parent_id FOR UPDATE;
+
+    SET CONSTRAINTS public.location_children_hold_no_stock DEFERRED;
+
+    -- Children first, so the moves below have somewhere to land.
+    FOR v_node IN SELECT * FROM jsonb_array_elements(p_nodes) LOOP
+        v_ref := v_node ->> 'ref';
+        IF v_ref IS NULL OR v_ref = '' THEN
+            RAISE EXCEPTION 'Every node needs a ref.' USING ERRCODE = 'check_violation';
+        END IF;
+
+        IF v_node ->> 'parent_ref' IS NULL THEN
+            v_parent := p_parent_id;
+        ELSIF v_map ? (v_node ->> 'parent_ref') THEN
+            v_parent := (v_map ->> (v_node ->> 'parent_ref'))::uuid;
+        ELSE
+            RAISE EXCEPTION 'Unknown parent_ref %; nodes must be ordered parent before child.',
+                v_node ->> 'parent_ref' USING ERRCODE = 'check_violation';
+        END IF;
+
+        INSERT INTO public.inventory_locations (company_id, parent_id, name, kind, sort_order)
+        VALUES (
+            v_company,
+            v_parent,
+            v_node ->> 'name',
+            v_node ->> 'kind',
+            COALESCE((v_node ->> 'sort_order')::integer, 0)
+        )
+        RETURNING id INTO v_new_id;
+
+        v_map     := v_map || jsonb_build_object(v_ref, v_new_id::text);
+        v_created := v_created || v_new_id;
+    END LOOP;
+
+    -- Then the stock, out of the parent and into the leaves the caller chose.
+    FOR v_move IN SELECT * FROM jsonb_array_elements(p_moves) LOOP
+        IF NOT (v_map ? (v_move ->> 'to_ref')) THEN
+            RAISE EXCEPTION 'Move targets unknown ref %.', v_move ->> 'to_ref'
+                USING ERRCODE = 'check_violation';
+        END IF;
+        v_to := (v_map ->> (v_move ->> 'to_ref'))::uuid;
+
+        PERFORM public.transfer_stock(
+            (v_move ->> 'part_id')::uuid,
+            p_parent_id,
+            v_to,
+            (v_move ->> 'quantity')::numeric,
+            v_move ->> 'unit',
+            (v_move ->> 'converted_quantity')::numeric,
+            v_move ->> 'notes',
+            NULLIF(v_move ->> 'operator_id', '')::uuid,
+            NULL
+        );
+    END LOOP;
+
+    RETURN QUERY
+        SELECT * FROM public.inventory_locations
+         WHERE id = ANY(v_created)
+         ORDER BY sort_order, name;
+END;
+$$;
+
+COMMENT ON FUNCTION public.subdivide_location(uuid, jsonb, jsonb) IS
+  'Creates a sub-location subtree under a place and moves that place''s stock down into the new leaves, in one transaction. The only caller permitted through the container/bin invariant''s illegal intermediate state, which is why location_children_hold_no_stock is DEFERRABLE. Delegates each move to transfer_stock so the ledger is identical to any other movement. Called by subdivideLocation in utils/inventoryLocationsAccess.ts.';
+
+REVOKE EXECUTE ON FUNCTION public.subdivide_location(uuid, jsonb, jsonb) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.subdivide_location(uuid, jsonb, jsonb) TO authenticated, service_role;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 5. Allowlist the new RPC for the CI execute-grant guard
+-- ─────────────────────────────────────────────────────────────────────────────
+-- WHY THE BROWSER NEEDS IT: `subdivide_location` is the "Divide it up…" button on
+-- the Storage page. It belongs in the "called directly from application code"
+-- group beside `bulk_put_away` and `transfer_stock`, and for the same reason —
+-- creating the sub-locations and moving the stock down must be ONE transaction,
+-- so it cannot be decomposed into client-side calls. Revoking it would leave
+-- that button raising 42501.
+--
+-- It is not an unguarded hole: the body asserts company membership, calls
+-- `inv_assert_can_write` for the billing gate, and its own deferred constraint
+-- check still fires at COMMIT — deferring is not skipping.
+--
+-- ⚠️ Recreated from 20260803043406 — the LATEST migration to declare this function
+-- — VERBATIM, with one name added. Not from 20260801181116, and not from the
+-- original: the allowlist lives in the body, so rebuilding it from a stale copy
+-- silently REVERTS every entry added since. The first draft of this migration did
+-- exactly that, copying 20260801181116 and dropping `mark_reactions_seen` while
+-- resurrecting `enable_location_tracking`/`disable_location_tracking`, two RPCs
+-- 20260802015101 had already deleted. `function_execute_leaks()` caught it, which
+-- is the third time in this file's history the same trap has been sprung.
+CREATE OR REPLACE FUNCTION public.function_execute_leaks()
+RETURNS TABLE(function_name text, role_name text)
+LANGUAGE sql
+STABLE
+SET search_path TO 'public', 'pg_temp'
+AS $$
+  SELECT p.proname::text, r.rolname::text
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  CROSS JOIN (VALUES ('anon'), ('authenticated')) AS r(rolname)
+  WHERE n.nspname = 'public'
+    -- SECURITY DEFINER only. An INVOKER function runs as the caller, so RLS and
+    -- table grants still contain it and a browser grant is not a hole; scoping
+    -- the guard this way keeps the allowlist to the set that actually matters
+    -- instead of every helper in the schema.
+    AND p.prosecdef
+    AND has_function_privilege(r.rolname, p.oid, 'EXECUTE')
+    AND p.proname NOT IN (
+      -- Named in an RLS policy: the browser cannot query the table without it.
+      'company_can_write', 'get_operator_access_id', 'get_user_company_ids',
+      'is_company_admin', 'is_system_admin',
+      -- Called directly from application code (utils/*Access.ts, app/, hooks/).
+      -- NB: enable_location_tracking / disable_location_tracking are deliberately absent.
+      -- 20260802015101 dropped both RPCs; re-listing them here would leave the allowlist
+      -- naming functions that no longer exist, which is how this list rots.
+      'accept_invitation', 'add_stock_at_location', 'adjust_stock_at_location',
+      'create_demo_company', 'create_shipment_with_line_items', 'delete_location',
+      'deplete_stock_at_location', 'log_note_views', 'log_operator_event',
+      'note_viewers', 'reset_demo_company', 'sync_demo_access', 'transfer_stock',
+      -- Added 20260801181116: the count sheet's put-away calls it directly
+      -- (`bulkPutAway` in utils/inventoryLocationsAccess.ts).
+      'bulk_put_away',
+      -- Added 20260803043406: the Me tab dismisses its recognition block through it
+      -- (`markHelpfulSeen` in utils/operatorAccess.ts).
+      'mark_reactions_seen',
+      -- Added 20260806160053: the Storage page's "Divide it up…" calls it
+      -- directly (`subdivideLocation` in utils/inventoryLocationsAccess.ts).
+      -- Creating the sub-locations and moving the stock down must be one
+      -- transaction, so it cannot be decomposed into client-side calls.
+      'subdivide_location',
+      -- Called BY a browser-callable SECURITY INVOKER function, which runs as the
+      -- caller — so the caller genuinely needs EXECUTE on this one.
+      -- (generate_quote_number / generate_direct_job_number -> next_order_number)
+      'next_order_number'
+    )
+  ORDER BY 1, 2;
+$$;
+
+COMMENT ON FUNCTION public.function_execute_leaks() IS
+  'Lists SECURITY DEFINER functions in public that a browser role can execute and that are not on the reviewed allowlist. Must always be empty. Exists because the ON FUNCTIONS default privileges auto-granted every new function to anon/authenticated, making the REVOKE ... FROM PUBLIC idiom used across this schema ineffective (issue #640) — and because over-granting is silent, so only a test finds it. To add a function here, say in the PR why the browser needs to call it.';

--- a/types/database.ts
+++ b/types/database.ts
@@ -3849,6 +3849,26 @@ export type Database = {
       }
       show_limit: { Args: never; Returns: number }
       show_trgm: { Args: { "": string }; Returns: string[] }
+      subdivide_location: {
+        Args: { p_moves?: Json; p_nodes: Json; p_parent_id: string }
+        Returns: {
+          company_id: string
+          created_at: string
+          id: string
+          kind: string | null
+          name: string
+          parent_id: string | null
+          photo_path: string | null
+          sort_order: number
+          updated_at: string
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "inventory_locations"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
       sync_demo_access: {
         Args: { p_demo_company_id: string; p_source_company_id: string }
         Returns: undefined

--- a/types/inventoryLocations.ts
+++ b/types/inventoryLocations.ts
@@ -85,6 +85,15 @@ export interface LocationContent {
   part_name: string;
   primary_unit: string | null;
   quantity: number;
+  /**
+   * Which bin this row is in.
+   *
+   * Redundant when the caller asked about one location and knew the answer already — and required
+   * the moment it asks about several, which counting a whole cabinet does. Kept **non-optional** so
+   * there is one row shape rather than one that sometimes knows where it is: a count line commits
+   * against this id, and a silently-absent field there would write to the wrong shelf.
+   */
+  location_id: string;
 }
 
 /** Result of resolving a scanned location id into a renderable view. */

--- a/utils/inventoryCountAccess.ts
+++ b/utils/inventoryCountAccess.ts
@@ -17,7 +17,7 @@ import {
   adjustStockAtLocation,
   getBalancesForPart,
   getBalancesForParts,
-  getLocationContentsPage,
+  getContentsPageForLocations,
   getLocations,
 } from '@/utils/inventoryLocationsAccess';
 import { resolveFallbackPlace, countNote } from '@/lib/inventoryCountPlan';
@@ -127,21 +127,67 @@ export async function loadLocationCountCandidates(
   locationName: string,
   opts: { search?: string; limit?: number; offset?: number } = {},
 ): Promise<{ candidates: CountCandidate[]; total: number }> {
-  const { contents, total } = await getLocationContentsPage(locationId, opts);
+  return loadCountCandidatesForPlaces(
+    // `locationPath` is the plain name here: every row on this sheet shares one place and the page
+    // title already says which, so an ancestor path would repeat down every row.
+    [{ id: locationId, name: locationName, path: locationName }],
+    opts,
+  );
+}
+
+/** One bin a count sheet may write to, with the label its rows should carry. */
+export interface CountPlace {
+  id: string;
+  name: string;
+  /** How the row names its bin. Full path when a sheet spans several, plain name when it doesn't. */
+  path: string;
+}
+
+/**
+ * Build the count sheet for a SET of bins — what counting a whole cabinet means.
+ *
+ * A container holds no stock itself (20260806160053), so "count Cabinet 1-A" can only be "count
+ * every bin under it". Nothing about committing changes: `commitCount` already adjusts each line at
+ * `candidate.target.locationId`, so a sheet spanning ten bins is ten independent one-bin
+ * assertions. That per-line target is what made this a small change rather than a new engine.
+ *
+ * **A part in two bins gets two lines, not one.** Aggregating would re-create precisely the
+ * ambiguity that forces the company-wide sheet to skip split parts — if a part holds 380 + 200 and
+ * you count 560, no bin defensibly absorbs the −20. Two lines means each number is an assertion
+ * about one shelf you are standing at, which is also how you would physically do it.
+ *
+ * Rows keep the bin's **full path** because, unlike the single-bin sheet, the page title can no
+ * longer say which place a row belongs to.
+ */
+export async function loadCountCandidatesForPlaces(
+  places: CountPlace[],
+  opts: { search?: string; limit?: number; offset?: number } = {},
+): Promise<{ candidates: CountCandidate[]; total: number }> {
+  const byId = new Map(places.map((p) => [p.id, p] as const));
+  const { contents, total } = await getContentsPageForLocations(
+    places.map((p) => p.id),
+    opts,
+  );
 
   return {
-    candidates: contents.map((c) => ({
-      partId: c.part_id,
-      partName: c.part_name,
-      // The paged read is deliberately narrow — it doesn't join descriptions, because this list is
-      // reached by searching for a part you're holding rather than by browsing for one.
-      description: null,
-      unit: c.primary_unit ?? 'ea',
-      systemQuantity: c.quantity,
-      // `locationPath` is the plain name here: every row on this sheet shares one place and the
-      // page title already says which, so an ancestor path would repeat down every row.
-      target: { locationId, locationName, locationPath: locationName },
-    })),
+    candidates: contents.map((c) => {
+      // Every row carries its own bin, so this lookup cannot miss — the ids came from `places`.
+      const place = byId.get(c.location_id);
+      return {
+        partId: c.part_id,
+        partName: c.part_name,
+        // The paged read is deliberately narrow — it doesn't join descriptions, because this list
+        // is reached by searching for a part you're holding rather than by browsing for one.
+        description: null,
+        unit: c.primary_unit ?? 'ea',
+        systemQuantity: c.quantity,
+        target: {
+          locationId: c.location_id,
+          locationName: place?.name ?? '',
+          locationPath: place?.path ?? '',
+        },
+      };
+    }),
     total,
   };
 }

--- a/utils/inventoryLocationsAccess.ts
+++ b/utils/inventoryLocationsAccess.ts
@@ -13,6 +13,7 @@ import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 import { ID_CHUNK } from '@/lib/queryLimits';
 import { convertToBaseUnit } from '@/lib/unitPresets';
 import { isReservedKind, RESERVED_KIND_MESSAGE } from '@/lib/locationKinds';
+import { computePathNames } from '@/lib/locationTree';
 import { resolveMovementAttribution } from '@/utils/movementAttribution';
 import { duplicateSubtreeAsSibling } from '@/utils/locationSpec';
 import {
@@ -451,6 +452,91 @@ export async function materializeLocationSpec(
   return insertSpecForest(companyId, parentId, nodes, startSortOrder);
 }
 
+/** One part's stock moving into one of the sub-locations about to be created. */
+export interface SubdivideMove {
+  partId: string;
+  /** `LocationSpecNode.key` of the destination — a leaf of the spec, which does not exist yet. */
+  toRef: string;
+  quantity: number;
+  unit: string;
+}
+
+/** Flatten a spec forest to `{ref, parent_ref}` rows, parent before child, as the RPC requires. */
+function flattenSpec(
+  nodes: LocationSpecNode[],
+  parentRef: string | null,
+  startSortOrder: number,
+): Array<{ ref: string; parent_ref: string | null; name: string; kind: string | null; sort_order: number }> {
+  const out: ReturnType<typeof flattenSpec> = [];
+  let sortOrder = startSortOrder;
+  for (const node of nodes) {
+    out.push({
+      ref: node.key,
+      parent_ref: parentRef,
+      name: node.name,
+      kind: node.kind,
+      sort_order: sortOrder++,
+    });
+    // Depth-first, so a child always follows its parent — the RPC rejects a forward reference
+    // rather than guessing, because silently rooting a node in the wrong place is unrecoverable.
+    out.push(...flattenSpec(node.children, node.key, 0));
+  }
+  return out;
+}
+
+/**
+ * Subdivide a place, moving whatever it holds down into the new sub-locations.
+ *
+ * ## Why this is an RPC and not `materializeLocationSpec` plus some transfers
+ *
+ * Since 20260806160053 a place with sub-locations cannot hold stock, and the two halves of this
+ * operation each break that rule on their own: creating the children first makes the parent a
+ * container while its stock is still in it, and moving the stock first has nowhere to move it to.
+ * Only doing both in one transaction is legal, so `subdivide_location` defers the constraint and
+ * the whole thing either happens or does not.
+ *
+ * It also fixes what `materializeLocationSpec` documents about itself two functions up: that path
+ * is sequential and not transactional, so a failure partway leaves the nodes created before it.
+ *
+ * Conversion happens here, per part, exactly as it does for `transferStock` — the RPC delegates
+ * each move to `transfer_stock`, which wants both the display values and the converted quantity.
+ * One `loadConversionContext` per distinct part rather than per move, since splitting one part
+ * across three bins is three moves against one part.
+ */
+export async function subdivideLocation(
+  parentId: string,
+  nodes: LocationSpecNode[],
+  moves: SubdivideMove[],
+  startSortOrder = 0,
+): Promise<InventoryLocation[]> {
+  const contexts = new Map<string, Awaited<ReturnType<typeof loadConversionContext>>>();
+  for (const partId of new Set(moves.map((m) => m.partId))) {
+    contexts.set(partId, await loadConversionContext(partId));
+  }
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase.rpc('subdivide_location', {
+    p_parent_id: parentId,
+    p_nodes: flattenSpec(nodes, null, startSortOrder),
+    p_moves: moves.map((m) => {
+      const { primaryUnit, conversions } = contexts.get(m.partId)!;
+      return {
+        part_id: m.partId,
+        to_ref: m.toRef,
+        quantity: m.quantity,
+        unit: m.unit,
+        converted_quantity: convertToBaseUnit(m.quantity, m.unit, primaryUnit, conversions),
+      };
+    }),
+  });
+
+  if (error) {
+    console.error('Error subdividing location:', error);
+    throw error;
+  }
+  return (data ?? []) as InventoryLocation[];
+}
+
 /**
  * Duplicate a location and its entire subtree as a new sibling — structure
  * only, no stock. The copy's root is named past the existing siblings
@@ -492,27 +578,13 @@ export async function duplicateLocation(
 // ===========================================================================
 
 /**
- * Root → leaf names for a location, e.g. `['Cabinet 1', 'Row 3', 'Left']`.
+ * Re-exported so existing importers keep working. The implementation moved to
+ * [`lib/locationTree.ts`](../lib/locationTree.ts) because it needs nothing from this module, and
+ * importing it from here forced a Supabase client into every consumer — and into every test of one.
  *
- * Exported because this walk had been hand-rolled in three other places (the operator bin page,
- * the count page, and `PartLocationInventory`). Use this one rather than writing a fourth — the
- * cycle guard in particular is easy to leave out, and re-parenting can produce one.
+ * New callers should import from `@/lib/locationTree` directly.
  */
-export function computePathNames(
-  locationId: string,
-  byId: Map<string, InventoryLocation>,
-): string[] {
-  const names: string[] = [];
-  let cursor: string | null = locationId;
-  const guard = new Set<string>();
-  while (cursor && byId.has(cursor) && !guard.has(cursor)) {
-    guard.add(cursor);
-    const node: InventoryLocation = byId.get(cursor)!;
-    names.unshift(node.name);
-    cursor = node.parent_id;
-  }
-  return names;
-}
+export { computePathNames };
 
 /** A part's balances across locations, each with its full display path. */
 export async function getBalancesForPart(
@@ -672,7 +744,7 @@ export async function getLocationContents(
   const { data, error, count } = await supabase
     .from('part_location_stock')
     .select(
-      'quantity, part:parts!part_location_stock_part_fkey!inner(id, part_name, primary_unit)',
+      'location_id, quantity, part:parts!part_location_stock_part_fkey!inner(id, part_name, primary_unit)',
       { count: 'exact' },
     )
     .eq('location_id', locationId)
@@ -685,15 +757,24 @@ export async function getLocationContents(
     throw error;
   }
 
-  type Row = {
-    quantity: number;
-    part:
-      | { id: string; part_name: string; primary_unit: string | null }
-      | Array<{ id: string; part_name: string; primary_unit: string | null }>
-      | null;
-  };
+  const contents = toLocationContents(data)
+    .sort((a, b) => a.part_name.localeCompare(b.part_name));
 
-  const contents = ((data ?? []) as Row[])
+  return { contents, total: count ?? contents.length };
+}
+
+type ContentRow = {
+  location_id: string;
+  quantity: number;
+  part:
+    | { id: string; part_name: string; primary_unit: string | null }
+    | Array<{ id: string; part_name: string; primary_unit: string | null }>
+    | null;
+};
+
+/** Shared row mapper — PostgREST types a to-one embed as possibly-an-array, so unwrap once. */
+function toLocationContents(data: unknown): LocationContent[] {
+  return ((data ?? []) as ContentRow[])
     .map((row) => {
       const part = Array.isArray(row.part) ? row.part[0] : row.part;
       if (!part) return null;
@@ -702,12 +783,10 @@ export async function getLocationContents(
         part_name: part.part_name,
         primary_unit: part.primary_unit,
         quantity: Number(row.quantity),
+        location_id: row.location_id,
       } as LocationContent;
     })
-    .filter((r): r is LocationContent => r !== null)
-    .sort((a, b) => a.part_name.localeCompare(b.part_name));
-
-  return { contents, total: count ?? contents.length };
+    .filter((r): r is LocationContent => r !== null);
 }
 
 /** Rows per page when working through a location's contents. */
@@ -739,16 +818,45 @@ export interface LocationContentsQuery {
  */
 export async function getLocationContentsPage(
   locationId: string,
+  query: LocationContentsQuery = {},
+): Promise<LocationContentsPage> {
+  return getContentsPageForLocations([locationId], query);
+}
+
+/**
+ * One page of the contents of SEVERAL bins at once — what counting a whole cabinet reads.
+ *
+ * A container holds no stock of its own (20260806160053), so "count Cabinet 1-A" can only mean the
+ * bins beneath it. Every row keeps its own `location_id`, which is what makes that safe: a count
+ * line commits with `adjustStockAtLocation` against the row's own bin, so a sheet spanning ten bins
+ * is ten independent one-bin assertions rather than one ambiguous total.
+ *
+ * That is also why the rows are NOT aggregated per part. A part in two bins yields two lines, and
+ * that is the point — it is exactly the ambiguity that forces the company-wide sheet to *skip*
+ * split parts ("count it at its locations"), and counting bin by bin is how the ambiguity stops
+ * existing.
+ *
+ * **Ordering is a walking route, as far as one query can express it:** by the bin's `sort_order`
+ * then its name, then the part. Across two shelves that interleaves by sibling position rather
+ * than strict depth-first, which is why every row also carries its bin so the sheet can label it —
+ * the label is what tells a counter where to stand, not the sort.
+ */
+export async function getContentsPageForLocations(
+  locationIds: string[],
   { search = '', limit = LOCATION_PAGE_SIZE, offset = 0 }: LocationContentsQuery = {},
 ): Promise<LocationContentsPage> {
+  if (locationIds.length === 0) return { contents: [], total: 0 };
+
   const supabase = getSupabase();
   let query = supabase
     .from('part_location_stock')
     .select(
-      'quantity, part:parts!part_location_stock_part_fkey!inner(id, part_name, primary_unit)',
+      'location_id, quantity, ' +
+        'place:inventory_locations!inner(id, name, sort_order), ' +
+        'part:parts!part_location_stock_part_fkey!inner(id, part_name, primary_unit)',
       { count: 'exact' },
     )
-    .eq('location_id', locationId)
+    .in('location_id', locationIds)
     .is('part.deleted_at', null);
 
   const term = search.trim();
@@ -758,9 +866,12 @@ export async function getLocationContentsPage(
   if (term) query = query.ilike('part.part_name', `%${term}%`);
 
   const { data, error, count } = await query
-    // `'part'` is the embed's ALIAS, not the table name. `referencedTable: 'parts'` makes PostgREST
-    // reject the whole request with `PGRST108 'parts' is not an embedded resource` — verified
-    // against the running stack, which is the only way this surfaces (it type-checks either way).
+    // `'part'` / `'place'` are the embeds' ALIASES, not table names. `referencedTable: 'parts'`
+    // makes PostgREST reject the whole request with `PGRST108 'parts' is not an embedded resource`
+    // — verified against the running stack, which is the only way this surfaces (it type-checks
+    // either way).
+    .order('sort_order', { referencedTable: 'place', ascending: true })
+    .order('name', { referencedTable: 'place', ascending: true })
     .order('part_name', { referencedTable: 'part', ascending: true })
     .range(offset, offset + limit - 1);
 
@@ -769,27 +880,9 @@ export async function getLocationContentsPage(
     throw error;
   }
 
-  type Row = {
-    quantity: number;
-    part:
-      | { id: string; part_name: string; primary_unit: string | null }
-      | Array<{ id: string; part_name: string; primary_unit: string | null }>
-      | null;
-  };
-
-  const contents = ((data ?? []) as Row[])
-    .map((row) => {
-      const part = Array.isArray(row.part) ? row.part[0] : row.part;
-      if (!part) return null;
-      return {
-        part_id: part.id,
-        part_name: part.part_name,
-        primary_unit: part.primary_unit,
-        quantity: Number(row.quantity),
-      } as LocationContent;
-    })
-    .filter((r): r is LocationContent => r !== null);
-
+  // Order is the server's — deliberately NOT re-sorted here, which would only reshuffle the
+  // current page and make the route jump at every page boundary.
+  const contents = toLocationContents(data);
   return { contents, total: count ?? contents.length };
 }
 

--- a/utils/locationDestinations.ts
+++ b/utils/locationDestinations.ts
@@ -1,0 +1,150 @@
+/**
+ * Which locations may be offered as a destination — the one place that answers it.
+ *
+ * ## Why this exists
+ *
+ * Six call sites each built their own `LocationPickerOption[]` with their own copy of the
+ * root→leaf ancestry walk, and **none of them filtered containers**. That is how a cabinet made
+ * only of Side 1 and Side 2 stayed a selectable place to put a part, on every surface at once.
+ * `LocationPicker` could not fix it centrally either: its option type carries `id`, `label`,
+ * `kind` and `quantity`, and nothing about parentage, so leafness is not even expressible there.
+ *
+ * As of 20260806160053 the database refuses the write, so an unfiltered picker no longer produces
+ * bad data — it produces an error dialog on a choice that should never have been offered. Filtering
+ * here is what keeps the guard from being something a user meets.
+ *
+ * ## Two rules, two functions, deliberately not merged
+ *
+ * "Where may this STOCK go" and "where may this SHELF go" look alike and are not:
+ *
+ * | | containers | the `Unassigned` pile | itself / its own subtree |
+ * |---|---|---|---|
+ * | `stockDestinationOptions` | **excluded** — stock lives on leaves | excluded | excluded |
+ * | `locationParentOptions`   | **required** — a container is the whole point | excluded | excluded |
+ *
+ * Collapsing them into one function with a flag would put the two opposite answers to the container
+ * question behind a boolean, which is exactly the shape that invites passing the wrong one.
+ *
+ * Pure and DB-free, like `locationSpec.ts` and `locationOccupancy.ts` beside it: decisions live in
+ * functions you can test without a network.
+ */
+import type { LocationPickerOption } from '@/components/inventory/locations/LocationPicker';
+import { computePathNames } from '@/lib/locationTree';
+import { SYSTEM_KIND } from '@/lib/locationKinds';
+import { occupancyFor, type OccupancyMap } from '@/utils/locationOccupancy';
+import type {
+  InventoryLocation,
+  PartLocationBalanceWithLocation,
+} from '@/types/inventoryLocations';
+
+/** Ids that are somebody's parent. One pass, so leafness is a set lookup rather than a scan. */
+function parentIds(locations: InventoryLocation[]): ReadonlySet<string> {
+  const out = new Set<string>();
+  for (const l of locations) if (l.parent_id) out.add(l.parent_id);
+  return out;
+}
+
+/** Full path root→leaf, falling back to the bare name for a root. */
+function labelFor(location: InventoryLocation, byId: Map<string, InventoryLocation>): string {
+  return computePathNames(location.id, byId).join(' › ') || location.name;
+}
+
+export interface StockDestinationOptions {
+  /** The source location, dropped so you cannot move something to where it already is. */
+  excludeId?: string | null;
+  /**
+   * The subject part's balances, merged in so each option can say what is already there.
+   * `LocationPicker` renders these only when the caller also passes `unit`.
+   */
+  balances?: PartLocationBalanceWithLocation[];
+}
+
+/**
+ * Where a PART may go: leaves only, never the put-away pile.
+ *
+ * Sorted with places already holding some of this part first — putting stock back with the rest of
+ * it is the common case, and it keeps one part from scattering across the shop — then
+ * alphabetically within each group, so the order is stable and learnable rather than shifting with
+ * stock levels. Callers that pass no balances get plain alphabetical.
+ */
+export function stockDestinationOptions(
+  locations: InventoryLocation[],
+  { excludeId, balances = [] }: StockDestinationOptions = {},
+): LocationPickerOption[] {
+  const byId = new Map(locations.map((l) => [l.id, l] as const));
+  const parents = parentIds(locations);
+  const heldAt = new Map(balances.map((b) => [b.location_id, Number(b.quantity ?? 0)] as const));
+
+  return locations
+    .filter(
+      (l) =>
+        l.id !== excludeId &&
+        l.kind !== SYSTEM_KIND &&
+        // The rule this module exists for: a container holds its children, not stock.
+        !parents.has(l.id),
+    )
+    .map((l) => ({
+      id: l.id,
+      label: labelFor(l, byId),
+      kind: l.kind,
+      quantity: heldAt.get(l.id) ?? 0,
+    }))
+    .sort((a, b) => {
+      const aHas = (a.quantity ?? 0) > 0;
+      const bHas = (b.quantity ?? 0) > 0;
+      if (aHas !== bHas) return aHas ? -1 : 1;
+      return a.label.localeCompare(b.label);
+    });
+}
+
+export interface LocationParentOptions {
+  /** The location being moved. It and everything under it are excluded. */
+  nodeId: string;
+  /**
+   * Roll-up occupancy, used to drop any location that holds stock DIRECTLY.
+   *
+   * Direct, not rolled-up: a cabinet whose shelves are full holds nothing itself and is a perfectly
+   * good parent. Using `hasStock` here would exclude every populated cabinet in the shop.
+   */
+  occupancy: OccupancyMap;
+}
+
+/**
+ * Where a LOCATION may go: any container except itself, its own descendants, the put-away pile, or
+ * a location that already holds stock directly.
+ *
+ * That last exclusion is new, and it is the reachability half of the guard. Re-parenting into a
+ * stocked location would make that location a container while stock sat in it — direction (b) of
+ * the invariant — and unlike "Divide it up…" there is no distribution step to hang on a Move, so
+ * the database simply refuses it. Dropping those targets means the user meets an absence rather
+ * than an error.
+ */
+export function locationParentOptions(
+  locations: InventoryLocation[],
+  { nodeId, occupancy }: LocationParentOptions,
+): LocationPickerOption[] {
+  const byId = new Map(locations.map((l) => [l.id, l] as const));
+
+  // A location cannot move inside itself. Walk up from each candidate rather than down from the
+  // node: same answer, and the cycle guard is already written in `computePathNames`' shape.
+  const isUnder = (candidate: InventoryLocation): boolean => {
+    let cursor: string | null = candidate.id;
+    const guard = new Set<string>();
+    while (cursor && !guard.has(cursor)) {
+      if (cursor === nodeId) return true;
+      guard.add(cursor);
+      cursor = byId.get(cursor)?.parent_id ?? null;
+    }
+    return false;
+  };
+
+  return locations
+    .filter(
+      (l) =>
+        l.kind !== SYSTEM_KIND &&
+        !isUnder(l) &&
+        occupancyFor(occupancy, l.id).directParts === 0,
+    )
+    .map((l) => ({ id: l.id, label: labelFor(l, byId), kind: l.kind }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}

--- a/utils/locationSpec.ts
+++ b/utils/locationSpec.ts
@@ -133,6 +133,25 @@ export function countSpecNodes(nodes: LocationSpecNode[]): number {
   return nodes.reduce((sum, n) => sum + 1 + countSpecNodes(n.children), 0);
 }
 
+/**
+ * The spec's leaves, each with its path within the spec — the only places stock may be sent when
+ * subdividing, since a node with children cannot hold any (20260806160053).
+ *
+ * Labels are scoped to the spec (`Row 1 › Left`) rather than the whole shop: the parent's own path
+ * is already the dialog's title, and repeating it down every row of the distribute table would push
+ * the part of the name that actually differs off the end.
+ */
+export function collectSpecLeaves(
+  nodes: LocationSpecNode[],
+  prefix: string[] = [],
+): Array<{ key: string; label: string }> {
+  return nodes.flatMap((n) =>
+    n.children.length === 0
+      ? [{ key: n.key, label: [...prefix, n.name].join(' › ') }]
+      : collectSpecLeaves(n.children, [...prefix, n.name]),
+  );
+}
+
 /** Remove a node (and its subtree) by key — used by the prune step. */
 export function removeSpecNode(nodes: LocationSpecNode[], key: string): LocationSpecNode[] {
   return nodes


### PR DESCRIPTION
If Cabinet 1-A is just Side 1 and Side 2, nobody ever means "put it in the cabinet" — they mean a side. Every layer allowed it anyway: no picker filtered containers, no RPC checked, and nothing in the schema said otherwise.

This makes *a location with children holds no stock* a real invariant, and follows it out to the surfaces that assumed otherwise.

## The invariant

Two directions, both closed, by two `DEFERRABLE INITIALLY IMMEDIATE` constraint triggers sharing one name:

| Direction | Trigger on | Refuses |
|---|---|---|
| (a) | `part_location_stock` INSERT | stock landing on a place that has children |
| (b) | `inventory_locations` INSERT / UPDATE OF `parent_id` | children under a place that holds stock, and any child under `Unassigned` |

This partly reverses [`20260623031347`](supabase/migrations/20260623031347_drop_location_display_flags.sql), which dropped `is_stockable` on the reasoning that *"every location can hold stock"*. That was right about leaves and about printing (a container's QR still navigates), wrong about containers. No flag comes back — containment is already `parent_id`, and a flag that must agree with it can drift.

### 🔒 The row locks are load-bearing, not defensive

Please read this bit rather than skimming it. Both trigger bodies test cross-row state with a plain `EXISTS`, and PostgREST runs at READ COMMITTED:

> T1 inserts children under Cabinet 1-A, uncommitted. T2 inserts stock at Cabinet 1-A; its `EXISTS` cannot see T1's uncommitted children, so it passes. T1's deferred check fires at its own commit, cannot see T2's uncommitted row, so it passes. **Both commit, and nothing raised.**

Textbook write skew. Deferral does not help — a deferred trigger takes a *fresh* snapshot at commit, which still excludes an uncommitted transaction — and Postgres only detects this at SERIALIZABLE. So (a) takes `FOR SHARE` on the location row and (b) takes `FOR UPDATE`; those conflict, the second transaction blocks, and its post-lock `EXISTS` sees the truth. The implicit FK locks are both `FOR KEY SHARE` and serialise nothing.

`test_concurrent_subdivide_and_stock_cannot_both_win` **fails only when the locks are removed** — I verified that by stripping them and re-running; every other case in the file still passed. `FOR SHARE` not conflicting with itself is deliberate: two operators receiving into the same bin still proceed concurrently, and only a *structural* change serialises against them.

### No backfill

Audited before writing it: prod held **0 of 141** balance rows at a container (38 locations, 8 of them containers), `supabase/seed.sql` stocks only leaves, and the demo template stocks only leaf refs. The migration still opens with a `DO` block that **refuses to install over violating data** — a constraint trigger never validates rows that already exist, so installing over bad data would hide a violation behind a guard claiming to prevent it.

## `subdivide_location`

Subdividing a loaded shelf *must* pass through the illegal intermediate state (create the children, then move the stock down), which is the only reason the triggers are deferrable. The RPC takes the parent lock up front, defers both triggers, inserts the subtree from a flat `{ref, parent_ref}` list, and delegates each move to the existing `transfer_stock` so the ledger and `transfer_group_id` are identical to any other movement. An incomplete distribution rolls the sub-locations back with it at COMMIT.

It also makes the loaded-parent subdivide **transactional**, which `materializeLocationSpec` never was (#618 — still open for the empty-parent path).

**Allowlist justification** (`function_execute_leaks()`): it is the Storage page's "Divide it up…" button and belongs with `bulk_put_away` and `transfer_stock`, for the same reason — creating the sub-locations and moving the stock down must be one transaction, so it cannot be decomposed into client-side calls. Revoking it leaves that button raising 42501. The body asserts company membership and calls `inv_assert_can_write`, and deferring is not skipping.

⚠️ While adding to that allowlist I rebuilt it from `20260801181116` and silently dropped `mark_reactions_seen` while resurrecting two RPCs `20260802015101` had deleted. CI caught it; rebased on `20260803043406`, the latest declaration. **That trap has now fired three times** — worth generating this list rather than retyping it.

## What follows from the invariant

- **Subdivide gains a distribution step** — per-part destinations with **quantity splitting**, because you divide a shelf *because* what is on it is already in two piles. Led by **"Send everything to…"**, since `LOCATION_CONTENTS_LIMIT` is 200 and a 200-row decision table is not a UI. Create stays disabled until each part's lines sum exactly to its on-hand — not politeness: an incomplete distribution rolls the whole subdivide back, so checking here turns a mystifying failure into arithmetic. An empty place keeps the original single screen.
- **Counting a container** gathers every bin beneath it, one line per (part, bin). No new write path — `commitCount` already adjusts each line at its own `target.locationId`, so `.eq('location_id', x)` becoming `.in(...)` was most of it. **A split part stays two lines, never one total**: aggregating re-creates precisely the ambiguity that forces the company-wide sheet to *skip* split parts (380 + 200 counted as 560 has no defensible home for the −20). Bulk put-away is withheld there — it moves parts out of *one* location and the rows come from several.
- **`utils/locationDestinations.ts`** becomes the single source of two rules: `stockDestinationOptions` (leaves only, no pile) and `locationParentOptions` (containers required, but not one holding stock *directly* — rolled-up would exclude every populated cabinet). Six call sites each hand-rolled their own list, and none filtered containers.
- **Storage table is an accordion with one open branch**, held as a path rather than a set of expanded ids so the stricter rule is the only representable one. Default-everything-expanded does not survive the builder's own 5 × 2 default turning one row into 16.
- **`computePathNames` moves to `lib/locationTree.ts`.** It needed nothing from the access layer, and importing it from there forced a Supabase client into every consumer and every test of one — a workaround `PutAwayPickerDialog.test.tsx` already records having to make.
- **Operator lookup says "None available"** instead of *"None in any place right now."* `parts.quantity` is a pure roll-up, so no rows means none on hand *anywhere* — a stock fact the old wording dressed as a placement one, sending someone to hunt for something not in the building.
- **A container's operator bin view drops "Stock a part"** — it sat directly above *"No stock recorded directly here"*, a button inviting you to break the sentence beside it.

## Verification

Driven end to end against the seeded shop, not just unit-tested:

- Subdivided **Shelf A** (580 bearings + 828 orings) into two bins, splitting the bearings **380 / 200**. Roll-ups unchanged, paired transfer ledger written, **0 rows left at any container**.
- Put-away picker offered exactly the four leaves; `Cabinet 3`, `Shelf A` and `Unassigned` all absent.
- "Count Cabinet 3" gathered both bins beneath it, showed the split part as two labelled lines, and counting 820 against Shelf A moved **Shelf A only** (828 → 820, Shelf B untouched), ledger naming the exact bin.

Green: **2045 vitest** tests (149 files), **253 backend integration** tests, `tsc`, `pnpm lint` (0 errors), `pnpm build`, `docLinkCheck`, `supabase db reset`.

## Deliberately out of scope

- The `Unassigned` name-vs-`kind` split — SQL resolves it by literal name, TypeScript by `kind === 'system'`. This change touches it but does not fix it.
- `materializeLocationSpec` remains non-transactional for the empty-parent path (#618).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
