### PR TITLE
Supabase failures report themselves (#708, part 1 of 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,9 +80,15 @@ before touching Sentry config or triaging. The rules that bind while writing cod
 - **Sentry is the error tracker; PostHog is product analytics.** Never add a second error tracker.
   **Vercel Web Analytics (`<Analytics />`) is kept deliberately** despite overlapping PostHog — do
   not remove either as "redundant".
+- **A failed `.from()` read or write reports itself — don't report it again.** `lib/supabase.ts`
+  installs Sentry's Supabase integration, so every `{ error }` is captured with its query
+  attached. Adding a `captureException` for one files the same failure as two issues. You still
+  capture by hand for **`.rpc()`** (deliberately excluded — only the call site can tell a raise
+  meant for the user from a bug), **storage**, and anything that isn't a Supabase response.
 - **Never pass a raw Supabase error to `Sentry.captureException`** — it can't fingerprint a plain
   object and you get an issue titled `"e"`. Wrap with `toError` from
-  [`lib/supabaseErrors.ts`](lib/supabaseErrors.ts).
+  [`lib/supabaseErrors.ts`](lib/supabaseErrors.ts). (The integration already does this on the
+  paths it covers.)
 - **"Couldn't check" is never "denied."** A failed access check must not render as a definitive
   negative — throw and give the UI a retryable state.
 - **Transient aborts are not failures.** `AbortError: Lock was stolen` means superseded; classify

--- a/__tests__/lib/supabaseSentryIntegration.test.ts
+++ b/__tests__/lib/supabaseSentryIntegration.test.ts
@@ -1,0 +1,182 @@
+/**
+ * The Supabase-integration contract that issue #708's fix rests on.
+ *
+ * These assert BEHAVIOUR OF THE SENTRY SDK, not of our code, which is exactly why they are
+ * worth having: the whole design — a net for table operations, the access layer for `.rpc()` —
+ * is only correct while the SDK keeps behaving this way, and an SDK upgrade would change it
+ * silently. Every one of these was established by experiment before the code was written, and
+ * one of them (rpc reaching the net at all) contradicted the first design.
+ *
+ * Two things cost real time to discover while writing these, worth knowing before editing:
+ *   - `beforeSend` runs during `flush`, NOT when the query is awaited. Asserting straight after
+ *     an `await` sees nothing.
+ *   - Calling `Sentry.init` twice in one file routes events to the FIRST client's `beforeSend`.
+ *     Hence one `init` per test file, and separate files where a fresh module registry matters.
+ */
+import * as Sentry from '@sentry/nextjs';
+import { createClient } from '@supabase/supabase-js';
+import { applySupabaseEventPolicy, RPC_SPAN_ATTRIBUTE } from '@/lib/sentryEventPolicy';
+
+interface Captured {
+  message: string;
+  dbTable: unknown;
+  isRpc: unknown;
+  mechanismType: string | undefined;
+}
+
+const captured: Captured[] = [];
+
+/** Everything the integration hands to `beforeSend`, before our policy runs. */
+function recordRaw(event: Sentry.ErrorEvent): void {
+  const span = Sentry.getActiveSpan();
+  const data = span ? Sentry.spanToJSON(span).data : undefined;
+  captured.push({
+    message: event.exception?.values?.[0]?.value ?? '',
+    dbTable: data?.['db.table'],
+    isRpc: data?.[RPC_SPAN_ATTRIBUTE],
+    mechanismType: event.exception?.values?.[0]?.mechanism?.type,
+  });
+}
+
+/**
+ * A client that fails every request, wired like the real one in `lib/supabase.ts`: a custom
+ * `fetch` that stamps the rpc span attribute.
+ */
+function failingClient(body: Record<string, unknown>) {
+  return createClient('https://example.supabase.co', 'anon-key', {
+    global: {
+      fetch: async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes('/rest/v1/rpc/')) {
+          Sentry.getActiveSpan()?.setAttribute(RPC_SPAN_ATTRIBUTE, true);
+        }
+        return new Response(JSON.stringify(body), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    },
+  });
+}
+
+const PG_RAISED = { code: 'P0001', message: 'work center 853e is not in company 7523' };
+
+beforeAll(() => {
+  Sentry.init({
+    dsn: 'https://abc123@o1.ingest.us.sentry.io/1',
+    enabled: true,
+    tracesSampleRate: 1,
+    beforeSend(event, hint) {
+      recordRaw(event);
+      return applySupabaseEventPolicy(event, hint);
+    },
+    transport: () => ({ send: async () => ({}), flush: async () => true }),
+  });
+});
+
+beforeEach(() => {
+  captured.length = 0;
+});
+
+describe('the net: what the Supabase integration captures on its own', () => {
+  it('captures a failed table write that no call site reports, tagged with the table', async () => {
+    const client = failingClient(PG_RAISED);
+    Sentry.instrumentSupabaseClient(client);
+
+    // Deliberately ignoring the returned `{ error }` — the exact shape of the #708 incident,
+    // where the only record of a day of failed saves was the Postgres log.
+    await client.from('notes').insert({ body: 'x' });
+    await Sentry.flush(200);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].message).toContain('work center 853e');
+    expect(captured[0].dbTable).toBe('notes');
+    expect(captured[0].mechanismType).toBe('auto.db.supabase.postgres');
+  });
+
+  it('reaches .rpc() too — which is why rpc has to be suppressed, not assumed absent', async () => {
+    const client = failingClient(PG_RAISED);
+    Sentry.instrumentSupabaseClient(client);
+
+    // Warm the lazy prototype patch, the way any real page load does.
+    await client.from('notes').select('id');
+    await Sentry.flush(200);
+    captured.length = 0;
+
+    await client.rpc('transfer_stock', { p_part_id: 'x' });
+    await Sentry.flush(200);
+
+    // `db.table` holds the FUNCTION name, indistinguishable from a table name without the URL.
+    expect(captured).toHaveLength(1);
+    expect(captured[0].dbTable).toBe('transfer_stock');
+    expect(captured[0].isRpc).toBe(true);
+  });
+});
+
+describe('the policy: what survives beforeSend', () => {
+  it('drops rpc, so the access layer stays its sole reporter', async () => {
+    const kept: unknown[] = [];
+    const event = {
+      exception: {
+        values: [{ value: 'raised', mechanism: { type: 'auto.db.supabase.postgres', handled: false } }],
+      },
+    } as unknown as Sentry.ErrorEvent;
+
+    // Stand in for the active span the real path provides.
+    Sentry.startSpan(
+      { name: 'insert(...) from(transfer_stock)', attributes: { [RPC_SPAN_ATTRIBUTE]: true } },
+      () => {
+        kept.push(applySupabaseEventPolicy(event, { originalException: { code: 'P0001' } }));
+      },
+    );
+
+    expect(kept[0]).toBeNull();
+  });
+
+  it('keeps a table failure, marks it handled, and tags the table', () => {
+    const event = {
+      exception: {
+        values: [{ value: 'raised', mechanism: { type: 'auto.db.supabase.postgres', handled: false } }],
+      },
+    } as unknown as Sentry.ErrorEvent;
+
+    let result: Sentry.ErrorEvent | null = null;
+    Sentry.startSpan(
+      { name: 'insert(...) from(notes)', attributes: { 'db.table': 'notes' } },
+      () => {
+        result = applySupabaseEventPolicy(event, { originalException: { code: 'P0001' } });
+      },
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.exception?.values?.[0]?.mechanism?.handled).toBe(true);
+    expect(result!.tags?.['db.table']).toBe('notes');
+  });
+
+  it.each([
+    ['a .single() that matched nothing', { code: 'PGRST116', message: 'no rows' }],
+    ['a cancelled request', { message: 'FetchError', hint: 'Request was aborted (timeout or manual cancellation)' }],
+    ['an expired session', { code: 'PGRST301', message: 'JWT expired' }],
+  ])('drops %s', (_label, originalException) => {
+    const event = {
+      exception: {
+        values: [{ value: 'x', mechanism: { type: 'auto.db.supabase.postgres', handled: false } }],
+      },
+    } as unknown as Sentry.ErrorEvent;
+
+    expect(applySupabaseEventPolicy(event, { originalException })).toBeNull();
+  });
+
+  it('leaves events that are not the integration\'s alone', () => {
+    const event = {
+      exception: { values: [{ value: 'render blew up', mechanism: { type: 'onerror', handled: false } }] },
+    } as unknown as Sentry.ErrorEvent;
+
+    const result = applySupabaseEventPolicy(event, { originalException: new Error('render blew up') });
+
+    expect(result).toBe(event);
+    // Untouched: a genuine unhandled error must keep saying so.
+    expect(result!.exception?.values?.[0]?.mechanism?.handled).toBe(false);
+  });
+});

--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -919,16 +919,25 @@ describe('getNewHelpful', () => {
  * failure therefore renders as though the person were not on the team.
  *
  * Control flow is deliberately unchanged (several callers are bare `.then()` with no
- * rejection handler), so what is asserted here is that the failure is REPORTED rather
- * than silent. The trigger that made it urgent: this branch added `reactions_seen_at` to
- * the select, so running it against a database without the migration returns 42703 and
+ * rejection handler). The trigger that made it urgent: this branch added `reactions_seen_at`
+ * to the select, so running it against a database without the migration returns 42703 and
  * empties every operator surface at once.
+ *
+ * WHERE THE "IT IS REPORTED" HALF NOW LIVES. This block used to assert
+ * `Sentry.captureException` was called here. It no longer is, and that is the intended change
+ * from #708: the Supabase integration reports this select's failure itself, with the query
+ * attached, so a second capture would file one failure as two issues. The guarantee did not
+ * weaken, it moved — and it is asserted against the real SDK, not a mock, in
+ * `__tests__/lib/supabaseSentryIntegration.test.ts` ("captures a failed table write that no
+ * call site reports" for the 42703 case, and the `PGRST116` row of the drop table for the
+ * absent-row case). It cannot be asserted here at all: this suite mocks both `@sentry/nextjs`
+ * and the Supabase client, so neither the net nor its filter exists in this file's world.
+ *
+ * What stays here is the half that IS this function's own behaviour: null for both outcomes,
+ * so no caller can mistake one for the other on the strength of the return value.
  */
 describe('getCurrentMember failure reporting', () => {
-  it('reports an indeterminate failure instead of silently answering "not a member"', async () => {
-    const Sentry = await import('@sentry/nextjs');
-    (Sentry.captureException as ReturnType<typeof vi.fn>).mockClear();
-
+  it('answers null — not a throw — when the lookup could not be completed', async () => {
     mockQueryBuilder.data = null;
     mockQueryBuilder.error = {
       code: '42703',
@@ -936,18 +945,13 @@ describe('getCurrentMember failure reporting', () => {
     };
 
     expect(await getCurrentMember('c1')).toBeNull();
-    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
   });
 
-  /** A genuinely absent row IS a definitive answer, and must stay quiet. */
-  it('stays silent when the row is simply not there', async () => {
-    const Sentry = await import('@sentry/nextjs');
-    (Sentry.captureException as ReturnType<typeof vi.fn>).mockClear();
-
+  /** A genuinely absent row IS a definitive answer, and takes the same quiet path. */
+  it('answers null when the row is simply not there', async () => {
     mockQueryBuilder.data = null;
     mockQueryBuilder.error = { code: 'PGRST116', message: 'no rows returned' };
 
     expect(await getCurrentMember('c1')).toBeNull();
-    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });

--- a/app/operator/[companyId]/my-work/page.tsx
+++ b/app/operator/[companyId]/my-work/page.tsx
@@ -2,9 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import * as Sentry from '@sentry/nextjs';
 import { useLoad } from '@/hooks/useLoad';
-import { toError } from '@/lib/supabaseErrors';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import ButtonBase from '@mui/material/ButtonBase';
@@ -485,14 +483,13 @@ export default function MyWorkPage() {
  * every load, through green CI (unit tests mock the access layer, so the select string
  * never met a database) and through a preview walkthrough that read the empty block as the
  * honest empty case. So the failure is reported; only the UI stays quiet.
+ *
+ * That reporting now comes from the Supabase integration rather than from an `onError` here
+ * (#708): `getNewHelpful` is a single `.from()` select, so the net sees the same 400 — with the
+ * query attached — and a capture here as well would file the one failure as two issues.
  */
 function NewHelpful({ companyId }: { companyId: string }) {
-  const { data, reload } = useLoad(() => getNewHelpful(companyId), [companyId], {
-    onError: (error) =>
-      Sentry.captureException(toError(error, 'Could not load new "helpful" reactions'), {
-        tags: { area: 'note_reactions' },
-      }),
-  });
+  const { data, reload } = useLoad(() => getNewHelpful(companyId), [companyId]);
 
   if (!data || data.length === 0) return null;
 

--- a/components/dashboard/PinnedMetrics.tsx
+++ b/components/dashboard/PinnedMetrics.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import * as Sentry from "@sentry/nextjs";
 import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
@@ -117,9 +116,11 @@ export default function PinnedMetrics({ companyId }: PinnedMetricsProps) {
     },
     [companyId, buildTimePeriods],
     {
+      // No `captureException` in this file any more: every call it makes is a `.from()` read or
+      // write in dashboardAccess, and the Supabase integration reports those itself with the
+      // query attached (#708). The console lines stay — they're for local debugging.
       onError: (err) => {
         console.error('Error loading pinned metrics:', err);
-        Sentry.captureException(err);
       },
     },
   );
@@ -133,7 +134,6 @@ export default function PinnedMetrics({ companyId }: PinnedMetricsProps) {
       setValues(vals);
     } catch (err) {
       console.error('Error fetching metric values:', err);
-      Sentry.captureException(err);
     }
     await setPinnedMetricKeys(keys);
   };
@@ -147,11 +147,10 @@ export default function PinnedMetrics({ companyId }: PinnedMetricsProps) {
       setValues(vals);
     } catch (err) {
       console.error('Error fetching metric values:', err);
-      Sentry.captureException(err);
     }
     for (const m of AVAILABLE_METRICS) {
       if (m.supportsTimePeriod) {
-        setMetricTimePeriod(m.key, newPeriod).catch((err) => Sentry.captureException(err, { level: 'warning' }));
+        setMetricTimePeriod(m.key, newPeriod).catch(() => {});
       }
     }
   };

--- a/components/providers/SubscriptionProvider.tsx
+++ b/components/providers/SubscriptionProvider.tsx
@@ -9,7 +9,6 @@ import {
   type ReactNode,
 } from 'react';
 import { useParams } from 'next/navigation';
-import * as Sentry from '@sentry/nextjs';
 import { useDemoMode } from '@/components/providers/DemoModeProvider';
 import { getCompanyBilling, type CompanyBilling } from '@/utils/companyAccess';
 import {
@@ -64,11 +63,14 @@ export default function SubscriptionProvider({ children }: { children: ReactNode
     try {
       const row = await getCompanyBilling(companyId);
       setBilling(row);
-    } catch (err) {
+    } catch {
       // Billing path: surface loudly, never silently default to full. Leaving
       // billing null resolves to `must_subscribe` (a banner, not a block), and the
       // DB still enforces writes regardless of this UI read.
-      Sentry.captureException(err);
+      //
+      // "Loudly" is now the Supabase integration's job (#708). `getCompanyBilling` is a single
+      // `.from('company_billing')` select, so the net reports the same failure with the query
+      // attached; capturing here too would file it twice.
       setBilling(null);
     } finally {
       setIsLoading(false);

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -276,17 +276,80 @@ sentry api '/api/0/organizations/jigged/stats_v2/?statsPeriod=30d&field=sum(quan
 
 ## Rules for writing code
 
+### Supabase failures report themselves — do not report them again
+
+**A failed `.from()` read or write is captured automatically.** `lib/supabase.ts` installs
+Sentry's `instrumentSupabaseClient`, which intercepts every `{ error }` response and files it
+with the query and request body attached. You do not have to remember anything at a call site,
+which is the point: the alternative considered in [#708](https://github.com/debola31/Jigged/issues/708)
+was a rule across ~174 call sites, and a rule nothing enforces decays (see the `deleted_at`
+rule, [#687](https://github.com/debola31/Jigged/issues/687)).
+
+Why it exists at all: Supabase returns failures as `{ data, error }` rather than throwing, so a
+caller that puts `error` into component state and stops — most of them — left no record
+anywhere. On 2026-08-05 that meant a day of failed maintenance-note saves whose only surviving
+trace was the Postgres log, found by hand.
+
+**So the rule is: do not add a `captureException` for a failure the integration already
+reports.** Two captures for one failure is worse than either alone — it becomes two issues,
+fingerprinted differently, and fixing one leaves the other looking live.
+
+**What it does NOT cover, where you still capture by hand:**
+
+| Not covered | Why |
+|---|---|
+| `.rpc()` | Suppressed on purpose — see below |
+| Storage (`supabase.storage.*`) | The integration doesn't instrument it |
+| Anything that isn't a Supabase response | A thrown `Error`, a FastAPI call, a `fetch` |
+
+### `.rpc()` is the access layer's to report, not the net's
+
+`beforeSend` drops the integration's automatic capture for rpc calls, so `utils/*Access.ts`
+stays their only reporter. Two reasons, both load-bearing:
+
+1. **The net's rpc coverage is real but order-dependent.** The integration classifies by HTTP
+   method, so an rpc POST reads as an `insert` — but the builder prototype is only patched as a
+   side effect of a `.from()` chain. An `.rpc()` that is the first Supabase call on a page load
+   is never captured. Coverage that depends on call ordering is not coverage.
+2. **Only the call site can tell a deliberate raise from a bug.** `P0001` covers both
+   *"Insufficient stock at location (have 0, need 999)"*, which is a user being told something,
+   and the cross-company bug behind #708, which was also a `P0001`. No rule in `beforeSend`
+   could separate them.
+
+The mechanism is a span attribute stamped by the client's own `fetch` when the path is
+`/rest/v1/rpc/…` — the one place the distinction is unambiguous. The span records only
+`db.table`, which for an rpc holds the *function* name and is otherwise indistinguishable from
+a table name; the list needed to tell them apart is not available at runtime, since
+`types/database.ts` is types-only.
+
+### What is never reported, and where that is decided
+
+`shouldReportSupabaseError` in [`lib/supabaseErrors.ts`](../lib/supabaseErrors.ts), applied from
+`beforeSend`:
+
+| Dropped | Why |
+|---|---|
+| `PGRST116` | A `.single()` that matched nothing. The caller asked "is there one?" and got "no" |
+| Transient aborts | Superseded, not failed. **Load-bearing:** postgrest-js does not reject on a cancelled request, it resolves `{ error }` with `hint: 'Request was aborted…'`, so without this every navigation-away becomes an issue |
+| Auth errors | Session expiry is already handled by the refresh-and-retry in `lib/supabase.ts` |
+
+Add to this list only with a recorded reason, exactly as with `ignoreErrors` below.
+
 ### Never hand a raw Supabase error to `captureException`
 
-Supabase rejects with a plain object (`{ code, details, hint, message }`), not an `Error`.
-Sentry cannot fingerprint that, so it lands as an issue titled `"e"` or `"<unknown>"` with
-the body *"Object captured as exception with keys: …"*, and the real message is buried in a
-`__serialized__` extra. One such issue went unread for four months.
+Still true wherever you capture by hand (the rpc, storage and thrown-error rows above). Supabase
+returns a plain object (`{ code, details, hint, message }`), not an `Error`. Sentry cannot
+fingerprint that, so it lands as an issue titled `"e"` or `"<unknown>"` with the body *"Object
+captured as exception with keys: …"*, and the real message is buried in a `__serialized__` extra.
+One such issue went unread for four months.
 
 ```ts
 import { toError } from '@/lib/supabaseErrors';
 Sentry.captureException(toError(err, 'Failed to verify company access'));
 ```
+
+The integration does this for you on the paths it covers — it builds a real `Error` and copies
+`code`/`details` onto it, which is the same job `toError` does.
 
 ### "Couldn't check" is not "denied"
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { applySupabaseEventPolicy } from "@/lib/sentryEventPolicy";
 
 // Sentry is the error tracker; PostHog (below) is product analytics. They are
 // deliberately NOT both capturing exceptions — see the `capture_exceptions` note.
@@ -48,6 +49,11 @@ Sentry.init({
   // issue (Sentry JAVASCRIPT-NEXTJS-H) rather than leaving it to retrain us to ignore
   // the queue, which is how this project got 55 stale issues in the first place.
   ignoreErrors: ["Invalid login credentials", "EmptyRanges", "Lock was stolen"],
+
+  // Policy for the Supabase integration's automatic captures — which expected failures are
+  // dropped, why `.rpc()` is left to the access layer, and the `db.table` tag. Shared with
+  // sentry.server.config.ts so the two cannot drift. See lib/sentryEventPolicy.ts.
+  beforeSend: applySupabaseEventPolicy,
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/lib/sentryEventPolicy.ts
+++ b/lib/sentryEventPolicy.ts
@@ -1,0 +1,87 @@
+import * as Sentry from '@sentry/nextjs';
+import type { ErrorEvent, EventHint } from '@sentry/nextjs';
+import { shouldReportSupabaseError } from '@/lib/supabaseErrors';
+
+/**
+ * What the Supabase integration's automatic captures are allowed to become issues.
+ *
+ * The integration (installed in `lib/supabase.ts`) is the error-reporting net for every table
+ * read and write — see issue #708 for the failure it exists to prevent. It exposes no per-call
+ * configuration: it captures EVERY `{ error }` response, at error level, marked unhandled. So
+ * every judgement about what is worth reporting has to be made here, from `beforeSend`.
+ *
+ * Shared by `instrumentation-client.ts` and `sentry.server.config.ts` so the two cannot drift.
+ */
+
+/**
+ * The integration's two mechanism types — database operations and auth operations. Events
+ * carrying neither are somebody else's (a React render error, a manual `captureException`) and
+ * pass through untouched.
+ */
+const AUTO_MECHANISM_TYPES = new Set(['auto.db.supabase.postgres', 'auto.db.supabase.auth']);
+
+/**
+ * Span attribute stamped by the Supabase client's own `fetch` when the request path is
+ * `/rest/v1/rpc/…`. Exported so `lib/supabase.ts` sets the same key this reads.
+ *
+ * WHY A SPAN ATTRIBUTE, and not a list of function names: the integration's span carries
+ * `db.table`, which for an rpc is the function name and for a table op is the table name — the
+ * two are indistinguishable without knowing which names are functions. That list is not
+ * available at runtime (`types/database.ts` is types-only; its `Constants` export carries enums
+ * and nothing else), and hand-maintaining one would rot. The request URL says it outright, and
+ * the db span is still active when the client's `fetch` runs, so the fetch can just mark it.
+ */
+export const RPC_SPAN_ATTRIBUTE = 'jigged.rpc';
+
+/**
+ * Decide whether one automatically-captured Supabase event survives, and clean it up if it does.
+ *
+ * Returns `null` to drop, or the event to keep.
+ */
+export function applySupabaseEventPolicy(
+  event: ErrorEvent,
+  hint: EventHint,
+): ErrorEvent | null {
+  const mechanism = event.exception?.values?.[0]?.mechanism;
+  if (!AUTO_MECHANISM_TYPES.has(mechanism?.type ?? '')) return event;
+
+  // Expected negatives: a `.single()` that matched nothing, a cancelled request, an expired
+  // session. Not failures, and an issue queue containing them is one nobody reads.
+  if (!shouldReportSupabaseError(hint.originalException)) return null;
+
+  const span = Sentry.getActiveSpan();
+  const spanData = span ? Sentry.spanToJSON(span).data : undefined;
+
+  /**
+   * `.rpc()` belongs to the access layer, not to the net.
+   *
+   * The net reaches rpc calls incidentally — the integration classifies by HTTP method, so an
+   * rpc POST looks like an `insert` — but only once a `.from()` query has run and lazily patched
+   * the shared builder prototype. An rpc that happens to be the first Supabase call on a page
+   * load is never captured. Coverage that depends on call ordering is not coverage.
+   *
+   * More importantly, only the call site can tell a `P0001` raised deliberately FOR the user
+   * ("Insufficient stock at location (have 0, need 999)") from a `P0001` that is a bug — and the
+   * incident behind #708 was itself a `P0001`, so no rule here could separate them. Dropping rpc
+   * leaves the access layer as its sole reporter, with the domain context to make that call.
+   */
+  if (spanData?.[RPC_SPAN_ATTRIBUTE] === true) return null;
+
+  /**
+   * These are handled. The integration hard-codes `handled: false`, which would count every
+   * failed query against crash-free sessions and match any alert rule scoped to unhandled
+   * errors — but the app caught this, rendered an error state, and carried on.
+   */
+  if (mechanism) mechanism.handled = true;
+
+  /**
+   * Tag with the table so alert rules and searches can be scoped to one.
+   * The integration puts the table in a *context*, and contexts are not searchable; tags are.
+   */
+  const table = spanData?.['db.table'];
+  if (typeof table === 'string' && table) {
+    event.tags = { ...event.tags, 'db.table': table };
+  }
+
+  return event;
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,4 +1,6 @@
 import { createBrowserClient } from '@supabase/ssr';
+import * as Sentry from '@sentry/nextjs';
+import { RPC_SPAN_ATTRIBUTE } from '@/lib/sentryEventPolicy';
 import { redirectToSessionExpiry } from '@/lib/supabaseErrors';
 import type { Database } from '@/types/database';
 
@@ -38,7 +40,7 @@ async function deduplicatedRefresh(): Promise<string | null> {
 }
 
 export function createClient() {
-  return createBrowserClient<Database>(supabaseUrl, supabaseAnonKey, {
+  const client = createBrowserClient<Database>(supabaseUrl, supabaseAnonKey, {
     global: {
       fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
         const response = await fetch(input, init);
@@ -50,6 +52,20 @@ export function createClient() {
             ? input.href
             : input.url;
         const isAuthEndpoint = url.includes('/auth/');
+
+        /**
+         * Mark the Supabase integration's db span when this request is an `.rpc()`, so
+         * `beforeSend` can drop the net's automatic capture and leave rpc reporting to the
+         * access layer. See `applySupabaseEventPolicy` for why rpc is drawn out of the net.
+         *
+         * This is the one place the distinction is unambiguous — the span itself only records
+         * `db.table`, which for an rpc holds the *function* name and is otherwise
+         * indistinguishable from a table name. The integration starts its span around the whole
+         * request, so the span is still active here.
+         */
+        if (url.includes('/rest/v1/rpc/')) {
+          Sentry.getActiveSpan()?.setAttribute(RPC_SPAN_ATTRIBUTE, true);
+        }
 
         // Check if this is already a retry to prevent infinite loops
         const headers = new Headers(init?.headers);
@@ -79,6 +95,35 @@ export function createClient() {
       },
     },
   });
+
+  /**
+   * THIS IS THE ERROR-REPORTING NET, and it is the whole of it for table reads and
+   * writes (issue #708).
+   *
+   * Supabase returns failures as `{ data, error }` rather than throwing, so a
+   * caller that puts `error` into component state and stops — which is most of
+   * them — leaves no trace anywhere. That is how a cross-company bug made every
+   * maintenance-note save fail for a day with nothing in Sentry to find.
+   *
+   * The integration patches `SupabaseClient.prototype.from`, so every
+   * select/insert/upsert/update/delete captures its own `{ error }` with the
+   * query and body attached, whether or not the call site remembers to. Nothing
+   * per-call-site means nothing to forget — which is the point, since the
+   * alternative was a rule across ~174 call sites with no enforcement.
+   *
+   * It patches a shared prototype, so calling it per client is free after the
+   * first (the integration carries its own `isInstrumented` guard), and capture
+   * is a no-op wherever the SDK is disabled — i.e. everywhere but a production
+   * build.
+   *
+   * `.rpc()` is deliberately NOT covered here even though it partly reaches this
+   * same code path: see the rpc branch in `beforeSend`
+   * (instrumentation-client.ts), which suppresses it so the access layer stays
+   * its sole reporter.
+   */
+  Sentry.instrumentSupabaseClient(client);
+
+  return client;
 }
 
 // Typed shape of the client when the `Database` generic is honored —

--- a/lib/supabaseErrors.ts
+++ b/lib/supabaseErrors.ts
@@ -108,6 +108,52 @@ export function isTransientAbortError(error: unknown): boolean {
 }
 
 /**
+ * `PGRST116` — PostgREST's "no rows returned" from `.single()`. A definitive answer, not a
+ * failure: the row genuinely is not there. Callers branch on it deliberately.
+ */
+const PGRST_NO_ROWS = 'PGRST116';
+
+/**
+ * Is this Supabase failure worth an issue in the queue?
+ *
+ * The Supabase Sentry integration (installed in `lib/supabase.ts`) captures EVERY `{ error }`
+ * response unconditionally — it exposes no per-call filter — so this is the only place the
+ * expected failures get dropped, and it runs from `beforeSend` in the Sentry configs.
+ *
+ * Excluding these is not about quota, which has ample headroom. It is that an issue queue with
+ * predictable non-failures in it is one people stop reading, which is the documented history of
+ * this project's queue (docs/observability.md "Why any of this matters").
+ */
+export function shouldReportSupabaseError(error: unknown): boolean {
+  if (!error) return false;
+
+  const code = asRecord(error).code;
+
+  // A `.single()` that matched nothing. The caller asked "is there one?" and got "no".
+  if (code === PGRST_NO_ROWS) return false;
+
+  /**
+   * Superseded, not failed.
+   *
+   * LOAD-BEARING, and not obviously so: postgrest-js does NOT reject on a fetch failure. It
+   * converts one into a resolved `{ error }` carrying `hint: 'Request was aborted (timeout or
+   * manual cancellation)'` (PostgrestBuilder's `res.catch`), which the integration then captures
+   * like any other database error. So every cancelled request — a component unmounting mid-query,
+   * a navigation away — would otherwise arrive as an issue.
+   *
+   * `isTransientAbortError` already matches that exact hint text. That is currently a happy
+   * coincidence rather than a designed contract, which is why the test pins it.
+   */
+  if (isTransientAbortError(error)) return false;
+
+  // Session expiry is not a bug and is already handled: the custom fetch in lib/supabase.ts
+  // refreshes and retries, and `redirectToSessionExpiry` covers the rest.
+  if (isAuthError(error)) return false;
+
+  return true;
+}
+
+/**
  * Normalise anything throwable into a real `Error`, for `Sentry.captureException`.
  *
  * Supabase rejects with a plain object (`{ code, details, hint, message }`), not an

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { applySupabaseEventPolicy } from "@/lib/sentryEventPolicy";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -20,4 +21,12 @@ Sentry.init({
   // Enable sending user PII (Personally Identifiable Information)
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
+
+  // Same Supabase-capture policy as the browser — see lib/sentryEventPolicy.ts.
+  //
+  // The rpc branch is effectively inert here: only the browser client stamps the rpc span
+  // attribute (in its own `fetch`), and server-side rpc calls have no access-layer helper to
+  // report them instead — `utils/*Access.ts` is browser code. So a route handler's failed rpc
+  // is captured by the net, which is the correct outcome rather than a gap.
+  beforeSend: applySupabaseEventPolicy,
 });

--- a/utils/dashboardAccess.ts
+++ b/utils/dashboardAccess.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/nextjs';
 // Typed Supabase client (typed-client rollout). Aliased so the 8 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
@@ -145,7 +144,11 @@ export async function getPinnedMetricKeys(): Promise<MetricKey[]> {
     const changed =
       withOverdue.length !== pinned.length || withOverdue.some((k, i) => k !== pinned[i]);
     if (changed || overdueFolded) {
-      setPinnedMetricKeys(withOverdue).catch((err) => Sentry.captureException(err, { level: 'warning' }));
+      // The `.catch` stays so a rejection here can never surface as an unhandled one, but it no
+      // longer captures: `setPinnedMetricKeys` doesn't inspect its own upsert error, and that
+      // upsert is now reported by the Supabase integration (#708). Capturing here as well would
+      // duplicate it.
+      setPinnedMetricKeys(withOverdue).catch(() => {});
     }
 
     return withOverdue.length > 0 ? withOverdue : DEFAULT_PINNED_METRICS;

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -18,9 +18,8 @@
 
 // Typed Supabase client (typed-client rollout). Aliased so the 19 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
-import * as Sentry from '@sentry/nextjs';
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage, toError } from '@/lib/supabaseErrors';
+import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import { voidAllOperationCompletions } from '@/utils/operationCompletionsAccess';
 import type {
   OperatorJob,
@@ -154,10 +153,9 @@ async function fetchCurrentMember(companyId: string): Promise<CurrentMember | nu
           'or point at the PR preview branch.',
       );
     }
-    Sentry.captureException(toError(error, 'Could not resolve the current member'), {
-      tags: { area: 'operator_member_lookup' },
-      extra: { companyId },
-    });
+    // No `captureException` here: the Supabase integration (lib/supabase.ts) already reports
+    // this select's `{ error }` with the query — including both ids this used to pass as
+    // `extra` — and a second capture would just duplicate the issue. See #708.
     return null;
   }
 

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -1,10 +1,9 @@
-import * as Sentry from '@sentry/nextjs';
 // Typed Supabase client — every .from('quotes').select(...) chain in this
 // file is now validated against types/database.ts at compile time. Aliased
 // to getSupabase so the existing call sites don't need touching. See
 // CLAUDE.md "Typed Supabase client (incremental adoption)".
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage, toError } from '@/lib/supabaseErrors';
+import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type {
   Quote,
   QuoteWithRelations,
@@ -279,11 +278,14 @@ export async function sweepExpiredQuotes(companyId: string): Promise<void> {
     .lt('expiration_date', today);
 
   if (error) {
+    // The Supabase integration reports this update's failure on its own (#708), so there is no
+    // `captureException` here — a second one would only duplicate the issue.
+    //
+    // ONE THING WAS LOST in that trade, deliberately: this used to report at `level: 'warning'`
+    // because the sweep is best-effort and a failure costs nothing immediately. The net has no
+    // per-call level, so it now arrives as `error`. If that proves noisy, downgrade it in
+    // `applySupabaseEventPolicy` and record the reason there, the way `ignoreErrors` entries are.
     console.warn('sweepExpiredQuotes failed:', error);
-    // Normalised: a raw Supabase error object reaches Sentry as an ungroupable
-    // "Object captured as exception with keys: …" with the real message hidden in a
-    // __serialized__ extra. See toError in lib/supabaseErrors.
-    Sentry.captureException(toError(error, 'sweepExpiredQuotes failed'), { level: 'warning' });
   }
 }
 
@@ -463,10 +465,11 @@ export async function createQuote(
     try {
       await writeCostSnapshotsForPart(quote.id, companyId, partId, qty);
     } catch (snapshotError) {
+      // No `captureException`: every error that can reach here began as a Supabase `{ error }`
+      // that the integration already reported — the inserts below, and `calculateRoutingCost`,
+      // whose only throw is a re-thrown `parts_unit_conversions` select error. Capturing again
+      // would file the same failure twice. (#708)
       console.warn('Failed to write cost snapshot for part:', partId, snapshotError);
-      Sentry.captureException(toError(snapshotError, 'Failed to write cost snapshot'), {
-        level: 'warning',
-      });
     }
   }
 

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,4 +1,5 @@
 import { createServerClient } from '@supabase/ssr';
+import * as Sentry from '@sentry/nextjs';
 import { cookies } from 'next/headers';
 import type { Database } from '@/types/database';
 
@@ -18,7 +19,7 @@ export async function createClient() {
   // CLAUDE.md "Typed Supabase client"). Without it the select-string parser can't know
   // a relation's cardinality and types every embed as an array, so `companies(is_demo)`
   // came back as `{ is_demo }[]` for what is a many-to-one FK.
-  return createServerClient<Database>(
+  const client = createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
@@ -40,4 +41,12 @@ export async function createClient() {
       },
     }
   );
+
+  // Same net as the browser client — see the long comment in lib/supabase.ts.
+  // A route handler that ignores an `{ error }` is exactly as silent as a
+  // component that does, and this client is created per request, so the
+  // integration's own `isInstrumented` guard is doing real work here.
+  Sentry.instrumentSupabaseClient(client);
+
+  return client;
 }


### PR DESCRIPTION
Closes half of #708. The `.rpc()` half, the enforcement scanner and the double-`friendlyErrorMessage` bug follow in PR 2, branched off this one.

## The change in one line

Supabase failures now report themselves, instead of ~174 call sites being asked to remember.

## Why not the approach in the issue

#708 proposes a repo-wide standard — every access-layer write captures before it throws — plus a CI scanner so it doesn't decay like the `deleted_at` rule (#687). Applied literally that is ~174 hand edits across 34 files.

`Sentry.supabaseIntegration` is already in the pinned SDK (`@sentry/core@10.50.0`, via `@sentry/nextjs`) and does the same job as configuration. It intercepts every `{ error }` response, builds a real `Error` carrying `code`/`details` — exactly `toError`'s job — and captures it with the query and request body attached. Nothing per-call-site means nothing to forget, and nothing to enforce.

## Why `.rpc()` is deliberately excluded

This is the part worth reviewing carefully, because the first draft of this design had it wrong. Both claims below were settled by driving a real instrumented client against a stubbed failing fetch, not from the docs:

1. **The net does reach rpc.** `DB_OPERATIONS_TO_INSTRUMENT` reads like an API-surface allowlist and isn't — the guard runs inside a patched `PostgrestFilterBuilder.prototype.then` and classifies by HTTP method, so an rpc POST reads as an `insert`.
2. **But only sometimes.** The patching is lazy: `FilterBuilder.prototype.then` is patched as a side effect of a `.from()` chain. An `.rpc()` that is the first Supabase call on a page load produces **zero** events. Coverage that depends on call ordering is not coverage.

And the reason it matters: only the call site can tell a `P0001` raised *for* the user ("Insufficient stock at location (have 0, need 999)") from a `P0001` that is a bug. **The #708 incident was itself a `P0001`**, so no code-based rule in `beforeSend` could separate them.

So rpc is suppressed here and becomes the access layer's job in PR 2. The mechanism is a span attribute stamped by the client's own `fetch` when the path is `/rest/v1/rpc/…` — the one place the distinction is unambiguous. (The span records only `db.table`, which for an rpc holds the *function* name; the list needed to tell them apart isn't available at runtime, since `types/database.ts` is types-only and its `Constants` export carries enums.)

## What else is in here

- **`shouldReportSupabaseError`** drops the expected negatives. The transient-abort case is load-bearing rather than defensive: postgrest-js resolves a cancelled request as `{ error }` with `hint: 'Request was aborted…'` instead of rejecting, so without it every navigation-away files an issue. `isTransientAbortError` already matches that hint — by coincidence until now, so a test pins it.
- **`handled: true`** re-marking. The integration hard-codes `handled: false`, which would count every failed query against crash-free sessions and trip any unhandled-scoped alert rule. The app caught these and rendered an error state.
- **A searchable `db.table` tag.** The integration puts the table in a *context*, and contexts aren't searchable. This is what #708's "tag vocabulary" requirement actually needs, and the table name is a better filter dimension than a hand-picked area string.
- **Seven manual captures removed** as now-duplicate. Each was checked rather than assumed — `quotesAccess`'s cost-snapshot `catch`, for example, can only ever receive a re-thrown Supabase error, since `calculateRoutingCost`'s only `throw` is a re-thrown select error. Sites with a mixed throw path (`NoteReactions`, the auth components, `AuthGuard`) are **left alone** on purpose and get resolved properly in PR 2, where the helper gives them a single owner.

### One deliberate regression

`sweepExpiredQuotes` and the cost-snapshot write reported at `level: 'warning'` because they're best-effort. The net has no per-call level, so they now arrive as `error`. Flagged in the code with how to undo it if it proves noisy.

## Verification

- `tsc --noEmit` clean; `pnpm lint` at 16 warnings against the cap of 17.
- New contract test pins the three SDK behaviours this design rests on — an upgrade could change any of them silently. Both branches of the policy were **mutation-tested**: breaking the rpc suppression fails 1 test, breaking the expected-negatives filter fails 3.
- Targeted specs green: `operatorAccess` + the new contract test (64), `MyWorkPage` + `Login` + `CompanySelector` (51), `docLinkCheck` (25).
- **The full local suite is not a clean signal right now** and I'm not claiming it as one. It passed at 2023 tests / 1 failure early on (that one failure was the `operatorAccess` assertion I intentionally invalidated, since the capture it asserted moved to the net — rewritten, with a pointer to where the guarantee now lives). Later full runs showed ~28 failures at a machine load average of 80, with single `userEvent` tests taking 20 minutes — the contention mode [vitest.config.ts](../blob/main/vitest.config.ts) documents by name. Every one I re-ran in isolation passed. **CI is the gate here.**
- The net itself cannot be verified locally at all: all three JS configs carry `enabled: NODE_ENV === "production"`, and that guard is load-bearing. Verify on the preview deploy — trigger a cross-company maintenance note and confirm via the Sentry MCP that it arrives with a `code`, `mechanism.handled: true` and a `db.table` tag of `notes`; confirm a `.single()` miss and an abort produce nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
