### PR TITLE
Report the rpc and storage failures the net can't see (#708, part 2 of 2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,14 @@ jobs:
         # needs no runner beyond what is already installed.
         run: pnpm exec vitest run __tests__/standards/docLinkCheck.test.ts
 
+      - name: Capture check — every .rpc()/storage call reports its failures (issue #708)
+        # Named for the same reason as the docs check above: this one fails for a reason a
+        # reviewer can act on in one line, and that is worth more than being the 1,900th line
+        # of the full run. Scoped deliberately narrow — `.from()` reads and writes are reported
+        # by the Supabase integration as configuration, so only rpc and storage have per-call
+        # code left that anyone could forget to write.
+        run: pnpm exec vitest run __tests__/standards/rpcCapture.test.ts
+
       - name: Run tests with coverage (enforced thresholds in vitest.config.ts)
         run: pnpm test --run --coverage
 

--- a/__tests__/lib/friendlyErrorIdempotence.test.ts
+++ b/__tests__/lib/friendlyErrorIdempotence.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The double-translation bug from #708, pinned.
+ *
+ * `addMachineNote` really did produce *"work center 853e… is not in company 7523…"* — a precise,
+ * actionable message — and the operator was shown "Could not save that." Nothing swallowed it:
+ * it was translated twice. The first call returned the P0001 text, `new Error(string)` dropped
+ * `code`, and the second call (in `useNoteCapture`) found no code to match on and fell through
+ * to the generic fallback.
+ *
+ * It affected every surface routing a save through `useNoteCapture`, not just maintenance.
+ */
+import { friendlyError, friendlyErrorMessage } from '@/lib/supabaseErrors';
+
+const RAISED = {
+  code: 'P0001',
+  message: 'work center 853e003b is not in company 752325ba',
+};
+
+describe('friendlyErrorMessage is idempotent', () => {
+  it('keeps a P0001 diagnostic through a second translation — the #708 regression', () => {
+    // What the access layer throws.
+    const thrown = friendlyError(RAISED, { entity: 'entry', fallback: 'Could not save that.' });
+    expect(thrown.message).toBe(RAISED.message);
+
+    // What the hook then does to it.
+    const shown = friendlyErrorMessage(thrown, { entity: 'note', fallback: 'Could not save that.' });
+
+    expect(shown).toBe(RAISED.message);
+    expect(shown).not.toBe('Could not save that.');
+  });
+
+  it('is what the OLD idiom got wrong, so the test cannot pass vacuously', () => {
+    // The exact shape that shipped: translate, then throw a bare Error.
+    const legacy = new Error(friendlyErrorMessage(RAISED, { fallback: 'Could not save that.' }));
+    const shown = friendlyErrorMessage(legacy, { entity: 'note', fallback: 'Could not save that.' });
+
+    // Reproduces the bug — which is why `friendlyError` exists.
+    expect(shown).toBe('Could not save that.');
+  });
+
+  it('carries code/details/hint forward, so callers can still branch on them', () => {
+    const thrown = friendlyError(
+      { code: '23505', message: 'duplicate key', details: 'Key (name)=(Vise) exists.' },
+      { entity: 'location' },
+    );
+
+    expect((thrown as Error & { code?: string }).code).toBe('23505');
+    expect((thrown as Error & { details?: string }).details).toBe('Key (name)=(Vise) exists.');
+    // And the user still gets copy, not the raw text.
+    expect(thrown.message).toBe('That location already exists — use a different value.');
+  });
+
+  it('does not re-derive foreign-key copy from its own prose on a second pass', () => {
+    const fk = {
+      code: '23503',
+      message:
+        'delete on table "customer_addresses" violates foreign key constraint ' +
+        '"quotes_billing_address_id_fkey" on table "quotes"',
+    };
+    const thrown = friendlyError(fk, { entity: 'address' });
+    expect(friendlyErrorMessage(thrown)).toBe(thrown.message);
+    expect(thrown.message).toContain('quotes');
+  });
+
+  it('leaves an untranslated error alone', () => {
+    expect(friendlyErrorMessage(new Error('boom'), { fallback: 'Nope.' })).toBe('Nope.');
+  });
+
+  it('keeps the marker off enumerable keys, so it never leaks into a Sentry extra', () => {
+    const thrown = friendlyError(RAISED, { entity: 'entry' });
+    expect(Object.keys({ ...thrown })).not.toContain('jigged.friendlyError');
+    expect(JSON.stringify(thrown)).not.toContain('friendlyError');
+  });
+});

--- a/__tests__/lib/supabaseSentryIntegration.test.ts
+++ b/__tests__/lib/supabaseSentryIntegration.test.ts
@@ -15,13 +15,18 @@
  */
 import * as Sentry from '@sentry/nextjs';
 import { createClient } from '@supabase/supabase-js';
-import { applySupabaseEventPolicy, RPC_SPAN_ATTRIBUTE } from '@/lib/sentryEventPolicy';
+import {
+  applySupabaseEventPolicy,
+  reportWriteFailure,
+  RPC_SPAN_ATTRIBUTE,
+} from '@/lib/sentryEventPolicy';
 
 interface Captured {
   message: string;
   dbTable: unknown;
   isRpc: unknown;
   mechanismType: string | undefined;
+  tags: Record<string, unknown> | undefined;
 }
 
 const captured: Captured[] = [];
@@ -35,6 +40,7 @@ function recordRaw(event: Sentry.ErrorEvent): void {
     dbTable: data?.['db.table'],
     isRpc: data?.[RPC_SPAN_ATTRIBUTE],
     mechanismType: event.exception?.values?.[0]?.mechanism?.type,
+    tags: event.tags,
   });
 }
 
@@ -178,5 +184,64 @@ describe('the policy: what survives beforeSend', () => {
     expect(result).toBe(event);
     // Untouched: a genuine unhandled error must keep saying so.
     expect(result!.exception?.values?.[0]?.mechanism?.handled).toBe(false);
+  });
+});
+
+describe('reportWriteFailure: the half the net cannot see', () => {
+  /**
+   * Goes through the REAL client rather than a spy — `vi.spyOn` cannot patch an ESM namespace,
+   * and this is the better test anyway: it proves the event survives `beforeSend`, which is
+   * where an event can still be dropped.
+   */
+  async function report(...args: Parameters<typeof reportWriteFailure>) {
+    captured.length = 0;
+    reportWriteFailure(...args);
+    await Sentry.flush(200);
+    return captured;
+  }
+
+  it('reports an rpc failure with its area tag', async () => {
+    const seen = await report(
+      { code: '42501', message: 'permission denied for function transfer_stock' },
+      { op: 'transferStock', area: 'inventory' },
+    );
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].message).toContain('permission denied');
+    expect(seen[0].tags?.area).toBe('inventory');
+  });
+
+  it('stays quiet for a raise the RPC makes ON PURPOSE, for the user', async () => {
+    const seen = await report(
+      { code: 'P0001', message: 'Insufficient stock at source location (have 5, need 10)' },
+      { op: 'transferStock', area: 'inventory', expectedCodes: ['P0001', '23514'] },
+    );
+
+    expect(seen).toEqual([]);
+  });
+
+  it('still reports a DIFFERENT code from that same RPC — the list is per-code, not per-call', async () => {
+    const seen = await report(
+      { code: '42703', message: 'column does not exist' },
+      { op: 'transferStock', area: 'inventory', expectedCodes: ['P0001', '23514'] },
+    );
+
+    expect(seen).toHaveLength(1);
+  });
+
+  it('applies the same do-not-report list the net uses', async () => {
+    const seen = await report({ code: 'PGRST116', message: 'no rows' }, { op: 'x', area: 'jobs' });
+    expect(seen).toEqual([]);
+  });
+
+  it('normalises a plain Supabase object into a real Error', async () => {
+    // Handing Sentry the raw object is the "issue titled e" failure CLAUDE.md warns about:
+    // it has no type or stack to fingerprint, so it groups as one unreadable blob.
+    const seen = await report(
+      { code: '23503', message: 'violates foreign key' },
+      { op: 'x', area: 'jobs' },
+    );
+
+    expect(seen[0].message).toBe('violates foreign key');
   });
 });

--- a/__tests__/standards/rpcCapture.test.ts
+++ b/__tests__/standards/rpcCapture.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Enforces the one part of #708's standard that still lives in per-call-site code.
+ *
+ * `.from()` reads and writes are reported by the Supabase integration as configuration, so
+ * there is nothing there to enforce. `.rpc()` and storage are not instrumented, and rpc is
+ * additionally suppressed from the net on purpose, so those call sites are the only place a
+ * human still has to write something down — and therefore the only place a rule can rot.
+ */
+import path from 'path';
+import {
+  ALLOWLIST,
+  findRpcCaptureViolations,
+  scanRepo,
+  splitTopLevelFunctions,
+} from '@/scripts/rpcCaptureCheck';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+describe('rpcCaptureCheck', () => {
+  it('finds no unreported .rpc() or storage call in the access layer', () => {
+    const violations = scanRepo(REPO_ROOT);
+    const detail = violations.map((v) => `${v.file}:${v.line} ${v.fn}`).join('\n');
+    expect(violations, `Unreported call sites:\n${detail}`).toEqual([]);
+  });
+
+  it('every allowlist entry carries a reason', () => {
+    for (const [key, reason] of ALLOWLIST) {
+      expect(reason.length, `${key} needs a real reason, not a placeholder`).toBeGreaterThan(30);
+    }
+  });
+
+  describe('the rule itself', () => {
+    it('flags an rpc call whose error branch reports nothing', () => {
+      const src = `
+export async function moveStock(id: string) {
+  const { error } = await supabase.rpc('transfer_stock', { p_id: id });
+  if (error) throw error;
+}`;
+      const found = findRpcCaptureViolations(src, 'utils/xAccess.ts');
+      expect(found).toHaveLength(1);
+      expect(found[0].fn).toBe('moveStock');
+    });
+
+    it('accepts one that reports', () => {
+      const src = `
+export async function moveStock(id: string) {
+  const { error } = await supabase.rpc('transfer_stock', { p_id: id });
+  if (error) {
+    reportWriteFailure(error, { op: 'moveStock', area: 'inventory' });
+    throw error;
+  }
+}`;
+      expect(findRpcCaptureViolations(src, 'utils/xAccess.ts')).toEqual([]);
+    });
+
+    it('leaves .from() alone — that is the integration\'s job, not a call site\'s', () => {
+      const src = `
+export async function listParts(companyId: string) {
+  const { data, error } = await supabase.from('parts').select('id').eq('company_id', companyId);
+  if (error) throw error;
+  return data;
+}`;
+      expect(findRpcCaptureViolations(src, 'utils/xAccess.ts')).toEqual([]);
+    });
+
+    it('does not trip on ".rpc()" written in a comment', () => {
+      const src = `
+export async function listParts(companyId: string) {
+  // Uses .from() rather than .rpc() because RLS already scopes it.
+  const { data } = await supabase.from('parts').select('id');
+  return data;
+}`;
+      expect(findRpcCaptureViolations(src, 'utils/xAccess.ts')).toEqual([]);
+    });
+
+    it('flags a storage upload with no reporting', () => {
+      const src = `
+export async function putFile(p: string, f: File) {
+  const { error } = await supabase.storage.from('b').upload(p, f);
+  if (error) throw error;
+}`;
+      expect(findRpcCaptureViolations(src, 'utils/storageHelpers.ts')).toHaveLength(1);
+    });
+
+    it('attributes a violation to its enclosing top-level function', () => {
+      const src = `
+export async function first(id: string) {
+  const { error } = await supabase.from('parts').select('id');
+  if (error) throw error;
+}
+
+export async function second(id: string) {
+  const { error } = await supabase.rpc('do_thing', { p_id: id });
+  if (error) throw error;
+}`;
+      const found = findRpcCaptureViolations(src, 'utils/xAccess.ts');
+      expect(found.map((v) => v.fn)).toEqual(['second']);
+    });
+  });
+
+  describe('splitTopLevelFunctions', () => {
+    it('closes a function on its own brace, not on a nested one', () => {
+      const src = `
+export async function outer() {
+  const cb = () => { return 1; };
+  if (true) { doThing(); }
+  return cb;
+}
+
+export function after() {
+  return 2;
+}`;
+      expect(splitTopLevelFunctions(src).map((f) => f.name)).toEqual(['outer', 'after']);
+    });
+  });
+});

--- a/__tests__/utils/machineMaintenanceAccess.test.ts
+++ b/__tests__/utils/machineMaintenanceAccess.test.ts
@@ -20,8 +20,11 @@ vi.mock('@/lib/supabase', () => ({
   getTypedSupabase: () => mockSupabase,
 }));
 
-vi.mock('@/lib/supabaseErrors', () => ({
+vi.mock('@/lib/supabaseErrors', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/supabaseErrors')>()),
   friendlyErrorMessage: (_err: unknown, opts?: { fallback?: string }) => opts?.fallback ?? 'error',
+  friendlyError: (_err: unknown, opts?: { fallback?: string }) =>
+    new Error(opts?.fallback ?? 'error'),
 }));
 
 const { mockAddNoteMedia } = vi.hoisted(() => ({ mockAddNoteMedia: vi.fn() }));

--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -28,11 +28,15 @@ vi.mock('@/lib/supabase', () => ({
 }));
 
 // friendlyErrorMessage just surfaces the fallback so we can assert thrown text.
-vi.mock('@/lib/supabaseErrors', () => ({
+// Spreads the real module rather than replacing it: `friendlyError` and
+// `shouldReportSupabaseError` are both used by paths under test, and a full replacement means
+// every future export added there breaks this file with "No X export is defined".
+vi.mock('@/lib/supabaseErrors', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/supabaseErrors')>()),
   friendlyErrorMessage: (_err: unknown, opts?: { fallback?: string }) =>
     opts?.fallback ?? 'error',
-  toError: (value: unknown, fallback = 'Unknown error') =>
-    value instanceof Error ? value : new Error(String((value as { message?: string })?.message ?? fallback)),
+  friendlyError: (_err: unknown, opts?: { fallback?: string }) =>
+    new Error(opts?.fallback ?? 'error'),
 }));
 
 // The member lookup reports indeterminate failures rather than swallowing them. Several

--- a/__tests__/utils/operatorNoteSubject.test.ts
+++ b/__tests__/utils/operatorNoteSubject.test.ts
@@ -67,8 +67,10 @@ vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
   getTypedSupabase: () => mockSupabase,
 }));
-vi.mock('@/lib/supabaseErrors', () => ({
+vi.mock('@/lib/supabaseErrors', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/supabaseErrors')>()),
   friendlyErrorMessage: (_e: unknown, o?: { fallback?: string }) => o?.fallback ?? 'error',
+  friendlyError: (_e: unknown, o?: { fallback?: string }) => new Error(o?.fallback ?? 'error'),
 }));
 
 import { addJobNote } from '@/utils/operatorAccess';

--- a/__tests__/utils/operatorPartPreviousNotes.test.ts
+++ b/__tests__/utils/operatorPartPreviousNotes.test.ts
@@ -29,8 +29,10 @@ vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
   getTypedSupabase: () => mockSupabase,
 }));
-vi.mock('@/lib/supabaseErrors', () => ({
+vi.mock('@/lib/supabaseErrors', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/supabaseErrors')>()),
   friendlyErrorMessage: (_e: unknown, o?: { fallback?: string }) => o?.fallback ?? 'error',
+  friendlyError: (_e: unknown, o?: { fallback?: string }) => new Error(o?.fallback ?? 'error'),
 }));
 
 import { getPartPreviousNotes } from '@/utils/operatorAccess';

--- a/components/maintenance/MachineComposer.tsx
+++ b/components/maintenance/MachineComposer.tsx
@@ -85,6 +85,12 @@ export default function MachineComposer({
       // useNoteCapture already put the message in the fields, next to the text
       // the operator is about to lose. A second surface for it would only make
       // the failure louder, not clearer.
+      //
+      // This empty catch is what #708 called "the terminal swallow" — with no rethrow, not even
+      // `onunhandledrejection` fired, so a day of failed saves left nothing behind. It is safe
+      // now for a reason that lives elsewhere: the write underneath is a `.from()` insert, and
+      // the Supabase integration reports it before this catch is ever reached. The UX decision
+      // (don't say it twice) was always right; it was the recording that was missing.
     }
   };
 

--- a/hooks/useNoteDwell.ts
+++ b/hooks/useNoteDwell.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef } from 'react';
-import * as Sentry from '@sentry/nextjs';
+import { reportWriteFailure } from '@/lib/sentryEventPolicy';
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 
 /**
@@ -81,10 +81,7 @@ export function useNoteDwell(
       })
       .then(({ error }) => {
         if (error) {
-          Sentry.captureException(error, {
-            level: 'warning',
-            tags: { area: 'note_views' },
-          });
+          reportWriteFailure(error, { op: 'logNoteViews', area: 'note_views', level: 'warning' });
         }
       });
   }, [jobId]);

--- a/lib/sentryEventPolicy.ts
+++ b/lib/sentryEventPolicy.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/nextjs';
 import type { ErrorEvent, EventHint } from '@sentry/nextjs';
-import { shouldReportSupabaseError } from '@/lib/supabaseErrors';
+import { shouldReportSupabaseError, toError } from '@/lib/supabaseErrors';
 
 /**
  * What the Supabase integration's automatic captures are allowed to become issues.
@@ -84,4 +84,93 @@ export function applySupabaseEventPolicy(
   }
 
   return event;
+}
+
+// ---------------------------------------------------------------------------
+// The other half: reporting what the net cannot see
+// ---------------------------------------------------------------------------
+
+/**
+ * The `area` tag vocabulary, as a union rather than a doc.
+ *
+ * #708 asked for "a short agreed list rather than ad-hoc strings" so alert rules stay
+ * filterable. A union is the version of that which cannot rot: adding a value is a deliberate
+ * edit here, and a typo is a compile error rather than a tag nobody notices is orphaned.
+ *
+ * Seeded from the tags already in use before this existed, plus one per access module that
+ * reports. Keep it coarse — this is for routing an alert, not for describing a call site.
+ */
+export type SentryArea =
+  | 'billing'
+  | 'bom'
+  | 'customers'
+  | 'demo'
+  | 'inventory'
+  | 'jobs'
+  | 'machine_maintenance'
+  | 'note_reactions'
+  | 'note_views'
+  | 'operator'
+  | 'operator_events'
+  | 'parts'
+  | 'pricing'
+  | 'quotes'
+  | 'routings'
+  | 'shipments'
+  | 'storage_upload'
+  | 'vendors'
+  | 'work_centers';
+
+interface ReportOptions {
+  /** The function that failed, e.g. 'transferStock'. Becomes the Sentry message prefix. */
+  op: string;
+  area: SentryArea;
+  /** Ids and arguments worth having while reading the issue. Keep it small. */
+  extra?: Record<string, unknown>;
+  /**
+   * `warning` for fire-and-forget telemetry whose failure costs the user nothing —
+   * `logOperatorEvent`, view logging. Default `error`.
+   */
+  level?: 'error' | 'warning';
+  /**
+   * SQLSTATEs this particular RPC raises ON PURPOSE, to say something to the user.
+   *
+   * Our stock RPCs `RAISE EXCEPTION` with `P0001`/`23514` to produce sentences like
+   * *"Insufficient stock at source location (have 5, need 10)"*. That is the database telling
+   * an operator they typed too big a number — a normal outcome of a normal action, not a defect,
+   * and filing it would recreate exactly the alert fatigue documented in docs/observability.md.
+   *
+   * This is per-call and not a global rule because the same code means the opposite elsewhere:
+   * the incident behind #708 was a `P0001` raised by a trigger, and it was a real bug. Only the
+   * caller knows which of the two its RPC does.
+   */
+  expectedCodes?: readonly string[];
+}
+
+/**
+ * Report a failure the Supabase integration does not see: an `.rpc()`, a storage operation, or
+ * a thrown JS error.
+ *
+ * Does NOT throw or swallow — it reports and returns, so the caller keeps full control of its
+ * own control flow (several of them deliberately continue, and the stock RPCs need to throw a
+ * *translated* error rather than whatever this was handed).
+ *
+ * Skips the expected negatives via the same predicate the net uses, so the two layers agree on
+ * what counts as a failure. It does NOT skip deliberate user-facing raises — the caller decides
+ * that, because only the caller knows whether its `P0001` is a message for the user or a bug.
+ * That judgement is the entire reason rpc is reported here instead of by the net.
+ */
+export function reportWriteFailure(error: unknown, opts: ReportOptions): void {
+  if (!shouldReportSupabaseError(error)) return;
+
+  const code = (error && typeof error === 'object'
+    ? (error as Record<string, unknown>).code
+    : undefined);
+  if (typeof code === 'string' && opts.expectedCodes?.includes(code)) return;
+
+  Sentry.captureException(toError(error, `${opts.op} failed`), {
+    level: opts.level ?? 'error',
+    tags: { area: opts.area },
+    extra: { op: opts.op, ...opts.extra },
+  });
 }

--- a/lib/supabaseErrors.ts
+++ b/lib/supabaseErrors.ts
@@ -261,17 +261,64 @@ function referencingEntityFromMessage(message: string): string | null {
 }
 
 /**
+ * Marks an Error whose message has ALREADY been through `friendlyErrorMessage`.
+ *
+ * Non-enumerable so it never shows up in a spread, a JSON dump or a Sentry extra.
+ */
+const FRIENDLY = Symbol.for('jigged.friendlyError');
+
+/** Has this error already been translated for a human? */
+function isAlreadyFriendly(error: unknown): error is Error {
+  return error instanceof Error && (error as unknown as Record<symbol, unknown>)[FRIENDLY] === true;
+}
+
+/**
+ * Build the Error that access-layer functions throw for a failed write.
+ *
+ * Prefer this over `throw new Error(friendlyErrorMessage(error, …))`, which silently DROPS the
+ * diagnosis. That idiom is what turned a precise database message into "Could not save that."
+ * (#708): `addMachineNote` produced *"work center 853e… is not in company 7523…"*, threw it as a
+ * bare `new Error(string)` — losing `code` — and then `useNoteCapture` called
+ * `friendlyErrorMessage` a SECOND time on the now-codeless Error. Every branch in there needs
+ * `code`, none matched, so the specific message was replaced by the generic fallback.
+ *
+ * Two things stop that here: `code`/`details`/`hint` are carried onto the thrown Error, and the
+ * Error is marked so a second translation returns the message it already has instead of
+ * re-deriving one. Translation becomes idempotent, which means a UI may call
+ * `friendlyErrorMessage` defensively without destroying a good message.
+ */
+export function friendlyError(error: unknown, options: FriendlyErrorOptions = {}): Error {
+  const built = toError(error);
+  const friendly = new Error(friendlyErrorMessage(error, options));
+
+  for (const key of ['code', 'details', 'hint'] as const) {
+    const value = (built as unknown as Record<string, unknown>)[key];
+    if (value !== undefined && value !== '') Object.assign(friendly, { [key]: value });
+  }
+  Object.defineProperty(friendly, FRIENDLY, { value: true, enumerable: false });
+
+  return friendly;
+}
+
+/**
  * Translate a raw Supabase/Postgres error into a single user-facing sentence.
  *
- * Access-layer functions should `throw new Error(friendlyErrorMessage(error, …))`
- * so the friendly text propagates to every caller's `err.message` — UIs then show
- * it directly instead of a raw SQLSTATE string. Use `options.entity` to name the
- * thing being acted on; FK-violation copy auto-detects what still references it.
+ * Access-layer functions should `throw friendlyError(error, …)` so the friendly text propagates
+ * to every caller's `err.message` — UIs then show it directly instead of a raw SQLSTATE string.
+ * Use `options.entity` to name the thing being acted on; FK-violation copy auto-detects what
+ * still references it.
+ *
+ * IDEMPOTENT: handed an error this module already translated, it returns that message unchanged
+ * rather than running a second translation over prose. See `friendlyError`.
  */
 export function friendlyErrorMessage(
   error: unknown,
   options: FriendlyErrorOptions = {},
 ): string {
+  // Already ours. Re-deriving would parse the friendly sentence as if it were Postgres output,
+  // which at best returns the same string and at worst downgrades it to the fallback.
+  if (isAlreadyFriendly(error)) return error.message;
+
   const err = asRecord(error);
   const code = typeof err.code === 'string' ? err.code : undefined;
   const message = typeof err.message === 'string' ? err.message : '';

--- a/scripts/rpcCaptureCheck.ts
+++ b/scripts/rpcCaptureCheck.ts
@@ -1,0 +1,160 @@
+/**
+ * rpcCaptureCheck — every `.rpc()` in the access layer must report its own failures.
+ *
+ * WHY THIS RULE IS SMALL, AND WHY THAT IS THE POINT. Issue #708 proposed a repo-wide standard
+ * ("every access-layer write captures before it throws") backed by a scanner. Applied literally
+ * that is ~174 call sites. Instead the Supabase integration reports every `.from()` read and
+ * write as configuration — nothing per-call-site, so nothing to enforce and nothing to decay.
+ *
+ * What it cannot see is `.rpc()`, which is deliberately excluded from the net because only the
+ * call site can tell a `P0001` raised FOR the user ("Insufficient stock…") from a `P0001` that
+ * is a bug. That judgement is the one thing a human must still write down, so it is the one
+ * thing worth guarding — roughly 30 sites rather than 174, which is a rule that can actually be
+ * held to.
+ *
+ * Storage is checked for the same reason: `supabase.storage` is not instrumented either.
+ *
+ * Mirrors scripts/interactionStandardsCheck.ts and scripts/docLinkCheck.ts: a pure scan
+ * function the test drives, plus a main() for `pnpm exec tsx`.
+ */
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+
+export interface RpcCaptureViolation {
+  file: string;
+  line: number;
+  /** The enclosing exported function, or '<module>' if it could not be determined. */
+  fn: string;
+  message: string;
+}
+
+/**
+ * Deliberate exceptions, keyed `relativePath::functionName`.
+ *
+ * Each entry needs a reason. An allowlist is the cheap way to green this check, so an entry
+ * without a stated reason should not survive review — that is exactly how an enforced rule
+ * becomes a decorative one.
+ */
+export const ALLOWLIST = new Map<string, string>([
+  // Empty, and worth keeping that way. Every `.rpc()` and storage call in the access layer
+  // currently reports. If you are about to add an entry, check first whether
+  // `expectedCodes` says what you actually mean — "this RPC raises for the user" is a
+  // property of some failures, not of the call site.
+]);
+
+/** `.rpc(` or a `supabase.storage` operation — the two things the net does not instrument. */
+const UNCOVERED_CALL = /\.rpc\(|\.storage\s*$|\.storage\./;
+
+/** Reporting helper, or an explicit Sentry capture, either counts. */
+const REPORTS = /reportWriteFailure\(|Sentry\.captureException\(/;
+
+/**
+ * Split a source file into top-level function bodies by brace depth.
+ *
+ * Deliberately simple, and it does not need to be a parser: access modules are flat lists of
+ * exported `async function`s. A nested arrow inside one is still attributed to its enclosing
+ * top-level function, which is the granularity the rule cares about.
+ */
+interface FunctionBody {
+  name: string;
+  startLine: number;
+  endLine: number;
+  text: string;
+}
+
+export function splitTopLevelFunctions(source: string): FunctionBody[] {
+  const lines = source.split('\n');
+  const out: FunctionBody[] = [];
+  const declaration = /^(?:export\s+)?(?:async\s+)?function\s+([A-Za-z0-9_$]+)/;
+
+  let current: { name: string; startLine: number; depth: number; buf: string[] } | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!current) {
+      const m = declaration.exec(line);
+      if (m) current = { name: m[1], startLine: i + 1, depth: 0, buf: [] };
+    }
+    if (!current) continue;
+
+    current.buf.push(line);
+    for (const ch of line) {
+      if (ch === '{') current.depth++;
+      else if (ch === '}') current.depth--;
+    }
+    // depth returns to 0 only once the body has opened and closed.
+    if (current.depth === 0 && current.buf.some((l) => l.includes('{'))) {
+      out.push({
+        name: current.name,
+        startLine: current.startLine,
+        endLine: i + 1,
+        text: current.buf.join('\n'),
+      });
+      current = null;
+    }
+  }
+  return out;
+}
+
+export function findRpcCaptureViolations(source: string, relPath: string): RpcCaptureViolation[] {
+  const out: RpcCaptureViolation[] = [];
+
+  for (const fn of splitTopLevelFunctions(source)) {
+    // Strip comments so a `.rpc()` mentioned in prose doesn't trip the rule.
+    const code = fn.text
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('*'))
+      .join('\n');
+
+    if (!UNCOVERED_CALL.test(code)) continue;
+    if (REPORTS.test(code)) continue;
+    if (ALLOWLIST.has(`${relPath}::${fn.name}`)) continue;
+
+    out.push({
+      file: relPath,
+      line: fn.startLine,
+      fn: fn.name,
+      message:
+        `${fn.name} calls .rpc() or storage but never reports a failure. The Supabase ` +
+        `integration does not cover either — call reportWriteFailure (lib/sentryEventPolicy.ts) ` +
+        `in the error branch, passing expectedCodes for any raise meant for the user. If it ` +
+        `genuinely should not report, add it to ALLOWLIST in scripts/rpcCaptureCheck.ts with a reason.`,
+    });
+  }
+  return out;
+}
+
+/** Every `utils/*Access.ts`, plus the hooks that call RPCs directly. */
+export function filesToScan(repoRoot: string): string[] {
+  const utils = path.join(repoRoot, 'utils');
+  const found = readdirSync(utils)
+    .filter((f) => f.endsWith('Access.ts'))
+    .map((f) => path.join('utils', f));
+  found.push('utils/storageHelpers.ts');
+  return found;
+}
+
+export function scanRepo(repoRoot: string): RpcCaptureViolation[] {
+  const out: RpcCaptureViolation[] = [];
+  for (const rel of filesToScan(repoRoot)) {
+    const source = readFileSync(path.join(repoRoot, rel), 'utf8');
+    out.push(...findRpcCaptureViolations(source, rel));
+  }
+  return out;
+}
+
+function main(): void {
+  const violations = scanRepo(process.cwd());
+  if (violations.length === 0) {
+    console.log('rpcCaptureCheck: no unreported .rpc()/storage calls.');
+    return;
+  }
+  for (const v of violations) {
+    console.error(`${v.file}:${v.line}  ${v.message}`);
+  }
+  console.error(`\n${violations.length} unreported call site(s).`);
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && process.argv[1].endsWith('rpcCaptureCheck.ts')) main();

--- a/utils/bomAccess.ts
+++ b/utils/bomAccess.ts
@@ -1,5 +1,5 @@
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { friendlyError } from '@/lib/supabaseErrors';
 import type {
   BomLine,
   BomLineFormData,
@@ -350,11 +350,9 @@ export async function deleteBomLine(bomLineId: string): Promise<void> {
   const { error } = await supabase.from('parts_bom').delete().eq('id', bomLineId);
   if (error) {
     console.error('Error deleting BOM line:', error);
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'BOM line',
         fallback: 'Failed to delete BOM line.',
-      }),
-    );
+      });
   }
 }

--- a/utils/customerAddressesAccess.ts
+++ b/utils/customerAddressesAccess.ts
@@ -14,7 +14,7 @@
  */
 
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { friendlyError } from '@/lib/supabaseErrors';
 import type {
   CustomerAddress,
   CustomerAddressFormData,
@@ -163,11 +163,9 @@ export async function deleteCustomerAddress(addressId: string): Promise<void> {
     .eq('id', addressId);
   if (error) {
     console.error('Error deleting customer address:', error);
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'address',
         fallback: 'Failed to delete address.',
-      }),
-    );
+      });
   }
 }

--- a/utils/customerCarrierAccountsAccess.ts
+++ b/utils/customerCarrierAccountsAccess.ts
@@ -8,7 +8,7 @@ import {
   type CustomerCarrierAccount,
   type CustomerCarrierAccountFormData,
 } from '@/types/customerCarrierAccount';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { friendlyError } from '@/lib/supabaseErrors';
 
 /**
  * Customer carrier accounts — a customer's own UPS/FedEx/LTL account, so their
@@ -87,13 +87,11 @@ export async function createCarrierAccount(
     console.error('Error creating carrier account:', error);
     // The account-required CHECK is the one a user can realistically trip, and
     // the raw constraint text would mean nothing to them.
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'carrier account',
         fallback:
           'Failed to save the carrier account. Billing a third party needs an account number.',
-      }),
-    );
+      });
   }
   return rowToAccount(data);
 }
@@ -112,13 +110,11 @@ export async function updateCarrierAccount(
 
   if (error) {
     console.error('Error updating carrier account:', error);
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'carrier account',
         fallback:
           'Failed to save the carrier account. Billing a third party needs an account number.',
-      }),
-    );
+      });
   }
   return rowToAccount(data);
 }

--- a/utils/customerContactsAccess.ts
+++ b/utils/customerContactsAccess.ts
@@ -18,7 +18,7 @@
  */
 
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { friendlyError } from '@/lib/supabaseErrors';
 import type { Database } from '@/types/database';
 import type {
   CustomerContact,
@@ -212,12 +212,10 @@ export async function archiveCustomerContact(contactId: string): Promise<void> {
     .eq('id', contactId);
   if (error) {
     console.error('Error archiving customer contact:', error);
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'contact',
         fallback: 'Failed to remove contact.',
-      }),
-    );
+      });
   }
 }
 

--- a/utils/demoAccess.ts
+++ b/utils/demoAccess.ts
@@ -1,4 +1,5 @@
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { reportWriteFailure } from '@/lib/sentryEventPolicy';
 
 export interface DemoStatus {
   isDemoCompany: boolean;
@@ -72,6 +73,7 @@ export async function createDemoCompany(sourceCompanyId: string, userId: string)
   });
 
   if (error) {
+    reportWriteFailure(error, { op: 'createDemoCompany', area: 'demo' });
     throw new Error(`Failed to create demo company: ${error.message}`);
   }
 
@@ -91,6 +93,7 @@ export async function resetDemoCompany(sourceCompanyId: string, userId: string):
   });
 
   if (error) {
+    reportWriteFailure(error, { op: 'resetDemoCompany', area: 'demo' });
     throw new Error(`Failed to reset demo company: ${error.message}`);
   }
 }
@@ -120,6 +123,7 @@ export async function syncDemoAccess(sourceCompanyId: string, demoCompanyId: str
   });
 
   if (error) {
+    reportWriteFailure(error, { op: 'syncDemoAccess', area: 'demo' });
     throw new Error(`Failed to sync demo access: ${error.message}`);
   }
 }

--- a/utils/inventoryLocationsAccess.ts
+++ b/utils/inventoryLocationsAccess.ts
@@ -10,6 +10,7 @@
  * both the display values and the converted quantity.
  */
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { reportWriteFailure } from '@/lib/sentryEventPolicy';
 import { ID_CHUNK } from '@/lib/queryLimits';
 import { convertToBaseUnit } from '@/lib/unitPresets';
 import { isReservedKind, RESERVED_KIND_MESSAGE } from '@/lib/locationKinds';
@@ -259,6 +260,20 @@ async function assertParentInCompany(
 const PG_UNIQUE_VIOLATION = '23505';
 
 /**
+ * The SQLSTATEs the stock RPCs raise ON PURPOSE, to say something to the operator —
+ * "Insufficient stock at source location (have 5, need 10)", "Too many parts at once".
+ *
+ * Passed to `reportWriteFailure` so those never become Sentry issues. An operator typing a
+ * number bigger than the shelf holds is the system working, and a queue full of it is a queue
+ * nobody reads. Every OTHER code from these RPCs (a permission failure, a missing column, a
+ * foreign-key violation) is a defect and is reported.
+ *
+ * `friendlyErrorMessage` keys off the same two codes to decide the text is ours to show —
+ * see PG_RAISED_BY_US / PG_CHECK_VIOLATION in lib/supabaseErrors.ts.
+ */
+const STOCK_RPC_USER_RAISES = ['P0001', '23514'] as const;
+
+/**
  * Turn a duplicate-sibling-name violation into something a shop owner can act on.
  *
  * `inventory_locations_unique_sibling_name` is the only unique index a write from this module can
@@ -392,8 +407,13 @@ export async function deleteLocation(id: string): Promise<void> {
   const supabase = getSupabase();
   const { error } = await supabase.rpc('delete_location', { p_location_id: id });
   if (error) {
-    console.error('Error deleting inventory location:', error);
     const msg = error.message ?? '';
+    // "Still holds stock" is the RPC refusing on purpose — the user is told to move it first,
+    // which is the feature working. Anything else is a defect worth an issue.
+    if (!msg.includes('still holds stock')) {
+      reportWriteFailure(error, { op: 'deleteLocation', area: 'inventory', extra: { id } });
+    }
+    console.error('Error deleting inventory location:', error);
     if (msg.includes('still holds stock')) {
       throw new Error('This location (or something inside it) still holds stock. Move it out first.');
     }
@@ -876,6 +896,15 @@ export async function addStockAtLocation(
     p_photo_path: opts.photoPath ?? undefined,
   });
   if (error) {
+    // `.rpc()` is invisible to the Supabase integration by design (#708) — see
+    // `applySupabaseEventPolicy`. The stock RPCs raise P0001/23514 deliberately to tell an
+    // operator their number was too big, so those are not reported; anything else is a defect.
+    reportWriteFailure(error, {
+      op: 'addStockAtLocation',
+      area: 'inventory',
+      extra: { partId, locationId, unit },
+      expectedCodes: STOCK_RPC_USER_RAISES,
+    });
     console.error('Error adding stock at location:', error);
     throw error;
   }
@@ -906,6 +935,12 @@ export async function depleteStockAtLocation(
     p_operator_id: opts.operatorId,
   });
   if (error) {
+    reportWriteFailure(error, {
+      op: 'depleteStockAtLocation',
+      area: 'inventory',
+      extra: { partId, locationId, unit, jobId: opts.jobId },
+      expectedCodes: STOCK_RPC_USER_RAISES,
+    });
     console.error('Error depleting stock at location:', error);
     throw error;
   }
@@ -935,6 +970,12 @@ export async function adjustStockAtLocation(
     p_operator_id: opts.operatorId ?? undefined,
   });
   if (error) {
+    reportWriteFailure(error, {
+      op: 'adjustStockAtLocation',
+      area: 'inventory',
+      extra: { partId, locationId, unit },
+      expectedCodes: STOCK_RPC_USER_RAISES,
+    });
     console.error('Error adjusting stock at location:', error);
     throw error;
   }
@@ -966,6 +1007,12 @@ export async function transferStock(
     p_photo_path: opts.photoPath ?? undefined,
   });
   if (error) {
+    reportWriteFailure(error, {
+      op: 'transferStock',
+      area: 'inventory',
+      extra: { partId, fromLocationId, toLocationId, unit },
+      expectedCodes: STOCK_RPC_USER_RAISES,
+    });
     console.error('Error transferring stock:', error);
     throw error;
   }
@@ -1017,6 +1064,11 @@ export async function bulkPutAway(
     p_part_ids: partIds,
   });
   if (error) {
+    reportWriteFailure(error, {
+      op: 'bulkPutAway',
+      area: 'inventory',
+      expectedCodes: STOCK_RPC_USER_RAISES,
+    });
     console.error('Error putting stock away:', error);
     throw error;
   }

--- a/utils/jobsAccess.ts
+++ b/utils/jobsAccess.ts
@@ -4,7 +4,8 @@
 // this also keeps the diff small for review. See CLAUDE.md "Typed
 // Supabase client (incremental adoption)" for the rollout contract.
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { reportWriteFailure } from '@/lib/sentryEventPolicy';
+import { friendlyError } from '@/lib/supabaseErrors';
 import type { Database } from '@/types/database';
 
 // Update payloads for tables this file mutates conditionally. The typed
@@ -227,6 +228,7 @@ export async function searchJobsByIdentifier(
     p_query: query.trim(),
   });
   if (error) {
+    reportWriteFailure(error, { op: 'searchJobsByIdentifier', area: 'jobs' });
     console.error('search_jobs_by_identifier failed:', error);
     throw new Error(`Search failed: ${error.message}`);
   }
@@ -369,12 +371,10 @@ export async function updateJobAddressContact(
 
   if (error) {
     console.error('Error updating job address/contact:', error);
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'job',
         fallback: 'Failed to update job billing/shipping details.',
-      }),
-    );
+      });
   }
 
   return data as Job;
@@ -416,9 +416,7 @@ export async function updateJobDetails(
 
   if (error) {
     console.error('Error updating job details:', error);
-    throw new Error(
-      friendlyErrorMessage(error, { entity: 'job', fallback: 'Failed to update job details.' }),
-    );
+    throw friendlyError(error, { entity: 'job', fallback: 'Failed to update job details.' });
   }
   return data as Job;
 }
@@ -593,6 +591,7 @@ export async function createJobFromPurchaseOrder(
     company_uuid: companyId,
   });
   if (numErr || !jobNumber) {
+    reportWriteFailure(numErr, { op: 'generateDirectJobNumber', area: 'jobs', extra: { companyId } });
     console.error('Error generating job number:', numErr);
     throw numErr || new Error('Could not generate a job number.');
   }
@@ -669,6 +668,7 @@ export async function createJobFromPurchaseOrder(
         p_routing_id: routingId,
       });
       if (rpcErr) {
+        reportWriteFailure(rpcErr, { op: 'createJobPartOperationsFromRouting', area: 'jobs' });
         console.error('Failed to copy operations from routing:', rpcErr);
         throw new Error('Job created but failed to copy operations from routing.');
       }
@@ -848,9 +848,7 @@ export async function updateJobPartQuantity(
     .single();
   if (updErr || !updated) {
     console.error('Error updating job_part quantity:', updErr);
-    throw new Error(
-      friendlyErrorMessage(updErr, { entity: 'job', fallback: 'Failed to update the quantity.' }),
-    );
+    throw friendlyError(updErr, { entity: 'job', fallback: 'Failed to update the quantity.' });
   }
 
   return {
@@ -958,9 +956,7 @@ export async function updateJobPartPrice(
     .single();
   if (updErr || !updated) {
     console.error('Error updating job_part price:', updErr);
-    throw new Error(
-      friendlyErrorMessage(updErr, { entity: 'job', fallback: 'Failed to update the price.' }),
-    );
+    throw friendlyError(updErr, { entity: 'job', fallback: 'Failed to update the price.' });
   }
 
   return {
@@ -1045,9 +1041,7 @@ export async function deleteJob(jobId: string, companyId: string): Promise<void>
 
   if (loadErr) {
     console.error('Error loading job for archive:', loadErr);
-    throw new Error(
-      friendlyErrorMessage(loadErr, { entity: 'job', fallback: 'Failed to load job.' }),
-    );
+    throw friendlyError(loadErr, { entity: 'job', fallback: 'Failed to load job.' });
   }
   if (!jobRow) {
     throw new Error('Job not found.');
@@ -1061,9 +1055,7 @@ export async function deleteJob(jobId: string, companyId: string): Promise<void>
 
   if (error) {
     console.error('Error archiving job:', error);
-    throw new Error(
-      friendlyErrorMessage(error, { entity: 'job', fallback: 'Failed to delete job.' }),
-    );
+    throw friendlyError(error, { entity: 'job', fallback: 'Failed to delete job.' });
   }
 }
 
@@ -1095,9 +1087,7 @@ export async function bulkCancelJobs(jobIds: string[]): Promise<void> {
 
     if (error) {
       console.error('Error bulk cancelling jobs:', error);
-      throw new Error(
-        friendlyErrorMessage(error, { entity: 'job', fallback: 'Failed to cancel jobs.' }),
-      );
+      throw friendlyError(error, { entity: 'job', fallback: 'Failed to cancel jobs.' });
     }
   }
 }
@@ -1448,6 +1438,9 @@ export async function getReadyOperationsForJobs(
   });
 
   if (error) {
+    // Swallowed into an empty Map for the caller, which is exactly the shape that hid failures
+    // before #708 — so it is reported here even though nothing is thrown.
+    reportWriteFailure(error, { op: 'getReadyOperationsBatch', area: 'jobs' });
     console.error('Error fetching ready operations batch:', error);
     return new Map();
   }

--- a/utils/machineMaintenanceAccess.ts
+++ b/utils/machineMaintenanceAccess.ts
@@ -1,5 +1,5 @@
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { friendlyError } from '@/lib/supabaseErrors';
 import { mapReactions } from '@/utils/operatorAccess';
 import type { ReactionRel } from '@/utils/operatorAccess';
 import { addNoteMedia, uploadNoteMediaFile } from '@/utils/jobNoteMediaAccess';
@@ -188,9 +188,7 @@ export async function addMachineNote(
     .single();
 
   if (error) {
-    throw new Error(
-      friendlyErrorMessage(error, { entity: 'entry', fallback: 'Could not save that.' }),
-    );
+    throw friendlyError(error, { entity: 'entry', fallback: 'Could not save that.' });
   }
 
   return rowToNote(data as unknown as MachineNoteRow);

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -19,7 +19,8 @@
 // Typed Supabase client (typed-client rollout). Aliased so the 19 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { reportWriteFailure } from '@/lib/sentryEventPolicy';
+import { friendlyError } from '@/lib/supabaseErrors';
 import { voidAllOperationCompletions } from '@/utils/operationCompletionsAccess';
 import type {
   OperatorJob,
@@ -226,6 +227,15 @@ async function getReadyOperationsForStation(
     // "no jobs" to operators rather than a visible error. Both callers
     // (getOperatorJobs / getAllStationsOperatorJobs) run inside the jobs page's
     // try/catch, which shows this message in an Alert.
+    //
+    // Surfacing it to the operator is not the same as recording it: `.rpc()` is outside the
+    // Supabase integration's net by design (#708), so without this the only trace is an Alert
+    // the operator reads and dismisses.
+    reportWriteFailure(error, {
+      op: 'getReadyOperationsForStation',
+      area: 'operator',
+      extra: { companyId, workCenterId },
+    });
     throw new Error(`Failed to load ready operations for station: ${error.message}`);
   }
 
@@ -1651,12 +1661,10 @@ export async function addJobNote(
     .single();
 
   if (error) {
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'note',
         fallback: 'Failed to add note.',
-      }),
-    );
+      });
   }
 
   return mapJobNoteRow(data as unknown as JobNoteRow);
@@ -1705,12 +1713,10 @@ export async function updateNoteBody(
     .single();
 
   if (error) {
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'note',
         fallback: 'Could not save that change.',
-      }),
-    );
+      });
   }
 
   return data as { body: string | null; edited_at: string | null };
@@ -1800,7 +1806,10 @@ export async function countPartPreviousNotes(
     { head: true, count: 'exact' },
   );
 
-  if (error) return 0;
+  if (error) {
+    reportWriteFailure(error, { op: 'countUnseenReactions', area: 'note_reactions' });
+    return 0;
+  }
   return count ?? 0;
 }
 
@@ -1828,6 +1837,7 @@ export async function getPartPreviousNotes(
   // second client-side filter would be a redundant source of truth.
   void companyId;
 
+  if (error) reportWriteFailure(error, { op: 'getPartPlaybookNotes', area: 'operator', extra: { partId } });
   if (error || !data) return [];
 
   return (data as unknown as PlaybookRow[]).map((r) => ({
@@ -1904,12 +1914,10 @@ export async function getMyContributionTotals(
   // facts, and rendering the first as the second tells an operator their notes are
   // gone. The caller has an error state; give it something to show.
   if (error) {
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'note',
         fallback: 'Could not load your work.',
-      }),
-    );
+      });
   }
   if (!data) return empty;
 
@@ -1998,12 +2006,10 @@ export async function getMyNotesPage(
   // the tab. The caller's catch is what shows the retry, and it can only fire if this
   // rejects.
   if (error) {
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'note',
         fallback: 'Could not load your notes.',
-      }),
-    );
+      });
   }
   if (!data) return empty;
 
@@ -2066,6 +2072,7 @@ export async function getMyNotesPage(
 export async function getNoteViewers(noteId: string): Promise<NoteViewer[]> {
   const supabase = getSupabase();
   const { data, error } = await supabase.rpc('note_viewers', { p_note_id: noteId });
+  if (error) reportWriteFailure(error, { op: 'getNoteViewers', area: 'note_views', extra: { noteId } });
   if (error || !data) return [];
   return data as unknown as NoteViewer[];
 }
@@ -2114,9 +2121,7 @@ export async function addReaction(
   // second device. The end state is what the caller asked for, so it is not an
   // error to report.
   if (error && error.code !== '23505') {
-    throw new Error(
-      friendlyErrorMessage(error, { entity: 'reaction', fallback: 'Could not save that.' }),
-    );
+    throw friendlyError(error, { entity: 'reaction', fallback: 'Could not save that.' });
   }
 }
 
@@ -2139,9 +2144,7 @@ export async function removeReaction(
     .eq('kind', kind);
 
   if (error) {
-    throw new Error(
-      friendlyErrorMessage(error, { entity: 'reaction', fallback: 'Could not undo that.' }),
-    );
+    throw friendlyError(error, { entity: 'reaction', fallback: 'Could not undo that.' });
   }
 }
 
@@ -2228,12 +2231,10 @@ export async function getNewHelpful(companyId: string): Promise<NewHelpful[]> {
     .order('created_at', { ascending: false });
 
   if (error) {
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'reaction',
         fallback: 'Could not load what came back.',
-      }),
-    );
+      });
   }
 
   type Row = {
@@ -2293,8 +2294,7 @@ export async function markHelpfulSeen(companyId: string, seenThrough: string): P
     p_seen_through: seenThrough,
   });
   if (error) {
-    throw new Error(
-      friendlyErrorMessage(error, { entity: 'reaction', fallback: 'Could not save that.' }),
-    );
+    reportWriteFailure(error, { op: 'markHelpfulSeen', area: 'note_reactions', extra: { companyId } });
+    throw friendlyError(error, { entity: 'reaction', fallback: 'Could not save that.' });
   }
 }

--- a/utils/operatorEventsAccess.ts
+++ b/utils/operatorEventsAccess.ts
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/nextjs';
+import { reportWriteFailure } from '@/lib/sentryEventPolicy';
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
 
 /**
@@ -81,18 +81,22 @@ export function logOperatorEvent(
       })
       .then(({ error }) => {
         if (error) {
-          Sentry.captureException(error, {
+          reportWriteFailure(error, {
+            op: 'logOperatorEvent',
+            area: 'operator_events',
             level: 'warning',
-            tags: { area: 'operator_events', kind },
+            extra: { kind },
           });
         }
       });
   } catch (err) {
     // Belt and braces: a throw before the promise exists (no client, no session)
     // must still not reach the operator.
-    Sentry.captureException(err, {
+    reportWriteFailure(err, {
+      op: 'logOperatorEvent',
+      area: 'operator_events',
       level: 'warning',
-      tags: { area: 'operator_events', kind },
+      extra: { kind },
     });
   }
 }

--- a/utils/partPricingTiersAccess.ts
+++ b/utils/partPricingTiersAccess.ts
@@ -1,5 +1,6 @@
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { reportWriteFailure } from '@/lib/sentryEventPolicy';
+import { friendlyError } from '@/lib/supabaseErrors';
 import type {
   PartPricingTier,
   PartPricingTierInput,
@@ -191,12 +192,10 @@ export async function deleteTier(tierId: string): Promise<void> {
   const { error } = await supabase.from('part_pricing_tiers').delete().eq('id', tierId);
   if (error) {
     console.error('Error deleting pricing tier:', error);
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'pricing tier',
         fallback: 'Failed to delete pricing tier.',
-      }),
-    );
+      });
   }
 }
 
@@ -214,6 +213,7 @@ export async function getPriceablePartIds(companyId: string): Promise<Set<string
     p_company_id: companyId,
   });
   if (error) {
+    reportWriteFailure(error, { op: 'getPriceablePartIds', area: 'pricing' });
     console.error('Error fetching priceable part ids:', error);
     throw error;
   }

--- a/utils/partsAccess.ts
+++ b/utils/partsAccess.ts
@@ -1,6 +1,7 @@
 // Typed Supabase client (typed-client rollout). Aliased so the 30 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { reportWriteFailure } from '@/lib/sentryEventPolicy';
 import type { Database } from '@/types/database';
 
 // Insert payload for the parts table. company_id is supplied at the call
@@ -1012,6 +1013,7 @@ export async function bulkDeleteParts(partIds: string[]): Promise<void> {
           'Permission denied. You may not have permission to delete these parts.',
         );
       }
+      reportWriteFailure(error, { op: 'archiveParts', area: 'parts', extra: { count: batch.length } });
       console.error('Error archiving parts:', error);
       throw new Error(error.message || 'Failed to archive parts');
     }
@@ -1048,6 +1050,7 @@ export async function getPartsDeletionImpact(partIds: string[]): Promise<PartsDe
   const { data, error } = await supabase.rpc('parts_deletion_impact', { p_ids: partIds });
 
   if (error) {
+    reportWriteFailure(error, { op: 'partsDeletionImpact', area: 'parts' });
     console.error('Error computing parts deletion impact:', error);
     return base;
   }
@@ -1190,6 +1193,7 @@ export async function getComputedPartCost(
   });
 
   if (error) {
+    reportWriteFailure(error, { op: 'computePartCostAtQty', area: 'pricing' });
     console.error('Error computing part cost:', error);
     throw error;
   }
@@ -1264,6 +1268,7 @@ export async function getPartCostExplain(
     .single();
 
   if (error) {
+    reportWriteFailure(error, { op: 'computePartCostExplain', area: 'pricing' });
     console.error('Error explaining part cost:', error);
     throw error;
   }

--- a/utils/procurementTiersAccess.ts
+++ b/utils/procurementTiersAccess.ts
@@ -1,5 +1,6 @@
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { reportWriteFailure } from '@/lib/sentryEventPolicy';
+import { friendlyError } from '@/lib/supabaseErrors';
 import type {
   ProcurementCostResult,
   ProcurementTier,
@@ -170,12 +171,10 @@ export async function deleteTier(tierId: string): Promise<void> {
     .eq('id', tierId);
   if (error) {
     console.error('Error deleting procurement tier:', error);
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'procurement tier',
         fallback: 'Failed to delete procurement tier.',
-      }),
-    );
+      });
   }
 }
 
@@ -202,6 +201,7 @@ export async function getProcurementCost(
   });
 
   if (error) {
+    reportWriteFailure(error, { op: 'getProcurementCost', area: 'pricing' });
     console.error('Error calling get_procurement_cost:', error);
     throw error;
   }

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -3,7 +3,8 @@
 // to getSupabase so the existing call sites don't need touching. See
 // CLAUDE.md "Typed Supabase client (incremental adoption)".
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { reportWriteFailure } from '@/lib/sentryEventPolicy';
+import { friendlyError } from '@/lib/supabaseErrors';
 import type {
   Quote,
   QuoteWithRelations,
@@ -846,12 +847,10 @@ export async function deleteQuote(quoteId: string, companyId: string): Promise<v
 
   if (error) {
     console.error('Error archiving quote:', error);
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'quote',
         fallback: 'Failed to delete quote.',
-      }),
-    );
+      });
   }
 }
 
@@ -1480,6 +1479,7 @@ export async function convertQuoteToJob(
         p_routing_id: routingId,
       });
       if (rpcErr) {
+        reportWriteFailure(rpcErr, { op: 'createJobPartOperationsFromRouting', area: 'quotes' });
         console.error('Failed to copy operations from routing:', rpcErr);
         throw new Error('Job created but failed to copy operations from routing.');
       }

--- a/utils/routingsAccess.ts
+++ b/utils/routingsAccess.ts
@@ -10,7 +10,7 @@
 // Typed Supabase client (typed-client rollout). Aliased so the 12 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { friendlyError } from '@/lib/supabaseErrors';
 import { orIlikeValue } from '@/utils/searchFilter';
 import type { Database } from '@/types/database';
 
@@ -282,9 +282,7 @@ export async function deleteRouting(routingId: string): Promise<void> {
   const { error } = await supabase.from('routings').delete().eq('id', routingId);
   if (error) {
     console.error('Error deleting routing:', error);
-    throw new Error(
-      friendlyErrorMessage(error, { entity: 'routing', fallback: 'Failed to delete routing.' }),
-    );
+    throw friendlyError(error, { entity: 'routing', fallback: 'Failed to delete routing.' });
   }
 }
 
@@ -385,12 +383,10 @@ export async function deleteRoutingOperation(operationId: string): Promise<void>
   const { error } = await supabase.from('routing_operations').delete().eq('id', operationId);
   if (error) {
     console.error('Error deleting routing operation:', error);
-    throw new Error(
-      friendlyErrorMessage(error, {
+    throw friendlyError(error, {
         entity: 'operation',
         fallback: 'Failed to delete operation.',
-      }),
-    );
+      });
   }
 }
 

--- a/utils/shipmentsAccess.ts
+++ b/utils/shipmentsAccess.ts
@@ -16,6 +16,7 @@
 // Typed Supabase client (typed-client rollout). Aliased so the 10 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { reportWriteFailure } from '@/lib/sentryEventPolicy';
 import type {
   CreateShipmentPayload,
   FreightTerms,
@@ -75,6 +76,10 @@ export async function createShipment(
   );
 
   if (error || !shipmentId) {
+    reportWriteFailure(error ?? new Error('createShipment returned no id'), {
+      op: 'createShipmentWithLineItems',
+      area: 'shipments',
+    });
     console.error('createShipment RPC failed:', error);
     throw new Error(
       error?.message
@@ -603,6 +608,7 @@ export async function getJobLastShipDate(jobId: string): Promise<Date | null> {
   });
 
   if (error) {
+    reportWriteFailure(error, { op: 'jobLastShipDate', area: 'shipments' });
     console.error('Error calling job_last_ship_date:', error);
     throw new Error('Failed to load last ship date.');
   }

--- a/utils/storageHelpers.ts
+++ b/utils/storageHelpers.ts
@@ -1,4 +1,5 @@
 import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { reportWriteFailure } from '@/lib/sentryEventPolicy';
 
 /**
  * Get the storage bucket name from environment variable
@@ -149,6 +150,14 @@ export async function uploadFileToStorage(
   );
 
   if (error) {
+    // Storage is outside the Supabase integration's net — it only instruments `.from()` and
+    // auth (#708) — and an upload is the failure-prone half of every photo capture on a
+    // shop-floor phone. Reported here or nowhere.
+    reportWriteFailure(error, {
+      op: 'uploadFileToStorage',
+      area: 'storage_upload',
+      extra: { bucket, sizeBytes: file.size },
+    });
     console.error('Storage upload error:', error);
     throw new Error(`Failed to upload file: ${error.message}`);
   }
@@ -173,6 +182,16 @@ export async function deleteFileFromStorage(
   );
 
   if (error) {
+    // `warning`, not `error`: almost every caller wraps this in `.catch(() => {})` because a
+    // failed cleanup only orphans bytes in the bucket — nothing the user can see is broken. But
+    // orphans accumulate silently and nothing else counts them, so this is the only signal they
+    // exist at all.
+    reportWriteFailure(error, {
+      op: 'deleteFileFromStorage',
+      area: 'storage_upload',
+      level: 'warning',
+      extra: { bucket },
+    });
     console.error('Storage delete error:', error);
     throw new Error(`Failed to delete file: ${error.message}`);
   }


### PR DESCRIPTION
Second half of #708. **Stacked on #711** — review that first; this targets its branch, so the diff here is only the rpc/storage half.

## What the net can't see

#711 made `.from()` reads and writes report themselves as configuration. Two things remain uncovered:

- **`.rpc()`** — excluded from the net on purpose. Only the call site can tell a `P0001` raised *for* the user (*"Insufficient stock at source location (have 5, need 10)"*) from a `P0001` that is a bug, and the #708 incident was itself a `P0001`.
- **Storage** — the integration doesn't instrument `supabase.storage` at all.

Those are the only places a human still has to write something down, so they get the helper and the check.

## `reportWriteFailure`

Reports without throwing or swallowing, so each caller keeps its own control flow — several deliberately continue, and the stock RPCs need to throw a *translated* error rather than whatever they were handed. It reuses the net's `shouldReportSupabaseError` so both layers agree on what counts as a failure, and takes `expectedCodes` for the raises an RPC makes on purpose. That list is **per-call rather than global**, because the same SQLSTATE means the opposite elsewhere.

Applied to every `.rpc()` in the access layer plus both storage paths. Several were previously silent in exactly the way the issue describes — `getReadyOperationsBatch` swallowed into an empty `Map`, `countUnseenReactions` into `0`, `note_viewers` and `part_playbook_notes` into `[]`. The storage *delete* reports at `warning`: a failed cleanup only orphans bytes, but nothing else counts them.

`SentryArea` is a union rather than a doc, so the tag vocabulary #708 asked for is a compile error when mistyped instead of an orphaned tag nobody notices.

## The sub-bug: a diagnostic computed and thrown away

`addMachineNote` really did produce *"work center 853e… is not in company 7523…"*, and the operator saw *"Could not save that."* Nothing swallowed it — it was **translated twice**. `throw new Error(friendlyErrorMessage(...))` drops `code`; `useNoteCapture` then called `friendlyErrorMessage` again on a now-codeless Error, every branch missed, and it fell through to the fallback. It affected every surface routing a save through that hook.

`friendlyError()` carries `code`/`details`/`hint` onto the thrown Error and marks it, so a second translation returns the message it already has. 25 throw sites converted; all four double-translation call sites are fixed **without being touched**.

The test suite includes the old idiom reproducing the bug, so it can't pass vacuously.

## Enforcement

`scripts/rpcCaptureCheck.ts` + a standards test + a named CI step, mirroring `docLinkCheck` and `interactionStandardsCheck`. Scoped to `.rpc()` and storage — roughly 30 sites rather than the ~174 the issue proposed guarding, which is the difference between a rule that holds and one that decays like `deleted_at` (#687).

It earned its place while being written: it found `deleteFileFromStorage` reporting nothing. **The allowlist is empty**, and a test asserts any future entry carries a real reason.

## Verification

- `tsc --noEmit` clean; `pnpm lint` at 16 warnings against the cap of 17.
- 488 tests green across `__tests__/lib`, `__tests__/standards`, and the four access specs this touches.
- Four test files mocked `@/lib/supabaseErrors` as a *full replacement* and broke on the new export. Rewritten to spread the real module via `importOriginal`, so the next export added there doesn't break them again.
- **The full local suite is still not a clean signal** — same machine-contention problem noted on #711 (load average 80, single `userEvent` tests taking 20 minutes). Not claiming it as green.
- ⚠️ **Neither PR has actually run CI.** The Tests and E2E workflows have not triggered on this branch, on #711, or on your own #710 — the last successful run was 2026-08-05T23:59. Actions is enabled (`allowed_actions: all`), so this looks like an exhausted minutes quota or a spending limit rather than anything in these PRs. Worth checking before merging either, since "CI is the gate" is doing real work in both descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
