### PR TITLE
refactor(supabase): collapse to one always-typed client and delete the ratchet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,12 +32,15 @@ roles `admin | user | operator` — and operators land on `/operator/{companyId}
 ([`homePathForRole`](utils/companyAccess.ts)). Model and auth flow:
 [architecture.md §3](docs/architecture.md).
 
-**Use `getTypedSupabase()` for every new access function** — it type-checks each `.from().select()`
-against [`types/database.ts`](types/database.ts). The untyped `getSupabase()` still exists but no
-`utils/*.ts` imports it any more; schema mistakes compile silently through it, which is how the
-May 2026 `jobs.status` regression shipped. **Regenerate types after any migration that changes
-columns** (`pnpm gen:db-types`, against a running local stack); CI fails on a diff. Details, and the
-three places the generator version is pinned: [architecture.md §6](docs/architecture.md).
+**`getSupabase()` is the only client getter, and it is always typed** — it type-checks each
+`.from().select()` against [`types/database.ts`](types/database.ts). The untyped second getter and
+the lint ratchet that policed it are **gone** (#573): there is no untyped symbol left to import, so
+the guarantee is structural rather than an exemption list. **Never reintroduce an untyped view of
+this client, and never launder a row through `as unknown as` — that erases the query result exactly
+like the old getter did.** Schema mistakes compiling silently is how the May 2026 `jobs.status`
+regression shipped. **Regenerate types after any migration that changes columns**
+(`pnpm gen:db-types`, against a running local stack); CI fails on a diff. Details, and the three
+places the generator version is pinned: [architecture.md §6](docs/architecture.md).
 
 ---
 

--- a/__tests__/app/operator/MyWorkPage.test.tsx
+++ b/__tests__/app/operator/MyWorkPage.test.tsx
@@ -46,7 +46,7 @@ vi.mock('@/lib/supabase', () => {
     },
     from: () => ({ insert: vi.fn(async () => ({ error: null })) }),
   });
-  return { getSupabase: stub, getTypedSupabase: stub, supabase: null };
+  return { getSupabase: stub, supabase: null };
 });
 
 const mockGetTotals = vi.mocked(getMyContributionTotals);

--- a/__tests__/components/dashboard/MetricPickerModal.test.tsx
+++ b/__tests__/components/dashboard/MetricPickerModal.test.tsx
@@ -14,7 +14,6 @@ import type { MetricKey } from '@/utils/dashboardAccess';
 // and don't touch Supabase, so they stay real.
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => ({}),
-  getTypedSupabase: () => ({}),
   createClient: () => ({}),
   supabase: null,
 }));

--- a/__tests__/components/inventory/locations/LocationsManager.test.tsx
+++ b/__tests__/components/inventory/locations/LocationsManager.test.tsx
@@ -15,7 +15,6 @@ import userEvent from '@testing-library/user-event';
 // import time. Stub the client so only the pure helper survives the import.
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => ({}),
-  getTypedSupabase: () => ({}),
 }));
 
 vi.mock('@/utils/inventoryLocationsAccess', async (importOriginal) => {

--- a/__tests__/components/operator/NoteUsageBanner.test.tsx
+++ b/__tests__/components/operator/NoteUsageBanner.test.tsx
@@ -7,7 +7,6 @@ import NoteUsageBanner from '@/components/operator/NoteUsageBanner';
 const rpc = vi.fn();
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => ({ rpc }),
-  getTypedSupabase: () => ({ rpc }),
 }));
 
 const SEEN_KEY = 'jigged:note-digest-acknowledged';

--- a/__tests__/components/operator/OperatorPartLookup.test.tsx
+++ b/__tests__/components/operator/OperatorPartLookup.test.tsx
@@ -7,7 +7,6 @@ import type { PartSelectOption } from '@/utils/partsAccess';
 /** Module-scope browser client; the import alone throws in jsdom without this. */
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => ({}),
-  getTypedSupabase: () => ({}),
 }));
 
 /**

--- a/__tests__/components/operator/OperatorWarehouseHome.test.tsx
+++ b/__tests__/components/operator/OperatorWarehouseHome.test.tsx
@@ -21,7 +21,6 @@ vi.mock('next/navigation', () => ({
  */
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => ({}),
-  getTypedSupabase: () => ({}),
 }));
 
 vi.mock('@/utils/inventoryLocationsAccess', () => ({

--- a/__tests__/components/operator/PutAwayPickerDialog.test.tsx
+++ b/__tests__/components/operator/PutAwayPickerDialog.test.tsx
@@ -9,7 +9,6 @@ import userEvent from '@testing-library/user-event';
  */
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => ({}),
-  getTypedSupabase: () => ({}),
 }));
 
 import PutAwayPickerDialog from '@/components/operator/PutAwayPickerDialog';

--- a/__tests__/components/parts/workspace/PartWorkspaceExitGuard.test.tsx
+++ b/__tests__/components/parts/workspace/PartWorkspaceExitGuard.test.tsx
@@ -28,7 +28,7 @@ vi.mock('@/lib/supabase', () => {
     auth: { getSession: async () => ({ data: { session: null } }) },
     from: () => ({ select: () => ({ data: [], error: null }) }),
   });
-  return { getSupabase: stub, getTypedSupabase: stub, supabase: stub() };
+  return { getSupabase: stub, supabase: stub() };
 });
 
 vi.mock('next/navigation', () => ({

--- a/__tests__/hooks/useNoteDwell.test.tsx
+++ b/__tests__/hooks/useNoteDwell.test.tsx
@@ -5,7 +5,6 @@ import { useNoteDwell } from '@/hooks/useNoteDwell';
 const rpc = vi.fn().mockResolvedValue({ error: null });
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => ({ rpc }),
-  getTypedSupabase: () => ({ rpc }),
 }));
 vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }));
 

--- a/__tests__/utils/bomAccess.test.ts
+++ b/__tests__/utils/bomAccess.test.ts
@@ -19,7 +19,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 import {

--- a/__tests__/utils/companyAccess.test.ts
+++ b/__tests__/utils/companyAccess.test.ts
@@ -33,8 +33,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 // Mock the supabase module
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  // companyAccess.ts adopted getTypedSupabase under the typed-client rollout.
-  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/__tests__/utils/customerAccess.test.ts
+++ b/__tests__/utils/customerAccess.test.ts
@@ -63,9 +63,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 // Mock the supabase module
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  // customerAccess.ts adopted getTypedSupabase under the typed-client
-  // rollout; both getters return the same singleton at runtime.
-  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/__tests__/utils/customerCarrierAccountsAccess.test.ts
+++ b/__tests__/utils/customerCarrierAccountsAccess.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, vi } from 'vitest';
 const { mockSupabase } = vi.hoisted(() => ({ mockSupabase: { from: () => ({}) } }));
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/__tests__/utils/customerContactsAccess.test.ts
+++ b/__tests__/utils/customerContactsAccess.test.ts
@@ -29,7 +29,6 @@ const { mockQueryBuilder, mockSupabase, errorQueue } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/__tests__/utils/dashboardAccess.test.ts
+++ b/__tests__/utils/dashboardAccess.test.ts
@@ -57,7 +57,6 @@ const mockSupabase = { from: vi.fn((t: string) => makeBuilder(t)) };
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 import { getDashboardActivity, getActivityStream } from '@/utils/dashboardAccess';

--- a/__tests__/utils/dashboardPinnedMetrics.test.ts
+++ b/__tests__/utils/dashboardPinnedMetrics.test.ts
@@ -32,7 +32,6 @@ const mockSupabase = {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 import {

--- a/__tests__/utils/homePathForRole.test.ts
+++ b/__tests__/utils/homePathForRole.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect, vi } from 'vitest';
 // without env vars. Same stub every other utils test uses.
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => ({}),
-  getTypedSupabase: () => ({}),
 }));
 
 import { homePathForRole } from '@/utils/companyAccess';

--- a/__tests__/utils/inventoryCountAccess.test.ts
+++ b/__tests__/utils/inventoryCountAccess.test.ts
@@ -48,7 +48,6 @@ const { sbState, sbMock } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => sbMock,
-  getTypedSupabase: () => sbMock,
 }));
 
 import {

--- a/__tests__/utils/inventoryLocationsAccess.test.ts
+++ b/__tests__/utils/inventoryLocationsAccess.test.ts
@@ -48,7 +48,6 @@ const { state, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 // The board resolves photo URLs through storageHelpers; stub the module so no real client is

--- a/__tests__/utils/jobAttachmentsAccess.test.ts
+++ b/__tests__/utils/jobAttachmentsAccess.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 
 // Isolate the pure validator from the real Supabase client / storage helpers.
-vi.mock('@/lib/supabase', () => ({ getTypedSupabase: () => ({}) }));
+vi.mock('@/lib/supabase', () => ({ getSupabase: () => ({}) }));
 
 import { validateAttachmentFile } from '@/utils/jobAttachmentsAccess';
 

--- a/__tests__/utils/jobNoteMediaAccess.test.ts
+++ b/__tests__/utils/jobNoteMediaAccess.test.ts
@@ -17,7 +17,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 const {

--- a/__tests__/utils/jobTravelerPdf.test.ts
+++ b/__tests__/utils/jobTravelerPdf.test.ts
@@ -42,7 +42,6 @@ vi.mock('qrcode', () => ({ default: { toDataURL: qrMock } }));
 // supabase: null and a company with no logo_url).
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => ({}),
-  getTypedSupabase: () => ({}),
   createClient: () => ({}),
 }));
 

--- a/__tests__/utils/jobsAccess.test.ts
+++ b/__tests__/utils/jobsAccess.test.ts
@@ -21,7 +21,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 // updateJobPartQuantity / deleteJob orchestrate cross-module readers — stub them

--- a/__tests__/utils/machineMaintenanceAccess.test.ts
+++ b/__tests__/utils/machineMaintenanceAccess.test.ts
@@ -17,7 +17,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 vi.mock('@/lib/supabaseErrors', () => ({

--- a/__tests__/utils/materialCheckAccess.test.ts
+++ b/__tests__/utils/materialCheckAccess.test.ts
@@ -40,7 +40,6 @@ const filterFor = (table: string, method: string) =>
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => ({ from: fromSpy }),
-  getTypedSupabase: () => ({ from: fromSpy }),
 }));
 
 import { getJobPartMaterialCheck } from '@/utils/materialCheckAccess';

--- a/__tests__/utils/operationCompletionsAccess.test.ts
+++ b/__tests__/utils/operationCompletionsAccess.test.ts
@@ -37,7 +37,6 @@ const { responses, captured, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 import {

--- a/__tests__/utils/operatorAccess.test.ts
+++ b/__tests__/utils/operatorAccess.test.ts
@@ -24,7 +24,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 // friendlyErrorMessage just surfaces the fallback so we can assert thrown text.

--- a/__tests__/utils/operatorNoteSubject.test.ts
+++ b/__tests__/utils/operatorNoteSubject.test.ts
@@ -65,7 +65,6 @@ const mockSupabase = { from: vi.fn((t: string) => makeBuilder(t)), rpc: vi.fn() 
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 vi.mock('@/lib/supabaseErrors', () => ({
   friendlyErrorMessage: (_e: unknown, o?: { fallback?: string }) => o?.fallback ?? 'error',

--- a/__tests__/utils/operatorPartPreviousNotes.test.ts
+++ b/__tests__/utils/operatorPartPreviousNotes.test.ts
@@ -27,7 +27,6 @@ const mockSupabase = { from: vi.fn(() => makeBuilder()), rpc: mockRpc };
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 vi.mock('@/lib/supabaseErrors', () => ({
   friendlyErrorMessage: (_e: unknown, o?: { fallback?: string }) => o?.fallback ?? 'error',

--- a/__tests__/utils/partAttachmentsAccess.test.ts
+++ b/__tests__/utils/partAttachmentsAccess.test.ts
@@ -17,7 +17,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 // --- Storage helpers are mocked: we assert the access layer calls them right ---

--- a/__tests__/utils/partPricingTiersAccess.test.ts
+++ b/__tests__/utils/partPricingTiersAccess.test.ts
@@ -16,7 +16,6 @@ const { mockBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 // The one canonical cost engine — every price (made or bought) derives from it,

--- a/__tests__/utils/partsAccess.test.ts
+++ b/__tests__/utils/partsAccess.test.ts
@@ -49,8 +49,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 // Mock the supabase module
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  // partsAccess.ts adopted getTypedSupabase under the typed-client rollout.
-  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/__tests__/utils/procurementTiersAccess.test.ts
+++ b/__tests__/utils/procurementTiersAccess.test.ts
@@ -32,8 +32,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  // procurementTiersAccess.ts adopted getTypedSupabase under the typed-client rollout.
-  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/__tests__/utils/quickbooksAccess.test.ts
+++ b/__tests__/utils/quickbooksAccess.test.ts
@@ -38,7 +38,6 @@ const { mockSupabase, queueBuilders } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 import {

--- a/__tests__/utils/quoteLineItemsAccess.test.ts
+++ b/__tests__/utils/quoteLineItemsAccess.test.ts
@@ -19,7 +19,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/__tests__/utils/quotesAccess.test.ts
+++ b/__tests__/utils/quotesAccess.test.ts
@@ -65,12 +65,11 @@ const { mockQueryBuilder, mockSupabase, mockStorageHelpers } = vi.hoisted(() => 
   return { mockQueryBuilder: builder, mockSupabase: supabase, mockStorageHelpers: storageHelpers };
 });
 
-// Mock the supabase module. quotesAccess.ts adopted getTypedSupabase
+// Mock the supabase module. quotesAccess.ts uses the typed client
 // (typed-client rollout); include it here returning the same chainable
 // mock so the existing tests keep working without rewriting fixtures.
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/__tests__/utils/routingCostCalculation.test.ts
+++ b/__tests__/utils/routingCostCalculation.test.ts
@@ -78,8 +78,6 @@ vi.mock('@/lib/supabase', () => {
   });
   return {
     getSupabase: makeClient,
-    // typed-client rollout: same singleton at runtime.
-    getTypedSupabase: makeClient,
   };
 });
 

--- a/__tests__/utils/routingsAccess.test.ts
+++ b/__tests__/utils/routingsAccess.test.ts
@@ -19,7 +19,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 import {

--- a/__tests__/utils/shipmentsAccess.test.ts
+++ b/__tests__/utils/shipmentsAccess.test.ts
@@ -70,8 +70,6 @@ const { mockSupabase, queueBuilders, mockAuthGetUser } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  // shipmentsAccess.ts adopted getTypedSupabase under the typed-client rollout.
-  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/__tests__/utils/storageHelpers.test.ts
+++ b/__tests__/utils/storageHelpers.test.ts
@@ -29,8 +29,6 @@ const { mockStorage, mockSupabase } = vi.hoisted(() => {
 // Mock the supabase module
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  // storageHelpers.ts adopted getTypedSupabase under the typed-client rollout.
-  getTypedSupabase: () => mockSupabase,
   createClient: () => mockSupabase,
   supabase: mockSupabase,
 }));

--- a/__tests__/utils/vendorsAccess.test.ts
+++ b/__tests__/utils/vendorsAccess.test.ts
@@ -19,7 +19,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 import { getAllVendors, getVendor, createVendor, deleteVendor } from '@/utils/vendorsAccess';

--- a/__tests__/utils/workCenterAttachmentsAccess.test.ts
+++ b/__tests__/utils/workCenterAttachmentsAccess.test.ts
@@ -18,7 +18,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 vi.mock('@/utils/storageHelpers', () => ({

--- a/__tests__/utils/workCentersAccess.test.ts
+++ b/__tests__/utils/workCentersAccess.test.ts
@@ -20,7 +20,6 @@ const { mockQueryBuilder, mockSupabase } = vi.hoisted(() => {
 
 vi.mock('@/lib/supabase', () => ({
   getSupabase: () => mockSupabase,
-  getTypedSupabase: () => mockSupabase,
 }));
 
 import {

--- a/app/accept-invite/[invitationId]/page.tsx
+++ b/app/accept-invite/[invitationId]/page.tsx
@@ -80,7 +80,11 @@ export default function AcceptInvitePage() {
 
     if (!session) {
       // Wait for auth state change (hash fragment processing may be async)
-      session = await new Promise<typeof session>((resolve) => {
+      // `Session | null` spelled out rather than `typeof session`: inside this
+      // `if (!session)` block the narrowed type is `null`, so `typeof session`
+      // would type the promise as `Promise<null>` and reject the `resolve(newSession)`
+      // below. It compiled before only because the untyped client made `session` `any`.
+      session = await new Promise<Session | null>((resolve) => {
         const timeout = setTimeout(() => resolve(null), 3000);
         const { data: { subscription } } = supabase.auth.onAuthStateChange((_event: AuthChangeEvent, newSession: Session | null) => {
           if (newSession) {

--- a/app/actions/waitlist.ts
+++ b/app/actions/waitlist.ts
@@ -2,6 +2,8 @@
 
 import { createClient } from '@supabase/supabase-js';
 
+import type { Database } from '@/types/database';
+
 interface WaitlistData {
   email: string;
   name: string;
@@ -18,7 +20,10 @@ export async function submitWaitlist(data: WaitlistData) {
   }
 
   // Secret key client — bypasses RLS. Safe because this is a server action.
-  const supabase = createClient(
+  // `<Database>` because the `no-restricted-imports` ratchet only ever guarded
+  // imports from `@/lib/supabase`; a client built inline here escaped it entirely,
+  // and this one writes to a real table with nothing checking the payload.
+  const supabase = createClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SECRET_KEY!,
   );

--- a/app/dashboard/[companyId]/import/page.tsx
+++ b/app/dashboard/[companyId]/import/page.tsx
@@ -68,7 +68,7 @@ import {
 } from '@/lib/dataImportReconcile';
 import { fetchExistingIdentities } from '@/lib/dataImportExisting';
 import { API_BASE_URL } from '@/lib/api';
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import type {
   EntityType,
   Finding,

--- a/components/operator/NoteUsageBanner.tsx
+++ b/components/operator/NoteUsageBanner.tsx
@@ -6,7 +6,7 @@ import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
 import ThumbUpAltIcon from '@mui/icons-material/ThumbUpAlt';
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 
 /**
  * "2 people found your notes helpful · 3 new views."

--- a/components/operator/OperatorAccountBlock.tsx
+++ b/components/operator/OperatorAccountBlock.tsx
@@ -79,9 +79,9 @@ import FeedbackIcon from '@mui/icons-material/Feedback';
 import LogoutIcon from '@mui/icons-material/Logout';
 
 import FeedbackDialog from '@/components/feedback/FeedbackDialog';
-// `getTypedSupabase`, not `getSupabase` — new code uses the typed client (issue #573). Only
+// `getSupabase`, not `getSupabase` — new code uses the typed client (issue #573). Only
 // `auth.signOut` is used here, which is schema-independent.
-import { getTypedSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { clearStoredStation } from '@/components/operator/OperatorStationContext';
 
 export interface OperatorIdentity {
@@ -116,7 +116,7 @@ export function OperatorIdentityRow({
     // Clears the persisted station (localStorage) on explicit logout — for every
     // company, not just this one, since the device may change hands.
     clearStoredStation();
-    const supabase = getTypedSupabase();
+    const supabase = getSupabase();
     // Local scope — sign out ONLY this device. An operator logging out here must not revoke
     // their session on their other devices (which surfaced as a forced re-login when marking
     // a job complete).

--- a/components/parts/PartBomPanel.tsx
+++ b/components/parts/PartBomPanel.tsx
@@ -32,7 +32,7 @@ import {
 } from '@/utils/bomAccess';
 import { getComputedPartCost, ensurePartUnitConversion } from '@/utils/partsAccess';
 import { getSuggestedConversionFactor } from '@/lib/unitPresets';
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import type { BomLineFormData, BomLineWithChildPart } from '@/types/bom';
 import MaterialRowEditor, {
   type MaterialEditorValue,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,28 +161,37 @@ chunk. One home, because four files had independently picked the same wrong numb
 
 *This subsection owns the typed-client contract — CLAUDE.md points here.*
 
-[`lib/supabase.ts`](../lib/supabase.ts) exposes two getters over **one singleton**.
-`getTypedSupabase()` applies the `<Database>` generic from
-[`types/database.ts`](../types/database.ts), so every `.from('t').select('…')` chain
-is checked at compile time; `getSupabase()` returns the *same runtime instance* with
-the generic erased. Same client, different type.
+[`lib/supabase.ts`](../lib/supabase.ts) exposes **one getter**, `getSupabase()`, and it always
+carries the `<Database>` generic from [`types/database.ts`](../types/database.ts) — so every
+`.from('t').select('…')` chain is checked at compile time.
 
-**As built (2026-08-03): the access layer is fully converted.** Every file under
-[`utils/`](../utils) that touches the client imports `getTypedSupabase`, almost always
-aliased `as getSupabase` so the call sites read unchanged. *(This doc and CLAUDE.md
-both said "existing `utils/*Access.ts` files use `getSupabase()`" — true when the
-migration started, false since it finished; the alias is what made it look otherwise.)*
-The untyped getter survives only at the page/component paths in the `files:` grandfather
-block at the bottom of [`eslint.config.mjs`](../eslint.config.mjs) — mostly `supabase.auth.*`
-callers, where the table generic buys nothing. **Drain that block, never extend it**
-([#573](https://github.com/debola31/Jigged/issues/573)).
+**Withdrawn (2026-08-06, [#573](https://github.com/debola31/Jigged/issues/573)): the
+two-getter split.** This section used to describe `getTypedSupabase()` alongside an untyped
+`getSupabase()`, plus a `no-restricted-imports` ratchet and a `files:` grandfather block in
+`eslint.config.mjs` listing the not-yet-migrated paths. All of it is gone. They were never two
+clients: `createClient()` has always built `createBrowserClient<Database>`, and the untyped
+getter returned that same singleton through `as unknown as UntypedSupabaseClient` — scaffolding
+so the rollout could go file by file instead of landing ~250 errors at once.
 
-**Enforced, not aspirational.** `no-restricted-imports` in `eslint.config.mjs` makes
-`import { getSupabase } from '@/lib/supabase'` an **error**, with the grandfathered paths
-as an explicit exemption list, so it ratchets. It exists because the material-yield PR
-dropped `part_procurement_tiers.vendor_id`, `types/database.ts` was regenerated correctly,
-and `PartBomPanel`'s **untyped** cost-ladder query kept filtering the dropped column — it
-compiled clean and shipped a false "No cost on file" on every bought material.
+**What the migration actually cost, because the estimate was wrong by an order of magnitude.**
+#573 scoped it as an 18-file conversion. Deleting the cast surfaced **one** type error in the
+whole project (`app/accept-invite`, where `session` had been silently `any`). The scaffolding had
+outlived its job by months, and an exemption list is easy to keep and hard to notice — that is
+the part worth remembering. **Never reintroduce an untyped view of this client**; there is no
+symbol left to import, so the guarantee is structural rather than lint-maintained.
+
+**`as unknown as` on a row defeats all of this**, which is why the rule is worth stating
+separately: a `SelectQueryError` from a dropped column casts clean through it, so the generic
+buys nothing at a site that launders its result. Narrowing a single field from `string` to a
+union is fine (the generated types render CHECK-constrained columns as bare `string` — see
+`toCreditStatus` in [`utils/customerAccess.ts`](../utils/customerAccess.ts)); casting a whole
+row is not.
+
+**Why any of this exists:** the material-yield PR dropped `part_procurement_tiers.vendor_id`,
+`types/database.ts` was regenerated correctly, and `PartBomPanel`'s **untyped** cost-ladder query
+kept filtering the dropped column — it compiled clean and shipped a false "No cost on file" on
+every bought material. The CI regen gate (#406) guarantees the types file *describes* the schema;
+the generic is what makes query code *read* it. Neither substitutes for the other.
 
 **Regen after any migration that changes columns:** `pnpm gen:db-types`, against a
 **running local stack** (`supabase start`). The generator reads `--local`, not a remote

--- a/docs/modules/inventory.md
+++ b/docs/modules/inventory.md
@@ -208,7 +208,7 @@ No item detail/create/edit/import page of its own; that is all Parts UI.
 
 ### Access layer
 
-Supabase + RLS via `getTypedSupabase()`, **no FastAPI**: `partsAccess.ts`, `inventoryLocationsAccess.ts`, `inventoryCountAccess.ts`, `locationOccupancy.ts`. Non-obvious:
+Supabase + RLS via `getSupabase()`, **no FastAPI**: `partsAccess.ts`, `inventoryLocationsAccess.ts`, `inventoryCountAccess.ts`, `locationOccupancy.ts`. Non-obvious:
 
 - `getLocationContents` caps at 200 (`LOCATION_CONTENTS_LIMIT`) and shows the exact total: uncapped, PostgREST `max_rows` clipped it silently — invisible on a 14-row seed, wrong on a 9,428-part shop. Archived parts excluded, matching the `inventory_location_occupancy` view.
 - `bulkPutAway` — **one atomic RPC, never chunked** (a half-moved pile is worse than none); it moves whole balances, so N parts cost one request, not 2N — every *other* location-stock wrapper first loads the part's conversion context and sends **both** display and converted quantities, which is the second read that makes an ordinary stock write cost 2; the 1000-part cap sits in the RPC, not the UI.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,44 +56,13 @@ const eslintConfig = defineConfig([
       // (package.json) rather than mass-suppressed with inline-disables. New
       // instances still surface in review; the cap only ratchets down.
       "react-hooks/set-state-in-effect": "warn",
-      // Typed-client ratchet: forbid the untyped `getSupabase` getter in new
-      // code so a Supabase schema change fails at compile time (types/database.ts
-      // is CI-verified against migrations) instead of silently at runtime.
-      // `getTypedSupabase()` — including `getTypedSupabase as getSupabase` — is
-      // allowed. Existing untyped sites are grandfathered by the block below and
-      // migrated per issue #573.
-      "no-restricted-imports": [
-        "error",
-        {
-          paths: [
-            {
-              name: "@/lib/supabase",
-              importNames: ["getSupabase"],
-              message:
-                "Use getTypedSupabase() so Supabase schema drift fails at compile time, not silently at runtime. New code must not import the untyped getSupabase. Existing sites are being migrated — see issue #573.",
-            },
-          ],
-        },
-      ],
+      // NOTE: a `no-restricted-imports` ratchet used to live here, forbidding the
+      // untyped `getSupabase` getter, alongside a grandfather block exempting the
+      // not-yet-migrated paths (issue #573). Both are gone: `lib/supabase.ts` now
+      // exports a single, always-typed getter, so there is no untyped symbol left
+      // to import and nothing for a lint rule to guard. Don't reintroduce either —
+      // the guarantee is structural now, not an exemption list someone maintains.
     },
-  },
-  {
-    // Grandfathered untyped `getSupabase` call sites (issue #573). The rule
-    // above blocks NEW untyped imports; these existing files stay exempt until
-    // migrated to getTypedSupabase(). Remove entries as files convert.
-    files: [
-      "components/auth/**",
-      "components/providers/AuthProvider.tsx",
-      "components/shipments/PackingSlipPreviewDialog.tsx",
-      "components/shipments/ShipmentForm.tsx",
-      "components/feedback/FeedbackDialog.tsx",
-      "components/jobs/JobTravelerPreviewDialog.tsx",
-      "app/admin/page.tsx",
-      "app/accept-invite/**",
-      "app/dashboard/**/team/**",
-      "app/operator/**",
-    ],
-    rules: { "no-restricted-imports": "off" },
   },
 ]);
 

--- a/hooks/useNoteDwell.ts
+++ b/hooks/useNoteDwell.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef } from 'react';
 import * as Sentry from '@sentry/nextjs';
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 
 /**
  * Logs that a note was actually READ.

--- a/hooks/useOperatorIdentity.ts
+++ b/hooks/useOperatorIdentity.ts
@@ -22,10 +22,10 @@
 import { useLoad } from '@/hooks/useLoad';
 import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 import { getCurrentMember } from '@/utils/operatorAccess';
-// `getTypedSupabase`, not `getSupabase` — new code uses the typed client (issue #573). Only
+// `getSupabase`, not `getSupabase` — new code uses the typed client (issue #573). Only
 // `auth.getSession()` is used here, which is schema-independent, so the two behave identically;
 // the typed one is simply what new files are required to reach for.
-import { getTypedSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import type { OperatorIdentity } from '@/components/operator/OperatorAccountBlock';
 
 export function useOperatorIdentity(companyId: string) {
@@ -38,7 +38,7 @@ export function useOperatorIdentity(companyId: string) {
       // promise — one throw took the whole identity down, name included, rather than degrading
       // to a missing email.
       const [session, member] = await Promise.all([
-        getTypedSupabase()
+        getSupabase()
           .auth.getSession()
           .then((r) => r.data.session)
           .catch(() => null),

--- a/lib/billingApi.ts
+++ b/lib/billingApi.ts
@@ -2,11 +2,11 @@
  * Thin client for the FastAPI Stripe endpoints. Checkout and Portal return
  * Stripe-hosted URLs; the caller redirects the browser to them (no Stripe.js).
  */
-import { getTypedSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { API_BASE_URL } from '@/lib/api';
 
 async function authToken(): Promise<string> {
-  const supabase = getTypedSupabase();
+  const supabase = getSupabase();
   const {
     data: { session },
   } = await supabase.auth.getSession();

--- a/lib/dataImportExisting.ts
+++ b/lib/dataImportExisting.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ExistingIdentities } from '@/lib/dataImportReconcile';
-import { getTypedSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 
 /** Normalize a query result's identity column into a lookup set, or null on a failed/absent
  *  read (best-effort: those rows are then treated as new). The picker keeps this fully typed —
@@ -20,7 +20,7 @@ function toSet<R>(
 }
 
 export async function fetchExistingIdentities(companyId: string): Promise<ExistingIdentities> {
-  const supabase = getTypedSupabase();
+  const supabase = getSupabase();
   // Explicit per-table literals (not a dynamic `.from(string)`) so the typed client
   // schema-checks each table, its identity column, and the company_id filter.
   const [vendors, parts, workCenters, customers] = await Promise.all([

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -126,56 +126,38 @@ export function createClient() {
   return client;
 }
 
-// Typed shape of the client when the `Database` generic is honored —
-// `createClient()` builds with this generic, but the runtime instance is
-// the same regardless of which getter returns it.
+// The client's shape with the `Database` generic honored. `createClient()`
+// has always built with that generic — see `createBrowserClient<Database>` above.
 export type TypedSupabaseClient = ReturnType<typeof createClient>;
-
-// Untyped shape — what every existing access file currently consumes via
-// `getSupabase()`. Cast at the boundary so adoption of typed mode can roll
-// out per-file without forcing a 250-error refactor up front.
-type UntypedSupabaseClient = ReturnType<typeof createBrowserClient>;
 
 let supabaseInstance: TypedSupabaseClient | null = null;
 
 /**
- * Returns the untyped Supabase client — preserves the legacy behavior
- * every `utils/*Access.ts` file currently relies on. Calls compile
- * regardless of whether the embed string matches the schema.
+ * THE Supabase browser client. One getter, always typed: every
+ * `.from('quotes').select('…')` chain is validated against types/database.ts at
+ * compile time, which is what would have caught the May 2026 `jobs.status`
+ * incident and the `part_procurement_tiers.vendor_id` one after it.
  *
- * Prefer `getTypedSupabase()` for new code. Per-file conversion to the
- * typed getter is the incremental adoption path — see comment above
- * `getTypedSupabase` for the contract and the May 2026 ADR in
- * docs/architecture.md for context.
- */
-export function getSupabase(): UntypedSupabaseClient {
-  if (!supabaseInstance) {
-    supabaseInstance = createClient();
-  }
-  return supabaseInstance as unknown as UntypedSupabaseClient;
-}
-
-/**
- * Returns the Supabase client with the `Database` generic applied, so
- * every `.from('quotes').select('...')` chain is validated against
- * types/database.ts at compile time. This is the path that
- * would have caught the May 2026 jobs.status incident.
+ * **There used to be two getters** — this one returning an untyped view, plus a
+ * `getTypedSupabase()` returning the typed one — over a single shared instance.
+ * They were never two clients: `getSupabase()` returned the same singleton with
+ * `as unknown as UntypedSupabaseClient` applied, purely so the typed rollout
+ * could proceed file by file instead of landing ~250 errors at once (#573).
  *
- * Use for any new access function or while converting an existing one.
- * When you switch a file from `getSupabase()` to `getTypedSupabase()`,
- * expect `tsc` to surface real bugs — fix them in that PR, don't paper
- * over with `as any`.
+ * That scaffolding outlived its job. By the time it came down the whole access
+ * layer was already typed, and deleting the cast surfaced exactly **one** type
+ * error in the entire project. The lesson worth keeping: the split cost real
+ * safety for two months after it stopped buying anything, because an
+ * exemption list is easy to keep and hard to notice. Don't reintroduce an
+ * untyped view of this client — if a query won't type-check, the query is
+ * wrong. Never paper over it with `as any` or `as unknown as`.
  */
-export function getTypedSupabase(): TypedSupabaseClient {
+export function getSupabase(): TypedSupabaseClient {
   if (!supabaseInstance) {
     supabaseInstance = createClient();
   }
   return supabaseInstance;
 }
-
-// Export a convenience alias. Stays untyped for back-compat with existing
-// `import { supabase } from '@/lib/supabase'` consumers.
-export const supabase = typeof window !== 'undefined' ? getSupabase() : null;
 
 /**
  * Get the base URL for Supabase Edge Functions.

--- a/scripts/schemaEmbedCheck.ts
+++ b/scripts/schemaEmbedCheck.ts
@@ -19,7 +19,7 @@
  * recording precisely, because the obvious way to make it redundant does not
  * work and someone will otherwise try it again.
  *
- * All 37 access files use `getTypedSupabase()`, and supabase-js validates select
+ * All access files use the typed `getSupabase()`, and supabase-js validates select
  * strings at the type level — so `tsc` does catch part of this class. Measured
  * by injecting a bogus embed column and running the whole project:
  *

--- a/utils/bomAccess.ts
+++ b/utils/bomAccess.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type {
   BomLine,

--- a/utils/companyAccess.ts
+++ b/utils/companyAccess.ts
@@ -1,6 +1,6 @@
 // Typed Supabase client (typed-client rollout). Aliased so the 10 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import type { CompanyMember } from '@/types/quote';
 import type { Json } from '@/types/database';
 import {

--- a/utils/customerAccess.ts
+++ b/utils/customerAccess.ts
@@ -2,7 +2,7 @@
 // this file is now validated against types/database.ts at compile time.
 // Aliased to getSupabase so the existing call sites stay untouched. See
 // CLAUDE.md "Typed Supabase client (incremental adoption)".
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import {
   toCreditStatus,
   type Customer,

--- a/utils/customerAddressesAccess.ts
+++ b/utils/customerAddressesAccess.ts
@@ -13,7 +13,7 @@
  * the DEFAULT, not a type assertion on the address.
  */
 
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type {
   CustomerAddress,

--- a/utils/customerCarrierAccountsAccess.ts
+++ b/utils/customerCarrierAccountsAccess.ts
@@ -2,7 +2,7 @@
 // file is validated against types/database.ts at compile time. Aliased to
 // getSupabase to match the other access modules. See CLAUDE.md "Typed Supabase
 // client (incremental adoption)".
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import {
   toBillToParty,
   type CustomerCarrierAccount,

--- a/utils/customerContactsAccess.ts
+++ b/utils/customerContactsAccess.ts
@@ -17,7 +17,7 @@
  * because the UI is single-user-per-customer at any given moment.
  */
 
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type { Database } from '@/types/database';
 import type {

--- a/utils/dashboardAccess.ts
+++ b/utils/dashboardAccess.ts
@@ -1,6 +1,6 @@
 // Typed Supabase client (typed-client rollout). Aliased so the 8 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { applyOverdueJobsFilter } from '@/utils/jobsAccess';
 
 // ============== Types ==============

--- a/utils/demoAccess.ts
+++ b/utils/demoAccess.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 
 export interface DemoStatus {
   isDemoCompany: boolean;

--- a/utils/insightsAccess.ts
+++ b/utils/insightsAccess.ts
@@ -1,5 +1,5 @@
 import { API_BASE_URL } from '@/lib/api';
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 
 // ============================================================
 // Types

--- a/utils/inventoryCountAccess.ts
+++ b/utils/inventoryCountAccess.ts
@@ -10,7 +10,7 @@
  * Commit is intentionally per-line and tolerant of partial failure: each counted line is an
  * independent fact, so line 50 failing doesn't invalidate lines 1-49.
  */
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { ID_CHUNK } from '@/lib/queryLimits';
 import { getStockedParts } from '@/utils/partsAccess';
 import {

--- a/utils/inventoryLocationsAccess.ts
+++ b/utils/inventoryLocationsAccess.ts
@@ -9,7 +9,7 @@
  * the caller's (quantity, unit) to the part's primary unit and hand the RPC
  * both the display values and the converted quantity.
  */
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { ID_CHUNK } from '@/lib/queryLimits';
 import { convertToBaseUnit } from '@/lib/unitPresets';
 import { isReservedKind, RESERVED_KIND_MESSAGE } from '@/lib/locationKinds';

--- a/utils/jobAttachmentsAccess.ts
+++ b/utils/jobAttachmentsAccess.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import {
   generateStoragePath,
   uploadFileToStorage,

--- a/utils/jobNoteMediaAccess.ts
+++ b/utils/jobNoteMediaAccess.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import {
   generateStoragePath,
   uploadFileToStorage,

--- a/utils/jobsAccess.ts
+++ b/utils/jobsAccess.ts
@@ -3,7 +3,7 @@
 // getSupabase so the dozens of call sites below don't need renaming —
 // this also keeps the diff small for review. See CLAUDE.md "Typed
 // Supabase client (incremental adoption)" for the rollout contract.
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type { Database } from '@/types/database';
 

--- a/utils/machineMaintenanceAccess.ts
+++ b/utils/machineMaintenanceAccess.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import { mapReactions } from '@/utils/operatorAccess';
 import type { ReactionRel } from '@/utils/operatorAccess';

--- a/utils/materialCheckAccess.ts
+++ b/utils/materialCheckAccess.ts
@@ -15,7 +15,7 @@
  * exists today. A pump job reads "needs 1 pump core", not the aluminium inside it. The card
  * says so on screen.
  */
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { ID_CHUNK } from '@/lib/queryLimits';
 
 import { buildRequirement } from '@/lib/materialRequirements';

--- a/utils/movementAttribution.ts
+++ b/utils/movementAttribution.ts
@@ -32,7 +32,7 @@
  * the movements are the point, the names are the caption.
  */
 
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { getSignedUrls } from '@/utils/storageHelpers';
 
 /** Matches the other media surfaces. Owned here, separate from the location-photo constant. */

--- a/utils/operationCompletionsAccess.ts
+++ b/utils/operationCompletionsAccess.ts
@@ -13,7 +13,7 @@
  * enforced, in the DB); the UI warns via operationMath.
  */
 
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import type {
   CreateOperationCompletionInput,
   OperationCompletionEvent,

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -18,7 +18,7 @@
 
 // Typed Supabase client (typed-client rollout). Aliased so the 19 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import { voidAllOperationCompletions } from '@/utils/operationCompletionsAccess';
 import type {

--- a/utils/operatorEventsAccess.ts
+++ b/utils/operatorEventsAccess.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 
 /**
  * Capture-funnel instrumentation.

--- a/utils/partAttachmentsAccess.ts
+++ b/utils/partAttachmentsAccess.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import {
   generateStoragePath,
   uploadFileToStorage,

--- a/utils/partPricingTiersAccess.ts
+++ b/utils/partPricingTiersAccess.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type {
   PartPricingTier,

--- a/utils/partsAccess.ts
+++ b/utils/partsAccess.ts
@@ -1,6 +1,6 @@
 // Typed Supabase client (typed-client rollout). Aliased so the 30 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import type { Database } from '@/types/database';
 
 // Insert payload for the parts table. company_id is supplied at the call

--- a/utils/procurementTiersAccess.ts
+++ b/utils/procurementTiersAccess.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type {
   ProcurementCostResult,

--- a/utils/quickbooksAccess.ts
+++ b/utils/quickbooksAccess.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { API_BASE_URL } from '@/lib/api';
 
 /**

--- a/utils/quoteLineItemsAccess.ts
+++ b/utils/quoteLineItemsAccess.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import type { Json } from '@/types/database';
 import type { QuoteLineItem } from '@/types/quote';
 import type { ComputedPartPricingTier } from '@/types/partPricing';

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -2,7 +2,7 @@
 // file is now validated against types/database.ts at compile time. Aliased
 // to getSupabase so the existing call sites don't need touching. See
 // CLAUDE.md "Typed Supabase client (incremental adoption)".
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type {
   Quote,

--- a/utils/routingCostCalculation.ts
+++ b/utils/routingCostCalculation.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { getRoutingForPart } from '@/utils/routingsAccess';
 import { getBomForPart } from '@/utils/bomAccess';
 import { getComputedPartCost, getPartCostExplain } from '@/utils/partsAccess';

--- a/utils/routingsAccess.ts
+++ b/utils/routingsAccess.ts
@@ -9,7 +9,7 @@
 
 // Typed Supabase client (typed-client rollout). Aliased so the 12 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import { orIlikeValue } from '@/utils/searchFilter';
 import type { Database } from '@/types/database';

--- a/utils/savedInsightsAccess.ts
+++ b/utils/savedInsightsAccess.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import type { Json } from '@/types/database';
 import type { ChartConfig, SavedInsight } from '@/utils/insightsAccess';
 

--- a/utils/shipmentsAccess.ts
+++ b/utils/shipmentsAccess.ts
@@ -15,7 +15,7 @@
 
 // Typed Supabase client (typed-client rollout). Aliased so the 10 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import type {
   CreateShipmentPayload,
   FreightTerms,

--- a/utils/storageHelpers.ts
+++ b/utils/storageHelpers.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 
 /**
  * Get the storage bucket name from environment variable

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -15,7 +15,7 @@ import type { Database } from '@/types/database';
 export async function createClient() {
   const cookieStore = await cookies();
 
-  // `<Database>`-generic, matching `getTypedSupabase()` on the browser side (see
+  // `<Database>`-generic, matching `getSupabase()` on the browser side (see
   // CLAUDE.md "Typed Supabase client"). Without it the select-string parser can't know
   // a relation's cardinality and types every embed as an array, so `companies(is_demo)`
   // came back as `{ is_demo }[]` for what is a many-to-one FK.

--- a/utils/unitsAccess.ts
+++ b/utils/unitsAccess.ts
@@ -4,7 +4,7 @@
  * specific units. Used by the UOM combobox to populate the "Custom" group.
  */
 
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import type { CompanyCustomUnit } from '@/types/units';
 
 /**

--- a/utils/vendorContactsAccess.ts
+++ b/utils/vendorContactsAccess.ts
@@ -16,7 +16,7 @@
  * because the UI is single-user-per-vendor at any given moment.
  */
 
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import type { Database } from '@/types/database';
 import type {
   VendorContact,

--- a/utils/vendorsAccess.ts
+++ b/utils/vendorsAccess.ts
@@ -1,6 +1,6 @@
 // Typed Supabase client (typed-client rollout). Aliased so the 11 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import type { Database } from '@/types/database';
 import { orIlikeValue } from '@/utils/searchFilter';
 

--- a/utils/workCenterAttachmentsAccess.ts
+++ b/utils/workCenterAttachmentsAccess.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import {
   generateStoragePath,
   uploadFileToStorage,

--- a/utils/workCentersAccess.ts
+++ b/utils/workCentersAccess.ts
@@ -1,4 +1,4 @@
-import { getTypedSupabase as getSupabase } from '@/lib/supabase';
+import { getSupabase } from '@/lib/supabase';
 import type {
   WorkCenter,
   WorkCenterFormData,
@@ -8,7 +8,7 @@ import type {
 } from '@/types/workCenter';
 import { orIlikeValue } from '@/utils/searchFilter';
 
-// ONE string literal, deliberately: getTypedSupabase infers the row type from
+// ONE string literal, deliberately: the typed client infers the row type from
 // the select string, and a concatenated expression widens to `string` — which
 // silently degrades every read in this file to GenericStringError. The optional
 // machine attributes (make…purchased_on) are read everywhere a work center is


### PR DESCRIPTION
Closes #573 — which scoped this as an 18-file migration. **It was one line.**

## What was actually there

`createClient()` has always built `createBrowserClient<Database>`. Both getters returned the **same singleton** — `getSupabase()` just applied `as unknown as UntypedSupabaseClient` on the way out. That was scaffolding, added so the typed rollout could proceed file by file instead of landing ~250 errors at once.

Dropping the cast type-checks all 18 remaining files with **zero call-site edits**.

So rather than migrating call sites *toward* `getTypedSupabase`, this keeps **`getSupabase`** — the name 63 files already use, including the 41 that imported `getTypedSupabase as getSupabase` precisely so they could keep writing it — and deletes the second symbol.

## The one type error it surfaced

`app/accept-invite` typed a promise as `typeof session`, which narrows to `null` inside `if (!session)`. It only ever compiled because the untyped client made `session` `any`. Fixed by spelling out `Session | null`. **No runtime behaviour changes anywhere in this PR** — it is the same singleton, type-level only.

## Changes

- **`lib/supabase.ts`** — one getter, always typed. Deletes `getTypedSupabase`, `UntypedSupabaseClient`, and the dead `export const supabase` (nothing imported it; the only textual hit was a comment in this file). *Side effect worth noting:* that const constructed a client eagerly at module load, so the singleton is now lazy. Harmless — `AuthProvider` calls a getter on mount.
- **`eslint.config.mjs`** — deletes **both** the `no-restricted-imports` rule and its grandfather block. There is no untyped symbol left to import, so the guarantee is structural instead of an exemption list someone maintains. That list was also leaking: it used *directory globs*, so `app/operator/**` exempted 13 files for 2 offenders and new code there could go untyped with CI green.
- **43 test mocks** — drop the now-dead `getTypedSupabase` key. All but one already mocked `getSupabase` too (`jobAttachmentsAccess.test.ts` is renamed). `tsconfig` excludes `__tests__`, so only `pnpm test` catches these.
- **`app/actions/waitlist.ts`** — add `<Database>`. The lint rule only ever guarded imports from `@/lib/supabase`, so this inline service-role client escaped it entirely while writing to a real table.
- **Docs** — CLAUDE.md and architecture.md §6.1 rewritten; §6.1 marks the two-getter split **Withdrawn** and records what the migration actually cost, since the estimate was off by an order of magnitude.

## Corrections to the issue text, for the record

- Says **19 files**; it is **18** (a raw `grep getSupabase` counts the 41 aliases).
- Says remaining sites carry inline `eslint-disable` comments — **none exist anywhere in the repo**. Suppression was entirely config globs, so its "done when" criterion was already vacuously satisfied.
- Predicts conversions will uncover latent bugs. Every column in all 9 table-querying files was checked against `types/database.ts`; **none had drifted.** The value here is removing the exemption list, not fixing live drift.

## Not in scope

`app/auth/callback/route.ts` builds an inline `createServerClient` with no `<Database>`, and `utils/supabase/server.ts` already exists as its shared equivalent. That is a dedup on an auth-critical path, not a typing fix — kept out so this PR stays provably behaviour-neutral. Same for `supabase/functions/_shared/supabase.ts` (Deno, excluded from `tsconfig`, never typechecked in CI).

The 6 remaining `as unknown as` row casts still defeat the generic at their sites — follow-up issue, not this PR.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `pnpm lint` | 0 errors, 16 warnings (cap 17, unchanged from base) |
| `docLinkCheck` | 25 passed |
| `pnpm test --run` | **2023 tests / 149 files passed** |
| `pnpm build` | succeeds |

🤖 Generated with [Claude Code](https://claude.com/claude-code)