### PR TITLE
fix(shipments): freight could bill to an archived carrier account

### DIFF
--- a/__tests__/utils/customerCarrierAccountsAccess.test.ts
+++ b/__tests__/utils/customerCarrierAccountsAccess.test.ts
@@ -12,7 +12,10 @@ vi.mock('@/lib/supabase', () => ({
   supabase: mockSupabase,
 }));
 
-import { pickCarrierAccount } from '@/utils/customerCarrierAccountsAccess';
+import {
+  pickCarrierAccount,
+  billableCarrierAccounts,
+} from '@/utils/customerCarrierAccountsAccess';
 import { resolveFreightLine } from '@/utils/shipmentsAccess';
 import { describeShipmentFreight } from '@/types/shipment';
 import {
@@ -62,6 +65,56 @@ describe('pickCarrierAccount — refuses to guess', () => {
     expect(pickCarrierAccount([])).toBeNull();
     expect(pickCarrierAccount(null)).toBeNull();
     expect(pickCarrierAccount(undefined)).toBeNull();
+  });
+});
+
+describe('billableCarrierAccounts — archived rows change the answer, not just the list', () => {
+  // These two cases ARE the bug this function was extracted for. ShipmentForm's
+  // customer mode passed carrier_accounts unfiltered, and because
+  // pickCarrierAccount resolves only at exactly one candidate, an archived row
+  // is not cosmetic — it moves the count across the threshold in both directions.
+
+  it('one live + one archived does not silently resolve to nothing', () => {
+    const live = account({ id: 'live' });
+    const archived = account({ id: 'dead', deleted_at: '2026-07-15T00:00:00Z' });
+
+    // Unfiltered this is length 2 → pickCarrierAccount returns null → the
+    // shipment saves NULL freight for a customer who plainly has an arrangement.
+    expect(pickCarrierAccount([live, archived])).toBeNull();
+
+    expect(billableCarrierAccounts([live, archived], null)).toEqual([live]);
+    expect(pickCarrierAccount(billableCarrierAccounts([live, archived], null))?.id).toBe('live');
+  });
+
+  it('zero live + one archived does not bill freight to the archived account', () => {
+    const archived = account({ id: 'dead', deleted_at: '2026-07-15T00:00:00Z' });
+
+    // The expensive direction: unfiltered this is length 1, so it resolves —
+    // and the shipment bills to an account the shop deliberately retired.
+    expect(pickCarrierAccount([archived])?.id).toBe('dead');
+
+    expect(billableCarrierAccounts([archived], null)).toEqual([]);
+    expect(pickCarrierAccount(billableCarrierAccounts([archived], null))).toBeNull();
+  });
+
+  it('keeps the account the job named, even once archived', () => {
+    // A shipment created against an old job has to keep resolving the
+    // arrangement that job was quoted under — re-opening a historical job and
+    // finding its freight blank, or re-resolved elsewhere, is the failure here.
+    const archived = account({ id: 'dead', deleted_at: '2026-07-15T00:00:00Z' });
+    expect(billableCarrierAccounts([archived], 'dead')).toEqual([archived]);
+  });
+
+  it('drops archived rows the job did not name', () => {
+    const named = account({ id: 'named', deleted_at: '2026-07-15T00:00:00Z' });
+    const other = account({ id: 'other', deleted_at: '2026-07-15T00:00:00Z' });
+    expect(billableCarrierAccounts([named, other], 'named')).toEqual([named]);
+  });
+
+  it('handles empty, null and undefined', () => {
+    expect(billableCarrierAccounts([], null)).toEqual([]);
+    expect(billableCarrierAccounts(null, null)).toEqual([]);
+    expect(billableCarrierAccounts(undefined, 'anything')).toEqual([]);
   });
 });
 

--- a/components/shipments/ShipmentForm.tsx
+++ b/components/shipments/ShipmentForm.tsx
@@ -62,6 +62,7 @@ import {
   carrierAccountMismatch,
   type ShipConsequence,
 } from '@/components/shipments/shipmentMath';
+import { billableCarrierAccounts } from '@/utils/customerCarrierAccountsAccess';
 
 /** UI-only carrier selection. 'other' reveals a free-text field whose value
  *  is what actually gets stored in shipments.carrier. */
@@ -262,8 +263,9 @@ export default function ShipmentForm({
           const freight = resolveFreightLine({
             jobFreightTerms: job.freight_terms,
             jobCarrierAccountId: job.customer_carrier_account_id,
-            customerAccounts: (job.customer.carrier_accounts ?? []).filter(
-              (a) => a.deleted_at === null || a.id === job.customer_carrier_account_id,
+            customerAccounts: billableCarrierAccounts(
+              job.customer.carrier_accounts,
+              job.customer_carrier_account_id,
             ),
           });
           setResolvedFreight(freight);
@@ -353,8 +355,13 @@ export default function ShipmentForm({
           const customerFreight = resolveFreightLine({
             jobFreightTerms: null,
             jobCarrierAccountId: null,
-            customerAccounts: (customerRow.carrier_accounts ??
-              []) as unknown as CustomerCarrierAccount[],
+            // `null` job account: no job is naming one here, so this is the plain
+            // live-only case. Passing the raw list is what billed freight to
+            // archived accounts — see billableCarrierAccounts.
+            customerAccounts: billableCarrierAccounts(
+              customerRow.carrier_accounts as unknown as CustomerCarrierAccount[],
+              null,
+            ),
           });
           setResolvedFreight(customerFreight);
           setFreightTerms(customerFreight.terms ?? '');

--- a/utils/customerCarrierAccountsAccess.ts
+++ b/utils/customerCarrierAccountsAccess.ts
@@ -165,3 +165,36 @@ export function pickCarrierAccount(
   if (!accounts || accounts.length !== 1) return null;
   return accounts[0];
 }
+
+/**
+ * The accounts a shipment may bill to: live ones, plus the one the job already
+ * named even if it has since been archived.
+ *
+ * BOTH HALVES MATTER, and they pull in opposite directions.
+ *
+ * Archived accounts must be excluded because `pickCarrierAccount` above resolves
+ * only at exactly one candidate — so a stale row does not merely clutter a list,
+ * it changes the answer. One live + one archived reads as two and silently
+ * resolves to nothing; **zero live + one archived reads as one and bills freight
+ * to a dead account.**
+ *
+ * The job-named account must survive that filter because a shipment created
+ * against an old job has to keep resolving the arrangement that job was quoted
+ * under. Re-opening a historical job and finding its freight blank — or worse,
+ * re-resolved to a different account — is the failure this exception prevents.
+ *
+ * Passing `null` for `jobCarrierAccountId` (customer mode, where no job names an
+ * account) is the plain "live only" case.
+ *
+ * This lives here, rather than inline at the call sites, because it was written
+ * twice in ShipmentForm and only the job-mode copy was correct — the customer-mode
+ * copy passed accounts unfiltered and could bill to an archived account.
+ */
+export function billableCarrierAccounts(
+  accounts: CustomerCarrierAccount[] | null | undefined,
+  jobCarrierAccountId: string | null,
+): CustomerCarrierAccount[] {
+  return (accounts ?? []).filter(
+    (a) => a.deleted_at === null || a.id === jobCarrierAccountId,
+  );
+}


### PR DESCRIPTION
`ShipmentForm` resolved billable carrier accounts **twice**, and only the job-mode copy was correct. Customer mode passed `carrier_accounts` straight through, unfiltered.

## Why an archived row isn't cosmetic here

`pickCarrierAccount` resolves only when there is **exactly one** candidate. So a stale account doesn't just clutter a list — it moves the count across the threshold, in both directions:

| Accounts | Unfiltered length | Result |
|---|---|---|
| 1 live + 1 archived | 2 | resolves to **nothing** — the shipment saves NULL freight for a customer who plainly has an arrangement |
| 0 live + 1 archived | 1 | **resolves, and bills the freight to an account the shop deliberately retired** |

A `deleted_at IS NULL` violation on a picker query (CLAUDE.md, *"Deletion is archive"*). **No type system would have caught this** — the embed types fine either way. It was found by reading the two copies side by side.

## The fix: write the rule once

`billableCarrierAccounts(accounts, jobCarrierAccountId)` now lives next to `pickCarrierAccount` in `utils/customerCarrierAccountsAccess.ts` — they're the two halves of one decision — and both call sites use it.

It preserves job mode's deliberate exception: **the account a job already named survives the filter even once archived**, so a shipment created against an old job still resolves the arrangement that job was quoted under. Re-opening a historical job to find its freight blank — or re-resolved elsewhere — is the failure that exception prevents.

Worth flagging for review: this is *not* `getCarrierAccountsForCustomer`, which filters `deleted_at` in SQL and would silently drop that exception.

## Tests

Five regression cases, with both threshold directions asserted against the *unfiltered* behaviour first, so the failure mode stays legible to the next reader rather than being implied by a passing test.

## Manual verification

- [ ] Customer with 0 live + 1 archived account → shipment form must **not** auto-resolve freight
- [ ] Customer with 1 live + 1 archived → resolves to the live one
- [ ] Job whose `customer_carrier_account_id` points at an archived account → must **still** resolve (the job-mode exception)

Found while auditing #573. Unrelated to the typed-client work, so it ships alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)