### PR TITLE
fix(operator): a network blip signed operators out mid-shift

### DIFF
--- a/__tests__/lib/supabaseErrors.test.ts
+++ b/__tests__/lib/supabaseErrors.test.ts
@@ -6,7 +6,39 @@ import {
   friendlyErrorMessage,
   isTransientAbortError,
   toError,
+  isIndeterminateSingleError,
 } from '@/lib/supabaseErrors';
+
+describe('isIndeterminateSingleError — "couldn\'t check" is never "denied"', () => {
+  it('is false with no error: the check completed', () => {
+    // The happy path. `data` decides; there is nothing indeterminate.
+    expect(isIndeterminateSingleError(null)).toBe(false);
+    expect(isIndeterminateSingleError(undefined)).toBe(false);
+  });
+
+  it('is false for PGRST116 — "no rows" is a real answer, not a failure', () => {
+    // A caller SHOULD act on this: the membership row genuinely is not there.
+    expect(isIndeterminateSingleError({ code: 'PGRST116', message: 'no rows' })).toBe(false);
+  });
+
+  it('is true for the failures that used to read as "not a member"', () => {
+    // Every one of these arrived as `data: null` alongside a discarded error, and
+    // the operator layout responded by clearing the station, signing the user out
+    // and bouncing to login. On a phone on shop wifi, the first of these is not
+    // an edge case — it is Tuesday.
+    expect(isIndeterminateSingleError({ message: 'Failed to fetch' })).toBe(true);
+    expect(isIndeterminateSingleError({ code: '500', message: 'server error' })).toBe(true);
+    expect(isIndeterminateSingleError({ code: 'PGRST301', message: 'JWT expired' })).toBe(true);
+    expect(isIndeterminateSingleError({ code: '42501', message: 'permission denied' })).toBe(true);
+  });
+
+  it('treats a near-miss code as indeterminate rather than guessing', () => {
+    // Fails safe: an unrecognised code must not be mistaken for "no rows", because
+    // the negative branch signs people out.
+    expect(isIndeterminateSingleError({ code: 'PGRST117' })).toBe(true);
+    expect(isIndeterminateSingleError({ code: 'pgrst116' })).toBe(true);
+  });
+});
 
 describe('isAuthError', () => {
   it('returns true for PGRST301 (JWT expired)', () => {

--- a/app/operator/[companyId]/layout.tsx
+++ b/app/operator/[companyId]/layout.tsx
@@ -26,6 +26,7 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import DashboardIcon from '@mui/icons-material/Dashboard';
 import { getSupabase } from '@/lib/supabase';
+import { isIndeterminateSingleError } from '@/lib/supabaseErrors';
 import AppAmbientBackdrop from '@/components/layout/AppAmbientBackdrop';
 import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 import { OperatorStationProvider, useStationContext } from '@/components/operator/OperatorStationContext';
@@ -60,6 +61,14 @@ export default function OperatorLayout({
   const [userRole, setUserRole] = useState<string>('operator');
   const [navValue, setNavValue] = useState<string>('jobs');
   const [isLoading, setIsLoading] = useState(true);
+  /**
+   * The membership read failed for a reason that is NOT "you are not a member" —
+   * so we do not know the answer and must not act as though we do. See the
+   * PGRST116 branch in checkAuth.
+   */
+  const [accessCheckFailed, setAccessCheckFailed] = useState(false);
+  /** Bumped by the retry button to re-run checkAuth. */
+  const [retryNonce, setRetryNonce] = useState(0);
 
   const supabase = getSupabase();
 
@@ -109,12 +118,27 @@ export default function OperatorLayout({
       }
 
       // 2. Validate user has access to this company (uses user_company_access)
-      const { data: operatorAccess } = await supabase
+      const { data: operatorAccess, error: accessError } = await supabase
         .from('user_company_access')
         .select('id, name, role')
         .eq('user_id', session.user.id)
         .eq('company_id', companyId)
         .single();
+
+      // "COULDN'T CHECK" IS NEVER "DENIED".
+      //
+      // The error used to be discarded here, so a dropped packet and a genuine
+      // non-membership both arrived as `data: null` and took the branch below:
+      // clear the station, sign out, bounce to login. On a personal phone on shop
+      // wifi that is not a rare path, and its cost is an operator mid-job thrown
+      // to a login screen having lost their station. Signing someone out is the
+      // most destructive thing this layout can do, and it was the response to a
+      // network blip.
+      if (isIndeterminateSingleError(accessError)) {
+        setAccessCheckFailed(true);
+        setIsLoading(false);
+        return;
+      }
 
       if (!operatorAccess) {
         // Local scope — only clear this device's bad session; don't revoke the
@@ -156,7 +180,9 @@ export default function OperatorLayout({
     return () => {
       subscription.unsubscribe();
     };
-  }, [companyId, router, isAuthPage, supabase]);
+    // `retryNonce` re-runs the check after a "couldn't check" failure. `validatedFor`
+    // is only set on success, so a failed check leaves nothing to skip past.
+  }, [companyId, router, isAuthPage, supabase, retryNonce]);
 
   // Update nav value based on current path.
   //
@@ -228,6 +254,49 @@ export default function OperatorLayout({
         }}
       >
         {children}
+      </Box>
+    );
+  }
+
+  // We could not determine membership. Deliberately NOT a sign-out and NOT an
+  // "access denied": both would assert something we do not know. The session is
+  // left intact and the stored station untouched, so Retry resumes exactly where
+  // the operator was. Sized for a gloved thumb on a phone, per the operator
+  // surface rules.
+  if (accessCheckFailed) {
+    return (
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 3,
+          px: 4,
+          textAlign: 'center',
+          bgcolor: 'background.default',
+        }}
+      >
+        <Typography variant="h6" sx={{ fontWeight: 600 }}>
+          Couldn&apos;t reach Jigged
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          We couldn&apos;t check your access just now. You&apos;re still signed in — this is
+          usually the shop&apos;s connection.
+        </Typography>
+        <Button
+          variant="contained"
+          size="large"
+          sx={{ minHeight: 56, minWidth: 200, fontSize: '1.05rem' }}
+          onClick={() => {
+            setAccessCheckFailed(false);
+            setIsLoading(true);
+            setRetryNonce((n) => n + 1);
+          }}
+        >
+          Retry
+        </Button>
       </Box>
     );
   }

--- a/app/operator/[companyId]/login/page.tsx
+++ b/app/operator/[companyId]/login/page.tsx
@@ -18,6 +18,7 @@ import { JiggedLogo } from '@/components/branding';
 import EmailIcon from '@mui/icons-material/Email';
 import LockIcon from '@mui/icons-material/Lock';
 import { getSupabase } from '@/lib/supabase';
+import { isIndeterminateSingleError } from '@/lib/supabaseErrors';
 import { clearStoredStation } from '@/lib/operatorStationStorage';
 import { getCompany } from '@/utils/companyAccess';
 
@@ -88,6 +89,11 @@ export default function OperatorLoginPage() {
           router.push(postLoginPath());
           return;
         }
+        // Discarding the error is DELIBERATE here, unlike the two other membership
+        // reads on this surface. Falling through only skips the auto-forward and
+        // shows the sign-in form — it asserts nothing about access and destroys
+        // no session, so there is no false "denied" to prevent. Adding a retry
+        // screen in front of a form the operator can simply use would be worse.
       }
 
       setCheckingSession(false);
@@ -139,7 +145,17 @@ export default function OperatorLoginPage() {
         .eq('company_id', companyId)
         .single();
 
-      if (opError || !operatorAccess) {
+      // "COULDN'T CHECK" IS NEVER "DENIED". This branch used to treat both alike,
+      // which produced the worst version of the bug: credentials that had just
+      // succeeded, immediately revoked, under a message telling the operator they
+      // don't work here. Keep the session; let them press sign in again.
+      if (isIndeterminateSingleError(opError)) {
+        throw new Error(
+          "Couldn't check your access just now — this is usually the shop's connection. Please try again.",
+        );
+      }
+
+      if (!operatorAccess) {
         // Local scope — only clear this device's session; don't revoke the
         // user's sessions on other devices. The station goes with it: the
         // session that chose it is over (see AuthProvider.signOut).

--- a/lib/supabaseErrors.ts
+++ b/lib/supabaseErrors.ts
@@ -114,6 +114,33 @@ export function isTransientAbortError(error: unknown): boolean {
 const PGRST_NO_ROWS = 'PGRST116';
 
 /**
+ * Did this `.single()` fail to ANSWER, as opposed to answering "no such row"?
+ *
+ * The distinction CLAUDE.md states as **"couldn't check is never denied"**, in the one
+ * shape it actually arrives in. `.single()` collapses two very different outcomes into
+ * `data: null`:
+ *
+ *   PGRST116  → the row is genuinely not there. A definitive answer; act on it.
+ *   anything  → dropped wifi, a 5xx, a token mid-refresh. We learned NOTHING, and
+ *   else        rendering that as a negative asserts something we do not know.
+ *
+ * Named here rather than open-coded because the `error.code !== 'PGRST116'` idiom is
+ * already in six files, and each one has to get an inverted condition right on a path
+ * that only runs when something is already going wrong — the least-exercised, least-
+ * reviewed branch in the file. The operator layout got it wrong by omission: it
+ * discarded the error entirely, so a dropped packet mid-shift cleared the stored
+ * station, signed the operator out, and bounced them to a login screen.
+ *
+ * Use for membership and existence checks whose negative branch DOES something —
+ * denies access, signs out, hides a surface. A read that merely returns `null` to a
+ * caller that treats it as "nothing to show" does not need this.
+ */
+export function isIndeterminateSingleError(error: unknown): boolean {
+  if (!error) return false;
+  return asRecord(error).code !== PGRST_NO_ROWS;
+}
+
+/**
  * Is this Supabase failure worth an issue in the queue?
  *
  * The Supabase Sentry integration (installed in `lib/supabase.ts`) captures EVERY `{ error }`


### PR DESCRIPTION
The operator layout confirmed membership against `user_company_access` and **discarded the error**:

```ts
const { data: operatorAccess } = await supabase...single();
if (!operatorAccess) { clearStoredStation(); signOut({scope:'local'}); → login }
```

`.single()` collapses two very different outcomes into `data: null`:

| Outcome | Meaning | Old behaviour |
|---|---|---|
| `PGRST116` | the row genuinely is not there — **a real answer** | sign out ✅ correct |
| anything else | dropped wifi, 5xx, token mid-refresh — **we learned nothing** | sign out ❌ |

So a dropped packet cleared the stored station, signed the operator out, and bounced them to a login screen **mid-job**. On a personal phone on shop wifi that is not an edge case, and signing someone out is the most destructive thing this layout can do.

CLAUDE.md states the rule this violates directly: **"Couldn't check is never denied."**

The login page had the same defect with a worse symptom: credentials that had *just succeeded*, immediately revoked, under a message telling the operator they don't work here.

## Changes

- **`lib/supabaseErrors.ts`** — `isIndeterminateSingleError(error)` names the distinction, next to the `PGRST116` constant that already lived there. The `error.code !== 'PGRST116'` idiom is open-coded in **six** files, each having to get an inverted condition right on the least-exercised, least-reviewed branch in the file. The layout got it wrong by omission.
- **Layout** — renders a retryable *"Couldn't reach Jigged"* screen. Session intact, stored station untouched, so **Retry resumes exactly where they were**. Thumb-sized target per the operator surface rules.
- **Login** — surfaces a retry message and keeps the session.

## Deliberately not changed

The login page's *mount-time* session check also discards its error — but falling through there only skips the auto-forward and shows the sign-in form. It asserts nothing and destroys no session, so there's no false denial to prevent. Left as-is **with a comment**, so it doesn't later get "fixed" into a retry screen standing in front of a form the operator could simply have used.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `pnpm lint` | 0 errors, 16 warnings (cap 17, unchanged) |
| Unit tests | 237 passed (incl. 4 new cases pinning the classification) |
| **Operator E2E, real local stack** | **8/8 passed**, including the `auth.setup` canary |

Manual check for review: throttle or kill the network on `/operator/{companyId}` → retryable screen, **not** a sign-out and bounce.

Found while auditing #573. Unrelated to the typed-client work, so it ships alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)