### PR TITLE
feat(layout): office account menu — say who is signed in

### DIFF
--- a/__tests__/components/layout/AccountMenu.test.tsx
+++ b/__tests__/components/layout/AccountMenu.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor, within, routerMocks, resetRouterMocks } from '../../test-utils';
+import AccountMenu from '@/components/layout/AccountMenu';
+
+/**
+ * These tests go through the real `useCurrentMember`, stubbing only the data layer beneath it.
+ * That is deliberate: the bug this component exists to fix was a WIRING bug — the header read
+ * `user_metadata.first_name` while the name actually lived on `user_company_access` — so a test
+ * that mocked the hook would assert the component renders whatever it is handed and prove nothing
+ * about where the name comes from. Every `useAuth` stub below therefore has an EMPTY
+ * `user_metadata`, and the name still has to appear.
+ */
+
+const mockSignOut = vi.fn();
+const mockGetCurrentMember = vi.fn();
+
+vi.mock('@/utils/operatorAccess', () => ({
+  getCurrentMember: (companyId: string) => mockGetCurrentMember(companyId),
+}));
+
+let authUser: { id: string; email?: string; user_metadata: Record<string, unknown> } | null = null;
+vi.mock('@/components/providers/AuthProvider', () => ({
+  useAuth: () => ({ user: authUser, signOut: mockSignOut }),
+}));
+
+/** Opens the menu and returns the trigger, so callers can assert focus returns to it. */
+async function openMenu(user: ReturnType<typeof userEvent.setup>) {
+  const trigger = await screen.findByRole('button', { name: /account/i });
+  await user.click(trigger);
+  await screen.findByRole('menu');
+  return trigger;
+}
+
+describe('AccountMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetRouterMocks();
+    authUser = { id: 'u1', email: 'hello@jigged.app', user_metadata: {} };
+    mockGetCurrentMember.mockResolvedValue({
+      id: 'm1',
+      name: 'Test User',
+      user_id: 'u1',
+      role: 'admin',
+      reactions_seen_at: null,
+    });
+  });
+
+  // The reported bug, pinned. `Welcome, {firstName}` read `user_metadata.first_name`, a key only
+  // two sign-up paths ever write — so an account created any other way showed NOTHING, while the
+  // Team page one route away showed the same person's name correctly off `user_company_access`.
+  it('names the signed-in person from their company membership, not from auth metadata', async () => {
+    render(<AccountMenu />);
+
+    expect(await screen.findByText('Test User')).toBeInTheDocument();
+    expect(mockGetCurrentMember).toHaveBeenCalledWith('test-company-id');
+  });
+
+  // The whole reason the component exists: two accounts can share a first name, so the office
+  // surface has to be able to answer WHICH account, not just roughly who.
+  it('states the signed-in email, so the account is identifiable and not just the person', async () => {
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+    await openMenu(user);
+
+    expect(screen.getByText('hello@jigged.app')).toBeInTheDocument();
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+  });
+
+  // `user_company_access.name` is nullable. Leading with the email is honest; synthesising a name
+  // from its local part would invent identity, which is the opposite of what this is for.
+  it('leads with the email rather than a blank line when the member has no name', async () => {
+    mockGetCurrentMember.mockResolvedValue({
+      id: 'm1',
+      name: null,
+      user_id: 'u1',
+      role: 'user',
+      reactions_seen_at: null,
+    });
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+    await openMenu(user);
+
+    const menu = screen.getByRole('menu');
+    expect(within(menu).getByText('hello@jigged.app')).toBeInTheDocument();
+    // Exactly one line carries the email — it was promoted, not duplicated into both slots.
+    expect(within(menu).getAllByText('hello@jigged.app')).toHaveLength(1);
+  });
+
+  // A lookup that fails must not take the way out with it — the same promise useOperatorIdentity
+  // makes for the operator's Log out button.
+  it('still reaches sign out when the identity lookup fails', async () => {
+    mockGetCurrentMember.mockRejectedValue(new Error('offline'));
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+    await openMenu(user);
+
+    await user.click(screen.getByRole('menuitem', { name: /sign out/i }));
+    await waitFor(() => expect(mockSignOut).toHaveBeenCalled());
+  });
+
+  // docs/interaction-standards.md §1: the destructive option sits at the END, away from the benign
+  // ones, so it is predictably located rather than crowded next to something routine.
+  it('puts sign out last, after the benign actions', async () => {
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+    await openMenu(user);
+
+    const items = screen.getAllByRole('menuitem').map((el) => el.textContent);
+    expect(items[items.length - 1]).toMatch(/sign out/i);
+    expect(items).toContain('Change password');
+  });
+
+  it('signs out and returns to the marketing home', async () => {
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+    await openMenu(user);
+
+    await user.click(screen.getByRole('menuitem', { name: /sign out/i }));
+
+    await waitFor(() => expect(mockSignOut).toHaveBeenCalled());
+    // No scope argument — AuthProvider's `local` default is what keeps the same person signed in
+    // on the shop-floor phone in their pocket. Passing a scope here would silently revoke it.
+    expect(mockSignOut).toHaveBeenCalledWith();
+    await waitFor(() => expect(routerMocks.replace).toHaveBeenCalledWith('/'));
+  });
+
+  it('offers a way to change password, which nothing else in the office chrome does', async () => {
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+    await openMenu(user);
+
+    expect(screen.getByRole('menuitem', { name: /change password/i })).toHaveAttribute(
+      'href',
+      '/change-password',
+    );
+  });
+
+  // Under `md` the avatar is all that survives, and this repo has twice rejected a bare glyph in
+  // this header (Header.tsx "Shop floor", operator layout: "our audience skews 50-60, where icon
+  // recognition is measurably worse"). The name must be on screen on desktop, and the control must
+  // be named at BOTH widths.
+  it('shows the name on screen on a desktop, and stays named when it collapses on a phone', async () => {
+    const { unmount } = render(<AccountMenu />);
+    expect(await screen.findByRole('button', { name: 'Account: Test User' })).toBeInTheDocument();
+    expect(screen.getByText('Test User')).toBeInTheDocument();
+    unmount();
+
+    render(<AccountMenu isMobile />);
+    expect(await screen.findByRole('button', { name: 'Account: Test User' })).toBeInTheDocument();
+    expect(screen.queryByText('Test User')).not.toBeInTheDocument();
+  });
+
+  // WAI-ARIA menu button pattern. `aria-expanded` is the only thing that tells a screen-reader user
+  // the trigger opens something and whether it is open.
+  it('announces itself as a menu button and tracks its own open state', async () => {
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+
+    const trigger = await screen.findByRole('button', { name: /account/i });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(trigger);
+    expect(await screen.findByRole('menu')).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('closes on Escape and hands focus back to the trigger', async () => {
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+    const trigger = await openMenu(user);
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+    expect(trigger).toHaveFocus();
+  });
+
+  /**
+   * The identity block is a statement, not an action. Without MUI's `muiSkipListHighlight`,
+   * `MenuList` picks the first non-disabled child as `activeItemIndex` and clones `autoFocus` and
+   * `tabIndex={0}` onto it — which would make the name/email block focusable, steal the menu's
+   * opening focus, and put a no-op at the first stop of every keyboard user's arrow-down. This
+   * fails if that static is ever dropped.
+   */
+  it('opens with focus on a real action, not on the identity block', async () => {
+    const user = userEvent.setup();
+    render(<AccountMenu />);
+    await openMenu(user);
+
+    expect(screen.getByRole('menuitem', { name: /change password/i })).toHaveFocus();
+  });
+});

--- a/__tests__/components/layout/Header.test.tsx
+++ b/__tests__/components/layout/Header.test.tsx
@@ -1,12 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../test-utils';
 import Header from '@/components/layout/Header';
 
 const mockSignOut = vi.fn();
 vi.mock('@/components/providers/AuthProvider', () => ({
   useAuth: () => ({
-    user: { id: 'u1', user_metadata: { first_name: 'Shane' } },
+    user: { id: 'u1', email: 'shane@lltool.test', user_metadata: {} },
     signOut: mockSignOut,
+  }),
+}));
+
+// The header composes the account menu; what the menu itself does with this data — and the fact
+// that the name comes off `user_company_access` rather than auth metadata — is pinned in
+// AccountMenu.test.tsx. Note the auth stub above deliberately carries no `user_metadata.first_name`:
+// the header must not depend on it again.
+vi.mock('@/hooks/useCurrentMember', () => ({
+  useCurrentMember: () => ({
+    name: 'Shane Miller',
+    email: 'shane@lltool.test',
+    role: 'admin',
+    loading: false,
   }),
 }));
 
@@ -44,11 +58,31 @@ describe('Header', () => {
     expect(screen.getByRole('link', { name: /shop floor/i })).toBeInTheDocument();
   });
 
-  it('still renders the page title and sign out', () => {
+  it('still renders the page title', () => {
     render(<Header />);
 
     expect(screen.getByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument();
+  });
+
+  // The office surface used to have no way to confirm which account you were in as — the shop
+  // floor did, and the header's `Welcome, {firstName}` read a key most accounts never had. Identity
+  // is now on screen at rest, without a click.
+  it('says who is signed in without making anyone open anything', () => {
+    render(<Header />);
+
+    expect(screen.getByText('Shane Miller')).toBeInTheDocument();
+  });
+
+  // Sign out did not disappear, it moved: it lives with the identity it belongs to instead of
+  // sitting bare beside Shop floor, where at phone widths one mis-tap ended the session.
+  it('reaches sign out through the account menu', async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+
+    expect(screen.queryByRole('button', { name: /sign out/i })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /account/i }));
+    expect(await screen.findByRole('menuitem', { name: /sign out/i })).toBeInTheDocument();
   });
 
   // The bell that used to sit in this slot was removed in August 2026 — at-risk jobs

--- a/components/layout/AccountMenu.tsx
+++ b/components/layout/AccountMenu.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+/**
+ * Who you are signed in as, in the office header — and the account actions that belong with it.
+ *
+ * ## The gap this closes
+ *
+ * The office surface had no way to answer "which account am I in as?". The shop floor did, and
+ * still does: `components/operator/OperatorAccountBlock.tsx` shows avatar, name, company and email
+ * in one row. The office header only ever had `Welcome, {firstName}` read from
+ * `user.user_metadata.first_name` — a key written by exactly two sign-up paths, so for an account
+ * created any other way the greeting rendered as nothing at all. Silent, and impossible to notice
+ * as a bug rather than a design choice, because a missing greeting looks like no greeting.
+ * `hooks/useCurrentMember.ts` documents the source swap that fixes it.
+ *
+ * Top-right avatar-into-menu is the settled convention (NN/g heuristic #4, "follow platform and
+ * industry conventions"), and knowing which account is acting is system status, not decoration
+ * (heuristic #1). The sidebar's `CompanySwitcher` owns *workspace* identity at top-left; this owns
+ * *person* identity at top-right. Two slots, two owners, no competition.
+ *
+ * ## Why the name is on screen and not only inside the menu
+ *
+ * A bare avatar is a bare glyph, and this repo has already rejected that argument twice for this
+ * exact header — `components/layout/Header.tsx` keeps "Shop floor" labelled at every width, and
+ * `app/operator/[companyId]/layout.tsx` says why: "our audience skews 50-60, where icon recognition
+ * is measurably worse". An avatar you must click to decode does not answer the question that
+ * prompted this; the name beside it does, at zero clicks. It hides under `md`, which is exactly
+ * where `Welcome, {firstName}` already hid, so no width loses anything it had.
+ *
+ * ## Why Sign out moved into a menu
+ *
+ * `docs/interaction-standards.md` §1 says the office surface should not bury a destructive control
+ * behind a kebab. That rule is about RECORD DELETES shown red-at-rest, and the two things it
+ * protects both survive here: Sign out is last, and it is `error.main` at rest (which the old bare
+ * header button was not — it was grey-until-hover, a deviation this fixes). Signing out is also
+ * recoverable by signing back in, which a delete is not.
+ *
+ * It is a net safety gain at narrow widths. The old header put a bare sign-out `IconButton`
+ * immediately beside the Shop floor button, so one mis-tap ended the session — the Fitts's-law slip
+ * `app/operator/[companyId]/layout.tsx` refuses to allow in the operator header. Now the same
+ * mis-tap opens a menu.
+ *
+ * No confirmation dialog, for the reason `OperatorAccountBlock` gives: a dialog on a recoverable
+ * action is the confirmation-fatigue trap that strips the dialogs that matter of their force.
+ */
+
+import { useId, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import Avatar from '@mui/material/Avatar';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Typography from '@mui/material/Typography';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import LockResetIcon from '@mui/icons-material/LockReset';
+import LogoutIcon from '@mui/icons-material/Logout';
+import PersonIcon from '@mui/icons-material/Person';
+
+import { useAuth } from '@/components/providers/AuthProvider';
+import { useCurrentMember } from '@/hooks/useCurrentMember';
+import { initials } from '@/lib/initials';
+
+/** `admin | user | operator` as it should read to a person. */
+const ROLE_LABELS: Record<string, string> = {
+  admin: 'Admin',
+  user: 'User',
+  operator: 'Operator',
+};
+
+/**
+ * The identity block at the top of the menu — the actual answer to "who am I signed in as".
+ *
+ * Not a `MenuItem`: it is a statement, not an action, so making it selectable would put a no-op at
+ * the first stop of every keyboard user's arrow-down. `muiSkipListHighlight` is MUI's own mechanism
+ * for this (`Divider` and `ListSubheader` both set it) — without it `MenuList` picks the first
+ * non-disabled child as `activeItemIndex` and clones `autoFocus` + `tabIndex={0}` onto it, which
+ * would make this block focusable and steal the menu's opening focus.
+ *
+ * `component="li"` because `MenuList` renders a `<ul>` and a bare `<div>` in there is invalid HTML.
+ */
+function AccountIdentity({
+  name,
+  email,
+  role,
+}: {
+  name: string | null;
+  email: string | null;
+  role: string | null;
+}) {
+  // Name leads when we have one. When we don't, the email is promoted rather than padded out with a
+  // placeholder — inventing a name from the email's local part would be inventing identity, which
+  // is the opposite of what this component is for.
+  const primary = name ?? email;
+  const secondary = name ? email : null;
+  const roleLabel = role ? (ROLE_LABELS[role] ?? role) : null;
+
+  return (
+    <Box
+      component="li"
+      sx={{ px: 2, py: 1.5, display: 'flex', alignItems: 'center', gap: 1.5, maxWidth: 320 }}
+    >
+      <Avatar sx={{ bgcolor: 'primary.main', width: 40, height: 40, flexShrink: 0 }}>
+        {name ? initials(name) : <PersonIcon />}
+      </Avatar>
+      {/* minWidth: 0 is what lets the lines below truncate instead of forcing the menu wider. */}
+      <Box sx={{ minWidth: 0 }}>
+        {primary && (
+          <Typography sx={{ fontWeight: 600 }} noWrap>
+            {primary}
+          </Typography>
+        )}
+        {secondary && (
+          // body2, not the caption the operator row uses for the same field. On the office surface
+          // the email is the load-bearing disambiguator between two accounts, and #C8CCD4 at 14px
+          // clears 4.5:1 where 12px is working harder than it needs to for a 50-60 audience.
+          <Typography variant="body2" color="text.secondary" noWrap>
+            {secondary}
+          </Typography>
+        )}
+        {roleLabel && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            noWrap
+            sx={{ display: 'block' }}
+          >
+            {roleLabel}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+}
+AccountIdentity.muiSkipListHighlight = true;
+
+export default function AccountMenu({ isMobile = false }: { isMobile?: boolean }) {
+  const router = useRouter();
+  const { signOut } = useAuth();
+  const { name, email, role } = useCurrentMember();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const id = useId();
+  const triggerId = `${id}-account-trigger`;
+  const menuId = `${id}-account-menu`;
+
+  const open = Boolean(anchorEl);
+  const close = () => setAnchorEl(null);
+
+  const handleSignOut = async () => {
+    close();
+    // Scope stays AuthProvider's `local` default on purpose: signing out at the office must not
+    // revoke the same person's session on the shop-floor phone in their pocket.
+    await signOut();
+    router.replace('/');
+  };
+
+  const label = name ?? email;
+
+  return (
+    <>
+      <Button
+        id={triggerId}
+        onClick={(e) => setAnchorEl(e.currentTarget)}
+        // Named even when the name is on screen beside it, because under `md` the avatar is all
+        // that is left and an unlabelled one says nothing. The visible text stays a substring of
+        // the accessible name (WCAG 2.5.3, Label in Name).
+        aria-label={label ? `Account: ${label}` : 'Account'}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        sx={{
+          // The theme floors every Button at minHeight 48. The width needs bringing DOWN: MUI's
+          // own `minWidth: 64` plus the theme's 20px side padding would reserve ~72px for a 32px
+          // avatar, and at 390px the header title is already truncating against this cluster.
+          // 48 is the design-system floor, so this is as tight as the control is allowed to get.
+          px: 1,
+          minWidth: 48,
+          gap: 1,
+          flexShrink: 0,
+          // White rather than the 70% white its neighbours use: this is identity, and 70% white on
+          // the header's top-right bloom does not clear 4.5:1 at body2.
+          color: 'common.white',
+          // Same hover as the Shop floor button two controls to the left, so the right-hand cluster
+          // reads as one thing.
+          '&:hover': { bgcolor: 'rgba(70, 130, 180, 0.16)' },
+        }}
+      >
+        <Avatar sx={{ bgcolor: 'primary.main', width: 32, height: 32 }}>
+          {name ? initials(name) : <PersonIcon fontSize="small" />}
+        </Avatar>
+        {!isMobile && label && (
+          <>
+            <Typography variant="body2" component="span" noWrap sx={{ maxWidth: 160 }}>
+              {label}
+            </Typography>
+            <KeyboardArrowDownIcon fontSize="small" />
+          </>
+        )}
+      </Button>
+
+      <Menu
+        id={menuId}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={close}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ list: { 'aria-labelledby': triggerId } }}
+      >
+        <AccountIdentity name={name} email={email} role={role} />
+        <Divider />
+        <MenuItem
+          component={Link}
+          href="/change-password"
+          onClick={close}
+          sx={{ minHeight: 48 }}
+        >
+          <ListItemIcon>
+            <LockResetIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Change password</ListItemText>
+        </MenuItem>
+        <Divider />
+        {/* Last, and error-coloured at rest — docs/design-system.md names Logout destructive, and
+            docs/interaction-standards.md puts the destructive option at the end, away from the
+            benign ones. Same shape as components/notes/NoteActionsMenu.tsx. */}
+        <MenuItem onClick={handleSignOut} sx={{ minHeight: 48, color: 'error.main' }}>
+          <ListItemIcon>
+            <LogoutIcon fontSize="small" color="error" />
+          </ListItemIcon>
+          <ListItemText>Sign out</ListItemText>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,16 +1,15 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter, usePathname, useParams } from 'next/navigation';
+import { usePathname, useParams } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
 import StatusChip from '@/components/common/StatusChip';
-import LogoutIcon from '@mui/icons-material/Logout';
 import MenuIcon from '@mui/icons-material/Menu';
 import PrecisionManufacturingIcon from '@mui/icons-material/PrecisionManufacturing';
-import { useAuth } from '@/components/providers/AuthProvider';
+import AccountMenu from '@/components/layout/AccountMenu';
 import { useDemoMode } from '@/components/providers/DemoModeProvider';
 import { usePageTitle } from './PageTitleProvider';
 
@@ -147,22 +146,14 @@ interface HeaderProps {
 }
 
 export default function Header({ isMobile = false, onMenuClick }: HeaderProps) {
-  const router = useRouter();
   const pathname = usePathname();
   const params = useParams();
   const companyId = params.companyId as string | undefined;
-  const { signOut, user } = useAuth();
-  const firstName = user?.user_metadata?.first_name;
   const { isDemoMode } = useDemoMode();
   // A page may override the title (e.g. the part page shows the part number) so
   // the record identity stays visible in the sticky app bar while scrolling.
   const { title: overrideTitle } = usePageTitle();
   const pageTitle = overrideTitle ?? getPageTitle(pathname);
-
-  const handleSignOut = async () => {
-    await signOut();
-    router.replace('/');
-  };
 
   return (
     <Box
@@ -213,14 +204,6 @@ export default function Header({ isMobile = false, onMenuClick }: HeaderProps) {
         )}
       </Box>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexShrink: 0 }}>
-        {!isMobile && firstName && (
-          <Typography
-            variant="body2"
-            sx={{ color: 'rgba(255, 255, 255, 0.7)', mr: 1 }}
-          >
-            Welcome, {firstName}
-          </Typography>
-        )}
         {/* The way to the shop floor, from every office page.
 
             The sidebar carries the same destination, but on a phone the sidebar is
@@ -249,36 +232,10 @@ export default function Header({ isMobile = false, onMenuClick }: HeaderProps) {
             Shop floor
           </Button>
         )}
-        {isMobile ? (
-          <IconButton
-            onClick={handleSignOut}
-            aria-label="Sign out"
-            sx={{
-              color: 'rgba(255, 255, 255, 0.7)',
-              '&:hover': {
-                bgcolor: 'rgba(239, 68, 68, 0.1)',
-                color: 'error.main',
-              },
-            }}
-          >
-            <LogoutIcon />
-          </IconButton>
-        ) : (
-          <Button
-            onClick={handleSignOut}
-            startIcon={<LogoutIcon />}
-            sx={{
-              color: 'rgba(255, 255, 255, 0.7)',
-              textTransform: 'none',
-              '&:hover': {
-                bgcolor: 'rgba(239, 68, 68, 0.1)',
-                color: 'error.main',
-              },
-            }}
-          >
-            Sign Out
-          </Button>
-        )}
+        {/* Who you are signed in as, and the account actions that belong with it — including the
+            sign-out this slot used to hold bare. See components/layout/AccountMenu.tsx for why the
+            name rides on screen beside the avatar rather than living only inside the menu. */}
+        <AccountMenu isMobile={isMobile} />
       </Box>
     </Box>
   );

--- a/components/operator/OperatorAccountBlock.tsx
+++ b/components/operator/OperatorAccountBlock.tsx
@@ -82,6 +82,9 @@ import FeedbackDialog from '@/components/feedback/FeedbackDialog';
 // `getSupabase`, not `getSupabase` — new code uses the typed client (issue #573). Only
 // `auth.signOut` is used here, which is schema-independent.
 import { getSupabase } from '@/lib/supabase';
+// First letters of the name, for the avatar. Falls back to a person-shaped blank. Shared with the
+// office header's account menu, which shows the same person the same way.
+import { initials } from '@/lib/initials';
 import { clearStoredStation } from '@/components/operator/OperatorStationContext';
 
 export interface OperatorIdentity {
@@ -89,16 +92,6 @@ export interface OperatorIdentity {
   email: string;
   companyName: string;
   userId: string;
-}
-
-/** First letters of the name, for the avatar. Falls back to a person-shaped blank. */
-function initials(name: string): string {
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return '';
-  return parts
-    .slice(0, 2)
-    .map((p) => p[0]!.toUpperCase())
-    .join('');
 }
 
 export function OperatorIdentityRow({

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -557,6 +557,30 @@ it with the record's identity (the part page sets the part number) — the app b
 identity stays visible while scrolling. An inline `<Typography variant="h4">Parts</Typography>` at the
 top of a page is a duplicate that also *loses* the sticky behaviour it duplicates.
 
+### Identity in the office chrome — two slots, two owners
+
+**Workspace identity is top-left; person identity is top-right.** The sidebar's
+[`CompanySwitcher`](../components/layout/CompanySwitcher.tsx) answers *which company*, and
+[`AccountMenu`](../components/layout/AccountMenu.tsx) in the header answers *which account* — name
+and avatar on screen at rest, with email and role a click away. Keep them apart; a second company
+control in the header, or a user name in the sidebar, puts one question in two places.
+
+**Read the person's name from `user_company_access.name`, never `user_metadata.first_name`.** The
+header greeted people from auth metadata for months and rendered *nothing* for every account the two
+sign-up paths didn't create, while the Team page showed the same name correctly off the membership
+row. `user_company_access` is the source every access-granting path populates;
+[`useCurrentMember`](../hooks/useCurrentMember.ts) is the way to read it. When the name is null,
+lead with the email — do not synthesise one from its local part.
+
+**Sign out lives in that menu, last, and `error.main` at rest.**
+[interaction-standards.md §1](interaction-standards.md#1-destructive-actions-delete--remove) names
+Logout destructive and puts the destructive option at the end, and both hold here — the old bare
+header button was grey-until-hover, which this corrected. Burying it is not the kebab anti-pattern
+that section warns about on office surfaces: that rule is about
+record deletes shown red-at-rest, and signing out is recoverable by signing back in. At phone widths
+it is a safety gain — the bare sign-out `IconButton` it replaced sat one mis-tap from ending the
+session, right beside a button people press often.
+
 **List pages** — `<Box>` with no padding (the layout supplies it) → one flex toolbar row → content.
 The toolbar reads left to right: search `TextField` (`size="small"`), any selection-dependent bulk
 actions, a `<Box sx={{ flex: 1 }} />` spacer, then `outlined` Import and `contained` New … pinned to

--- a/hooks/useCurrentMember.ts
+++ b/hooks/useCurrentMember.ts
@@ -1,0 +1,83 @@
+'use client';
+
+/**
+ * Who the signed-in person is on the OFFICE surface — the counterpart of
+ * `useOperatorIdentity`, for `components/layout/AccountMenu`.
+ *
+ * ## Why this exists rather than reading `user_metadata`
+ *
+ * The header used to greet you with `user.user_metadata.first_name`, and that key is only ever
+ * WRITTEN by two paths — `components/auth/SignUp.tsx` and the accept-invite flow. An account
+ * created any other way (the `/admin` company-creation flow, a seed, OAuth) has no `first_name`,
+ * so the greeting rendered as nothing at all: no name, no email, no fallback, no error. The Team
+ * page one route away showed the same person's name correctly the whole time, because it reads
+ * `user_company_access.name`. Two sources for one fact, one of them sparse, and the sparse one was
+ * wired to the only place that answers "who am I signed in as".
+ *
+ * So: the NAME comes from the membership row, which every path that grants access populates, and
+ * the EMAIL comes from the session, which is the authoritative answer to the question being asked
+ * and costs no round trip.
+ *
+ * ## Cost
+ *
+ * One indexed single-row `user_company_access` select per dashboard mount, via `getCurrentMember`,
+ * which shares one in-flight request between concurrent callers. It is the same table and filter
+ * `useUserRole` already hits for the Sidebar; `useLoad` does not dedupe across hooks, so the two
+ * are separate round trips by construction. Deliberately does NOT fetch the company row for a
+ * company name: the sidebar's CompanySwitcher shows it permanently, and `getCompany` has no
+ * in-flight map, so asking here would be a second `companies` fetch on every page.
+ *
+ * ## Never blocks
+ *
+ * A failed lookup degrades to `name: null` (the menu then leads with the email) rather than
+ * throwing. Sign out has to stay reachable even when identity does not resolve — the same promise
+ * `useOperatorIdentity` makes for the operator's Log out button.
+ */
+
+import { useParams } from 'next/navigation';
+import { useAuth } from '@/components/providers/AuthProvider';
+import { getCurrentMember } from '@/utils/operatorAccess';
+import { useLoad } from '@/hooks/useLoad';
+import type { UserRole } from '@/hooks/useUserRole';
+
+export interface CurrentMemberIdentity {
+  /** Display name from `user_company_access.name`. Null when unset or the lookup failed. */
+  name: string | null;
+  /** The session's email — present whenever there is a session at all. */
+  email: string | null;
+  /** The caller's role in THIS company. */
+  role: UserRole;
+  loading: boolean;
+}
+
+export function useCurrentMember(): CurrentMemberIdentity {
+  const { user } = useAuth();
+  const params = useParams();
+  const companyId = params.companyId as string | undefined;
+  // Key on the id, NOT the `user` object — AuthProvider hands out a fresh User with the same id on
+  // every auth event, and `useLoad` warns (loudly, in dev) about non-primitive deps. Same reasoning
+  // as `useUserRole`; don't widen this back to [user].
+  const userId = user?.id;
+
+  // The no-user / no-company guard lives inside the loader rather than a synchronous setState in
+  // the effect body, which is what keeps `react-hooks/set-state-in-effect` quiet. `pnpm lint` runs
+  // at --max-warnings 17 and that cap only ever ratchets down.
+  const { data, loading } = useLoad(
+    async () => {
+      if (!userId || !companyId) return null;
+      try {
+        return await getCurrentMember(companyId);
+      } catch {
+        return null;
+      }
+    },
+    [userId, companyId],
+  );
+
+  return {
+    name: data?.name ?? null,
+    email: user?.email ?? null,
+    role: (data?.role ?? null) as UserRole,
+    loading,
+  };
+}

--- a/lib/initials.ts
+++ b/lib/initials.ts
@@ -1,0 +1,22 @@
+/**
+ * Initials for a person's avatar.
+ *
+ * Lifted out of `components/operator/OperatorAccountBlock.tsx` when the office header gained an
+ * account menu and would otherwise have hand-rolled a third copy of the same four lines.
+ *
+ * Returns `''` rather than a placeholder glyph when there is no name: MUI's `Avatar` falls back to
+ * whatever child you give it, so an empty string lets the call site decide between a person-shaped
+ * icon and a blank — and neither of them invents a name that isn't there.
+ *
+ * NOT shared with `CompanySwitcher.getInitials`, which is deliberately left alone: it splits on a
+ * literal `' '` (so it treats a double space in a company name as an empty word), and it is paired
+ * with `getAvatarColor` in the same file. Company names and people's names are different problems.
+ */
+export function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '';
+  return parts
+    .slice(0, 2)
+    .map((p) => p[0]!.toUpperCase())
+    .join('');
+}


### PR DESCRIPTION
## The problem

The office surface gave you no way to confirm **which account you were signed in as**. The shop floor did, and still does — `OperatorIdentityRow` shows avatar, name, company and email in one row.

The header *looked* like it had an equivalent. It didn't work.

`Welcome, {firstName}` read `user.user_metadata.first_name` — a key written by exactly two paths, [`SignUp.tsx:75`](https://github.com/debola31/Jigged/blob/main/components/auth/SignUp.tsx#L75) and the accept-invite flow. An account created any other way (the `/admin` company-creation flow, a seed, OAuth) has no `first_name`, so the greeting rendered as **nothing at all**: no name, no email, no fallback, and no way to tell a blank greeting apart from a deliberate absence.

Confirmed against the local stack — this is every seeded account:

```
       email          | meta_first_name | membership_name | role
-----------------------+-----------------+-----------------+----------
 admin2@jigged.test   |                 | Morgan Reyes    | admin
 dev@jigged.test      |                 | Dev Seed User   | admin
 operator1@jigged.test|                 | Diego Alvarez   | operator
```

The Team page one route away had the name right the whole time, because it reads `user_company_access.name`. Two sources for one fact, and the sparse one was wired to the only place that answers "who am I?".

## The change

| File | What |
|---|---|
| `components/layout/AccountMenu.tsx` | **new** — avatar + name + chevron in the header, opening name / email / role, Change password, Sign out |
| `hooks/useCurrentMember.ts` | **new** — name + role from `user_company_access` via `getCurrentMember` (in-flight deduped); email from the session |
| `lib/initials.ts` | **new** — the helper `OperatorAccountBlock` already had, shared rather than copied a third time |
| `components/layout/Header.tsx` | drops the broken greeting and the bare Sign Out |
| `docs/design-system.md` | the two-slots rule, the source-of-truth rule, and why Sign out sits where it does |

```
┌──────────────────────────────────────────────────────────────────┐
│  Dashboard                      🤖 Shop floor  (DS) Dev Seed User ▾│
└──────────────────────────────────────────────────────────────────┘
                                     ┌────────────────────────────┐
                                     │ (DS) Dev Seed User         │
                                     │      dev@jigged.test       │
                                     │      Admin                 │
                                     ├────────────────────────────┤
                                     │  🔑  Change password       │
                                     ├────────────────────────────┤
                                     │  ⏻   Sign out              │
                                     └────────────────────────────┘
   < 900px:                       🤖 Shop floor            (DS)
```

## Decisions a reviewer will want to poke at

**The name is on screen, not hidden behind the avatar.** This repo has twice rejected a bare glyph in this exact header — `Header.tsx` keeps "Shop floor" labelled at every width, and the operator layout says why: *"our audience skews 50-60, where icon recognition is measurably worse."* An avatar you must click to decode doesn't answer the question that prompted this. It hides under `md`, which is exactly where `Welcome, {firstName}` already hid.

**Sign out moving into a menu is not the kebab anti-pattern.** `interaction-standards.md` §1 says office surfaces shouldn't bury destructive controls behind a kebab — but that rule is about **record deletes** shown red-at-rest, and the two things it protects both hold here: Sign out is last, and it's now `error.main` at rest (the old button was grey-until-hover, so this *corrects* a standing deviation from `design-system.md`, which names Logout destructive). Signing out is also recoverable by signing back in, which a delete is not.

It's a net safety gain at phone widths: the bare sign-out `IconButton` it replaces sat one mis-tap from ending the session, immediately beside a button people press often — the Fitts's-law slip the operator header explicitly refuses to allow. Now the same mis-tap opens a menu.

**No company name in the menu.** The sidebar's `CompanySwitcher` shows it permanently, and `getCompany` has no in-flight map, so including it would mean a second `companies` fetch on every page — exactly the waste `useOperatorIdentity`'s docstring documents. Cheap follow-up if wanted: give `getCompany` the same in-flight map `getCurrentMember` has, then it's free.

**Cost:** one indexed single-row `user_company_access` select per dashboard mount. Same table and filter `useUserRole` already hits for the Sidebar.

**`muiSkipListHighlight`** on the identity block — MUI's own mechanism (`Divider` and `ListSubheader` both set it). Without it `MenuList` clones `autoFocus` + `tabIndex={0}` onto the first child, which would make the name/email block focusable and put a no-op at the first stop of every keyboard user's arrow-down. Pinned by a test.

## Verification

- `tsc --noEmit` clean · `pnpm lint` 16 warnings (cap 17, **none** in the new files) · **2071/2071 tests pass**
- 11 new tests in `AccountMenu.test.tsx`, going through the real `useCurrentMember` with an **empty `user_metadata`** — so the regression pin genuinely proves where the name comes from rather than asserting the component renders what it's handed
- Driven in the running app at 1280px and 390px: trigger reads `Account: Dev Seed User`, menu opens focused on Change password, Escape returns focus to the trigger, sign-out ends the session

**Behaviour note:** sign-out lands on `/login` rather than `/` because AuthGuard's redirect wins the race with `router.replace('/')`. Unchanged — the handler was moved verbatim, scope still AuthProvider's `local` default so signing out at the office doesn't revoke the shop-floor phone.

**Out of scope:** `/admin` has its own AppBar with the same gap; left alone deliberately. `CompanySwitcher.getInitials` left alone too — it splits on a literal `' '` and pairs with `getAvatarColor`; company names and people's names are different problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
