### PR TITLE
fix(billing): tell a lapsed shop why the write failed, and make blocked updates loud

### DIFF
--- a/__tests__/components/billing/SubscribeButton.test.tsx
+++ b/__tests__/components/billing/SubscribeButton.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@/__tests__/test-utils';
+import SubscribeButton from '@/components/billing/SubscribeButton';
+
+let subscriptionStub: Record<string, unknown> | null = null;
+let roleStub = { role: 'admin' as string | null, isAdmin: true, loading: false };
+
+vi.mock('@/components/providers/SubscriptionProvider', () => ({
+  useOptionalSubscription: () => subscriptionStub,
+}));
+vi.mock('@/hooks/useUserRole', () => ({ useUserRole: () => roleStub }));
+vi.mock('@/lib/billingApi', () => ({
+  startCheckout: vi.fn(),
+  openBillingPortal: vi.fn(),
+}));
+
+beforeEach(() => {
+  subscriptionStub = { mustSubscribe: true, hasCustomer: false, refresh: vi.fn() };
+  roleStub = { role: 'admin', isAdmin: true, loading: false };
+});
+
+describe('SubscribeButton', () => {
+  it('offers Subscribe to an admin who has no Stripe customer yet', () => {
+    render(<SubscribeButton />);
+    expect(screen.getByRole('button', { name: 'Subscribe' })).toBeInTheDocument();
+  });
+
+  it('offers Manage billing once Stripe knows the shop', () => {
+    subscriptionStub = { mustSubscribe: false, hasCustomer: true, refresh: vi.fn() };
+    render(<SubscribeButton />);
+    expect(screen.getByRole('button', { name: 'Manage billing' })).toBeInTheDocument();
+  });
+
+  it('renders nothing for a non-admin', () => {
+    // The role gate lives here rather than in each caller, so BillingBanner and ErrorAlert
+    // cannot drift. Pressing it as a `user` hit `_verify_company_admin` and 403'd — a
+    // confirm-then-error dead end (interaction-standards.md §4).
+    roleStub = { role: 'user', isAdmin: false, loading: false };
+    const { container } = render(<SubscribeButton />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing while the role is still unknown', () => {
+    roleStub = { role: null, isAdmin: false, loading: true };
+    const { container } = render(<SubscribeButton />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing outside a SubscriptionProvider', () => {
+    // The operator app mounts none, and an operator cannot subscribe.
+    subscriptionStub = null;
+    const { container } = render(<SubscribeButton />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/__tests__/components/billing/SubscriptionRequiredNotice.test.tsx
+++ b/__tests__/components/billing/SubscriptionRequiredNotice.test.tsx
@@ -13,7 +13,23 @@ vi.mock('@/components/billing/SubscribeButton', () => ({
   default: () => <button type="button">Subscribe</button>,
 }));
 
-const BASE = { isLoading: false, isDemo: false, canWrite: false, mustSubscribe: true };
+const billingRow = (subscription_status: string | null) => ({
+  billing_exempt: false,
+  subscription_status,
+  current_period_end: null,
+  cancel_at: null,
+  ended_at: null,
+});
+
+// Never subscribed: no company_billing row at all. Copy derives from the row, not from
+// `mustSubscribe`, so the stub has to carry one.
+const BASE = {
+  isLoading: false,
+  isDemo: false,
+  canWrite: false,
+  mustSubscribe: true,
+  billing: null as ReturnType<typeof billingRow> | null,
+};
 
 beforeEach(() => {
   subscriptionStub = { ...BASE };
@@ -28,16 +44,37 @@ describe('SubscriptionRequiredNotice', () => {
   });
 
   it('says "resubscribe" for a shop that lapsed rather than never started', () => {
-    subscriptionStub = { ...BASE, mustSubscribe: false };
+    subscriptionStub = { ...BASE, mustSubscribe: false, billing: billingRow('canceled') };
     render(<SubscriptionRequiredNotice entityPlural="quotes" />);
     expect(screen.getByText(/read-only.*resubscribe to add quotes again/i)).toBeInTheDocument();
   });
 
+  it('says paused, not ended, for a paused subscription', () => {
+    subscriptionStub = { ...BASE, mustSubscribe: false, billing: billingRow('paused') };
+    render(<SubscriptionRequiredNotice entityPlural="quotes" />);
+    expect(screen.getByText(/paused/i)).toBeInTheDocument();
+    expect(screen.queryByText(/ended/i)).not.toBeInTheDocument();
+  });
+
+  it('does not say "ended" to a shop that never subscribed', () => {
+    render(<SubscriptionRequiredNotice entityPlural="parts" />);
+    expect(screen.queryByText(/ended|again/i)).not.toBeInTheDocument();
+  });
+
   it('points a non-admin at their admin and offers no button', () => {
+    // BASE is never-subscribed, so the verb is "start it" — not "restart it", which would imply
+    // there had been something to restart.
+    roleStub = { role: 'user', isAdmin: false, loading: false };
+    render(<SubscriptionRequiredNotice entityPlural="customers" />);
+    expect(screen.getByText(/an admin at your shop can start it/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /subscribe/i })).not.toBeInTheDocument();
+  });
+
+  it('says "restart it" to a non-admin once there was a subscription to restart', () => {
+    subscriptionStub = { ...BASE, mustSubscribe: false, billing: billingRow('canceled') };
     roleStub = { role: 'user', isAdmin: false, loading: false };
     render(<SubscriptionRequiredNotice entityPlural="customers" />);
     expect(screen.getByText(/an admin at your shop can restart it/i)).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /subscribe/i })).not.toBeInTheDocument();
   });
 
   it('renders nothing while entitlement is still loading', () => {

--- a/__tests__/components/billing/SubscriptionRequiredNotice.test.tsx
+++ b/__tests__/components/billing/SubscriptionRequiredNotice.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@/__tests__/test-utils';
+import SubscriptionRequiredNotice from '@/components/billing/SubscriptionRequiredNotice';
+
+let subscriptionStub: Record<string, unknown> | null = null;
+let roleStub = { role: 'admin' as string | null, isAdmin: true, loading: false };
+
+vi.mock('@/components/providers/SubscriptionProvider', () => ({
+  useOptionalSubscription: () => subscriptionStub,
+}));
+vi.mock('@/hooks/useUserRole', () => ({ useUserRole: () => roleStub }));
+vi.mock('@/components/billing/SubscribeButton', () => ({
+  default: () => <button type="button">Subscribe</button>,
+}));
+
+const BASE = { isLoading: false, isDemo: false, canWrite: false, mustSubscribe: true };
+
+beforeEach(() => {
+  subscriptionStub = { ...BASE };
+  roleStub = { role: 'admin', isAdmin: true, loading: false };
+});
+
+describe('SubscriptionRequiredNotice', () => {
+  it('tells an admin who has never subscribed what to do, with a way to do it', () => {
+    render(<SubscriptionRequiredNotice entityPlural="parts" />);
+    expect(screen.getByText(/start your subscription to add parts/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /subscribe/i })).toBeInTheDocument();
+  });
+
+  it('says "resubscribe" for a shop that lapsed rather than never started', () => {
+    subscriptionStub = { ...BASE, mustSubscribe: false };
+    render(<SubscriptionRequiredNotice entityPlural="quotes" />);
+    expect(screen.getByText(/read-only.*resubscribe to add quotes again/i)).toBeInTheDocument();
+  });
+
+  it('points a non-admin at their admin and offers no button', () => {
+    roleStub = { role: 'user', isAdmin: false, loading: false };
+    render(<SubscriptionRequiredNotice entityPlural="customers" />);
+    expect(screen.getByText(/an admin at your shop can restart it/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /subscribe/i })).not.toBeInTheDocument();
+  });
+
+  it('renders nothing while entitlement is still loading', () => {
+    // The guard that matters. isLoading starts true with billing null, which resolves to
+    // must_subscribe — so canWrite is false for a healthy shop until the first fetch lands.
+    // Without this the notice would flash on every create page load, for everyone.
+    subscriptionStub = { ...BASE, isLoading: true };
+    const { container } = render(<SubscriptionRequiredNotice entityPlural="parts" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for a shop that can write', () => {
+    subscriptionStub = { ...BASE, canWrite: true, mustSubscribe: false };
+    const { container } = render(<SubscriptionRequiredNotice entityPlural="parts" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for a demo company', () => {
+    subscriptionStub = { ...BASE, isDemo: true };
+    const { container } = render(<SubscriptionRequiredNotice entityPlural="parts" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing outside a SubscriptionProvider', () => {
+    subscriptionStub = null;
+    const { container } = render(<SubscriptionRequiredNotice entityPlural="parts" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/__tests__/components/common/ErrorAlert.test.tsx
+++ b/__tests__/components/common/ErrorAlert.test.tsx
@@ -24,26 +24,46 @@ vi.mock('@/components/billing/SubscribeButton', () => ({
   default: () => <button type="button">Subscribe</button>,
 }));
 
+/** Copy is derived from `billing.subscription_status`, so the stubs carry a real row. */
+const billingRow = (subscription_status: string | null) => ({
+  billing_exempt: false,
+  subscription_status,
+  current_period_end: null,
+  cancel_at: null,
+  ended_at: null,
+});
+
 /** A shop that can write: the healthy case. */
 const CAN_WRITE = {
   isLoading: false,
   canWrite: true,
   mustSubscribe: false,
   isReadOnly: false,
+  billing: billingRow('active'),
 };
-/** Never subscribed. */
+/** Never subscribed — no company_billing row at all. */
 const MUST_SUBSCRIBE = {
   isLoading: false,
   canWrite: false,
   mustSubscribe: true,
   isReadOnly: false,
+  billing: null,
 };
-/** Subscribed once, lapsed past the grace window. */
+/** Subscribed once, canceled, past the grace window. */
 const READ_ONLY = {
   isLoading: false,
   canWrite: false,
   mustSubscribe: false,
   isReadOnly: true,
+  billing: billingRow('canceled'),
+};
+/** Paused — also read-only, but emphatically NOT ended. */
+const PAUSED = {
+  isLoading: false,
+  canWrite: false,
+  mustSubscribe: false,
+  isReadOnly: true,
+  billing: billingRow('paused'),
 };
 
 const BLOCKED_INSERT = {
@@ -172,6 +192,20 @@ describe('ErrorAlert', () => {
       render(<ErrorAlert error={BLOCKED_INSERT} entity="part" />);
       expect(screen.getByText(/an admin at your shop can restart it/i)).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /subscribe/i })).not.toBeInTheDocument();
+    });
+
+    it('does not tell a shop that never subscribed that anything ended', () => {
+      subscriptionStub = { ...MUST_SUBSCRIBE };
+      render(<ErrorAlert error={BLOCKED_INSERT} entity="part" />);
+      expect(screen.queryByText(/ended|resubscribe/i)).not.toBeInTheDocument();
+    });
+
+    it('says paused, not ended, for a paused subscription', () => {
+      // Entitlement collapses paused into read_only alongside canceled/unpaid; the copy must not.
+      subscriptionStub = { ...PAUSED };
+      render(<ErrorAlert error={BLOCKED_INSERT} entity="part" />);
+      expect(screen.getByText(/subscription is paused/i)).toBeInTheDocument();
+      expect(screen.queryByText(/ended/i)).not.toBeInTheDocument();
     });
 
     it('offers no button while the role is still loading', () => {

--- a/__tests__/components/common/ErrorAlert.test.tsx
+++ b/__tests__/components/common/ErrorAlert.test.tsx
@@ -83,6 +83,32 @@ describe('ErrorAlert', () => {
     expect(screen.queryByRole('button', { name: /subscribe/i })).not.toBeInTheDocument();
   });
 
+  it('passes through a hand-written Error message rather than genericising it', () => {
+    // The access layer throws plenty of these — "This operation cannot be received.",
+    // "A quote must include at least one part." They carry no SQLSTATE, so code-matching finds
+    // nothing and would fall back to "Something went wrong"; the message IS the useful part.
+    render(
+      <ErrorAlert
+        error={new Error('This operation cannot be received.')}
+        entity="operation"
+        fallback="Something went wrong. Please try again."
+      />,
+    );
+    expect(screen.getByText('This operation cannot be received.')).toBeInTheDocument();
+  });
+
+  it('does NOT pass through a raw Supabase message', () => {
+    // The other half of that rule: anything carrying a SQLSTATE is DB text, and
+    // "raw DB strings must never reach a user".
+    render(
+      <ErrorAlert
+        error={{ code: '23503', message: 'violates foreign key constraint "x_fkey"' }}
+        entity="address"
+      />,
+    );
+    expect(screen.queryByText(/x_fkey/)).not.toBeInTheDocument();
+  });
+
   describe('context-first classification', () => {
     it('reads a zero-row failure as billing when the shop cannot write', () => {
       // The reason context is checked before error shape. A billing-blocked UPDATE is filtered

--- a/__tests__/components/common/ErrorAlert.test.tsx
+++ b/__tests__/components/common/ErrorAlert.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@/__tests__/test-utils';
+import ErrorAlert from '@/components/common/ErrorAlert';
+
+/**
+ * The two collaborators ErrorAlert reads. Both are mocked at module level and driven per test
+ * through these mutable stubs, because the component's whole job is choosing copy from their
+ * combination.
+ */
+let subscriptionStub: Record<string, unknown> | null = null;
+let roleStub = { role: 'admin' as string | null, isAdmin: true, loading: false };
+
+vi.mock('@/components/providers/SubscriptionProvider', () => ({
+  useOptionalSubscription: () => subscriptionStub,
+}));
+
+vi.mock('@/hooks/useUserRole', () => ({
+  useUserRole: () => roleStub,
+}));
+
+// The button redirects to Stripe; its internals are covered by its own surface, and rendering it
+// for real would pull in billingApi.
+vi.mock('@/components/billing/SubscribeButton', () => ({
+  default: () => <button type="button">Subscribe</button>,
+}));
+
+/** A shop that can write: the healthy case. */
+const CAN_WRITE = {
+  isLoading: false,
+  canWrite: true,
+  mustSubscribe: false,
+  isReadOnly: false,
+};
+/** Never subscribed. */
+const MUST_SUBSCRIBE = {
+  isLoading: false,
+  canWrite: false,
+  mustSubscribe: true,
+  isReadOnly: false,
+};
+/** Subscribed once, lapsed past the grace window. */
+const READ_ONLY = {
+  isLoading: false,
+  canWrite: false,
+  mustSubscribe: false,
+  isReadOnly: true,
+};
+
+const BLOCKED_INSERT = {
+  code: '42501',
+  message: 'new row violates row-level security policy "billing_gate_insert" for table "parts"',
+};
+/** What a billing-blocked UPDATE actually looks like today: RLS filters it to zero rows. */
+const NO_ROWS = {
+  code: 'PGRST116',
+  message: 'JSON object requested, multiple (or no) rows returned',
+};
+const FK_VIOLATION = {
+  code: '23503',
+  message:
+    'delete on table "customer_addresses" violates foreign key constraint "quotes_x_fkey" on table "quotes"',
+};
+
+beforeEach(() => {
+  subscriptionStub = { ...CAN_WRITE };
+  roleStub = { role: 'admin', isAdmin: true, loading: false };
+});
+
+describe('ErrorAlert', () => {
+  it('renders nothing without an error', () => {
+    const { container } = render(<ErrorAlert error={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a plain string as given', () => {
+    render(<ErrorAlert error="Part name is required" />);
+    expect(screen.getByText('Part name is required')).toBeInTheDocument();
+  });
+
+  it('translates an ordinary failure and offers no Subscribe button', () => {
+    render(<ErrorAlert error={FK_VIOLATION} entity="address" />);
+    expect(screen.getByText(/still referenced by/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /subscribe/i })).not.toBeInTheDocument();
+  });
+
+  describe('context-first classification', () => {
+    it('reads a zero-row failure as billing when the shop cannot write', () => {
+      // The reason context is checked before error shape. A billing-blocked UPDATE is filtered
+      // by RLS to zero rows, so it arrives as PGRST116 with nothing billing-shaped about it.
+      subscriptionStub = { ...READ_ONLY };
+      render(<ErrorAlert error={NO_ROWS} entity="part" />);
+      expect(screen.getByText(/subscription has ended/i)).toBeInTheDocument();
+    });
+
+    it('reads a nameless storage denial as billing when the shop cannot write', () => {
+      // Storage policies are permissive, so their denial carries no policy name and error-shape
+      // classification cannot see it.
+      subscriptionStub = { ...READ_ONLY };
+      render(
+        <ErrorAlert
+          error={{ status: 403, message: 'new row violates row-level security policy' }}
+          entity="attachment"
+        />,
+      );
+      expect(screen.getByText(/subscription has ended/i)).toBeInTheDocument();
+    });
+
+    it('does NOT read a zero-row failure as billing while entitlement is still loading', () => {
+      // The false-negative-flash guard. isLoading starts true with billing null, which resolves
+      // to must_subscribe — so canWrite is false for a healthy shop during its first fetch.
+      // Without the isLoading check every error on every page would briefly read as billing.
+      subscriptionStub = { ...MUST_SUBSCRIBE, isLoading: true };
+      render(<ErrorAlert error={NO_ROWS} entity="part" fallback="Failed to save part." />);
+      expect(screen.queryByText(/subscription/i)).not.toBeInTheDocument();
+      expect(screen.getByText('Failed to save part.')).toBeInTheDocument();
+    });
+
+    it('falls back to error shape when the shop looks writable but the DB disagreed', () => {
+      // The lapsed-mid-session race: the cached context still says canWrite.
+      subscriptionStub = { ...CAN_WRITE };
+      render(<ErrorAlert error={BLOCKED_INSERT} entity="part" />);
+      expect(screen.getByText(/subscription/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('who is offered a way to fix it', () => {
+    it('offers Subscribe to an admin who has never subscribed', () => {
+      subscriptionStub = { ...MUST_SUBSCRIBE };
+      render(<ErrorAlert error={BLOCKED_INSERT} entity="part" />);
+      expect(screen.getByText(/subscription hasn't started yet/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /subscribe/i })).toBeInTheDocument();
+    });
+
+    it('offers Subscribe to an admin whose subscription lapsed', () => {
+      subscriptionStub = { ...READ_ONLY };
+      render(<ErrorAlert error={BLOCKED_INSERT} entity="part" />);
+      expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /subscribe/i })).toBeInTheDocument();
+    });
+
+    it('tells a non-admin to ask an admin, with no button', () => {
+      // Settings is behind AdminGuard and the Stripe routes 403 a non-admin, so a button here
+      // would be a two-step dead end.
+      subscriptionStub = { ...READ_ONLY };
+      roleStub = { role: 'user', isAdmin: false, loading: false };
+      render(<ErrorAlert error={BLOCKED_INSERT} entity="part" />);
+      expect(screen.getByText(/an admin at your shop can restart it/i)).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /subscribe/i })).not.toBeInTheDocument();
+    });
+
+    it('offers no button while the role is still loading', () => {
+      subscriptionStub = { ...READ_ONLY };
+      roleStub = { role: null, isAdmin: false, loading: true };
+      render(<ErrorAlert error={BLOCKED_INSERT} entity="part" />);
+      expect(screen.queryByRole('button', { name: /subscribe/i })).not.toBeInTheDocument();
+    });
+
+    it('points an operator at the office, never at Settings', () => {
+      // No SubscriptionProvider in the operator shell, and an operator cannot reach Settings.
+      subscriptionStub = null;
+      roleStub = { role: 'operator', isAdmin: false, loading: false };
+      render(<ErrorAlert error={BLOCKED_INSERT} entity="operation" />);
+      expect(screen.getByText(/let the office know/i)).toBeInTheDocument();
+      expect(screen.queryByText(/settings/i)).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /subscribe/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/lib/billingCopy.test.ts
+++ b/__tests__/lib/billingCopy.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  blockedMessageForAdmin,
+  blockedMessageForNonAdmin,
+  blockedNoticeForAdmin,
+  blockedNoticeForNonAdmin,
+  writeBlockedState,
+} from '@/lib/billingCopy';
+import type { BillingRow } from '@/lib/entitlement';
+
+const row = (status: string | null): BillingRow => ({
+  billing_exempt: false,
+  subscription_status: status,
+  current_period_end: null,
+  cancel_at: null,
+  ended_at: null,
+});
+
+describe('writeBlockedState', () => {
+  it('treats a company with no billing row as never started', () => {
+    // The common case: a brand-new company has no company_billing row at all.
+    expect(writeBlockedState(null)).toBe('never_started');
+  });
+
+  it('treats a subscription that never completed as never started', () => {
+    expect(writeBlockedState(row('incomplete'))).toBe('never_started');
+    expect(writeBlockedState(row('incomplete_expired'))).toBe('never_started');
+    expect(writeBlockedState(row(null))).toBe('never_started');
+  });
+
+  it('treats canceled and unpaid as ended', () => {
+    expect(writeBlockedState(row('canceled'))).toBe('ended');
+    expect(writeBlockedState(row('unpaid'))).toBe('ended');
+  });
+
+  it('keeps paused distinct from ended', () => {
+    // The bug this file exists to fix. Entitlement collapses canceled, unpaid AND paused into
+    // `read_only` because the write gate treats them identically — correct for enforcement,
+    // untrue as copy.
+    expect(writeBlockedState(row('paused'))).toBe('paused');
+  });
+
+  it('falls back to never started for an unrecognised status', () => {
+    // Safer than "ended": inventing an ending for something that may never have begun reads as
+    // a billing error to the user.
+    expect(writeBlockedState(row('something_new_from_stripe'))).toBe('never_started');
+  });
+});
+
+describe('blocked copy', () => {
+  it('never tells a shop that has not subscribed that anything ended', () => {
+    const admin = blockedMessageForAdmin('never_started', 'part');
+    expect(admin).toContain("hasn't started yet");
+    expect(admin).not.toMatch(/ended|resubscribe/i);
+    expect(blockedMessageForNonAdmin('never_started')).not.toMatch(/ended|restart/i);
+    expect(blockedNoticeForAdmin('never_started', 'parts')).not.toMatch(/ended|again/i);
+  });
+
+  it('never tells a paused shop that its subscription ended', () => {
+    for (const text of [
+      blockedMessageForAdmin('paused', 'part'),
+      blockedMessageForNonAdmin('paused'),
+      blockedNoticeForAdmin('paused', 'parts'),
+      blockedNoticeForNonAdmin('paused', 'parts'),
+    ]) {
+      expect(text).toMatch(/paused/i);
+      expect(text).not.toMatch(/ended/i);
+    }
+  });
+
+  it('uses a verb that matches the state', () => {
+    expect(blockedMessageForAdmin('never_started', 'part')).toContain('Start it');
+    expect(blockedMessageForAdmin('ended', 'part')).toContain('Resubscribe');
+    expect(blockedMessageForAdmin('paused', 'part')).toContain('Resume it');
+    // Non-admins get the same verb, attributed to whoever can use it.
+    expect(blockedMessageForNonAdmin('never_started')).toContain('start it');
+    expect(blockedMessageForNonAdmin('ended')).toContain('restart it');
+    expect(blockedMessageForNonAdmin('paused')).toContain('resume it');
+  });
+
+  it('names the entity the user was acting on', () => {
+    expect(blockedMessageForAdmin('ended', 'quote')).toContain('save this quote');
+    expect(blockedNoticeForAdmin('never_started', 'work centers')).toContain(
+      'add work centers to Jigged',
+    );
+    expect(blockedNoticeForNonAdmin('ended', 'customers')).toContain("new customers can't be saved");
+  });
+
+  it('points a non-admin at an admin rather than at an action they cannot take', () => {
+    for (const state of ['never_started', 'ended', 'paused'] as const) {
+      expect(blockedMessageForNonAdmin(state)).toContain('An admin at your shop');
+      expect(blockedNoticeForNonAdmin(state, 'parts')).toContain('An admin at your shop');
+    }
+  });
+});

--- a/__tests__/lib/supabaseErrors.test.ts
+++ b/__tests__/lib/supabaseErrors.test.ts
@@ -4,9 +4,46 @@ import {
   redirectToSessionExpiry,
   consumeSessionExpiry,
   friendlyErrorMessage,
+  isBillingWriteBlocked,
+  isFriendlyError,
   isTransientAbortError,
+  shouldReportSupabaseError,
   toError,
+  toFriendlyError,
 } from '@/lib/supabaseErrors';
+
+/**
+ * The exact payloads Postgres produces for a billing-gate denial. Hard-coded rather than built by
+ * a helper: these strings are a contract with the DB, and the integration tests
+ * (`test_blocked_insert_names_the_billing_policy`) assert the same shapes from the other side.
+ */
+const BLOCKED_INSERT = {
+  code: '42501',
+  details: null,
+  hint: null,
+  message:
+    'new row violates row-level security policy "billing_gate_insert" for table "parts"',
+};
+const BLOCKED_UPDATE = {
+  code: '42501',
+  details: null,
+  hint: null,
+  message:
+    'new row violates row-level security policy "billing_gate_update" for table "parts"',
+};
+const BLOCKED_RPC = {
+  code: '42501',
+  details: null,
+  hint: null,
+  message: 'company 0f3ab1e2-1111-4222-8333-444455556666 has no active subscription',
+};
+/** A membership failure: permissive policies OR-fold into ONE nameless WithCheckOption. */
+const NAMELESS_DENIAL = {
+  code: '42501',
+  details: null,
+  hint: null,
+  message: 'new row violates row-level security policy for table "parts"',
+};
 
 describe('isAuthError', () => {
   it('returns true for PGRST301 (JWT expired)', () => {
@@ -357,5 +394,195 @@ describe('toError', () => {
       message: 'AbortError: Lock was stolen by another request',
     });
     expect(isTransientAbortError(result)).toBe(true);
+  });
+});
+
+describe('isBillingWriteBlocked', () => {
+  it('matches a blocked INSERT by its restrictive policy name', () => {
+    expect(isBillingWriteBlocked(BLOCKED_INSERT)).toBe(true);
+  });
+
+  it('matches a blocked UPDATE by its restrictive policy name', () => {
+    expect(isBillingWriteBlocked(BLOCKED_UPDATE)).toBe(true);
+  });
+
+  it('matches the stock RPC raise from inv_assert_can_write', () => {
+    expect(isBillingWriteBlocked(BLOCKED_RPC)).toBe(true);
+  });
+
+  it('does NOT match a nameless RLS denial', () => {
+    // THE guard for the whole discriminator. Permissive policies OR-fold into a single
+    // nameless WithCheckOption, so a plain membership failure looks like this. If this ever
+    // flips to true, every non-member is shown a Subscribe button for a permission problem
+    // that paying would not fix.
+    expect(isBillingWriteBlocked(NAMELESS_DENIAL)).toBe(false);
+  });
+
+  it('does NOT match a nameless storage 403 (the documented gap ErrorAlert covers)', () => {
+    expect(
+      isBillingWriteBlocked({
+        status: 403,
+        message: 'new row violates row-level security policy',
+      }),
+    ).toBe(false);
+  });
+
+  it('does not match unrelated failures', () => {
+    expect(isBillingWriteBlocked({ code: 'PGRST116', message: 'no rows' })).toBe(false);
+    expect(isBillingWriteBlocked({ code: '23505', message: 'duplicate key' })).toBe(false);
+    expect(isBillingWriteBlocked({ code: '23503', message: 'violates foreign key' })).toBe(false);
+    expect(isBillingWriteBlocked(null)).toBe(false);
+    expect(isBillingWriteBlocked(undefined)).toBe(false);
+    expect(isBillingWriteBlocked('billing_gate_insert')).toBe(false);
+  });
+
+  it('does not match the right message under the wrong code', () => {
+    expect(
+      isBillingWriteBlocked({ code: '23514', message: 'billing_gate_insert' }),
+    ).toBe(false);
+  });
+
+  it('sees through one cause hop, so toFriendlyError output still classifies', () => {
+    expect(isBillingWriteBlocked(toFriendlyError(BLOCKED_INSERT, { entity: 'part' }))).toBe(true);
+  });
+
+  it('sees through two cause hops', () => {
+    const wrapped = new Error('outer', { cause: new Error('inner', { cause: BLOCKED_INSERT }) });
+    expect(isBillingWriteBlocked(wrapped)).toBe(true);
+  });
+
+  it('terminates on a self-referential cause chain', () => {
+    const cyclic: Record<string, unknown> = { code: 'X', message: 'nope' };
+    cyclic.cause = cyclic;
+    expect(() => isBillingWriteBlocked(cyclic)).not.toThrow();
+    expect(isBillingWriteBlocked(cyclic)).toBe(false);
+  });
+
+  it('gives up past the depth cap rather than walking forever', () => {
+    let deep: unknown = BLOCKED_INSERT;
+    for (let i = 0; i < 6; i++) deep = new Error(`layer ${i}`, { cause: deep });
+    expect(isBillingWriteBlocked(deep)).toBe(false);
+  });
+});
+
+describe('friendlyErrorMessage — billing write gate', () => {
+  it('beats the generic privilege branch for a billing denial', () => {
+    // Ordering guard. Both branches match 42501; the billing one must win, or a lapsed shop is
+    // told to go ask their admin for permission instead of to subscribe.
+    const message = friendlyErrorMessage(BLOCKED_INSERT, { entity: 'part' });
+    expect(message).toContain("subscription isn't active");
+    expect(message).not.toContain('permission');
+  });
+
+  it('names the entity', () => {
+    expect(friendlyErrorMessage(BLOCKED_INSERT, { entity: 'part' })).toContain(
+      "that part wasn't saved",
+    );
+  });
+
+  it('says "change" when no entity is given', () => {
+    expect(friendlyErrorMessage(BLOCKED_INSERT)).toContain("that change wasn't saved");
+  });
+
+  it('says "change" rather than the "item" default', () => {
+    expect(friendlyErrorMessage(BLOCKED_INSERT, { entity: 'item' })).toContain(
+      "that change wasn't saved",
+    );
+  });
+
+  it('translates the RPC raise the same way', () => {
+    expect(friendlyErrorMessage(BLOCKED_RPC, { entity: 'stock move' })).toContain(
+      "subscription isn't active",
+    );
+  });
+
+  it('still reports a nameless denial as a permission problem', () => {
+    expect(friendlyErrorMessage(NAMELESS_DENIAL)).toBe("You don't have permission to do that.");
+  });
+});
+
+describe('toFriendlyError', () => {
+  it('returns a real Error, which is what the UI catch sites test for', () => {
+    const result = toFriendlyError(BLOCKED_INSERT, { entity: 'part' });
+    expect(result).toBeInstanceOf(Error);
+    // The bug this whole helper exists to fix: Supabase's plain object fails this check, so
+    // `err instanceof Error ? err.message : 'Failed to create part'` took the fallback.
+    expect(BLOCKED_INSERT instanceof Error).toBe(false);
+  });
+
+  it('carries the friendly copy as its message', () => {
+    const result = toFriendlyError(BLOCKED_INSERT, { entity: 'part' });
+    expect(result.message).toBe(friendlyErrorMessage(BLOCKED_INSERT, { entity: 'part' }));
+  });
+
+  it('keeps code/details/hint as own properties for Sentry context', () => {
+    const result = toFriendlyError({ code: '23505', hint: 'try again', message: 'dup' });
+    expect(result).toHaveProperty('code', '23505');
+    expect(result).toHaveProperty('hint', 'try again');
+  });
+
+  it('sets cause to the original error', () => {
+    expect(toFriendlyError(BLOCKED_INSERT).cause).toBe(BLOCKED_INSERT);
+  });
+
+  it('is idempotent — re-wrapping returns the same instance', () => {
+    const once = toFriendlyError(BLOCKED_INSERT, { entity: 'part' });
+    expect(toFriendlyError(once, { entity: 'something else' })).toBe(once);
+  });
+
+  it('does not degrade FK copy when translated twice', () => {
+    // The regression this brand prevents. The FK branch reads the DB clause to name what still
+    // references the row; a second pass over friendly text would find nothing and fall back to
+    // the vague "other records".
+    const fkError = {
+      code: '23503',
+      message:
+        'delete on table "customer_addresses" violates foreign key constraint "quotes_billing_address_id_fkey" on table "quotes"',
+    };
+    const once = toFriendlyError(fkError, { entity: 'address' });
+    expect(once.message).toContain('quotes');
+    expect(friendlyErrorMessage(once, { entity: 'address' })).toBe(once.message);
+    expect(friendlyErrorMessage(once, { entity: 'address' })).not.toContain('other records');
+  });
+
+  it('brands invisibly, so serialisation is unaffected', () => {
+    const result = toFriendlyError(BLOCKED_INSERT);
+    expect(isFriendlyError(result)).toBe(true);
+    expect(Object.keys(result)).not.toContain('jigged.friendlyError');
+    expect(JSON.stringify({ ...result })).not.toContain('friendlyError');
+  });
+
+  it('isFriendlyError is false for anything it did not make', () => {
+    expect(isFriendlyError(new Error('plain'))).toBe(false);
+    expect(isFriendlyError(BLOCKED_INSERT)).toBe(false);
+    expect(isFriendlyError(null)).toBe(false);
+  });
+});
+
+describe('shouldReportSupabaseError — billing denials', () => {
+  it('drops a blocked INSERT', () => {
+    // The gate working as designed, once per attempted write for as long as the shop stays
+    // lapsed. The user is still told (see friendlyErrorMessage); nobody needs paging.
+    expect(shouldReportSupabaseError(BLOCKED_INSERT)).toBe(false);
+  });
+
+  it('drops a blocked UPDATE and the RPC raise', () => {
+    expect(shouldReportSupabaseError(BLOCKED_UPDATE)).toBe(false);
+    expect(shouldReportSupabaseError(BLOCKED_RPC)).toBe(false);
+  });
+
+  it('drops one that has already been wrapped by toFriendlyError', () => {
+    expect(shouldReportSupabaseError(toFriendlyError(BLOCKED_INSERT))).toBe(false);
+  });
+
+  it('STILL reports a nameless privilege denial', () => {
+    // A real permission failure is a bug — a missing policy or a broken membership row — and
+    // must not be swept up by the billing exemption.
+    expect(shouldReportSupabaseError(NAMELESS_DENIAL)).toBe(true);
+  });
+
+  it('still reports ordinary failures', () => {
+    expect(shouldReportSupabaseError({ code: '23505', message: 'duplicate key' })).toBe(true);
+    expect(shouldReportSupabaseError({ code: '23503', message: 'fk violation' })).toBe(true);
   });
 });

--- a/__tests__/utils/customerAccess.test.ts
+++ b/__tests__/utils/customerAccess.test.ts
@@ -289,14 +289,19 @@ describe('customerAccess utilities', () => {
       expect(result).toEqual(mockCreatedCustomer);
     });
 
-    it('throws error when insert fails', async () => {
+    it('throws a real Error with user-facing copy when insert fails', async () => {
+      // Was `rejects.toEqual({ message: 'Insert failed', code: '23505' })` — the raw Supabase
+      // object. That plain object is exactly the bug: `err instanceof Error` is false, so every
+      // UI catch site fell through to its generic 'Failed to…' fallback and discarded the reason.
       mockQueryBuilder.data = null;
       mockQueryBuilder.error = { message: 'Insert failed', code: '23505' };
 
-      await expect(createCustomer('company-1', mockFormData)).rejects.toEqual({
-        message: 'Insert failed',
-        code: '23505',
-      });
+      const rejection = await createCustomer('company-1', mockFormData).catch((e) => e);
+      expect(rejection).toBeInstanceOf(Error);
+      expect(rejection.message).toMatch(/already exists/i);
+      // The raw error is still reachable for Sentry context and for classification.
+      expect(rejection.code).toBe('23505');
+      expect(rejection.cause).toEqual({ message: 'Insert failed', code: '23505' });
     });
 
     // A name collision with an ARCHIVED customer revives that row rather than

--- a/__tests__/utils/inventoryLocationsAccess.test.ts
+++ b/__tests__/utils/inventoryLocationsAccess.test.ts
@@ -607,9 +607,29 @@ describe('duplicate sibling names', () => {
     );
   });
 
-  it('leaves an unrelated write failure with its own message', async () => {
+  it('does not map an unrelated write failure to the duplicate-name copy', async () => {
+    // Renamed from "…with its own message": the fallback no longer passes `error.message`
+    // straight through, because that rendered raw PostgREST text to the user. It now goes
+    // through the shared translator. What still matters here is that a NON-23505 failure does
+    // not get the "There's already a …" wording.
     queueFrom({ data: null, error: { code: '42501', message: 'permission denied' } });
-    await expect(createLocation('co1', { name: 'Shelf A' })).rejects.toThrow(/permission denied/i);
+    await expect(createLocation('co1', { name: 'Shelf A' })).rejects.toThrow(
+      /don't have permission/i,
+    );
+  });
+
+  it('tells a lapsed shop to restart its subscription rather than blaming permissions', async () => {
+    queueFrom({
+      data: null,
+      error: {
+        code: '42501',
+        message:
+          'new row violates row-level security policy "billing_gate_insert" for table "inventory_locations"',
+      },
+    });
+    await expect(createLocation('co1', { name: 'Shelf A' })).rejects.toThrow(
+      /subscription isn't active/i,
+    );
   });
 
   // Every node the wizard generates goes through the same insert, so a collision mid-run surfaces

--- a/__tests__/utils/jobNoteMediaAccess.test.ts
+++ b/__tests__/utils/jobNoteMediaAccess.test.ts
@@ -174,6 +174,9 @@ describe('getJobNoteMediaUrl', () => {
 
 describe('deleteJobNoteMedia', () => {
   it('deletes the row first, then the file (row-first)', async () => {
+    // Returns the removed row — a DELETE blocked by the billing gate is filtered out silently
+    // rather than raising, so the row count is the only way to notice. See assertDeleted.
+    mockQueryBuilder.data = [{ id: 'media-1' }];
     await deleteJobNoteMedia({ id: 'media-1', storage_path: 'c1/jobs/j1/x.jpg' });
     expect(mockSupabase.from).toHaveBeenCalledWith('note_media');
     expect(mockQueryBuilder.delete).toHaveBeenCalled();

--- a/__tests__/utils/operationCompletionsAccess.test.ts
+++ b/__tests__/utils/operationCompletionsAccess.test.ts
@@ -85,10 +85,31 @@ describe('createOperationCompletion', () => {
   });
 
   it('throws when the insert fails', async () => {
-    responses['job_operation_completions'] = { data: null, error: { message: 'permission denied' } };
+    // Was asserting the raw DB text reached the caller. It no longer does: the message is now
+    // translated, because 'raw DB strings must never reach a user' (lib/supabaseErrors.ts).
+    responses['job_operation_completions'] = {
+      data: null,
+      error: { code: '42501', message: 'permission denied' },
+    };
     await expect(
       createOperationCompletion({ companyId: 'co-1', jobOperationId: 'op-1', jobPartId: 'jp-1', quantityGood: 1 }),
-    ).rejects.toThrow(/permission denied/);
+    ).rejects.toThrow(/don't have permission/i);
+  });
+
+  it('tells a lapsed shop about its subscription, not about permissions', async () => {
+    // The operator's most frequent write. Before, a blocked completion read as
+    // 'Failed to record completion: new row violates row-level security policy ...'.
+    responses['job_operation_completions'] = {
+      data: null,
+      error: {
+        code: '42501',
+        message:
+          'new row violates row-level security policy "billing_gate_insert" for table "job_operation_completions"',
+      },
+    };
+    await expect(
+      createOperationCompletion({ companyId: 'co-1', jobOperationId: 'op-1', jobPartId: 'jp-1', quantityGood: 1 }),
+    ).rejects.toThrow(/subscription isn't active/i);
   });
 });
 

--- a/__tests__/utils/partsAccess.test.ts
+++ b/__tests__/utils/partsAccess.test.ts
@@ -273,10 +273,19 @@ describe('partsAccess utilities', () => {
 
   describe('deletePartNote', () => {
     it('deletes by id (RLS enforces author/admin)', async () => {
+      // The delete returns the removed row: the billing gate blocks DELETE via a policy USING
+      // clause, which filters the row out silently rather than raising, so the row count is the
+      // only signal that anything happened. See assertDeleted.
+      mockQueryBuilder.data = [{ id: 'n1' }];
       await deletePartNote('n1');
       expect(mockSupabase.from).toHaveBeenCalledWith('part_comments');
       expect(mockQueryBuilder.delete).toHaveBeenCalled();
       expect(mockQueryBuilder.eq).toHaveBeenCalledWith('id', 'n1');
+    });
+
+    it('throws when the delete removed nothing (a silently-filtered write)', async () => {
+      mockQueryBuilder.data = [];
+      await expect(deletePartNote('n1')).rejects.toThrow(/couldn't be removed/i);
     });
 
     it('throws on error', async () => {
@@ -650,14 +659,32 @@ describe('partsAccess utilities', () => {
 
     it('re-throws a duplicate-name error when no archived part matches (a live duplicate)', async () => {
       // 23505 with no archived same-name row → reviveArchivedPartByName returns null,
-      // so the original duplicate error is re-thrown (a genuine live duplicate).
+      // so the duplicate is surfaced (a genuine live duplicate). It now arrives as a real Error
+      // carrying user-facing copy rather than the raw Supabase object, which `err instanceof
+      // Error` rejected — the reason "Failed to create part" reached the user instead.
       mockQueryBuilder.data = null;
       mockQueryBuilder.error = { message: 'Insert failed', code: '23505' };
 
-      await expect(createPart('company-1', mockFormData)).rejects.toEqual({
-        message: 'Insert failed',
-        code: '23505',
-      });
+      const rejection = await createPart('company-1', mockFormData).catch((e) => e);
+      expect(rejection).toBeInstanceOf(Error);
+      expect(rejection.message).toMatch(/already exists/i);
+      expect(rejection.code).toBe('23505');
+      expect(rejection.cause).toEqual({ message: 'Insert failed', code: '23505' });
+    });
+
+    it('tells a lapsed shop about its subscription instead of "Failed to create part"', async () => {
+      // The screenshot this whole change came from.
+      mockQueryBuilder.data = null;
+      mockQueryBuilder.error = {
+        code: '42501',
+        message:
+          'new row violates row-level security policy "billing_gate_insert" for table "parts"',
+      };
+
+      const rejection = await createPart('company-1', mockFormData).catch((e) => e);
+      expect(rejection).toBeInstanceOf(Error);
+      expect(rejection.message).toMatch(/subscription isn't active/i);
+      expect(rejection.message).not.toMatch(/row-level security/i);
     });
   });
 

--- a/__tests__/utils/storageHelpers.test.ts
+++ b/__tests__/utils/storageHelpers.test.ts
@@ -178,7 +178,7 @@ describe('storageHelpers', () => {
       const mockFile = new File(['test'], 'test.pdf', { type: 'application/pdf' });
 
       await expect(uploadFileToStorage('path/to/file.pdf', mockFile)).rejects.toThrow(
-        'Failed to upload file: Upload failed'
+        'Failed to upload that file.'
       );
     });
 
@@ -279,7 +279,7 @@ describe('storageHelpers', () => {
       });
 
       await expect(deleteFileFromStorage('path/to/file.pdf')).rejects.toThrow(
-        'Failed to delete file: Delete failed'
+        'Failed to delete that file.'
       );
     });
   });
@@ -395,7 +395,7 @@ describe('storageHelpers', () => {
       });
 
       await expect(moveFileInStorage('old/path.pdf', 'new/path.pdf')).rejects.toThrow(
-        'Failed to upload file'
+        'Failed to upload that file.'
       );
     });
 

--- a/api/tests/integration/test_billing_enforcement.py
+++ b/api/tests/integration/test_billing_enforcement.py
@@ -52,6 +52,28 @@ def _assert_rls_blocked(exc: Exception) -> None:
     )
 
 
+def _seed_customer(admin, company_id: str) -> str:
+    """A customer row created with the service role, so it exists regardless of billing."""
+    res = admin.table("customers").insert(
+        {"company_id": company_id, "name": "gate-fixture"}
+    ).execute()
+    return res.data[0]["id"]
+
+
+def _try_update(user_client, row_id: str):
+    """PATCH a gated tenant row as the authenticated user."""
+    return (
+        user_client.table("customers")
+        .update({"name": "gate-fixture-renamed"})
+        .eq("id", row_id)
+        .execute()
+    )
+
+
+def _try_delete(user_client, row_id: str):
+    return user_client.table("customers").delete().eq("id", row_id).execute()
+
+
 # ── golden cases: (label, billing fields | None, is_demo, write allowed?) ──────
 # Mirrors __tests__/lib/entitlement.test.ts GOLDEN_CASES + verify_billing_parity.sql.
 CASES = [
@@ -110,6 +132,185 @@ def test_select_still_works_when_write_blocked(supabase_admin, billing_user):
     with pytest.raises(Exception) as exc:
         _try_write(billing_user["client"], company_id)
     _assert_rls_blocked(exc.value)
+
+
+def test_update_blocked_when_billing_lapsed(supabase_admin, billing_user):
+    """A blocked UPDATE must RAISE, not quietly change nothing.
+
+    Until `billing_gate_update_with_check` the gate blocked updates through the policy's USING
+    clause, which FILTERS the row out of the statement rather than refusing it — so a lapsed
+    shop's save affected zero rows and returned no error. `markOperationReceived` reported
+    `{"success": true}` on a row it never touched because of exactly this.
+    """
+    company_id = billing_user["company_id"]
+    row_id = _seed_customer(supabase_admin, company_id)
+    _set_billing(supabase_admin, company_id, subscription_status="canceled", ended_at=_iso(-30))
+
+    with pytest.raises(Exception) as exc:
+        _try_update(billing_user["client"], row_id)
+    _assert_rls_blocked(exc.value)
+
+    # And the row genuinely did not change.
+    row = supabase_admin.table("customers").select("name").eq("id", row_id).single().execute()
+    assert row.data["name"] == "gate-fixture"
+
+
+def test_update_blocked_on_parent_resolved_child(supabase_admin, billing_user):
+    """The same, for a child table that resolves its company through a parent FK.
+
+    job_operations is the one that matters: it is the table behind markOperationReceived, and
+    it has no company_id of its own, so it cannot use apply_billing_write_gate.
+    """
+    company_id = billing_user["company_id"]
+    job = supabase_admin.table("jobs").insert(
+        {
+            "company_id": company_id,
+            "job_number": "J-GATE-1",
+            "production_status": "not_started",
+            "fulfillment_status": "unshipped",
+        }
+    ).execute().data[0]
+    part = supabase_admin.table("parts").insert(
+        {
+            "company_id": company_id,
+            "part_name": "gate-part",
+            "source": "made",
+            "primary_unit": "ea",
+        }
+    ).execute().data[0]
+    job_part = supabase_admin.table("job_parts").insert(
+        {
+            "company_id": company_id,
+            "job_id": job["id"],
+            "part_id": part["id"],
+            "sequence": 1,
+            "quantity": 1,
+            "production_status": "not_started",
+            "fulfillment_status": "unshipped",
+        }
+    ).execute().data[0]
+    op = supabase_admin.table("job_operations").insert(
+        {"job_id": job["id"], "job_part_id": job_part["id"], "operation_name": "mill", "sequence": 1}
+    ).execute().data[0]
+
+    _set_billing(supabase_admin, company_id, subscription_status="canceled", ended_at=_iso(-30))
+
+    with pytest.raises(Exception) as exc:
+        billing_user["client"].table("job_operations").update(
+            {"status": "completed"}
+        ).eq("id", op["id"]).execute()
+    _assert_rls_blocked(exc.value)
+
+
+def test_blocked_writes_name_the_billing_policy(supabase_admin, billing_user):
+    """The message must name `billing_gate_*`.
+
+    This is a CONTRACT, not an incidental detail. `isBillingWriteBlocked` in
+    lib/supabaseErrors.ts keys on that substring to tell a lapsed subscription from a plain
+    permission denial, and everything downstream — the copy, the Subscribe button, the Sentry
+    exemption — hangs off it. Rename the policies and every one of those silently reverts to
+    "You don't have permission to do that."
+
+    It holds because Postgres emits one WithCheckOption per RESTRICTIVE policy, each carrying
+    its own name, while OR-folding the permissive ones into a single nameless entry.
+    """
+    company_id = billing_user["company_id"]
+    row_id = _seed_customer(supabase_admin, company_id)
+    _set_billing(supabase_admin, company_id, subscription_status="canceled", ended_at=_iso(-30))
+
+    with pytest.raises(Exception) as exc:
+        _try_write(billing_user["client"], company_id)
+    assert "billing_gate_insert" in str(exc.value), (
+        f"INSERT denial must name its policy, got: {exc.value}"
+    )
+
+    with pytest.raises(Exception) as exc:
+        _try_update(billing_user["client"], row_id)
+    assert "billing_gate_update" in str(exc.value), (
+        f"UPDATE denial must name its policy, got: {exc.value}"
+    )
+
+
+def test_permissive_denial_is_nameless(supabase_admin, billing_user):
+    """The other half of that contract: a MEMBERSHIP failure must NOT name a billing policy.
+
+    Permissive policies OR-fold into one unnamed WithCheckOption, so writing into a company you
+    do not belong to produces the bare form. If this ever changes, `isBillingWriteBlocked`
+    starts matching non-members and the product offers a Subscribe button to someone whose
+    problem paying would not fix.
+    """
+    other = supabase_admin.table("companies").insert({"name": "gate-nonmember-co"}).execute().data[0]
+    # Writable, so billing is definitively not the reason this write fails.
+    supabase_admin.table("company_billing").upsert(
+        {"company_id": other["id"], "subscription_status": "active"}, on_conflict="company_id"
+    ).execute()
+    try:
+        with pytest.raises(Exception) as exc:
+            billing_user["client"].table("customers").insert(
+                {"company_id": other["id"], "name": "intruder"}
+            ).execute()
+        _assert_rls_blocked(exc.value)
+        assert "billing_gate" not in str(exc.value), (
+            f"a membership denial must stay nameless, got: {exc.value}"
+        )
+    finally:
+        supabase_admin.table("companies").delete().eq("id", other["id"]).execute()
+
+
+def test_delete_is_silently_filtered_when_lapsed(supabase_admin, billing_user):
+    """DELETE stays silent, deliberately — this pins the decision so nobody 'fixes' it.
+
+    A DELETE policy has no WITH CHECK to fail through, so the only RLS-shaped fix would be
+    USING (true) plus a BEFORE DELETE trigger that raises — which inverts the failure mode from
+    fail-closed to fail-OPEN if that trigger is ever dropped. Not worth it: this repo
+    soft-deletes every user-facing entity (archive is an UPDATE, covered above), and the
+    remaining hard deletes assert the returned row count in TypeScript instead (assertDeleted).
+    """
+    company_id = billing_user["company_id"]
+    row_id = _seed_customer(supabase_admin, company_id)
+    _set_billing(supabase_admin, company_id, subscription_status="canceled", ended_at=_iso(-30))
+
+    res = _try_delete(billing_user["client"], row_id)
+    assert res.data == [], "expected the delete to be filtered to zero rows, not to raise"
+
+    still = supabase_admin.table("customers").select("id").eq("id", row_id).execute()
+    assert still.data, "the row should still be there — the delete was refused"
+
+
+def test_update_gate_never_filters(supabase_admin):
+    """Every billing_gate_update must be USING (true) WITH CHECK (...).
+
+    The completeness guard next door checks a tenant table IS gated; it cannot see that one is
+    gated the OLD, silent way. That is exactly how this bug would come back, because the
+    natural thing to hand-write is the USING(...) WITH CHECK(...) pair visible on every other
+    policy.
+    """
+    res = supabase_admin.rpc("tenant_tables_with_silent_update_gate", {}).execute()
+    assert res.data == [], (
+        f"these tables still filter blocked updates instead of raising: {res.data}"
+    )
+
+
+def test_gate_key_is_immutable(supabase_admin, billing_user):
+    """company_id cannot be moved to another company from the browser.
+
+    `USING (true)` is only equivalent to the old shape because NEW.company_id ≡ OLD.company_id.
+    Without this trigger a member of both a lapsed company A and a writable company B could
+    PATCH an A row's company_id to B and pass both checks.
+    """
+    company_id = billing_user["company_id"]
+    row_id = _seed_customer(supabase_admin, company_id)
+    other = supabase_admin.table("companies").insert({"name": "gate-move-target"}).execute().data[0]
+    try:
+        with pytest.raises(Exception) as exc:
+            billing_user["client"].table("customers").update(
+                {"company_id": other["id"]}
+            ).eq("id", row_id).execute()
+        assert "immutable" in str(exc.value).lower(), (
+            f"expected the gate-key immutability trigger to fire, got: {exc.value}"
+        )
+    finally:
+        supabase_admin.table("companies").delete().eq("id", other["id"]).execute()
 
 
 def test_company_can_write_parity(supabase_admin, billing_user):

--- a/app/dashboard/[companyId]/customers/new/page.tsx
+++ b/app/dashboard/[companyId]/customers/new/page.tsx
@@ -3,10 +3,12 @@
 import Box from '@mui/material/Box';
 import { CustomerForm } from '@/components/customers';
 import { EMPTY_CUSTOMER_FORM } from '@/types/customer';
+import SubscriptionRequiredNotice from '@/components/billing/SubscriptionRequiredNotice';
 
 export default function NewCustomerPage() {
   return (
     <Box>
+      <SubscriptionRequiredNotice entityPlural="customers" />
       <CustomerForm initialData={EMPTY_CUSTOMER_FORM} />
     </Box>
   );

--- a/app/dashboard/[companyId]/parts/new/page.tsx
+++ b/app/dashboard/[companyId]/parts/new/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import PartWorkspace from '@/components/parts/workspace/PartWorkspace';
+import SubscriptionRequiredNotice from '@/components/billing/SubscriptionRequiredNotice';
 
 /**
  * New-part route. Renders the same PartWorkspace as the detail page in create
@@ -18,6 +19,9 @@ export default function NewPartPage() {
         </Box>
       }
     >
+      <Box sx={{ maxWidth: 900, mx: 'auto' }}>
+        <SubscriptionRequiredNotice entityPlural="parts" />
+      </Box>
       <PartWorkspace mode="create" />
     </Suspense>
   );

--- a/app/dashboard/[companyId]/quotes/new/page.tsx
+++ b/app/dashboard/[companyId]/quotes/new/page.tsx
@@ -8,6 +8,7 @@ import { EMPTY_QUOTE_FORM, defaultExpirationDate } from '@/types/quote';
 import { getCompany } from '@/utils/companyAccess';
 import { readQuoteValidityDays } from '@/lib/companyDefaults';
 import { useLoad } from '@/hooks/useLoad';
+import SubscriptionRequiredNotice from '@/components/billing/SubscriptionRequiredNotice';
 
 export default function NewQuotePage() {
   const params = useParams();
@@ -36,6 +37,7 @@ export default function NewQuotePage() {
 
   return (
     <Box>
+      <SubscriptionRequiredNotice entityPlural="quotes" />
       <QuoteForm mode="create" initialData={initialData} />
     </Box>
   );

--- a/app/dashboard/[companyId]/vendors/new/page.tsx
+++ b/app/dashboard/[companyId]/vendors/new/page.tsx
@@ -6,6 +6,7 @@ import Button from '@mui/material/Button';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { VendorForm } from '@/components/vendors';
 import { EMPTY_VENDOR_FORM } from '@/types/vendor';
+import SubscriptionRequiredNotice from '@/components/billing/SubscriptionRequiredNotice';
 
 export default function NewVendorPage() {
   const router = useRouter();
@@ -21,6 +22,7 @@ export default function NewVendorPage() {
       >
         Back to Vendors
       </Button>
+      <SubscriptionRequiredNotice entityPlural="vendors" />
       <VendorForm mode="create" initialData={EMPTY_VENDOR_FORM} />
     </Box>
   );

--- a/app/dashboard/[companyId]/work-centers/new/page.tsx
+++ b/app/dashboard/[companyId]/work-centers/new/page.tsx
@@ -6,6 +6,7 @@ import Button from '@mui/material/Button';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { WorkCenterForm } from '@/components/work-centers';
 import { EMPTY_WORK_CENTER_FORM } from '@/types/workCenter';
+import SubscriptionRequiredNotice from '@/components/billing/SubscriptionRequiredNotice';
 
 export default function NewWorkCenterPage() {
   const router = useRouter();
@@ -21,6 +22,7 @@ export default function NewWorkCenterPage() {
       >
         Back to Work Centers
       </Button>
+      <SubscriptionRequiredNotice entityPlural="work centers" />
       <WorkCenterForm mode="create" initialData={EMPTY_WORK_CENTER_FORM} />
     </Box>
   );

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import ErrorAlert from '@/components/common/ErrorAlert';
 import { useState, useEffect, useMemo } from 'react';
 import posthog from 'posthog-js';
 import { useParams } from 'next/navigation';
@@ -84,7 +85,10 @@ export default function OperatorOperationActionPage() {
 
   const [currentOperatorId, setCurrentOperatorId] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Holds the caught error, not a formatted string. This page carries four separate writes
+  // (complete, undo, send, receive) and every one of them can be refused by the billing gate;
+  // ErrorAlert needs the object to say so rather than 'Failed to record completion'.
+  const [error, setError] = useState<unknown>(null);
   // Good-quantity the operator is about to record. Blank until the summary loads,
   // then defaults to the remaining balance (dialled down for a partial).
   const [qtyInput, setQtyInput] = useState('');
@@ -150,7 +154,7 @@ export default function OperatorOperationActionPage() {
     [jobOperationId, companyId],
     {
       onError: (err) => {
-        setError(err instanceof Error ? err.message : 'Failed to load operation');
+        setError(err);
       },
     },
   );
@@ -268,7 +272,7 @@ export default function OperatorOperationActionPage() {
 
       await reloadAll();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to record completion');
+      setError(err);
     } finally {
       setActionLoading(false);
     }
@@ -307,7 +311,7 @@ export default function OperatorOperationActionPage() {
       setQtyDirty(false);
       await reloadAll();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to undo completion');
+      setError(err);
     } finally {
       setActionLoading(false);
     }
@@ -322,7 +326,7 @@ export default function OperatorOperationActionPage() {
       await markOperationSent(jobOperationId);
       await loadJob();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to mark sent out');
+      setError(err);
     } finally {
       setActionLoading(false);
     }
@@ -335,7 +339,7 @@ export default function OperatorOperationActionPage() {
       await markOperationReceived(jobOperationId);
       await loadJob();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to mark received');
+      setError(err);
     } finally {
       setActionLoading(false);
     }
@@ -391,10 +395,13 @@ export default function OperatorOperationActionPage() {
     // action bar instead of ending underneath it — the documented failure mode
     // of sticky bars is obscuring the content or the error you need to read.
     <Box>
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
+      {error != null && (
+        <ErrorAlert
+          error={error}
+          entity="operation"
+          fallback="Something went wrong. Please try again."
+          sx={{ mb: 2 }}
+        />
       )}
 
       <Card

--- a/components/billing/BillingBanner.tsx
+++ b/components/billing/BillingBanner.tsx
@@ -1,13 +1,8 @@
 'use client';
 
-import { useState } from 'react';
 import Alert from '@mui/material/Alert';
-import Button from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
-import Snackbar from '@mui/material/Snackbar';
-import { useParams } from 'next/navigation';
 import { useSubscription } from '@/components/providers/SubscriptionProvider';
-import { startCheckout, openBillingPortal } from '@/lib/billingApi';
+import SubscribeButton from '@/components/billing/SubscribeButton';
 
 /**
  * Persistent, app-wide billing banner rendered below the header (sibling of the
@@ -16,12 +11,7 @@ import { startCheckout, openBillingPortal } from '@/lib/billingApi';
  * DB is the actual write gate.
  */
 export default function BillingBanner() {
-  const params = useParams();
-  const companyId = params.companyId as string;
-  const { entitlement, isLoading, isPastDue, isReadOnly, mustSubscribe, hasCustomer, refresh } =
-    useSubscription();
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { entitlement, isLoading, isPastDue, isReadOnly, mustSubscribe } = useSubscription();
 
   // Render nothing until billing is known. While the cache is still loading,
   // `billing` is null → entitlement resolves to `must_subscribe`, which would
@@ -31,10 +21,6 @@ export default function BillingBanner() {
   if (isLoading) return null;
 
   if (!isPastDue && !isReadOnly && !mustSubscribe) return null;
-
-  // Past-due / lapsed-with-a-customer manage billing in the Portal; a
-  // never-subscribed (or customer-less) company starts a new Checkout.
-  const useCheckout = mustSubscribe || !hasCustomer;
 
   const config = {
     past_due: {
@@ -54,64 +40,23 @@ export default function BillingBanner() {
     full: { severity: 'info' as const, message: '' },
   }[entitlement];
 
-  const actionLabel = useCheckout ? 'Subscribe' : 'Manage billing';
-
-  const handleAction = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      const url = useCheckout
-        ? await startCheckout(companyId)
-        : await openBillingPortal(companyId);
-      window.location.href = url;
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Something went wrong. Please try again.');
-      setBusy(false);
-      // A stale-cache "Manage billing" attempt may have reconciled the cache
-      // server-side — refresh so the banner/button corrects.
-      void refresh();
-    }
-  };
-
   return (
-    <>
-      <Alert
-        severity={config.severity}
-        sx={{
-          borderRadius: 0,
-          py: 0.5,
-          '& .MuiAlert-message': {
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            width: '100%',
-            gap: 2,
-          },
-        }}
-      >
-        {config.message}
-        <Button
-          size="small"
-          variant="contained"
-          color="inherit"
-          onClick={handleAction}
-          disabled={busy}
-          startIcon={busy ? <CircularProgress size={16} color="inherit" /> : undefined}
-          sx={{ flexShrink: 0 }}
-        >
-          {busy ? 'Redirecting…' : actionLabel}
-        </Button>
-      </Alert>
-
-      <Snackbar
-        open={Boolean(error)}
-        autoHideDuration={6000}
-        onClose={() => setError(null)}
-      >
-        <Alert severity="error" onClose={() => setError(null)}>
-          {error}
-        </Alert>
-      </Snackbar>
-    </>
+    <Alert
+      severity={config.severity}
+      sx={{
+        borderRadius: 0,
+        py: 0.5,
+        '& .MuiAlert-message': {
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          width: '100%',
+          gap: 2,
+        },
+      }}
+    >
+      {config.message}
+      <SubscribeButton color="inherit" />
+    </Alert>
   );
 }

--- a/components/billing/BillingBanner.tsx
+++ b/components/billing/BillingBanner.tsx
@@ -3,6 +3,7 @@
 import Alert from '@mui/material/Alert';
 import { useSubscription } from '@/components/providers/SubscriptionProvider';
 import SubscribeButton from '@/components/billing/SubscribeButton';
+import { useUserRole } from '@/hooks/useUserRole';
 
 /**
  * Persistent, app-wide billing banner rendered below the header (sibling of the
@@ -12,6 +13,10 @@ import SubscribeButton from '@/components/billing/SubscribeButton';
  */
 export default function BillingBanner() {
   const { entitlement, isLoading, isPastDue, isReadOnly, mustSubscribe } = useSubscription();
+  // Only an admin can act on any of this: SubscribeButton renders nothing for anyone else, so
+  // telling a `user` to "resubscribe" or "update your payment method" would name an action they
+  // have no way to take. They get told who can instead.
+  const { isAdmin, loading: roleLoading } = useUserRole();
 
   // Render nothing until billing is known. While the cache is still loading,
   // `billing` is null → entitlement resolves to `must_subscribe`, which would
@@ -22,20 +27,26 @@ export default function BillingBanner() {
 
   if (!isPastDue && !isReadOnly && !mustSubscribe) return null;
 
+  const canAct = !roleLoading && isAdmin;
+
   const config = {
     past_due: {
       severity: 'warning' as const,
-      message:
-        "Your last payment didn't go through. Update your payment method to keep your shop running.",
+      message: canAct
+        ? "Your last payment didn't go through. Update your payment method to keep your shop running."
+        : "Your shop's last payment didn't go through. An admin at your shop can update the payment method in Settings.",
     },
     read_only: {
       severity: 'error' as const,
-      message:
-        'Your subscription has ended — your account is read-only. Resubscribe to make changes again.',
+      message: canAct
+        ? 'Your subscription has ended — your account is read-only. Resubscribe to make changes again.'
+        : "Your shop's subscription has ended, so Jigged is read-only. An admin at your shop can restart it in Settings.",
     },
     must_subscribe: {
       severity: 'info' as const,
-      message: 'Start your subscription to unlock Jigged for your shop.',
+      message: canAct
+        ? 'Start your subscription to unlock Jigged for your shop.'
+        : "Your shop's subscription hasn't started yet, so changes can't be saved. An admin at your shop can start it in Settings.",
     },
     full: { severity: 'info' as const, message: '' },
   }[entitlement];

--- a/components/billing/BillingBanner.tsx
+++ b/components/billing/BillingBanner.tsx
@@ -4,6 +4,7 @@ import Alert from '@mui/material/Alert';
 import { useSubscription } from '@/components/providers/SubscriptionProvider';
 import SubscribeButton from '@/components/billing/SubscribeButton';
 import { useUserRole } from '@/hooks/useUserRole';
+import { blockedMessageForNonAdmin, writeBlockedState } from '@/lib/billingCopy';
 
 /**
  * Persistent, app-wide billing banner rendered below the header (sibling of the
@@ -12,7 +13,7 @@ import { useUserRole } from '@/hooks/useUserRole';
  * DB is the actual write gate.
  */
 export default function BillingBanner() {
-  const { entitlement, isLoading, isPastDue, isReadOnly, mustSubscribe } = useSubscription();
+  const { entitlement, billing, isLoading, isPastDue, isReadOnly, mustSubscribe } = useSubscription();
   // Only an admin can act on any of this: SubscribeButton renders nothing for anyone else, so
   // telling a `user` to "resubscribe" or "update your payment method" would name an action they
   // have no way to take. They get told who can instead.
@@ -28,6 +29,7 @@ export default function BillingBanner() {
   if (!isPastDue && !isReadOnly && !mustSubscribe) return null;
 
   const canAct = !roleLoading && isAdmin;
+  const blockedState = writeBlockedState(billing);
 
   const config = {
     past_due: {
@@ -38,9 +40,11 @@ export default function BillingBanner() {
     },
     read_only: {
       severity: 'error' as const,
+      // `read_only` covers paused as well as canceled/unpaid, so the wording comes from the
+      // actual status — telling a PAUSED shop its subscription "has ended" is untrue.
       message: canAct
-        ? 'Your subscription has ended — your account is read-only. Resubscribe to make changes again.'
-        : "Your shop's subscription has ended, so Jigged is read-only. An admin at your shop can restart it in Settings.",
+        ? `Your subscription ${blockedState === 'paused' ? 'is paused' : 'has ended'} — your account is read-only. ${blockedState === 'paused' ? 'Resume it' : 'Resubscribe'} to make changes again.`
+        : blockedMessageForNonAdmin(blockedState),
     },
     must_subscribe: {
       severity: 'info' as const,

--- a/components/billing/SubscribeButton.tsx
+++ b/components/billing/SubscribeButton.tsx
@@ -7,6 +7,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Snackbar from '@mui/material/Snackbar';
 import { useParams } from 'next/navigation';
 import { useOptionalSubscription } from '@/components/providers/SubscriptionProvider';
+import { useUserRole } from '@/hooks/useUserRole';
 import { startCheckout, openBillingPortal } from '@/lib/billingApi';
 
 /**
@@ -16,9 +17,14 @@ import { startCheckout, openBillingPortal } from '@/lib/billingApi';
  * details that matter: which of Checkout vs Portal a given billing state needs, and the
  * refresh-on-failure that corrects a stale cache.
  *
- * Renders nothing outside a SubscriptionProvider — the operator app has none, and an operator
- * cannot subscribe anyway. Callers are responsible for the *role* check: the Stripe routes require
- * admin (`_verify_company_admin`), so showing this to a `user` is a two-step dead end.
+ * Renders nothing when pressing it could not work:
+ *   - outside a SubscriptionProvider (the operator app has none, and an operator cannot subscribe);
+ *   - for anyone who is not an admin, or while the role is still unknown. `/settings` is behind
+ *     AdminGuard and both Stripe routes call `_verify_company_admin`, so a `user` who clicked this
+ *     got a 403 — the confirm-then-error two-step interaction-standards.md §4 forbids.
+ *
+ * The role check lives HERE rather than in each caller so the rule cannot drift between them, and
+ * so callers only have to get the *copy* right.
  */
 interface SubscribeButtonProps {
   size?: 'small' | 'medium';
@@ -38,10 +44,12 @@ export default function SubscribeButton({
   const params = useParams();
   const companyId = params.companyId as string;
   const subscription = useOptionalSubscription();
+  const { isAdmin, loading: roleLoading } = useUserRole();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   if (!subscription) return null;
+  if (roleLoading || !isAdmin) return null;
 
   const { mustSubscribe, hasCustomer, refresh } = subscription;
 

--- a/components/billing/SubscribeButton.tsx
+++ b/components/billing/SubscribeButton.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Snackbar from '@mui/material/Snackbar';
+import { useParams } from 'next/navigation';
+import { useOptionalSubscription } from '@/components/providers/SubscriptionProvider';
+import { startCheckout, openBillingPortal } from '@/lib/billingApi';
+
+/**
+ * The one way into Stripe from inside the app.
+ *
+ * Extracted from BillingBanner so the banner and the inline write-denial alert cannot drift on the
+ * details that matter: which of Checkout vs Portal a given billing state needs, and the
+ * refresh-on-failure that corrects a stale cache.
+ *
+ * Renders nothing outside a SubscriptionProvider — the operator app has none, and an operator
+ * cannot subscribe anyway. Callers are responsible for the *role* check: the Stripe routes require
+ * admin (`_verify_company_admin`), so showing this to a `user` is a two-step dead end.
+ */
+interface SubscribeButtonProps {
+  size?: 'small' | 'medium';
+  variant?: 'contained' | 'outlined' | 'text';
+  /** MUI colour. The banner needs `inherit` to sit on a tinted Alert. */
+  color?: 'primary' | 'inherit';
+  /** Overrides the entitlement-derived label. */
+  label?: string;
+}
+
+export default function SubscribeButton({
+  size = 'small',
+  variant = 'contained',
+  color = 'primary',
+  label,
+}: SubscribeButtonProps) {
+  const params = useParams();
+  const companyId = params.companyId as string;
+  const subscription = useOptionalSubscription();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!subscription) return null;
+
+  const { mustSubscribe, hasCustomer, refresh } = subscription;
+
+  // A never-subscribed (or customer-less) company starts a new Checkout; anyone Stripe already
+  // knows manages the existing subscription in the Portal.
+  const useCheckout = mustSubscribe || !hasCustomer;
+  const actionLabel = label ?? (useCheckout ? 'Subscribe' : 'Manage billing');
+
+  const handleAction = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const url = useCheckout
+        ? await startCheckout(companyId)
+        : await openBillingPortal(companyId);
+      window.location.href = url;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong. Please try again.');
+      setBusy(false);
+      // A stale-cache "Manage billing" attempt may have reconciled the cache server-side —
+      // refresh so the button corrects itself.
+      void refresh();
+    }
+  };
+
+  return (
+    <>
+      <Button
+        size={size}
+        variant={variant}
+        color={color}
+        onClick={handleAction}
+        disabled={busy}
+        startIcon={busy ? <CircularProgress size={16} color="inherit" /> : undefined}
+        sx={{ flexShrink: 0 }}
+      >
+        {busy ? 'Redirecting…' : actionLabel}
+      </Button>
+
+      <Snackbar
+        open={Boolean(error)}
+        autoHideDuration={6000}
+        onClose={() => setError(null)}
+      >
+        <Alert severity="error" onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}

--- a/components/billing/SubscriptionRequiredNotice.tsx
+++ b/components/billing/SubscriptionRequiredNotice.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import { useOptionalSubscription } from '@/components/providers/SubscriptionProvider';
+import SubscribeButton from '@/components/billing/SubscribeButton';
+import { useUserRole } from '@/hooks/useUserRole';
+
+interface SubscriptionRequiredNoticeProps {
+  /** Plural, as it appears mid-sentence: "parts", "customers", "work centers". */
+  entityPlural: string;
+}
+
+/**
+ * Says up front that this shop can't save yet, on the pages whose whole purpose is creating
+ * something.
+ *
+ * Deliberately NOT a disabled button or a hidden form. interaction-standards.md §4 rule 1 is
+ * "keep it visible; explain on attempt" — a disabled control isn't focusable, so keyboard and
+ * screen-reader users never learn it exists or why. This adds the explanation *before* the
+ * attempt; the form and its submit stay exactly as they are, and a submit still produces the
+ * full ErrorAlert with the same Subscribe action.
+ *
+ * Renders nothing when there is nothing to say: while entitlement is still loading, for demo
+ * companies, outside a SubscriptionProvider, and — the common case — when the shop can write.
+ */
+export default function SubscriptionRequiredNotice({
+  entityPlural,
+}: SubscriptionRequiredNoticeProps) {
+  const subscription = useOptionalSubscription();
+  const { isAdmin, loading: roleLoading } = useUserRole();
+
+  if (!subscription) return null;
+  // `isLoading` starts true with `billing: null`, which resolves to `must_subscribe` — so
+  // `canWrite` is false for a perfectly healthy shop until the first fetch lands. Without this
+  // the notice would flash on every create page load.
+  if (subscription.isLoading) return null;
+  if (subscription.isDemo) return null;
+  if (subscription.canWrite) return null;
+
+  const canSubscribe = !roleLoading && isAdmin;
+
+  const message = !canSubscribe
+    ? `Your shop's subscription isn't active, so new ${entityPlural} can't be saved yet. An admin at your shop can restart it in Settings.`
+    : subscription.mustSubscribe
+      ? `Start your subscription to add ${entityPlural} to Jigged.`
+      : `Your subscription has ended, so Jigged is read-only. Resubscribe to add ${entityPlural} again.`;
+
+  return (
+    <Alert
+      severity="info"
+      sx={{
+        mb: 3,
+        ...(canSubscribe && {
+          '& .MuiAlert-message': {
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+            gap: 2,
+            flexWrap: 'wrap',
+          },
+        }),
+      }}
+    >
+      {message}
+      {canSubscribe && (
+        <Box component="span" sx={{ flexShrink: 0 }}>
+          <SubscribeButton label={subscription.mustSubscribe ? 'Subscribe' : undefined} />
+        </Box>
+      )}
+    </Alert>
+  );
+}

--- a/components/billing/SubscriptionRequiredNotice.tsx
+++ b/components/billing/SubscriptionRequiredNotice.tsx
@@ -5,6 +5,11 @@ import Box from '@mui/material/Box';
 import { useOptionalSubscription } from '@/components/providers/SubscriptionProvider';
 import SubscribeButton from '@/components/billing/SubscribeButton';
 import { useUserRole } from '@/hooks/useUserRole';
+import {
+  blockedNoticeForAdmin,
+  blockedNoticeForNonAdmin,
+  writeBlockedState,
+} from '@/lib/billingCopy';
 
 interface SubscriptionRequiredNoticeProps {
   /** Plural, as it appears mid-sentence: "parts", "customers", "work centers". */
@@ -39,12 +44,13 @@ export default function SubscriptionRequiredNotice({
   if (subscription.canWrite) return null;
 
   const canSubscribe = !roleLoading && isAdmin;
+  // Branch on the real subscription status, not on `mustSubscribe`: entitlement collapses
+  // canceled, unpaid AND paused into `read_only`, so a paused shop was told it "has ended".
+  const state = writeBlockedState(subscription.billing);
 
-  const message = !canSubscribe
-    ? `Your shop's subscription isn't active, so new ${entityPlural} can't be saved yet. An admin at your shop can restart it in Settings.`
-    : subscription.mustSubscribe
-      ? `Start your subscription to add ${entityPlural} to Jigged.`
-      : `Your subscription has ended, so Jigged is read-only. Resubscribe to add ${entityPlural} again.`;
+  const message = canSubscribe
+    ? blockedNoticeForAdmin(state, entityPlural)
+    : blockedNoticeForNonAdmin(state, entityPlural);
 
   return (
     <Alert
@@ -66,7 +72,7 @@ export default function SubscriptionRequiredNotice({
       {message}
       {canSubscribe && (
         <Box component="span" sx={{ flexShrink: 0 }}>
-          <SubscribeButton label={subscription.mustSubscribe ? 'Subscribe' : undefined} />
+          <SubscribeButton />
         </Box>
       )}
     </Alert>

--- a/components/common/ErrorAlert.tsx
+++ b/components/common/ErrorAlert.tsx
@@ -7,6 +7,13 @@ import { useOptionalSubscription } from '@/components/providers/SubscriptionProv
 import SubscribeButton from '@/components/billing/SubscribeButton';
 import { useUserRole } from '@/hooks/useUserRole';
 import { friendlyErrorMessage, isBillingWriteBlocked } from '@/lib/supabaseErrors';
+import {
+  blockedMessageForAdmin,
+  blockedMessageForNonAdmin,
+  blockedMessageForOperator,
+  writeBlockedState,
+  type WriteBlockedState,
+} from '@/lib/billingCopy';
 
 interface ErrorAlertProps {
   /** Whatever was caught, or a message a caller already formatted. Falsy renders nothing. */
@@ -72,7 +79,7 @@ export default function ErrorAlert({
   if (isBilling && subscription) {
     return (
       <BillingBlockedAlert
-        mustSubscribe={subscription.mustSubscribe}
+        state={writeBlockedState(subscription.billing)}
         entity={entity ?? 'change'}
         onClose={onClose}
         sx={sx}
@@ -85,8 +92,7 @@ export default function ErrorAlert({
     // so name neither — "the office" is what a machinist would actually say.
     return (
       <Alert severity="warning" onClose={onClose} sx={sx}>
-        Your shop&apos;s subscription isn&apos;t active, so this can&apos;t be saved. Let the office
-        know — an admin can turn it back on.
+        {blockedMessageForOperator()}
       </Alert>
     );
   }
@@ -134,12 +140,12 @@ function messageFor(
  * branch that cannot be reached without a SubscriptionProvider above it.
  */
 function BillingBlockedAlert({
-  mustSubscribe,
+  state,
   entity,
   onClose,
   sx,
 }: {
-  mustSubscribe: boolean;
+  state: WriteBlockedState;
   entity: string;
   onClose?: () => void;
   sx?: SxProps<Theme>;
@@ -152,11 +158,9 @@ function BillingBlockedAlert({
   // while the role is still loading, for the same reason.
   const canSubscribe = !loading && isAdmin;
 
-  const message = !canSubscribe
-    ? `Your shop's subscription isn't active, so this can't be saved. An admin at your shop can restart it in Settings.`
-    : mustSubscribe
-      ? `Your subscription hasn't started yet, so Jigged can't save changes. Start it to save this ${entity}.`
-      : `Your subscription has ended, so Jigged is read-only. Resubscribe to save this ${entity}.`;
+  const message = canSubscribe
+    ? blockedMessageForAdmin(state, entity)
+    : blockedMessageForNonAdmin(state);
 
   return (
     <Alert
@@ -179,7 +183,7 @@ function BillingBlockedAlert({
       {message}
       {canSubscribe && (
         <Box component="span" sx={{ flexShrink: 0 }}>
-          <SubscribeButton label={mustSubscribe ? 'Subscribe' : undefined} />
+          <SubscribeButton />
         </Box>
       )}
     </Alert>

--- a/components/common/ErrorAlert.tsx
+++ b/components/common/ErrorAlert.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import type { SxProps, Theme } from '@mui/material/styles';
+import { useOptionalSubscription } from '@/components/providers/SubscriptionProvider';
+import SubscribeButton from '@/components/billing/SubscribeButton';
+import { useUserRole } from '@/hooks/useUserRole';
+import { friendlyErrorMessage, isBillingWriteBlocked } from '@/lib/supabaseErrors';
+
+interface ErrorAlertProps {
+  /** Whatever was caught, or a message a caller already formatted. Falsy renders nothing. */
+  error: unknown;
+  /** What the user was acting on: "part", "customer", "operation". Shapes the copy. */
+  entity?: string;
+  /** What typically references the entity, for FK-violation copy (e.g. "quotes or jobs"). */
+  references?: string;
+  /** Message when no specific mapping applies. */
+  fallback?: string;
+  onClose?: () => void;
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * One error alert, for write failures that need to say something better than "Failed to save".
+ *
+ * Its reason to exist is the billing write-gate: a shop whose subscription lapsed is blocked by
+ * RLS on every write, and told nothing actionable. This renders the real reason and — for someone
+ * who can actually fix it — the Subscribe button.
+ *
+ * CLASSIFICATION ORDER, and the ordering is the whole design:
+ *
+ *   1. SUBSCRIPTION CONTEXT FIRST. If the shop is known not to be able to write, any write failure
+ *      is a billing failure. This catches the three shapes error inspection CANNOT classify:
+ *        - a blocked UPDATE, which RLS filters to zero rows and `.single()` reports as PGRST116
+ *          ("no rows returned") — no privilege error at all;
+ *        - a blocked Storage upload, whose policies are permissive and so produce a NAMELESS
+ *          row-level-security message, indistinguishable from a real permission failure;
+ *        - a bare zero-row write with no error object whatsoever.
+ *      The `!isLoading` guard is essential, not defensive: `isLoading` starts true with
+ *      `billing: null`, and `getEntitlement(false, null)` resolves to `must_subscribe`, so
+ *      `canWrite` is false for a perfectly healthy shop during its first fetch. Without the guard
+ *      every error on every page would briefly read as a billing problem.
+ *
+ *   2. ERROR SHAPE SECOND, via `isBillingWriteBlocked`. Covers the operator app, which mounts no
+ *      SubscriptionProvider, and the race where a subscription lapses mid-session so the cached
+ *      context still says `canWrite`.
+ *
+ *   3. Otherwise the normal translation.
+ *
+ * Billing renders at `warning`, not `error`: nothing is broken, there is a bill to pay — the same
+ * treatment BillingBanner gives `past_due`. Everything else renders at `error`, matching the
+ * hand-rolled `<Alert severity="error">` this replaces, so adopting it is never a visual change.
+ */
+export default function ErrorAlert({
+  error,
+  entity,
+  references,
+  fallback,
+  onClose,
+  sx,
+}: ErrorAlertProps) {
+  const subscription = useOptionalSubscription();
+  const { isAdmin, loading: roleLoading } = useUserRole();
+
+  if (!error) return null;
+
+  const contextSaysBlocked = Boolean(
+    subscription && !subscription.isLoading && !subscription.canWrite,
+  );
+  const isBilling = contextSaysBlocked || isBillingWriteBlocked(error);
+
+  if (!isBilling) {
+    const message =
+      typeof error === 'string' ? error : friendlyErrorMessage(error, { entity, references, fallback });
+
+    return (
+      <Alert severity="error" onClose={onClose} sx={sx}>
+        {message}
+      </Alert>
+    );
+  }
+
+  const noun = entity ?? 'change';
+
+  // Only an admin can act on this. `/dashboard/[companyId]/settings` is behind AdminGuard and the
+  // Stripe routes call `_verify_company_admin`, so offering the button to anyone else ends in a
+  // 403 — the confirm-then-error two-step interaction-standards.md §4 tells us to avoid. Suppress
+  // it while the role is still loading too, for the same reason.
+  const canSubscribe = Boolean(subscription) && !roleLoading && isAdmin;
+
+  const message = !canSubscribe
+    ? // True whether they are a `user` on the dashboard or an operator on the shop floor. The
+      // operator wording deliberately avoids naming Settings, which they cannot reach.
+      subscription
+      ? `Your shop's subscription isn't active, so this can't be saved. An admin at your shop can restart it in Settings.`
+      : `Your shop's subscription isn't active, so this can't be saved. Let the office know — an admin can turn it back on.`
+    : subscription?.mustSubscribe
+      ? `Your subscription hasn't started yet, so Jigged can't save changes. Start it to save this ${noun}.`
+      : `Your subscription has ended, so Jigged is read-only. Resubscribe to save this ${noun}.`;
+
+  return (
+    <Alert
+      severity="warning"
+      onClose={onClose}
+      sx={{
+        ...(canSubscribe && {
+          '& .MuiAlert-message': {
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+            gap: 2,
+            flexWrap: 'wrap',
+          },
+        }),
+        ...sx,
+      }}
+    >
+      {message}
+      {canSubscribe && (
+        <Box component="span" sx={{ flexShrink: 0 }}>
+          <SubscribeButton label={subscription?.mustSubscribe ? 'Subscribe' : undefined} />
+        </Box>
+      )}
+    </Alert>
+  );
+}

--- a/components/common/ErrorAlert.tsx
+++ b/components/common/ErrorAlert.tsx
@@ -61,7 +61,6 @@ export default function ErrorAlert({
   sx,
 }: ErrorAlertProps) {
   const subscription = useOptionalSubscription();
-  const { isAdmin, loading: roleLoading } = useUserRole();
 
   if (!error) return null;
 
@@ -70,34 +69,94 @@ export default function ErrorAlert({
   );
   const isBilling = contextSaysBlocked || isBillingWriteBlocked(error);
 
-  if (!isBilling) {
-    const message =
-      typeof error === 'string' ? error : friendlyErrorMessage(error, { entity, references, fallback });
-
+  if (isBilling && subscription) {
     return (
-      <Alert severity="error" onClose={onClose} sx={sx}>
-        {message}
+      <BillingBlockedAlert
+        mustSubscribe={subscription.mustSubscribe}
+        entity={entity ?? 'change'}
+        onClose={onClose}
+        sx={sx}
+      />
+    );
+  }
+
+  if (isBilling) {
+    // No SubscriptionProvider: the operator app. They cannot subscribe and cannot reach Settings,
+    // so name neither — "the office" is what a machinist would actually say.
+    return (
+      <Alert severity="warning" onClose={onClose} sx={sx}>
+        Your shop&apos;s subscription isn&apos;t active, so this can&apos;t be saved. Let the office
+        know — an admin can turn it back on.
       </Alert>
     );
   }
 
-  const noun = entity ?? 'change';
+  return (
+    <Alert severity="error" onClose={onClose} sx={sx}>
+      {messageFor(error, { entity, references, fallback })}
+    </Alert>
+  );
+}
+
+/**
+ * An Error we threw ourselves, whose message is a sentence already written for a human —
+ * "This operation cannot be received.", "A quote must include at least one part."
+ *
+ * Told apart by the absence of a SQLSTATE: a raw Supabase failure is a plain object (not an
+ * Error) carrying `code`, and `toFriendlyError` copies that `code` onto what it produces.
+ * A hand-written Error has neither.
+ *
+ * Without this check those messages were replaced by the generic fallback, because
+ * `friendlyErrorMessage` matches on codes and finds none — a regression against the
+ * `err instanceof Error ? err.message : …` this component replaces, which passed them through.
+ */
+function isHandWrittenMessage(error: unknown): error is Error {
+  return (
+    error instanceof Error &&
+    !(error as Error & { code?: unknown }).code &&
+    Boolean(error.message)
+  );
+}
+
+function messageFor(
+  error: unknown,
+  options: { entity?: string; references?: string; fallback?: string },
+): string {
+  if (typeof error === 'string') return error;
+  if (isHandWrittenMessage(error)) return error.message;
+  return friendlyErrorMessage(error, options);
+}
+
+/**
+ * The billing branch, split out for one reason: it needs the caller's ROLE, and reading that
+ * pulls in `useAuth` and `useParams`. An error alert must never be the thing that throws — it is
+ * what renders when something has already gone wrong — so those hooks are confined to the one
+ * branch that cannot be reached without a SubscriptionProvider above it.
+ */
+function BillingBlockedAlert({
+  mustSubscribe,
+  entity,
+  onClose,
+  sx,
+}: {
+  mustSubscribe: boolean;
+  entity: string;
+  onClose?: () => void;
+  sx?: SxProps<Theme>;
+}) {
+  const { isAdmin, loading } = useUserRole();
 
   // Only an admin can act on this. `/dashboard/[companyId]/settings` is behind AdminGuard and the
   // Stripe routes call `_verify_company_admin`, so offering the button to anyone else ends in a
-  // 403 — the confirm-then-error two-step interaction-standards.md §4 tells us to avoid. Suppress
-  // it while the role is still loading too, for the same reason.
-  const canSubscribe = Boolean(subscription) && !roleLoading && isAdmin;
+  // 403 — the confirm-then-error two-step interaction-standards.md §4 tells us to avoid. Suppressed
+  // while the role is still loading, for the same reason.
+  const canSubscribe = !loading && isAdmin;
 
   const message = !canSubscribe
-    ? // True whether they are a `user` on the dashboard or an operator on the shop floor. The
-      // operator wording deliberately avoids naming Settings, which they cannot reach.
-      subscription
-      ? `Your shop's subscription isn't active, so this can't be saved. An admin at your shop can restart it in Settings.`
-      : `Your shop's subscription isn't active, so this can't be saved. Let the office know — an admin can turn it back on.`
-    : subscription?.mustSubscribe
-      ? `Your subscription hasn't started yet, so Jigged can't save changes. Start it to save this ${noun}.`
-      : `Your subscription has ended, so Jigged is read-only. Resubscribe to save this ${noun}.`;
+    ? `Your shop's subscription isn't active, so this can't be saved. An admin at your shop can restart it in Settings.`
+    : mustSubscribe
+      ? `Your subscription hasn't started yet, so Jigged can't save changes. Start it to save this ${entity}.`
+      : `Your subscription has ended, so Jigged is read-only. Resubscribe to save this ${entity}.`;
 
   return (
     <Alert
@@ -120,7 +179,7 @@ export default function ErrorAlert({
       {message}
       {canSubscribe && (
         <Box component="span" sx={{ flexShrink: 0 }}>
-          <SubscribeButton label={subscription?.mustSubscribe ? 'Subscribe' : undefined} />
+          <SubscribeButton label={mustSubscribe ? 'Subscribe' : undefined} />
         </Box>
       )}
     </Alert>

--- a/components/customers/CustomerForm.tsx
+++ b/components/customers/CustomerForm.tsx
@@ -8,7 +8,7 @@ import CardContent from '@mui/material/CardContent';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
-import Alert from '@mui/material/Alert';
+import ErrorAlert from '@/components/common/ErrorAlert';
 import CircularProgress from '@mui/material/CircularProgress';
 import Grid from '@mui/material/Grid';
 import FormControl from '@mui/material/FormControl';
@@ -70,7 +70,9 @@ export default function CustomerForm({
     EMPTY_CUSTOMER_CONTACT_FORM,
   );
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Holds the caught error, not a formatted string — ErrorAlert needs the object to tell
+  // a billing block from an ordinary failure.
+  const [error, setError] = useState<unknown>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   const handleChange =
@@ -170,7 +172,7 @@ export default function CustomerForm({
         router.push(`/dashboard/${companyId}/customers/${customer.id}`);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
+      setError(err);
     } finally {
       setLoading(false);
     }
@@ -186,10 +188,13 @@ export default function CustomerForm({
 
   return (
     <Box component="form" onSubmit={handleSubmit}>
-      {error && (
-        <Alert severity="error" sx={{ mb: 3 }}>
-          {error}
-        </Alert>
+      {error != null && (
+        <ErrorAlert
+          error={error}
+          entity="customer"
+          fallback="Couldn't save this customer. Please try again."
+          sx={{ mb: 3 }}
+        />
       )}
 
       {/* Basic Information */}

--- a/components/jobs/AcceptPurchaseOrderModal.tsx
+++ b/components/jobs/AcceptPurchaseOrderModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import ErrorAlert from '@/components/common/ErrorAlert';
 import { useState, useEffect, useMemo, useRef } from 'react';
 import posthog from 'posthog-js';
 import Dialog from '@mui/material/Dialog';
@@ -92,7 +93,9 @@ export default function AcceptPurchaseOrderModal({
   onCreated,
 }: AcceptPurchaseOrderModalProps) {
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Holds the caught error, not a formatted string — ErrorAlert needs the object to tell
+  // a billing block from an ordinary failure.
+  const [error, setError] = useState<unknown>(null);
   const [attachmentWarning, setAttachmentWarning] = useState<string | null>(null);
   // Set when the job was created but we paused (e.g. the PDF failed) so the
   // primary button becomes "Open Job" instead of silently navigating away.
@@ -285,7 +288,7 @@ export default function AcceptPurchaseOrderModal({
       });
       onCreated(result.job_id);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create the job.');
+      setError(err);
     } finally {
       setLoading(false);
     }
@@ -306,10 +309,14 @@ export default function AcceptPurchaseOrderModal({
       <DialogTitle>Accept Purchase Order</DialogTitle>
       <DialogContent>
         <Box sx={{ pt: 1 }}>
-          {error && (
-            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-              {error}
-            </Alert>
+          {error != null && (
+            <ErrorAlert
+              error={error}
+              entity="job"
+              fallback="Couldn't create the job. Please try again."
+              onClose={() => setError(null)}
+              sx={{ mb: 2 }}
+            />
           )}
           {attachmentWarning && (
             <Alert severity="warning" sx={{ mb: 2 }}>

--- a/components/operator/OperatorLocationActionModal.tsx
+++ b/components/operator/OperatorLocationActionModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import ErrorAlert from '@/components/common/ErrorAlert';
 import { useState } from 'react';
 import posthog from 'posthog-js';
 import Dialog from '@mui/material/Dialog';
@@ -11,7 +12,6 @@ import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import Alert from '@mui/material/Alert';
 
 import {
   addStockAtLocation,
@@ -19,7 +19,6 @@ import {
   adjustStockAtLocation,
   transferStock,
 } from '@/utils/inventoryLocationsAccess';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import JobTagPicker, { loadTaggableJobs } from '@/components/inventory/JobTagPicker';
 import MovementPhotoField from '@/components/operator/MovementPhotoField';
 import { generateStoragePath, uploadFileToStorage } from '@/utils/storageHelpers';
@@ -95,7 +94,9 @@ export default function OperatorLocationActionModal({
   const [unit, setUnit] = useState(primaryUnit);
   const [notes, setNotes] = useState('');
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Holds the caught error, not a formatted string — ErrorAlert needs the object to tell a
+  // billing block from an ordinary failure. Validation still sets plain strings, which it renders.
+  const [error, setError] = useState<unknown>(null);
 
   // Optional job tag, deplete only. Loaded on open via onEnter (house
   // convention — not a useEffect, which would trip set-state-in-effect lint).
@@ -211,7 +212,7 @@ export default function OperatorLocationActionModal({
     } catch (e) {
       // Supabase errors are plain objects, not Error instances — `instanceof` would drop the
       // reason the database gave us.
-      setError(friendlyErrorMessage(e, { entity: 'stock', fallback: 'Failed to update stock.' }));
+      setError(e);
     } finally {
       setSaving(false);
     }
@@ -293,7 +294,9 @@ export default function OperatorLocationActionModal({
           {showPhoto && (
             <MovementPhotoField value={photo} onChange={setPhoto} disabled={saving} />
           )}
-          {error && <Alert severity="error">{error}</Alert>}
+          {error != null && (
+            <ErrorAlert error={error} entity="stock" fallback="Failed to update stock." />
+          )}
         </Stack>
       </DialogContent>
       <DialogActions>

--- a/components/parts/PartLocationActionModal.tsx
+++ b/components/parts/PartLocationActionModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import ErrorAlert from '@/components/common/ErrorAlert';
 import { useState } from 'react';
 import posthog from 'posthog-js';
 import Dialog from '@mui/material/Dialog';
@@ -25,7 +26,6 @@ import JobTagPicker, { loadTaggableJobs } from '@/components/inventory/JobTagPic
 import LocationPicker, {
   type LocationPickerOption,
 } from '@/components/inventory/locations/LocationPicker';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type { JobWithRelations } from '@/types/job';
 
 export type LocationAction = 'add' | 'deplete' | 'adjust' | 'move';
@@ -100,7 +100,9 @@ export default function PartLocationActionModal({
   const [unit, setUnit] = useState(primaryUnit);
   const [notes, setNotes] = useState('');
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Holds the caught error, not a formatted string — ErrorAlert needs the object to tell a
+  // billing block from an ordinary failure. Validation still sets plain strings, which it renders.
+  const [error, setError] = useState<unknown>(null);
 
   // Optional job tag on a removal — issue #59. The operator path has always had this; the
   // owner path lost it in the May parts unification.
@@ -256,7 +258,7 @@ export default function PartLocationActionModal({
     } catch (e) {
       // Supabase errors are plain objects, not Error instances, so `instanceof` fell through
       // to the generic string and threw away the reason the database gave us.
-      setError(friendlyErrorMessage(e, { entity: 'stock', fallback: 'Failed to update stock.' }));
+      setError(e);
     } finally {
       setSaving(false);
     }
@@ -375,7 +377,9 @@ export default function PartLocationActionModal({
             minRows={2}
             fullWidth
           />
-          {error && <Alert severity="error">{error}</Alert>}
+          {error != null && (
+            <ErrorAlert error={error} entity="stock" fallback="Failed to update stock." />
+          )}
         </Stack>
       </DialogContent>
       <DialogActions>

--- a/components/parts/workspace/PartIdentitySection.tsx
+++ b/components/parts/workspace/PartIdentitySection.tsx
@@ -8,7 +8,7 @@ import CardContent from '@mui/material/CardContent';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
-import Alert from '@mui/material/Alert';
+import ErrorAlert from '@/components/common/ErrorAlert';
 import CircularProgress from '@mui/material/CircularProgress';
 import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
@@ -67,7 +67,9 @@ export default function PartIdentitySection({
     mode === 'existing' && part ? partToFormData(part) : { ...EMPTY_PART_FORM, ...initialDefaults },
   );
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
-  const [error, setError] = useState<string | null>(null);
+  // Holds the caught error itself, not a pre-formatted string — ErrorAlert needs the object to
+  // tell a billing block from an ordinary failure.
+  const [error, setError] = useState<unknown>(null);
   const [creating, setCreating] = useState(false);
   const [saveStatus, setSaveStatus] = useState<SaveState>('idle');
 
@@ -123,7 +125,7 @@ export default function PartIdentitySection({
       onSaved?.(updated);
     } catch (err) {
       setSaveStatus('error');
-      setError(err instanceof Error ? err.message : 'Failed to save');
+      setError(err);
     }
   };
 
@@ -182,7 +184,7 @@ export default function PartIdentitySection({
       });
       onCreated?.(created);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create part');
+      setError(err);
       setCreating(false);
     }
   };
@@ -321,10 +323,13 @@ export default function PartIdentitySection({
           {mode === 'existing' && <SaveStatus state={saveStatus} />}
         </Box>
 
-        {error && (
-          <Alert severity="error" sx={{ mb: 3 }}>
-            {error}
-          </Alert>
+        {error != null && (
+          <ErrorAlert
+            error={error}
+            entity="part"
+            fallback="Couldn't save this part. Please try again."
+            sx={{ mb: 3 }}
+          />
         )}
 
         {mode === 'create' ? (

--- a/components/providers/SubscriptionProvider.tsx
+++ b/components/providers/SubscriptionProvider.tsx
@@ -47,6 +47,20 @@ export function useSubscription(): SubscriptionContextType {
   return context;
 }
 
+/**
+ * The subscription context, or `null` outside a provider.
+ *
+ * For components shared between the two shells. The provider wraps `/dashboard/[companyId]/*` only;
+ * the operator app deliberately does not mount it (operators cannot subscribe, and the bundle costs
+ * them cellular data), so `useSubscription` would throw there.
+ *
+ * `useSubscription` still throws — an accidental omission inside the dashboard should stay loud.
+ * Reach for this one only when rendering outside the provider is a supported case.
+ */
+export function useOptionalSubscription(): SubscriptionContextType | null {
+  return useContext(SubscriptionContext);
+}
+
 export default function SubscriptionProvider({ children }: { children: ReactNode }) {
   const params = useParams();
   const companyId = params.companyId as string;

--- a/components/quotes/ConvertToJobModal.tsx
+++ b/components/quotes/ConvertToJobModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import ErrorAlert from '@/components/common/ErrorAlert';
 import { useState, useMemo } from 'react';
 import posthog from 'posthog-js';
 import Dialog from '@mui/material/Dialog';
@@ -105,7 +106,9 @@ export default function ConvertToJobModal({
   onConverted,
 }: ConvertToJobModalProps) {
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Holds the caught error, not a formatted string — ErrorAlert needs the object to tell
+  // a billing block from an ordinary failure.
+  const [error, setError] = useState<unknown>(null);
 
   // Due date is entered manually — lead time is free text and no longer
   // implies a date. Starts empty; required + not-in-the-past to convert.
@@ -308,7 +311,7 @@ export default function ConvertToJobModal({
       });
       onConverted(result.job.id);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to convert quote to job');
+      setError(err);
     } finally {
       setLoading(false);
     }
@@ -334,10 +337,14 @@ export default function ConvertToJobModal({
       <DialogTitle>Convert to Job</DialogTitle>
       <DialogContent>
         <Box sx={{ pt: 1 }}>
-          {error && (
-            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-              {error}
-            </Alert>
+          {error != null && (
+            <ErrorAlert
+              error={error}
+              entity="job"
+              fallback="Couldn't convert this quote to a job. Please try again."
+              onClose={() => setError(null)}
+              sx={{ mb: 2 }}
+            />
           )}
 
           {attachmentWarning && (

--- a/components/shipments/ShipmentForm.tsx
+++ b/components/shipments/ShipmentForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import ErrorAlert from '@/components/common/ErrorAlert';
 import {
   useCallback,
   useDeferredValue,
@@ -141,7 +142,9 @@ export default function ShipmentForm({
 }: ShipmentFormProps) {
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Holds the caught error, not a formatted string — ErrorAlert needs the object to tell
+  // a billing block from an ordinary failure.
+  const [error, setError] = useState<unknown>(null);
 
   const [customer, setCustomer] = useState<CustomerContext | null>(null);
   const [company, setCompany] = useState<Company | null>(null);
@@ -634,7 +637,7 @@ export default function ShipmentForm({
       });
     } catch (err) {
       console.error('createShipment failed:', err);
-      setError(err instanceof Error ? err.message : 'Failed to create shipment.');
+      setError(err);
     } finally {
       setSubmitting(false);
     }
@@ -657,12 +660,20 @@ export default function ShipmentForm({
   }
 
   if (!customer) {
-    return <Alert severity="error">{error ?? 'Shipment context not available.'}</Alert>;
+    return (
+      <ErrorAlert error={error ?? 'Shipment context not available.'} entity="shipment" />
+    );
   }
 
   return (
     <Stack spacing={3}>
-      {error && <Alert severity="error">{error}</Alert>}
+      {error != null && (
+        <ErrorAlert
+          error={error}
+          entity="shipment"
+          fallback="Couldn't save this shipment. Please try again."
+        />
+      )}
 
       {/* CREDIT HOLD — warn, never gate.
           Deliberately a standalone render off `customer`, not an entry in

--- a/components/vendors/VendorForm.tsx
+++ b/components/vendors/VendorForm.tsx
@@ -8,7 +8,7 @@ import CardContent from '@mui/material/CardContent';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
-import Alert from '@mui/material/Alert';
+import ErrorAlert from '@/components/common/ErrorAlert';
 import CircularProgress from '@mui/material/CircularProgress';
 import Grid from '@mui/material/Grid';
 import FormControl from '@mui/material/FormControl';
@@ -81,7 +81,9 @@ export default function VendorForm({
     EMPTY_VENDOR_CONTACT_FORM,
   );
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Holds the caught error, not a formatted string — ErrorAlert needs the object to tell
+  // a billing block from an ordinary failure.
+  const [error, setError] = useState<unknown>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   const handleChange =
@@ -204,7 +206,7 @@ export default function VendorForm({
         }
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
+      setError(err);
     } finally {
       setLoading(false);
     }
@@ -222,10 +224,13 @@ export default function VendorForm({
 
   return (
     <Box component="form" onSubmit={handleSubmit}>
-      {error && (
-        <Alert severity="error" sx={{ mb: 3 }}>
-          {error}
-        </Alert>
+      {error != null && (
+        <ErrorAlert
+          error={error}
+          entity="vendor"
+          fallback="Couldn't save this vendor. Please try again."
+          sx={{ mb: 3 }}
+        />
       )}
 
       {/* Basic Information */}

--- a/components/work-centers/WorkCenterForm.tsx
+++ b/components/work-centers/WorkCenterForm.tsx
@@ -9,6 +9,7 @@ import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
+import ErrorAlert from '@/components/common/ErrorAlert';
 import CircularProgress from '@mui/material/CircularProgress';
 import InputAdornment from '@mui/material/InputAdornment';
 import ToggleButton from '@mui/material/ToggleButton';
@@ -73,7 +74,9 @@ export default function WorkCenterForm({
 
   const [formData, setFormData] = useState<WorkCenterFormData>(initialData);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Holds the caught error, not a formatted string — ErrorAlert needs the object to tell
+  // a billing block from an ordinary failure.
+  const [error, setError] = useState<unknown>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   const handleTextChange = (field: keyof WorkCenterFormData) => (
@@ -186,7 +189,7 @@ export default function WorkCenterForm({
         }
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
+      setError(err);
     } finally {
       setLoading(false);
     }
@@ -204,10 +207,13 @@ export default function WorkCenterForm({
 
   return (
     <Box component="form" onSubmit={handleSubmit}>
-      {error && (
-        <Alert severity="error" sx={{ mb: 3 }}>
-          {error}
-        </Alert>
+      {error != null && (
+        <ErrorAlert
+          error={error}
+          entity="work center"
+          fallback="Couldn't save this work center. Please try again."
+          sx={{ mb: 3 }}
+        />
       )}
 
       <Card elevation={2} sx={{ mb: 3 }}>

--- a/docs/interaction-standards.md
+++ b/docs/interaction-standards.md
@@ -421,3 +421,37 @@ When an action can't be performed in the current state, prefer (in order):
 
 Avoid: a confirm dialog that ends in an error ("are you sure?" → "can't do that")
 — two steps to a dead-end. Resolve via rule 1.
+
+### Worked example — a shop whose subscription lapsed (rule 1)
+
+The billing write-gate blocks every write in Postgres, so *every* create and save
+button on the dashboard is a control whose press will be refused. It is the largest
+"unavailable action" surface in the app, and the temptation is rule 3 — hide the New
+buttons — or rule 2, disable them. Both are wrong here: this is not irrelevant to the
+user and not a permanent property of the object. It is temporary, and **the user can
+unlock it themselves**.
+
+So it is rule 1 throughout:
+
+- The controls stay exactly as they are — visible, focusable, pressable. No
+  `disabled`, no hiding, on any of the ~90 write surfaces.
+- Pressing one produces
+  [`ErrorAlert`](../components/common/ErrorAlert.tsx), which says *why* in plain
+  words and carries the fix — a **Subscribe** button, for the one role that can use
+  it. That is the "explain on attempt" half.
+- [`SubscriptionRequiredNotice`](../components/billing/SubscriptionRequiredNotice.tsx)
+  adds the explanation *before* the attempt on the five create routes, so nobody
+  fills a whole form to find out. It is an explanation, **not** a disable — the form
+  and its submit are untouched.
+
+Two details generalise beyond billing:
+
+- **The reason must fit the role.** Only an admin can subscribe (`/settings` is
+  behind `AdminGuard`; the Stripe routes 403 everyone else), so the button renders
+  only for them. Showing it to a `user` would be precisely the confirm-then-error
+  two-step above. Everyone else gets copy naming who *can* act.
+- **Never assert a negative you haven't confirmed.** Entitlement starts unresolved,
+  and unresolved reads as "cannot write" — so both components render nothing until
+  it loads. Otherwise every healthy shop sees a subscription warning flash on every
+  page load, which is the "couldn't check is never denied" rule from
+  [CLAUDE.md](../CLAUDE.md) in UI form.

--- a/docs/modules/billing.md
+++ b/docs/modules/billing.md
@@ -215,6 +215,14 @@ The DB refuses the write; the UI has to explain it. That path lives in
 - `SubscriptionRequiredNotice` says it up front on the five create routes, as an
   explanation rather than a disabled control — see
   [interaction-standards §4](../interaction-standards.md).
+- **The wording comes from `subscription_status`, not from entitlement.**
+  [`lib/billingCopy.ts`](../../lib/billingCopy.ts) maps the billing row to
+  `never_started | ended | paused`, because `read_only` deliberately collapses
+  canceled, unpaid *and* paused — right for the write gate, wrong for a sentence.
+  Telling a paused shop it "has ended", or a never-subscribed one to "resubscribe",
+  are both false, and both were shipped before this split. It is the same field
+  `BillingCard` branches on, so the message on a blocked save matches the one in
+  Settings when the user goes looking for the cause.
 - `shouldReportSupabaseError` **drops** billing denials. The Supabase capture net
   files every `{ error }` response, so a lapsed shop would otherwise generate a Sentry
   issue on every write it attempts — the most predictable non-failure the app can

--- a/docs/modules/billing.md
+++ b/docs/modules/billing.md
@@ -125,7 +125,100 @@ seeder are unaffected.
 
 **Storage:** the private `attachments` bucket's `storage.objects` INSERT/DELETE
 policies also call `company_can_write` (company derived from the first path
-segment), so a lapsed shop can't upload; SELECT stays open.
+segment), so a lapsed shop can't upload; SELECT stays open. Note these are
+**permissive**, not restrictive — which is why a blocked upload's message carries no
+policy name (see §4.1).
+
+### 4.1 How a blocked write fails, per verb
+
+The three verbs do **not** fail the same way, and the difference is load-bearing.
+
+| Verb | Policy shape | What the client sees |
+|---|---|---|
+| INSERT | `WITH CHECK (company_can_write(...))` | raises **42501**, message names `billing_gate_insert` |
+| UPDATE | `USING (true) WITH CHECK (company_can_write(...))` | raises **42501**, message names `billing_gate_update` |
+| DELETE | `USING (company_can_write(...))` | **silent** — zero rows, no error |
+
+**UPDATE used to be silent too**, and that was a bug rather than a design:
+`USING (company_can_write(...))` *filters* the row out of the statement instead of
+refusing it, so a blocked save changed nothing and reported nothing. A call site with
+`.select().single()` saw `PGRST116` ("no rows returned") — a misleading *not found*
+for a write that was refused — and one without it saw success.
+`markOperationReceived` returned `{ success: true }` and told the shop floor that
+outside work was back while the row sat untouched.
+[`20260807015028_billing_gate_update_with_check.sql`](../../supabase/migrations/20260807015028_billing_gate_update_with_check.sql)
+moved the check to `WITH CHECK` so it raises. Enforcement is unchanged, because
+`NEW.company_id ≡ OLD.company_id` on every real path — and a
+`<table>_gate_key_immutable` trigger now enforces that for the browser roles, so the
+equivalence is guaranteed rather than argued. It is also one `company_can_write()`
+call per row instead of two.
+
+**DELETE stays silent on purpose.** A DELETE policy has no `WITH CHECK`, so the only
+RLS-shaped fix is `USING (true)` plus a `BEFORE DELETE` trigger that raises — which
+inverts the failure mode from fail-closed to **fail-open** if that trigger is ever
+dropped. Not worth it here: this repo soft-deletes every user-facing entity
+(archive is an UPDATE, so it is covered above), and the remaining hard deletes are
+line items, contacts, tiers and reactions, where the worst outcome is the row
+reappearing on reload. Those call sites assert the returned row count instead —
+`assertDeleted` in [`lib/supabaseErrors.ts`](../../lib/supabaseErrors.ts).
+`test_delete_is_silently_filtered_when_lapsed` pins the decision so it is not
+"fixed" by accident.
+
+**The policy name in the message is a contract.**
+`isBillingWriteBlocked` keys on the `billing_gate` substring to tell a lapsed
+subscription from a plain permission denial, and the user-facing copy, the Subscribe
+button and the Sentry exemption all hang off that. It works because Postgres emits
+one `WithCheckOption` per RESTRICTIVE policy, each carrying its own `polname`, while
+OR-folding the permissive ones into a single **nameless** entry — so a membership
+failure produces the bare `new row violates row-level security policy for table "x"`
+and is never mistaken for a billing block. Both directions are asserted:
+`test_blocked_writes_name_the_billing_policy` and
+`test_permissive_denial_is_nameless`. **Renaming these policies silently reverts
+every billing message in the product to "You don't have permission to do that."**
+
+A third CI guard covers the shape itself:
+`tenant_tables_with_silent_update_gate()` → `test_update_gate_never_filters` fails if
+any `billing_gate_update` still uses a filtering `USING`, because the natural thing
+for the next person to hand-write is the `USING(...) WITH CHECK(...)` pair they see
+on every other policy.
+
+**Triggers are safe by construction, and worth stating so nobody re-audits it:** a
+trigger that cascades an UPDATE onto a gated table only fires because the user's
+primary write succeeded, which means the shop can write, which means the cascade
+passes too. The audit of invoker-rights trigger functions that update gated tables
+found no exceptions.
+
+### 4.2 What the user is told
+
+The DB refuses the write; the UI has to explain it. That path lives in
+[`lib/supabaseErrors.ts`](../../lib/supabaseErrors.ts) and
+[`components/common/ErrorAlert.tsx`](../../components/common/ErrorAlert.tsx):
+
+- `isBillingWriteBlocked(err)` — matches the two denial shapes: the RLS policy name
+  above, and `inv_assert_can_write`'s `company … has no active subscription`. Walks
+  `Error.cause`, so it still classifies after normalisation.
+- `friendlyErrorMessage` checks billing **before** its generic 42501 branch. Without
+  that ordering a lapsed owner was told *"You don't have permission to do that."* —
+  a role diagnosis that sends them to ask an admin for access they already have.
+- `toFriendlyError` is what the access layer throws. Supabase rejects with a plain
+  object on the `{ data, error }` path, so `err instanceof Error` was false at ~179
+  catch sites and every one fell through to a generic `'Failed to …'`.
+- `ErrorAlert` checks **subscription context before error shape**. That ordering is
+  what catches the cases the error cannot describe: a `PGRST116` from a filtered
+  update, and a nameless storage 403. It guards on `!isLoading`, because
+  `isLoading` starts true with `billing: null`, which resolves to `must_subscribe` —
+  so `canWrite` is false for a *healthy* shop during its first fetch.
+- The Subscribe button renders **only for an admin**: `/settings` is behind
+  `AdminGuard` and the Stripe routes call `_verify_company_admin`, so offering it to
+  anyone else ends in a 403. Operators get wording pointing at the office rather than
+  a page they cannot reach.
+- `SubscriptionRequiredNotice` says it up front on the five create routes, as an
+  explanation rather than a disabled control — see
+  [interaction-standards §4](../interaction-standards.md).
+- `shouldReportSupabaseError` **drops** billing denials. The Supabase capture net
+  files every `{ error }` response, so a lapsed shop would otherwise generate a Sentry
+  issue on every write it attempts — the most predictable non-failure the app can
+  produce. A *nameless* privilege denial still reports; that one is a bug.
 
 ## 5. Webhook + sync — single source-of-truth pattern
 

--- a/hooks/useUserRole.ts
+++ b/hooks/useUserRole.ts
@@ -10,7 +10,9 @@ export type UserRole = 'admin' | 'user' | 'operator' | null;
 export function useUserRole() {
   const { user } = useAuth();
   const params = useParams();
-  const companyId = params.companyId as string | undefined;
+  // `useParams()` returns null outside a route segment, so this must be optional — the loader
+  // below already treats a missing company as "no role".
+  const companyId = params?.companyId as string | undefined;
   // Key on the id, NOT the `user` object. AuthProvider calls setUser on every
   // auth event (INITIAL_SESSION, SIGNED_IN, each TOKEN_REFRESHED), each time
   // with a fresh User object carrying the same id — keying on the object

--- a/lib/billingCopy.ts
+++ b/lib/billingCopy.ts
@@ -1,0 +1,106 @@
+import type { BillingRow } from '@/lib/entitlement';
+
+/**
+ * Why a company can't write, in the terms a human would use.
+ *
+ * `Entitlement` is deliberately coarse — it answers "may this shop write?", and `read_only`
+ * covers canceled, unpaid AND paused because the write gate treats them identically. That is
+ * right for enforcement and wrong for copy: telling a shop whose subscription is *paused* that it
+ * "has ended" is simply untrue, and telling one that never subscribed to "resubscribe" names an
+ * action that does not exist for them.
+ *
+ * So the copy branches on `subscription_status`, the same field
+ * [`BillingCard`](../components/settings/BillingCard.tsx) uses for its status chip and detail
+ * line — which is what keeps the message a user sees on a blocked save consistent with the one
+ * they see in Settings when they go looking for the cause.
+ */
+export type WriteBlockedState = 'never_started' | 'ended' | 'paused';
+
+/**
+ * Map the billing row to the reason writes are refused.
+ *
+ * Only meaningful for a company that actually cannot write; callers check entitlement first.
+ * `null` billing is the common case — a new company has no `company_billing` row at all.
+ */
+export function writeBlockedState(billing: BillingRow | null): WriteBlockedState {
+  switch (billing?.subscription_status) {
+    case 'paused':
+      return 'paused';
+    case 'canceled':
+    case 'unpaid':
+      return 'ended';
+    // No row, `incomplete`, `incomplete_expired`, a null status, or anything unexpected: nothing
+    // ever successfully started, so "ended" would be wrong and "resubscribe" would be a verb for
+    // an action they have never taken.
+    default:
+      return 'never_started';
+  }
+}
+
+/** How the state reads mid-sentence: "Your subscription {…}". */
+const CLAUSE: Record<WriteBlockedState, string> = {
+  never_started: "hasn't started yet",
+  ended: 'has ended',
+  paused: 'is paused',
+};
+
+/** The consequence clause that follows. */
+const CONSEQUENCE: Record<WriteBlockedState, string> = {
+  never_started: "so Jigged can't save changes",
+  ended: 'so Jigged is read-only',
+  paused: 'so Jigged is read-only',
+};
+
+/** What the person who CAN fix it does — imperative, for a sentence they are the subject of. */
+const ACTION: Record<WriteBlockedState, string> = {
+  never_started: 'Start it',
+  ended: 'Resubscribe',
+  paused: 'Resume it',
+};
+
+/** The same action as something an admin does, for copy aimed at everyone else. */
+const ADMIN_ACTION: Record<WriteBlockedState, string> = {
+  never_started: 'start it',
+  ended: 'restart it',
+  paused: 'resume it',
+};
+
+/**
+ * "Your subscription hasn't started yet, so Jigged can't save changes. Start it to save this part."
+ * For someone who can act on it.
+ */
+export function blockedMessageForAdmin(state: WriteBlockedState, entity: string): string {
+  return `Your subscription ${CLAUSE[state]}, ${CONSEQUENCE[state]}. ${ACTION[state]} to save this ${entity}.`;
+}
+
+/**
+ * For a `user` who cannot reach Settings' billing card or the Stripe routes — names who can
+ * instead of an action they cannot take.
+ */
+export function blockedMessageForNonAdmin(state: WriteBlockedState): string {
+  return `Your shop's subscription ${CLAUSE[state]}, so this can't be saved. An admin at your shop can ${ADMIN_ACTION[state]} in Settings.`;
+}
+
+/**
+ * For the operator app, which mounts no SubscriptionProvider and whose users can neither
+ * subscribe nor open Settings. Deliberately names neither.
+ */
+export function blockedMessageForOperator(): string {
+  return `Your shop's subscription isn't active, so this can't be saved. Let the office know — an admin can turn it back on.`;
+}
+
+/**
+ * Said BEFORE the attempt, on a create page: "Start your subscription to add parts to Jigged."
+ * `entityPlural` reads mid-sentence — "parts", "customers", "work centers".
+ */
+export function blockedNoticeForAdmin(state: WriteBlockedState, entityPlural: string): string {
+  if (state === 'never_started') {
+    return `Start your subscription to add ${entityPlural} to Jigged.`;
+  }
+  return `Your subscription ${CLAUSE[state]}, ${CONSEQUENCE[state]}. ${ACTION[state]} to add ${entityPlural} again.`;
+}
+
+/** The same notice for someone who cannot act on it. */
+export function blockedNoticeForNonAdmin(state: WriteBlockedState, entityPlural: string): string {
+  return `Your shop's subscription ${CLAUSE[state]}, so new ${entityPlural} can't be saved yet. An admin at your shop can ${ADMIN_ACTION[state]} in Settings.`;
+}

--- a/lib/supabaseErrors.ts
+++ b/lib/supabaseErrors.ts
@@ -114,6 +114,63 @@ export function isTransientAbortError(error: unknown): boolean {
 const PGRST_NO_ROWS = 'PGRST116';
 
 /**
+ * `insufficient_privilege` — every RLS denial, and every deliberate raise that borrows the code.
+ *
+ * Declared up here rather than with the other SQLSTATE constants below because
+ * `isBillingWriteBlocked` needs it and `shouldReportSupabaseError` needs *that*. `const` is not
+ * hoisted, so the order is load-bearing.
+ */
+const PG_INSUFFICIENT_PRIVILEGE = '42501';
+
+/**
+ * The two shapes a billing-gate denial arrives in — a lapsed or never-subscribed shop hitting the
+ * write gate, as opposed to a member who genuinely lacks permission.
+ *
+ *  1. RLS. A RESTRICTIVE policy carries its OWN name into the message:
+ *       new row violates row-level security policy "billing_gate_insert" for table "parts"
+ *     Postgres emits one WithCheckOption per restrictive policy, each keeping its `polname`, while
+ *     OR-folding all the permissive ones into a single NAMELESS entry. That is why `billing_gate`
+ *     is a safe discriminator: a plain membership denial produces the nameless form and is never
+ *     mistaken for a lapsed subscription. `test_permissive_denial_is_nameless` pins it in CI,
+ *     because the whole Subscribe CTA rests on it.
+ *  2. RPC. `inv_assert_can_write()` raises `insufficient_privilege` with
+ *       company <uuid> has no active subscription
+ *     (migration 20260801150944). The five SECURITY DEFINER stock RPCs bypass RLS by construction,
+ *     so they assert the gate themselves.
+ *
+ * NOT covered, deliberately: a blocked Storage upload. Those policies are permissive with
+ * `company_can_write` inlined, so the message carries no policy name and is indistinguishable by
+ * shape from a real permission failure. `ErrorAlert` catches that case from SubscriptionProvider
+ * context instead — see its classification order.
+ *
+ * Walks `cause` so it still answers correctly after `toFriendlyError` has replaced the message
+ * with user-facing copy. Depth-capped, and tolerant of a self-referential chain.
+ */
+const BILLING_GATE_POLICY_PREFIX = 'billing_gate';
+const BILLING_RPC_PHRASE = 'no active subscription';
+
+export function isBillingWriteBlocked(value: unknown): boolean {
+  let node: unknown = value;
+  for (let depth = 0; node && depth < 4; depth++) {
+    const record = asRecord(node);
+    const code = typeof record.code === 'string' ? record.code : '';
+    const message = typeof record.message === 'string' ? record.message : '';
+
+    if (
+      code === PG_INSUFFICIENT_PRIVILEGE &&
+      (message.includes(BILLING_GATE_POLICY_PREFIX) || message.includes(BILLING_RPC_PHRASE))
+    ) {
+      return true;
+    }
+
+    const next = record.cause;
+    if (next === node) return false;
+    node = next;
+  }
+  return false;
+}
+
+/**
  * Is this Supabase failure worth an issue in the queue?
  *
  * The Supabase Sentry integration (installed in `lib/supabase.ts`) captures EVERY `{ error }`
@@ -149,6 +206,20 @@ export function shouldReportSupabaseError(error: unknown): boolean {
   // Session expiry is not a bug and is already handled: the custom fetch in lib/supabase.ts
   // refreshes and retries, and `redirectToSessionExpiry` covers the rest.
   if (isAuthError(error)) return false;
+
+  /**
+   * The billing write-gate doing its job. A shop whose subscription lapsed generates one of these
+   * on every write it attempts, for as long as it stays lapsed — the single most predictable
+   * non-failure this app can produce, and the queue would fill with it.
+   *
+   * Note this is NOT the same judgement as "don't tell the user": the user gets a clear message
+   * and a Subscribe button (see `friendlyErrorMessage` and `ErrorAlert`). It only means nobody
+   * needs to be paged about a system working exactly as designed.
+   *
+   * A genuine permission denial still reports — that one IS a bug, and it produces the nameless
+   * form `isBillingWriteBlocked` deliberately does not match.
+   */
+  if (isBillingWriteBlocked(error)) return false;
 
   return true;
 }
@@ -186,6 +257,52 @@ export function toError(value: unknown, fallbackMessage = 'Unknown error'): Erro
   return error;
 }
 
+/**
+ * Brands an Error whose `.message` is already user-facing copy, so a second translation pass
+ * knows to leave it alone. `Symbol.for` rather than a property: invisible to `JSON.stringify`,
+ * to Sentry's serialiser, and to any `{ ...err }` spread.
+ */
+const FRIENDLY_ERROR = Symbol.for('jigged.friendlyError');
+
+/** True for an Error produced by `toFriendlyError`. */
+export function isFriendlyError(value: unknown): boolean {
+  return (
+    value instanceof Error &&
+    (value as unknown as Record<symbol, unknown>)[FRIENDLY_ERROR] === true
+  );
+}
+
+/**
+ * The access layer's throw: a real `Error` whose message is already the sentence to show a user.
+ *
+ * WHY THIS EXISTS. Supabase does not reject with an Error on the `{ data, error }` path — the
+ * builder does a bare `error = JSON.parse(body)` and hands back a plain object. (`PostgrestError`
+ * IS an Error subclass, but it is only constructed on the `.throwOnError()` path, which this repo
+ * does not use.) So `throw error` in an access function throws a non-Error, every
+ * `err instanceof Error ? err.message : 'Failed to X'` catch site takes the fallback branch, and
+ * the real reason is discarded — that is how a lapsed subscription rendered as "Failed to create
+ * part". Throwing this instead fixes the copy at ~90 existing catch sites with no UI change.
+ *
+ * `cause` keeps the original so `isBillingWriteBlocked` still classifies it after the message has
+ * been replaced; `code`/`details`/`hint` are copied as own properties so Sentry context survives.
+ * Idempotent, because several UI sites call `friendlyErrorMessage` on whatever they caught.
+ */
+export function toFriendlyError(value: unknown, options: FriendlyErrorOptions = {}): Error {
+  if (isFriendlyError(value)) return value as Error;
+
+  const error = new Error(friendlyErrorMessage(value, options), { cause: value });
+
+  const record = asRecord(value);
+  for (const key of ['code', 'details', 'hint'] as const) {
+    if (record[key] !== undefined && record[key] !== '') {
+      Object.assign(error, { [key]: record[key] });
+    }
+  }
+  Object.defineProperty(error, FRIENDLY_ERROR, { value: true, enumerable: false });
+
+  return error;
+}
+
 // ---------------------------------------------------------------------------
 // User-facing error translation
 // ---------------------------------------------------------------------------
@@ -195,7 +312,7 @@ export function toError(value: unknown, fallbackMessage = 'Unknown error'): Erro
 // never reach a user.
 const PG_FOREIGN_KEY_VIOLATION = '23503';
 const PG_UNIQUE_VIOLATION = '23505';
-const PG_INSUFFICIENT_PRIVILEGE = '42501';
+// PG_INSUFFICIENT_PRIVILEGE ('42501') is declared above, next to isBillingWriteBlocked.
 /**
  * `raise_exception` — what a bare `RAISE EXCEPTION` in one of our own SECURITY DEFINER
  * functions produces. Unlike a constraint code, this means *we* wrote the message deliberately
@@ -272,6 +389,11 @@ export function friendlyErrorMessage(
   error: unknown,
   options: FriendlyErrorOptions = {},
 ): string {
+  // Already translated. Re-deriving from friendly text loses information rather than adding any:
+  // the FK branch reads the *DB* clause to name what still references the row, so a second pass
+  // over "…still referenced by quotes" degrades it to "…by other records".
+  if (isFriendlyError(error)) return (error as Error).message;
+
   const err = asRecord(error);
   const code = typeof err.code === 'string' ? err.code : undefined;
   const message = typeof err.message === 'string' ? err.message : '';
@@ -284,6 +406,18 @@ export function friendlyErrorMessage(
 
   if (code === PG_UNIQUE_VIOLATION) {
     return `That ${entity} already exists — use a different value.`;
+  }
+
+  // Checked BEFORE the generic privilege branch below, which would otherwise answer a billing
+  // question with a role diagnosis — sending the owner to ask their admin for access instead of
+  // to the Subscribe button sitting at the top of the same page.
+  //
+  // Role-agnostic on purpose: this is the copy that appears wherever `ErrorAlert` is not used, so
+  // it has to be true for an operator as well as an owner, while still naming the way out for the
+  // one person who can take it. `ErrorAlert` replaces it with role-aware copy when it knows more.
+  if (isBillingWriteBlocked(error)) {
+    const noun = options.entity && options.entity !== 'item' ? options.entity : 'change';
+    return `Your shop's subscription isn't active, so that ${noun} wasn't saved. An admin can start one in Settings.`;
   }
 
   if (

--- a/lib/supabaseErrors.ts
+++ b/lib/supabaseErrors.ts
@@ -303,6 +303,29 @@ export function toFriendlyError(value: unknown, options: FriendlyErrorOptions = 
   return error;
 }
 
+/**
+ * Throw when a DELETE that should have removed one known row removed nothing.
+ *
+ * The billing gate blocks DELETE through a policy `USING` clause, which FILTERS the row out of
+ * the statement rather than raising. Unlike INSERT and UPDATE there is no `WITH CHECK` for a
+ * DELETE policy to fail loudly through, so a blocked delete is indistinguishable from a
+ * successful one at the client — it just quietly removes nothing and the row returns on reload.
+ * Counting the returned rows is the only way to notice.
+ *
+ * The wording is conditional on purpose: zero rows can equally mean the row was already gone (a
+ * double submit, a stale list), so the sentence has to be true either way.
+ *
+ * ONLY for deleting one specific row. Do NOT use where matching nothing is a normal outcome —
+ * clearing an already-empty list, or toggling a reaction off twice — or it reports failure for
+ * an operation that did exactly what was asked.
+ */
+export function assertDeleted(rows: unknown[] | null | undefined, entity: string): void {
+  if (rows && rows.length > 0) return;
+  throw new Error(
+    `That ${entity} couldn't be removed. If your shop's subscription isn't active, an admin can restart it in Settings.`,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // User-facing error translation
 // ---------------------------------------------------------------------------

--- a/supabase/migrations/20260807015028_billing_gate_update_with_check.sql
+++ b/supabase/migrations/20260807015028_billing_gate_update_with_check.sql
@@ -1,0 +1,229 @@
+-- Make a billing-blocked UPDATE fail loudly instead of silently doing nothing.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- THE PROBLEM
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- The billing gate blocks UPDATE through a RESTRICTIVE policy's USING clause:
+--
+--   USING (company_can_write(company_id)) WITH CHECK (company_can_write(company_id))
+--
+-- USING FILTERS. It removes the row from the statement's scan rather than raising,
+-- so a blocked UPDATE affects zero rows and reports no error at all. What the user
+-- gets depends only on how the call site was written:
+--
+--   .update(...).select().single()  →  PGRST116 "JSON object requested, multiple
+--                                      (or no) rows returned" — a misleading
+--                                      "not found" for a write that was refused
+--   .update(...)                    →  nothing. The save appears to succeed.
+--
+-- The second is the dangerous one. `markOperationReceived` returned
+-- `{ success: true }` and told the shop floor that outside work was back while the
+-- row sat untouched. (That call site is now checked in TypeScript too, but the
+-- database should not have been able to lie to it in the first place.)
+--
+-- INSERT never had this problem: a WITH CHECK failure raises 42501, and because
+-- restrictive policies each get their own WithCheckOption the message even names
+-- the policy — which is what lets the UI tell a lapsed subscription apart from a
+-- plain permission denial.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- THE FIX, AND WHY IT IS EQUIVALENT
+-- ═══════════════════════════════════════════════════════════════════════════════
+--   USING (true) WITH CHECK (company_can_write(company_id))
+--
+-- The gate stops pruning rows; the WITH CHECK still refuses the write, now raising
+--   ERROR: new row violates row-level security policy "billing_gate_update" for table "parts"
+-- with SQLSTATE 42501 — classifiable, and carrying the policy name the UI keys on.
+--
+-- Enforcement is unchanged because NEW.company_id ≡ OLD.company_id on every real
+-- path: no access function in utils/ writes company_id, or a gate-resolving parent
+-- FK. The one case that separates the two shapes is a caller who deliberately
+-- CHANGES the key to a company they may write in — which the trigger below closes,
+-- so the equivalence is enforced rather than argued.
+--
+-- It is also cheaper: the old shape evaluated company_can_write() twice per row
+-- (once in the scan qual, once in the check), the new one evaluates it once.
+--
+-- DELETE IS DELIBERATELY LEFT ALONE. There is no WITH CHECK for DELETE, so the
+-- only RLS-shaped fix would be USING (true) plus a BEFORE DELETE trigger that
+-- raises — which inverts the failure mode from fail-closed to fail-OPEN if that
+-- trigger is ever dropped. Not worth it here: this repo soft-deletes every
+-- user-facing entity (archive is an UPDATE, so it is covered by the above), and
+-- the remaining hard deletes are line items, contacts, tiers and reactions, where
+-- the worst outcome is the row reappearing on reload. Those call sites assert the
+-- returned row count instead — see assertDeleted in lib/supabaseErrors.ts.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. The immutability guard
+-- ─────────────────────────────────────────────────────────────────────────────
+-- With USING (true), a user who belongs to BOTH a lapsed company A and a writable
+-- company B could hand-craft a PATCH setting company_id = B on an A row: the
+-- restrictive WITH CHECK passes (B is writable) and so does the permissive
+-- membership check. That is not a billing bypass — it does not let them write in A
+-- — but it is a genuine loosening versus the old shape, and it is cheap to close.
+--
+-- Scoped to the browser roles on purpose. A future migration that legitimately
+-- re-parents rows runs as the owner or postgres and must not be blocked by this;
+-- the threat model is a crafted PostgREST request, not our own DDL.
+CREATE OR REPLACE FUNCTION public.reject_gate_key_change()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION
+    'the billing-gate key column on %.% is immutable', TG_TABLE_SCHEMA, TG_TABLE_NAME
+    USING ERRCODE = 'insufficient_privilege';
+END;
+$$;
+
+COMMENT ON FUNCTION public.reject_gate_key_change() IS
+  'BEFORE UPDATE trigger that refuses a change to the column the billing write-gate resolves on (company_id, or the parent FK for a child table). Exists so `billing_gate_update USING (true)` is provably equivalent to the old USING (company_can_write(...)) shape rather than merely close. Trigger function: needs no EXECUTE grant.';
+
+-- Trigger functions are permission-checked when the trigger is CREATED, not when
+-- it fires, so this needs no grant. Revoking is free and correct under either
+-- default (see CLAUDE.md "Function EXECUTE grants").
+REVOKE EXECUTE ON FUNCTION public.reject_gate_key_change() FROM PUBLIC, anon, authenticated;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. The helper new tenant tables call
+-- ─────────────────────────────────────────────────────────────────────────────
+-- CREATE OR REPLACE, so the ACL survives — but the COMMENT is re-issued because a
+-- future DROP would take both (CLAUDE.md).
+CREATE OR REPLACE FUNCTION public.apply_billing_write_gate(p_table regclass)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_name text := (SELECT relname FROM pg_class WHERE oid = p_table);
+BEGIN
+  EXECUTE format('DROP POLICY IF EXISTS billing_gate_insert ON %s', p_table);
+  EXECUTE format('DROP POLICY IF EXISTS billing_gate_update ON %s', p_table);
+  EXECUTE format('DROP POLICY IF EXISTS billing_gate_delete ON %s', p_table);
+
+  EXECUTE format(
+    'CREATE POLICY billing_gate_insert ON %s AS RESTRICTIVE FOR INSERT TO authenticated '
+    'WITH CHECK (public.company_can_write(company_id))', p_table);
+  -- USING (true): the check, not the filter, is what refuses the write — so it
+  -- raises 42501 instead of quietly matching zero rows. See the header.
+  EXECUTE format(
+    'CREATE POLICY billing_gate_update ON %s AS RESTRICTIVE FOR UPDATE TO authenticated '
+    'USING (true) WITH CHECK (public.company_can_write(company_id))', p_table);
+  EXECUTE format(
+    'CREATE POLICY billing_gate_delete ON %s AS RESTRICTIVE FOR DELETE TO authenticated '
+    'USING (public.company_can_write(company_id))', p_table);
+
+  EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s', v_name || '_gate_key_immutable', p_table);
+  EXECUTE format(
+    'CREATE TRIGGER %I BEFORE UPDATE ON %s FOR EACH ROW '
+    'WHEN (NEW.company_id IS DISTINCT FROM OLD.company_id '
+    '      AND current_user IN (''authenticated'', ''anon'')) '
+    'EXECUTE FUNCTION public.reject_gate_key_change()',
+    v_name || '_gate_key_immutable', p_table);
+END;
+$$;
+
+COMMENT ON FUNCTION public.apply_billing_write_gate(regclass) IS
+  'Attach the billing write-gate (restrictive INSERT/UPDATE/DELETE policies calling company_can_write, plus a company_id-immutability trigger) to a tenant table with a direct company_id column. Call in the migration for any new tenant table. Parent-resolved child tables (no company_id) still need hand-written policies. UPDATE uses USING (true) WITH CHECK so a blocked update RAISES rather than silently matching zero rows. See docs/modules/billing.md.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. Re-apply to every already-gated direct table
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Redefining the helper changes NOTHING on its own: the original tables were gated
+-- by inline DO blocks in 20260725210136, not through the helper. Discovering them
+-- from pg_policies rather than a hard-coded list means every table gated since —
+-- and every table gated between writing this and running it — is covered, and that
+-- renames (job_notes → notes, job_note_media → note_media in 20260728040701)
+-- cannot leave a stale name behind.
+DO $$
+DECLARE
+  rec record;
+BEGIN
+  FOR rec IN
+    SELECT DISTINCT p.tablename
+    FROM pg_policies p
+    JOIN pg_class c ON c.relname = p.tablename
+    JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+    JOIN pg_attribute a
+      ON a.attrelid = c.oid AND a.attname = 'company_id' AND NOT a.attisdropped
+    WHERE p.schemaname = 'public'
+      AND p.policyname = 'billing_gate_insert'
+      AND c.relkind = 'r'
+    ORDER BY 1
+  LOOP
+    PERFORM public.apply_billing_write_gate(format('public.%I', rec.tablename)::regclass);
+  END LOOP;
+END $$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. The parent-resolved children
+-- ─────────────────────────────────────────────────────────────────────────────
+-- No company_id of their own, so they resolve the parent's and cannot use the
+-- helper. Same UPDATE reshape; the immutability trigger keys on the parent FK,
+-- which is the gate key for these.
+--
+-- job_operations is why this half matters as much as the direct tables: it is the
+-- table behind markOperationReceived, the write that reported success on a row it
+-- never touched.
+DO $$
+DECLARE
+  rec record;
+BEGIN
+  FOR rec IN
+    SELECT * FROM (VALUES
+      ('customer_addresses',    'customers', 'customer_id'),
+      ('customer_contacts',     'customers', 'customer_id'),
+      ('vendor_contacts',       'vendors',   'vendor_id'),
+      ('parts_bom',             'parts',     'parent_part_id'),
+      ('parts_unit_conversions','parts',     'part_id'),
+      ('part_procurement_tiers','parts',     'part_id'),
+      ('job_materials',         'jobs',      'job_id'),
+      ('job_operations',        'jobs',      'job_id'),
+      ('routing_operations',    'routings',  'routing_id'),
+      ('shipment_line_items',   'shipments', 'shipment_id')
+    ) AS m(child, parent, fk)
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', 'billing_gate_update', rec.child);
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I AS RESTRICTIVE FOR UPDATE TO authenticated '
+      'USING (true) '
+      'WITH CHECK (public.company_can_write((SELECT p.company_id FROM public.%I p WHERE p.id = %I.%I)))',
+      'billing_gate_update', rec.child, rec.parent, rec.child, rec.fk);
+
+    EXECUTE format('DROP TRIGGER IF EXISTS %I ON public.%I',
+      rec.child || '_gate_key_immutable', rec.child);
+    EXECUTE format(
+      'CREATE TRIGGER %I BEFORE UPDATE ON public.%I FOR EACH ROW '
+      'WHEN (NEW.%I IS DISTINCT FROM OLD.%I '
+      '      AND current_user IN (''authenticated'', ''anon'')) '
+      'EXECUTE FUNCTION public.reject_gate_key_change()',
+      rec.child || '_gate_key_immutable', rec.child, rec.fk, rec.fk);
+  END LOOP;
+END $$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 5. Stop the silent shape coming back
+-- ─────────────────────────────────────────────────────────────────────────────
+-- The completeness guard next door checks that a tenant table IS gated. It cannot
+-- see that a gate is gated the OLD way — which is exactly how this bug would
+-- return, because the natural thing for the next person to hand-write is the
+-- USING(...) WITH CHECK(...) pair they see elsewhere. A CI test asserts this is
+-- empty (api/tests/integration/test_billing_enforcement.py).
+CREATE OR REPLACE FUNCTION public.tenant_tables_with_silent_update_gate()
+RETURNS TABLE(table_name text)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT p.tablename::text
+  FROM pg_policies p
+  WHERE p.schemaname = 'public'
+    AND p.policyname = 'billing_gate_update'
+    -- `qual` is the USING clause. Anything other than a plain `true` means the
+    -- gate filters rows, so a blocked update matches nothing and never raises.
+    AND (p.qual IS DISTINCT FROM 'true' OR p.with_check IS NULL)
+  ORDER BY 1;
+$$;
+
+COMMENT ON FUNCTION public.tenant_tables_with_silent_update_gate() IS
+  'Lists billing_gate_update policies still shaped USING (company_can_write(...)), which FILTERS the row instead of raising — so a blocked update silently affects zero rows. A CI test asserts this returns none. See migration billing_gate_update_with_check.';
+
+GRANT EXECUTE ON FUNCTION public.tenant_tables_with_silent_update_gate() TO service_role;

--- a/types/database.ts
+++ b/types/database.ts
@@ -3883,6 +3883,12 @@ export type Database = {
           table_name: string
         }[]
       }
+      tenant_tables_with_silent_update_gate: {
+        Args: never
+        Returns: {
+          table_name: string
+        }[]
+      }
       transfer_stock: {
         Args: {
           p_converted_quantity: number

--- a/utils/bomAccess.ts
+++ b/utils/bomAccess.ts
@@ -1,4 +1,5 @@
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type {
   BomLine,
@@ -281,7 +282,7 @@ export async function addBomLine(
     if (error.code === '23505') {
       throw new Error('This child part is already in the BOM. Adjust the existing line instead.');
     }
-    throw error;
+    throw toFriendlyError(error, { entity: 'BOM line' });
   }
   return data as BomLine;
 }
@@ -340,7 +341,7 @@ export async function updateBomLine(
     if (error.code === '23505') {
       throw new Error('This child part is already in the BOM. Adjust the existing line instead.');
     }
-    throw error;
+    throw toFriendlyError(error, { entity: 'BOM line' });
   }
   return data as BomLine;
 }

--- a/utils/companyAccess.ts
+++ b/utils/companyAccess.ts
@@ -8,7 +8,7 @@ import {
   readCompanyDefaultPaymentTerms,
   MAX_CUSTOM_PAYMENT_TERMS,
 } from '@/lib/companyDefaults';
-import { toError } from '@/lib/supabaseErrors';
+import { toError, toFriendlyError } from '@/lib/supabaseErrors';
 
 export interface Company {
   id: string;
@@ -356,7 +356,10 @@ export async function updateCompanyLogo(
 
   if (error) {
     console.error('Error updating company logo:', error);
-    throw new Error(`Failed to update company logo: ${error.message}`);
+    throw toFriendlyError(error, {
+      entity: 'logo',
+      fallback: 'Failed to update the company logo.',
+    });
   }
 }
 
@@ -385,7 +388,10 @@ export async function updateCompanyProfile(
 
   if (error) {
     console.error('Error updating company profile:', error);
-    throw new Error(`Failed to update company profile: ${error.message}`);
+    throw toFriendlyError(error, {
+      entity: 'company profile',
+      fallback: 'Failed to update the company profile.',
+    });
   }
 }
 
@@ -420,7 +426,10 @@ export async function updateCompanyDefaults(
 
   if (error) {
     console.error('Error updating company defaults:', error);
-    throw new Error(`Failed to update company defaults: ${error.message}`);
+    throw toFriendlyError(error, {
+      entity: 'settings',
+      fallback: 'Failed to update company defaults.',
+    });
   }
 }
 
@@ -452,7 +461,10 @@ async function writeCustomPaymentTerms(companyId: string, terms: string[]): Prom
     .eq('id', companyId);
   if (error) {
     console.error('Error updating custom payment terms:', error);
-    throw new Error(`Failed to save payment term: ${error.message}`);
+    throw toFriendlyError(error, {
+      entity: 'payment term',
+      fallback: 'Failed to save that payment term.',
+    });
   }
 }
 
@@ -522,7 +534,10 @@ export async function setCompanyDefaultPaymentTerms(
     .eq('id', companyId);
   if (error) {
     console.error('Error updating default payment terms:', error);
-    throw new Error(`Failed to save default payment terms: ${error.message}`);
+    throw toFriendlyError(error, {
+      entity: 'payment terms',
+      fallback: 'Failed to save default payment terms.',
+    });
   }
   return next;
 }

--- a/utils/customerAccess.ts
+++ b/utils/customerAccess.ts
@@ -3,6 +3,7 @@
 // Aliased to getSupabase so the existing call sites stay untouched. See
 // CLAUDE.md "Typed Supabase client (incremental adoption)".
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import {
   toCreditStatus,
   type Customer,
@@ -323,7 +324,7 @@ export async function createCustomer(
       if (revived) return revived;
     }
     console.error('Error creating customer:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'customer' });
   }
 
   if (initialContact) {
@@ -404,7 +405,7 @@ async function reviveArchivedCustomerByName(
 
   if (error) {
     console.error('Error reviving archived customer:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'customer' });
   }
 
   return { ...data, credit_status: toCreditStatus(data.credit_status) };
@@ -428,7 +429,7 @@ export async function updateCustomer(
 
   if (error) {
     console.error('Error updating customer:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'customer' });
   }
 
   return { ...data, credit_status: toCreditStatus(data.credit_status) };
@@ -447,7 +448,7 @@ export async function softDeleteCustomer(customerId: string): Promise<void> {
     .eq('id', customerId);
   if (error) {
     console.error('Error archiving customer:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'customer' });
   }
 }
 

--- a/utils/customerAccess.ts
+++ b/utils/customerAccess.ts
@@ -481,7 +481,10 @@ export async function bulkSoftDeleteCustomers(customerIds: string[]): Promise<vo
         );
       }
       console.error('Error bulk archiving customers:', error);
-      throw new Error(error.message || 'Failed to delete customers');
+      throw toFriendlyError(error, {
+        entity: 'customer',
+        fallback: 'Failed to archive these customers.',
+      });
     }
   }
 }

--- a/utils/customerAddressesAccess.ts
+++ b/utils/customerAddressesAccess.ts
@@ -14,6 +14,7 @@
  */
 
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type {
   CustomerAddress,
@@ -74,7 +75,7 @@ async function clearDefaultBillingForCustomer(
   const { error } = await query;
   if (error) {
     console.error('Error clearing default_billing flag:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'address' });
   }
 }
 
@@ -92,7 +93,7 @@ async function clearDefaultShippingForCustomer(
   const { error } = await query;
   if (error) {
     console.error('Error clearing default_shipping flag:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'address' });
   }
 }
 
@@ -118,7 +119,7 @@ export async function createCustomerAddress(
       );
     }
     console.error('Error creating customer address:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'address' });
   }
   return data as CustomerAddress;
 }
@@ -150,7 +151,7 @@ export async function updateCustomerAddress(
       );
     }
     console.error('Error updating customer address:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'address' });
   }
   return data as CustomerAddress;
 }

--- a/utils/customerCarrierAccountsAccess.ts
+++ b/utils/customerCarrierAccountsAccess.ts
@@ -3,6 +3,7 @@
 // getSupabase to match the other access modules. See CLAUDE.md "Typed Supabase
 // client (incremental adoption)".
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import {
   toBillToParty,
   type CustomerCarrierAccount,
@@ -137,7 +138,7 @@ export async function archiveCarrierAccount(accountId: string): Promise<void> {
 
   if (error) {
     console.error('Error archiving carrier account:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'carrier account' });
   }
 }
 

--- a/utils/customerContactsAccess.ts
+++ b/utils/customerContactsAccess.ts
@@ -18,6 +18,7 @@
  */
 
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type { Database } from '@/types/database';
 import type {
@@ -92,7 +93,7 @@ async function clearPrimaryForCustomer(customerId: string): Promise<void> {
     .eq('is_primary', true);
   if (error) {
     console.error('Error clearing primary contact:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'contact' });
   }
 }
 
@@ -125,7 +126,7 @@ export async function createCustomerContact(
       );
     }
     console.error('Error creating customer contact:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'contact' });
   }
   return data as CustomerContact;
 }
@@ -180,7 +181,7 @@ export async function updateCustomerContact(
       );
     }
     console.error('Error updating customer contact:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'contact' });
   }
   return data as CustomerContact;
 }
@@ -245,7 +246,7 @@ export async function setPrimaryContact(
       );
     }
     console.error('Error setting primary contact:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'contact' });
   }
 }
 
@@ -287,6 +288,6 @@ export async function setBillingDefaultContact(
       );
     }
     console.error('Error setting billing-default contact:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'contact' });
   }
 }

--- a/utils/inventoryLocationsAccess.ts
+++ b/utils/inventoryLocationsAccess.ts
@@ -10,6 +10,7 @@
  * both the display values and the converted quantity.
  */
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import { ID_CHUNK } from '@/lib/queryLimits';
 import { convertToBaseUnit } from '@/lib/unitPresets';
 import { isReservedKind, RESERVED_KIND_MESSAGE } from '@/lib/locationKinds';
@@ -274,7 +275,11 @@ function mapLocationWriteError(error: { code?: string; message?: string }, name?
         : 'There\'s already a location with that name in the same place. Pick a different name.',
     );
   }
-  return new Error(error.message ?? 'Failed to save location.');
+  // Everything else goes through the shared translator rather than passing `error.message`
+  // straight out: that fallback rendered raw PostgREST text to the user, so a lapsed shop saw
+  // 'new row violates row-level security policy "billing_gate_insert"…' instead of being told
+  // its subscription needs restarting.
+  return toFriendlyError(error, { entity: 'location', fallback: 'Failed to save location.' });
 }
 
 /**
@@ -398,7 +403,7 @@ export async function deleteLocation(id: string): Promise<void> {
     if (msg.includes('still holds stock')) {
       throw new Error('This location (or something inside it) still holds stock. Move it out first.');
     }
-    throw new Error('Failed to delete location.');
+    throw toFriendlyError(error, { entity: 'location', fallback: 'Failed to delete location.' });
   }
 }
 
@@ -532,7 +537,7 @@ export async function subdivideLocation(
 
   if (error) {
     console.error('Error subdividing location:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'location' });
   }
   return (data ?? []) as InventoryLocation[];
 }
@@ -970,7 +975,7 @@ export async function addStockAtLocation(
   });
   if (error) {
     console.error('Error adding stock at location:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'stock' });
   }
   return data as unknown as StockMutationResult;
 }
@@ -1000,7 +1005,7 @@ export async function depleteStockAtLocation(
   });
   if (error) {
     console.error('Error depleting stock at location:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'stock' });
   }
   return data as unknown as StockMutationResult;
 }
@@ -1029,7 +1034,7 @@ export async function adjustStockAtLocation(
   });
   if (error) {
     console.error('Error adjusting stock at location:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'stock' });
   }
   return data as unknown as StockMutationResult;
 }
@@ -1060,7 +1065,7 @@ export async function transferStock(
   });
   if (error) {
     console.error('Error transferring stock:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'stock' });
   }
   return data as unknown as TransferResult;
 }
@@ -1111,7 +1116,7 @@ export async function bulkPutAway(
   });
   if (error) {
     console.error('Error putting stock away:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'stock' });
   }
   return data as unknown as PutAwayResult;
 }

--- a/utils/jobAttachmentsAccess.ts
+++ b/utils/jobAttachmentsAccess.ts
@@ -1,4 +1,5 @@
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import {
   generateStoragePath,
   uploadFileToStorage,
@@ -101,7 +102,7 @@ export async function deleteJobAttachment(att: {
   const { error } = await supabase.from('job_attachments').delete().eq('id', att.id);
   if (error) {
     console.error('Error deleting job attachment row:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'attachment' });
   }
 }
 

--- a/utils/jobNoteMediaAccess.ts
+++ b/utils/jobNoteMediaAccess.ts
@@ -1,4 +1,5 @@
 import { getSupabase } from '@/lib/supabase';
+import { assertDeleted, toFriendlyError } from '@/lib/supabaseErrors';
 import {
   generateStoragePath,
   uploadFileToStorage,
@@ -209,11 +210,16 @@ export async function deleteJobNoteMedia(media: {
   storage_path: string;
 }): Promise<void> {
   const supabase = getSupabase();
-  const { error } = await supabase.from('note_media').delete().eq('id', media.id);
+  const { data, error } = await supabase
+    .from('note_media')
+    .delete()
+    .eq('id', media.id)
+    .select('id');
   if (error) {
     console.error('Error deleting job note media row:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'photo' });
   }
+  assertDeleted(data, 'photo');
   await deleteFileFromStorage(media.storage_path).catch((err) =>
     console.warn('Failed to delete media file after row delete:', err),
   );
@@ -242,11 +248,16 @@ export async function deleteJobNote(noteId: string): Promise<void> {
       .filter(Boolean);
   }
 
-  const { error } = await supabase.from('notes').delete().eq('id', noteId);
+  const { data, error } = await supabase
+    .from('notes')
+    .delete()
+    .eq('id', noteId)
+    .select('id');
   if (error) {
     console.error('Error deleting job note:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'note' });
   }
+  assertDeleted(data, 'note');
 
   for (const path of paths) {
     await deleteFileFromStorage(path).catch((err) =>

--- a/utils/jobsAccess.ts
+++ b/utils/jobsAccess.ts
@@ -4,7 +4,7 @@
 // this also keeps the diff small for review. See CLAUDE.md "Typed
 // Supabase client (incremental adoption)" for the rollout contract.
 import { getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { friendlyErrorMessage, toFriendlyError } from '@/lib/supabaseErrors';
 import type { Database } from '@/types/database';
 
 // Update payloads for tables this file mutates conditionally. The typed
@@ -1319,10 +1319,18 @@ export async function completeJobOperation(
     });
   }
   if (data.notes !== undefined) {
-    await supabase
+    // Checked: postgrest-js resolves with `{ error }` rather than rejecting, so an
+    // un-destructured await threw the note away silently on any write failure.
+    const { error: notesError } = await supabase
       .from('job_operations')
       .update({ notes: data.notes, updated_at: new Date().toISOString() })
       .eq('id', operationId);
+    if (notesError) {
+      throw toFriendlyError(notesError, {
+        entity: 'note',
+        fallback: 'Failed to save the operation note.',
+      });
+    }
   }
 
   // Read back the op + resulting statuses (the trigger already cascaded).

--- a/utils/operationCompletionsAccess.ts
+++ b/utils/operationCompletionsAccess.ts
@@ -14,6 +14,7 @@
  */
 
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import type {
   CreateOperationCompletionInput,
   OperationCompletionEvent,
@@ -67,7 +68,10 @@ export async function createOperationCompletion(
 
   if (error || !data) {
     console.error('createOperationCompletion failed:', error);
-    throw new Error(error?.message ?? 'Failed to record completion.');
+    throw toFriendlyError(error, {
+      entity: 'completion',
+      fallback: 'Failed to record completion.',
+    });
   }
   return { id: data.id };
 }
@@ -98,7 +102,10 @@ export async function voidOperationCompletion(completionId: string): Promise<voi
 
   if (error) {
     console.error('voidOperationCompletion failed:', error);
-    throw new Error(`Failed to void completion: ${error.message}`);
+    throw toFriendlyError(error, {
+      entity: 'completion',
+      fallback: 'Failed to void that completion.',
+    });
   }
 }
 
@@ -126,7 +133,10 @@ export async function voidAllOperationCompletions(jobOperationId: string): Promi
 
   if (error) {
     console.error('voidAllOperationCompletions failed:', error);
-    throw new Error(`Failed to undo completion: ${error.message}`);
+    throw toFriendlyError(error, {
+      entity: 'completion',
+      fallback: 'Failed to undo that completion.',
+    });
   }
 }
 

--- a/utils/operatorAccess.ts
+++ b/utils/operatorAccess.ts
@@ -19,7 +19,7 @@
 // Typed Supabase client (typed-client rollout). Aliased so the 19 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
 import { getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { friendlyErrorMessage, toFriendlyError } from '@/lib/supabaseErrors';
 import { voidAllOperationCompletions } from '@/utils/operationCompletionsAccess';
 import type {
   OperatorJob,
@@ -798,13 +798,29 @@ async function loadOpOutsideContext(jobOperationId: string): Promise<OpOutsideCo
 }
 
 /**
+ * Throw when a write failed, instead of continuing as though it hadn't.
+ *
+ * postgrest-js RESOLVES with `{ error }` rather than rejecting, so `await supabase.from(…)
+ * .update(…)` with nothing destructured discards every failure. Several operator actions did
+ * exactly that and then returned `{ success: true }` — the shop floor was told the work was
+ * recorded while the row sat untouched. A lapsed subscription is one way to hit it (RLS blocks
+ * the write), but so is any constraint or policy failure.
+ *
+ * Matching zero rows is NOT a failure here: several of these updates carry a deliberate `.not(…)`
+ * guard that legitimately matches nothing. Only a real `error` throws.
+ */
+function assertWrote(error: unknown, entity: string, fallback: string): void {
+  if (error) throw toFriendlyError(error, { entity, fallback });
+}
+
+/**
  * Move a job_part to 'in_progress' because work on it has begun. The guard skips
  * parts already in_progress/completed/cancelled, leaving their started_at
  * untouched. Shared by complete, receive, and send (all are "work has begun").
  */
 async function movePartToInProgress(jobPartId: string, now: string): Promise<void> {
   const supabase = getSupabase();
-  await supabase
+  const { error } = await supabase
     .from('job_parts')
     .update({
       production_status: 'in_progress',
@@ -814,6 +830,7 @@ async function movePartToInProgress(jobPartId: string, now: string): Promise<voi
     })
     .eq('id', jobPartId)
     .not('production_status', 'in', '("in_progress","completed","cancelled")');
+  assertWrote(error, 'part', 'Failed to update the part status.');
 }
 
 /**
@@ -834,7 +851,7 @@ async function rollupPartAfterCompletion(jobPartId: string, now: string): Promis
   const partCompleted = !remaining || remaining.length === 0;
 
   if (partCompleted) {
-    await supabase
+    const { error } = await supabase
       .from('job_parts')
       .update({
         production_status: 'completed',
@@ -844,6 +861,7 @@ async function rollupPartAfterCompletion(jobPartId: string, now: string): Promis
       })
       .eq('id', jobPartId)
       .not('production_status', 'in', '("cancelled")');
+    assertWrote(error, 'part', 'Failed to update the part status.');
   } else {
     await movePartToInProgress(jobPartId, now);
   }
@@ -886,10 +904,11 @@ export async function markOperationSent(jobOperationId: string): Promise<void> {
   const { data: { user } } = await supabase.auth.getUser();
   const now = new Date().toISOString();
 
-  await supabase
+  const { error: sendError } = await supabase
     .from('job_operations')
     .update({ status: 'sent', sent_at: now, sent_by: user?.id ?? null })
     .eq('id', jobOperationId);
+  assertWrote(sendError, 'operation', 'Failed to mark the operation sent out.');
 
   await movePartToInProgress(op.job_part_id, now);
 }
@@ -936,7 +955,20 @@ export async function markOperationReceived(
     update.sent_by = user?.id ?? null;
   }
 
-  await supabase.from('job_operations').update(update).eq('id', jobOperationId);
+  // Checked, not fire-and-forget. postgrest-js RESOLVES with `{ error }` rather than rejecting,
+  // so an un-destructured `await` swallows every failure silently — this reported
+  // `{ success: true }` and told the operator the vendor work was back while the row was
+  // untouched. A lapsed subscription is one way to hit it; so is any RLS or constraint failure.
+  const { error: updateError } = await supabase
+    .from('job_operations')
+    .update(update)
+    .eq('id', jobOperationId);
+  if (updateError) {
+    throw toFriendlyError(updateError, {
+      entity: 'operation',
+      fallback: 'Failed to mark the operation received.',
+    });
+  }
 
   const partCompleted = await rollupPartAfterCompletion(op.job_part_id, now);
 
@@ -977,25 +1009,27 @@ export async function revertOperationCompletion(
     const supabase = getSupabase();
     const now = new Date().toISOString();
 
+    let stepBackError: unknown = null;
     if (op.status === 'completed' && op.sent_at) {
       // Received → back to sent (parts are still out); keep sent_at/by.
-      await supabase
+      ({ error: stepBackError } = await supabase
         .from('job_operations')
         .update({ status: 'sent', completed_at: null, completed_by: null })
-        .eq('id', jobOperationId);
+        .eq('id', jobOperationId));
     } else if (op.status === 'sent') {
       // Un-send → back to pending; clear the send stamp.
-      await supabase
+      ({ error: stepBackError } = await supabase
         .from('job_operations')
         .update({ status: 'pending', sent_at: null, sent_by: null })
-        .eq('id', jobOperationId);
+        .eq('id', jobOperationId));
     } else {
       // Legacy external completed op that never went through send → pending.
-      await supabase
+      ({ error: stepBackError } = await supabase
         .from('job_operations')
         .update({ status: 'pending', completed_at: null, completed_by: null, sent_at: null, sent_by: null })
-        .eq('id', jobOperationId);
+        .eq('id', jobOperationId));
     }
+    assertWrote(stepBackError, 'operation', 'Failed to undo the operation.');
 
     const { data: stillCompleted } = await supabase
       .from('job_operations')
@@ -1005,7 +1039,7 @@ export async function revertOperationCompletion(
 
     const hasCompleted = !!stillCompleted && stillCompleted.length > 0;
 
-    await supabase
+    const { error: rollbackError } = await supabase
       .from('job_parts')
       .update({
         production_status: hasCompleted ? 'in_progress' : 'not_started',
@@ -1015,6 +1049,7 @@ export async function revertOperationCompletion(
       })
       .eq('id', op.job_part_id)
       .not('production_status', 'in', '("cancelled")');
+    assertWrote(rollbackError, 'part', 'Failed to undo the operation.');
     return;
   }
 

--- a/utils/partAttachmentsAccess.ts
+++ b/utils/partAttachmentsAccess.ts
@@ -1,4 +1,5 @@
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import {
   generateStoragePath,
   uploadFileToStorage,
@@ -203,7 +204,7 @@ export async function deletePartAttachment(att: {
   const { error } = await supabase.from('part_attachments').delete().eq('id', att.id);
   if (error) {
     console.error('Error deleting part attachment row:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'attachment' });
   }
   // Row is gone; best-effort remove the file. A failure here is a recoverable
   // orphan, not a user-visible problem, so don't surface it.

--- a/utils/partPricingTiersAccess.ts
+++ b/utils/partPricingTiersAccess.ts
@@ -1,4 +1,5 @@
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type {
   PartPricingTier,
@@ -152,7 +153,7 @@ export async function replaceTiersForPart(
       .from('part_pricing_tiers')
       .delete()
       .in('id', toDelete);
-    if (error) throw error;
+    if (error) throw toFriendlyError(error, { entity: 'pricing tier' });
   }
 
   for (const tier of tiers) {
@@ -165,7 +166,7 @@ export async function replaceTiersForPart(
           markup_percent: tier.markup_percent,
         })
         .eq('id', tier.id);
-      if (error) throw error;
+      if (error) throw toFriendlyError(error, { entity: 'pricing tier' });
     } else {
       const { error } = await supabase
         .from('part_pricing_tiers')
@@ -176,7 +177,7 @@ export async function replaceTiersForPart(
           quantity: tier.quantity,
           markup_percent: tier.markup_percent,
         });
-      if (error) throw error;
+      if (error) throw toFriendlyError(error, { entity: 'pricing tier' });
     }
   }
 

--- a/utils/partsAccess.ts
+++ b/utils/partsAccess.ts
@@ -1008,13 +1008,10 @@ export async function bulkDeleteParts(partIds: string[]): Promise<void> {
     const { error } = await supabase.rpc('archive_parts', { p_ids: batch });
 
     if (error) {
-      if (error.code === '42501' || error.message?.includes('policy')) {
-        throw new Error(
-          'Permission denied. You may not have permission to delete these parts.',
-        );
-      }
-      console.error('Error archiving parts:', error);
-      throw new Error(error.message || 'Failed to archive parts');
+      throw toFriendlyError(error, {
+        entity: 'part',
+        fallback: 'Failed to archive these parts.',
+      });
     }
   }
 }

--- a/utils/partsAccess.ts
+++ b/utils/partsAccess.ts
@@ -1,6 +1,7 @@
 // Typed Supabase client (typed-client rollout). Aliased so the 30 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
 import { getSupabase } from '@/lib/supabase';
+import { assertDeleted, toFriendlyError } from '@/lib/supabaseErrors';
 import type { Database } from '@/types/database';
 
 // Insert payload for the parts table. company_id is supplied at the call
@@ -850,7 +851,7 @@ export async function createPart(companyId: string, formData: PartFormData): Pro
       if (revived) return revived;
     }
     console.error('Error creating part:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'part' });
   }
 
   // No pricing is seeded on create — each part owns its markup directly. The
@@ -895,7 +896,7 @@ async function reviveArchivedPartByName(
 
   if (error) {
     console.error('Error reviving archived part:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'part' });
   }
 
   return rowToPart(data as PartRow);
@@ -920,7 +921,7 @@ export async function updatePart(partId: string, formData: PartFormData): Promis
 
   if (error) {
     console.error('Error updating part:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'part' });
   }
 
   return rowToPart(data as PartRow);
@@ -946,7 +947,7 @@ export async function updatePartPreferredVendor(
     .eq('id', partId);
   if (error) {
     console.error('Error updating preferred vendor:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'preferred vendor' });
   }
 }
 
@@ -972,7 +973,7 @@ export async function updatePartCostingBatchQuantity(
     .eq('id', partId);
   if (error) {
     console.error('Error updating costing batch quantity:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'costing quantity' });
   }
 }
 
@@ -1334,7 +1335,7 @@ export async function updateTransactionNotes(
 
   if (error) {
     console.error('Error updating transaction notes:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'note' });
   }
 }
 
@@ -1493,7 +1494,7 @@ export async function addPartNote(
 
   if (error) {
     console.error('Error adding part note:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'note' });
   }
 
   return mapPartCommentRow(data as unknown as PartCommentRow);
@@ -1526,7 +1527,7 @@ export async function updatePartNote(noteId: string, body: string): Promise<Part
 
   if (error) {
     console.error('Error updating part note:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'note' });
   }
 
   return mapPartCommentRow(data as unknown as PartCommentRow);
@@ -1552,11 +1553,16 @@ export async function addPartPricingNote(
  */
 export async function deletePartNote(noteId: string): Promise<void> {
   const supabase = getSupabase();
-  const { error } = await supabase.from('part_comments').delete().eq('id', noteId);
+  const { data, error } = await supabase
+    .from('part_comments')
+    .delete()
+    .eq('id', noteId)
+    .select('id');
   if (error) {
     console.error('Error deleting part note:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'note' });
   }
+  assertDeleted(data, 'note');
 }
 
 /**

--- a/utils/procurementTiersAccess.ts
+++ b/utils/procurementTiersAccess.ts
@@ -1,4 +1,5 @@
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import type {
   ProcurementCostResult,
@@ -117,7 +118,7 @@ export async function addTier(
         'A tier already exists at this break. Edit the existing tier instead.',
       );
     }
-    throw error;
+    throw toFriendlyError(error, { entity: 'tier' });
   }
   return normalizeTierRow(data as Record<string, unknown>);
 }
@@ -157,7 +158,7 @@ export async function updateTier(
         'A tier already exists at this break. Edit the existing tier instead.',
       );
     }
-    throw error;
+    throw toFriendlyError(error, { entity: 'tier' });
   }
   return normalizeTierRow(data as Record<string, unknown>);
 }

--- a/utils/quoteLineItemsAccess.ts
+++ b/utils/quoteLineItemsAccess.ts
@@ -1,4 +1,5 @@
 import { getSupabase } from '@/lib/supabase';
+import { assertDeleted, toFriendlyError } from '@/lib/supabaseErrors';
 import type { Json } from '@/types/database';
 import type { QuoteLineItem } from '@/types/quote';
 import type { ComputedPartPricingTier } from '@/types/partPricing';
@@ -153,7 +154,7 @@ export async function insertLineItemForPart(
 
   if (error) {
     console.error('Error inserting quote line item:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'line item' });
   }
   return data as unknown as QuoteLineItem;
 }
@@ -237,7 +238,7 @@ export async function updateLineItemQuantity(
     .single();
   if (error) {
     console.error('Error updating line item quantity:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'line item' });
   }
   return data as unknown as QuoteLineItem;
 }
@@ -261,7 +262,7 @@ export async function updateLineItemLeadTime(
     .eq('id', lineItemId);
   if (error) {
     console.error('Error updating line item lead time:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'line item' });
   }
 }
 
@@ -342,7 +343,7 @@ export async function repriceLineItemToCurrent(
     .single();
   if (error) {
     console.error('Error repricing line item:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'line item' });
   }
   return data as unknown as QuoteLineItem;
 }
@@ -353,25 +354,30 @@ export async function repriceLineItemToCurrent(
  */
 export async function deleteLineItem(lineItemId: string): Promise<void> {
   const supabase = getSupabase();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('quote_line_items')
     .delete()
-    .eq('id', lineItemId);
+    .eq('id', lineItemId)
+    .select('id');
   if (error) {
     console.error('Error deleting quote line item:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'line item' });
   }
+  assertDeleted(data, 'line item');
 }
 
 /**
  * Delete every line item on a quote. Used by bulk delete and by re-snapshot
  * flows that rebuild the full list.
  */
+// No row-count assertion here, unlike deleteLineItem: clearing a quote that already has no line
+// items is a normal outcome (the re-snapshot flow calls this before rebuilding), so zero rows
+// would report a failure for an operation that did exactly what was asked.
 export async function clearLineItemsForQuote(quoteId: string): Promise<void> {
   const supabase = getSupabase();
   const { error } = await supabase.from('quote_line_items').delete().eq('quote_id', quoteId);
   if (error) {
     console.error('Error clearing quote line items:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'line item' });
   }
 }

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -3,7 +3,11 @@
 // to getSupabase so the existing call sites don't need touching. See
 // CLAUDE.md "Typed Supabase client (incremental adoption)".
 import { getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage, toFriendlyError } from '@/lib/supabaseErrors';
+import {
+  friendlyErrorMessage,
+  isBillingWriteBlocked,
+  toFriendlyError,
+} from '@/lib/supabaseErrors';
 import type {
   Quote,
   QuoteWithRelations,
@@ -278,6 +282,15 @@ export async function sweepExpiredQuotes(companyId: string): Promise<void> {
     .lt('expiration_date', today);
 
   if (error) {
+    // A read-only shop cannot sweep, and SHOULD not: this is a background status mutation the
+    // user never asked for, fired on every quotes-page load. Expected, not a failure.
+    //
+    // It only became visible when the billing gate started raising on a blocked UPDATE instead
+    // of filtering it to zero rows — before that this call quietly did nothing. Returning early
+    // keeps a lapsed shop's quotes list loading exactly as it does today. (Sentry already drops
+    // these via shouldReportSupabaseError; this is about not logging noise either.)
+    if (isBillingWriteBlocked(error)) return;
+
     // The Supabase integration reports this update's failure on its own (#708), so there is no
     // `captureException` here — a second one would only duplicate the issue.
     //

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -3,7 +3,7 @@
 // to getSupabase so the existing call sites don't need touching. See
 // CLAUDE.md "Typed Supabase client (incremental adoption)".
 import { getSupabase } from '@/lib/supabase';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { friendlyErrorMessage, toFriendlyError } from '@/lib/supabaseErrors';
 import type {
   Quote,
   QuoteWithRelations,
@@ -417,7 +417,7 @@ export async function createQuote(
 
   if (error) {
     console.error('Error creating quote:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'quote' });
   }
 
   // Snapshot one line item per (part, quantity) entry (auto-resolving the
@@ -574,7 +574,7 @@ export async function updateQuote(
 
   if (error) {
     console.error('Error updating quote:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'quote' });
   }
 
   await reconcileQuoteLineItems(quoteId, companyId, formData, options);
@@ -928,7 +928,7 @@ async function writeCostSnapshotsForPart(
       setup_cost: item.setup_cost,
     }));
     const { error } = await supabase.from('quote_operations').insert(opRows);
-    if (error) throw error;
+    if (error) throw toFriendlyError(error, { entity: 'quote' });
   }
 
   if (breakdown.material_items.length > 0) {
@@ -949,7 +949,7 @@ async function writeCostSnapshotsForPart(
       units_consumed: item.units_consumed,
     }));
     const { error } = await supabase.from('quote_materials').insert(matRows);
-    if (error) throw error;
+    if (error) throw toFriendlyError(error, { entity: 'quote' });
   }
 }
 
@@ -1034,7 +1034,7 @@ export async function expireQuote(quoteId: string, companyId: string): Promise<Q
 
   if (error) {
     console.error('Error expiring quote:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'quote' });
   }
   return asQuote(data);
 }

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -882,7 +882,10 @@ export async function bulkDeleteQuotes(quoteIds: string[], companyId: string): P
         throw new Error('Permission denied. You may not have permission to delete these quotes.');
       }
       console.error('Error bulk archiving quotes:', error);
-      throw new Error(error.message || 'Failed to delete quotes');
+      throw toFriendlyError(error, {
+        entity: 'quote',
+        fallback: 'Failed to archive these quotes.',
+      });
     }
   }
 }

--- a/utils/routingsAccess.ts
+++ b/utils/routingsAccess.ts
@@ -10,6 +10,7 @@
 // Typed Supabase client (typed-client rollout). Aliased so the 12 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 import { orIlikeValue } from '@/utils/searchFilter';
 import type { Database } from '@/types/database';
@@ -350,7 +351,7 @@ export async function createRoutingOperation(
 
   if (error) {
     console.error('Error creating routing operation:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'operation' });
   }
 
   return data as RoutingOperation;
@@ -374,7 +375,7 @@ export async function updateRoutingOperation(
 
   if (error) {
     console.error('Error updating routing operation:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'operation' });
   }
 
   return data as RoutingOperation;

--- a/utils/storageHelpers.ts
+++ b/utils/storageHelpers.ts
@@ -1,4 +1,5 @@
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 
 /**
  * Get the storage bucket name from environment variable
@@ -150,7 +151,10 @@ export async function uploadFileToStorage(
 
   if (error) {
     console.error('Storage upload error:', error);
-    throw new Error(`Failed to upload file: ${error.message}`);
+    throw toFriendlyError(error, {
+      entity: 'file',
+      fallback: 'Failed to upload that file.',
+    });
   }
 }
 
@@ -174,7 +178,10 @@ export async function deleteFileFromStorage(
 
   if (error) {
     console.error('Storage delete error:', error);
-    throw new Error(`Failed to delete file: ${error.message}`);
+    throw toFriendlyError(error, {
+      entity: 'file',
+      fallback: 'Failed to delete that file.',
+    });
   }
 }
 

--- a/utils/unitsAccess.ts
+++ b/utils/unitsAccess.ts
@@ -5,6 +5,7 @@
  */
 
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import type { CompanyCustomUnit } from '@/types/units';
 
 /**
@@ -56,7 +57,7 @@ export async function addCompanyCustomUnit(
       throw new Error(`Unit "${trimmed}" already exists for this company`);
     }
     console.error('Error adding company custom unit:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'unit' });
   }
 
   return data as CompanyCustomUnit;

--- a/utils/vendorContactsAccess.ts
+++ b/utils/vendorContactsAccess.ts
@@ -17,6 +17,7 @@
  */
 
 import { getSupabase } from '@/lib/supabase';
+import { assertDeleted, toFriendlyError } from '@/lib/supabaseErrors';
 import type { Database } from '@/types/database';
 import type {
   VendorContact,
@@ -181,14 +182,16 @@ export async function updateVendorContact(
 
 export async function deleteVendorContact(contactId: string): Promise<void> {
   const supabase = getSupabase();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('vendor_contacts')
     .delete()
-    .eq('id', contactId);
+    .eq('id', contactId)
+    .select('id');
   if (error) {
     console.error('Error deleting vendor contact:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'contact' });
   }
+  assertDeleted(data, 'contact');
 }
 
 /**

--- a/utils/vendorContactsAccess.ts
+++ b/utils/vendorContactsAccess.ts
@@ -82,7 +82,7 @@ async function clearPrimaryForVendor(vendorId: string): Promise<void> {
     .eq('is_primary', true);
   if (error) {
     console.error('Error clearing primary contact:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'contact' });
   }
 }
 
@@ -115,7 +115,7 @@ export async function createVendorContact(
       );
     }
     console.error('Error creating vendor contact:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'contact' });
   }
   return data as VendorContact;
 }
@@ -175,7 +175,7 @@ export async function updateVendorContact(
       );
     }
     console.error('Error updating vendor contact:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'contact' });
   }
   return data as VendorContact;
 }
@@ -218,6 +218,6 @@ export async function setPrimaryContact(
       );
     }
     console.error('Error setting primary contact:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'contact' });
   }
 }

--- a/utils/vendorsAccess.ts
+++ b/utils/vendorsAccess.ts
@@ -1,6 +1,7 @@
 // Typed Supabase client (typed-client rollout). Aliased so the 11 call
 // sites stay untouched. See CLAUDE.md "Typed Supabase client".
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import type { Database } from '@/types/database';
 import { orIlikeValue } from '@/utils/searchFilter';
 
@@ -262,11 +263,11 @@ export async function createVendor(
         vendor = revived;
       } else {
         console.error('Error creating vendor:', error);
-        throw error;
+        throw toFriendlyError(error, { entity: 'vendor' });
       }
     } else {
       console.error('Error creating vendor:', error);
-      throw error;
+      throw toFriendlyError(error, { entity: 'vendor' });
     }
   } else {
     vendor = data as Vendor;
@@ -335,7 +336,7 @@ async function reviveArchivedVendorByName(
 
   if (error) {
     console.error('Error reviving archived vendor:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'vendor' });
   }
 
   return data as Vendor;
@@ -359,7 +360,7 @@ export async function updateVendor(
 
   if (error) {
     console.error('Error updating vendor:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'vendor' });
   }
   return data as Vendor;
 }
@@ -379,7 +380,7 @@ export async function deleteVendor(vendorId: string): Promise<void> {
 
   if (error) {
     console.error('Error archiving vendor:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'vendor' });
   }
 }
 

--- a/utils/vendorsAccess.ts
+++ b/utils/vendorsAccess.ts
@@ -406,7 +406,10 @@ export async function bulkDeleteVendors(vendorIds: string[]): Promise<void> {
 
     if (error) {
       console.error('Error archiving vendors:', error);
-      throw new Error(error.message || 'Failed to archive vendors');
+      throw toFriendlyError(error, {
+        entity: 'vendor',
+        fallback: 'Failed to archive these vendors.',
+      });
     }
   }
 }

--- a/utils/workCenterAttachmentsAccess.ts
+++ b/utils/workCenterAttachmentsAccess.ts
@@ -1,4 +1,5 @@
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import {
   generateStoragePath,
   uploadFileToStorage,
@@ -185,7 +186,7 @@ export async function deleteWorkCenterAttachment(att: {
   const { error } = await supabase.from('work_center_attachments').delete().eq('id', att.id);
   if (error) {
     console.error('Error deleting work center attachment row:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'attachment' });
   }
   await deleteFileFromStorage(att.storage_path).catch((err) =>
     console.warn('Failed to delete manual file after row delete:', err),

--- a/utils/workCentersAccess.ts
+++ b/utils/workCentersAccess.ts
@@ -1,4 +1,5 @@
 import { getSupabase } from '@/lib/supabase';
+import { toFriendlyError } from '@/lib/supabaseErrors';
 import type {
   WorkCenter,
   WorkCenterFormData,
@@ -331,7 +332,7 @@ export async function createWorkCenter(
       if (revived) return revived;
     }
     console.error('Error creating work center:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'work center' });
   }
 
   return data as WorkCenter;
@@ -380,7 +381,7 @@ async function reviveArchivedWorkCenterByName(
 
   if (error) {
     console.error('Error reviving archived work center:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'work center' });
   }
 
   return data as WorkCenter;
@@ -412,7 +413,7 @@ export async function updateWorkCenter(
 
   if (error) {
     console.error('Error updating work center:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'work center' });
   }
 
   return data as WorkCenter;
@@ -434,7 +435,7 @@ export async function deleteWorkCenter(workCenterId: string): Promise<void> {
 
   if (error) {
     console.error('Error archiving work center:', error);
-    throw error;
+    throw toFriendlyError(error, { entity: 'work center' });
   }
 }
 

--- a/utils/workCentersAccess.ts
+++ b/utils/workCentersAccess.ts
@@ -463,7 +463,10 @@ export async function bulkDeleteWorkCenters(workCenterIds: string[]): Promise<vo
 
     if (error) {
       console.error('Error archiving work centers:', error);
-      throw new Error(error.message || 'Failed to archive work centers');
+      throw toFriendlyError(error, {
+        entity: 'work center',
+        fallback: 'Failed to archive these work centers.',
+      });
     }
   }
 }


### PR DESCRIPTION
A company with no active subscription is correctly blocked by the DB write gate, but the UI said
nothing useful. On `/parts/new` you fill the whole form, click **Create part**, and get
**"Failed to create part"** — with a *"Start your subscription"* banner sitting directly above it,
unconnected.

## Why it happened

Three things had to be true at once.

**Supabase does not reject with an `Error`** on the `{ data, error }` path — postgrest-js does a bare
`error = JSON.parse(body)` and hands back a plain object. (`PostgrestError` *is* an Error subclass,
but only on the `.throwOnError()` path, which this repo does not use.) So `throw error` in an access
function throws a non-Error, and every `err instanceof Error ? err.message : 'Failed to X'` catch
site — ~179 of them — took the fallback branch and discarded the reason.

**The one translator that existed answered a billing question with a role diagnosis.**
`friendlyErrorMessage` mapped 42501 to *"You don't have permission to do that."*, sending an owner to
ask their admin for access they already have.

**`canWrite` was computed on every dashboard page and had zero consumers.**

## The shape of the fix

Layered, so the broad half needed almost no UI edits — ~90 catch sites already render `err.message`
when it is an `Error`, so making the access layer throw one fixes their copy without touching them.

| Layer | Where |
|---|---|
| Classify + copy | `lib/supabaseErrors.ts`, `lib/billingCopy.ts` |
| Access layer adopts it | ~77 write fns across 20 `utils/*Access.ts` |
| CTA at the failure | `components/common/ErrorAlert.tsx`, `SubscribeButton` |
| Explain before the form | `SubscriptionRequiredNotice` on 5 create routes |
| Make blocked UPDATEs loud | `20260807015028_billing_gate_update_with_check.sql` |

Telling a billing block from a permission denial works because a RESTRICTIVE policy carries its own
name into the message, while permissive policies OR-fold into a single **nameless** entry. That is
structural Postgres behaviour, but also exactly what a policy rename would silently break, so both
directions are CI tests.

## Three things found on the way that were worse than the copy

- **`markOperationReceived` reported success on a write it never checked.**
  `await supabase...update()` with nothing destructured — postgrest resolves with `{ error }` rather
  than rejecting, so it returned `{ success: true }` and told the shop floor vendor work was back
  while the row sat untouched. Same shape in seven more operator paths, now checked via a named
  `assertWrote`.
- **A blocked UPDATE was silent.** The gate's `USING` clause *filtered* the row instead of refusing
  it, so a blocked save changed nothing and raised nothing. Moved to `WITH CHECK`.
- **Every lapsed shop was already generating Sentry issues.** The #711 capture net files every
  `{ error }` and 42501 was not on the drop list.

## Reviewing

Four ordered commits plus two follow-ups; each stands alone.

1. `dfb0914` — classify a billing denial and say so (helpers, `ErrorAlert`, `SubscribeButton`)
2. `e5a3be5` — stop the write path throwing raw Supabase objects (tier-1 access, checked writes,
   delete assertions, 11 journey surfaces)
3. `fb4a0ae` — finish the sweep + the raw-message leak class + the up-front notice
4. `500dffc` — **the migration**
5. `98bcdb3` — don't offer Subscribe to someone the Stripe route will 403
6. `ac095d5` — derive the copy from `subscription_status`, not entitlement

## ⚠ The migration is the one piece with a different failure mode

`billing_gate_update` moves from `USING (company_can_write(...))` to
`USING (true) WITH CHECK (company_can_write(...))`. Enforcement is unchanged because
`NEW.company_id ≡ OLD.company_id` on every real path — no access function writes `company_id` or a
gate-resolving parent FK — and a `<table>_gate_key_immutable` trigger now enforces that for the
browser roles so the equivalence is guaranteed rather than argued. It is also one
`company_can_write()` call per row instead of two.

It is **last in the branch on purpose**: nothing in commits 1–3 depends on it (they degrade to
today's silent behaviour), so it can be dropped without touching the rest. Given the 2026-08-03
outage, **confirm it actually reached prod after merge rather than trusting a green PR.**

`DELETE` is deliberately left silent — no `WITH CHECK` exists for it, and the trigger alternative
inverts fail-closed to fail-**open**. Archive is an UPDATE so it is covered; the remaining hard
deletes assert row counts in TS. A test pins the decision so it is not "fixed" by accident.

`types/database.ts` IS regenerated here. Policies and triggers genuinely do not appear in it, but the migration also adds a callable function (`tenant_tables_with_silent_update_gate`), and those do — caught by CI's byte-exact check after I claimed the opposite. The trigger function is correctly absent; the generator skips `returns trigger`.

## Verified

Behaviour was checked against a real Postgres and a running app, not reasoned about:

- blocked UPDATE raises naming `billing_gate_update` on a direct table **and** a parent-resolved
  child; INSERT still names `billing_gate_insert`; the immutability trigger fires; an active shop's
  update still succeeds; SELECT still works while lapsed
- a **non-member's** denial is still **nameless**, so a Subscribe button is never offered to someone
  whose problem paying would not fix
- all three billing states in the browser: never-subscribed → *"hasn't started yet … Start it"*,
  canceled → *"has ended … Resubscribe"*, paused → *"is paused … Resume it"* (with **Manage billing**,
  since resuming happens in the portal)
- admin / non-admin / operator, and a healthy shop seeing no banner, no notice, no flash

Gates: 2133 frontend tests, 541 backend, lint (0 errors), doc-links, interaction-standards, no
`types/database.ts` drift, `supabase db reset` replays clean.

## Docs

`billing.md` §4.1–4.2 (per-verb failure shapes, the policy-name contract, why DELETE stays silent,
the write-denial UX) and `interaction-standards.md` §4 gains the lapsed-subscription case as a
worked rule-1 example.

Related: #708 / #711 (the capture net this builds on), #645 (the definer-RPC gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

