### PR TITLE
feat(analytics): a CI-enforced tracking plan, PostHog event naming, and docs/telemetry.md

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,15 @@ jobs:
         # needs no runner beyond what is already installed.
         run: pnpm exec vitest run __tests__/standards/docLinkCheck.test.ts
 
+      - name: Analytics check — captured events match the tracking plan (issue #702)
+        # Named for the same reason as the docs check above: this fails on a PR
+        # that adds a posthog.capture() without a row in docs/analytics-events.md,
+        # and the author needs to see "Analytics check" rather than one assertion
+        # buried in the full suite. Both directions are enforced — a stale row
+        # describing an event nobody sends fails too, because a registry with one
+        # wrong row stops being read.
+        run: pnpm exec vitest run __tests__/standards/analyticsEvents.test.ts
+
       - name: Run tests with coverage (enforced thresholds in vitest.config.ts)
         run: pnpm test --run --coverage
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,14 +75,26 @@ the migration finishes, and the read path should have one shape with no "what if
 branch. If a backfill is genuinely impossible, prefer an explicit "no data available" state — it
 surfaces the gap instead of hiding it.
 
-### Observability: Sentry owns errors, and never lies about them
+### Telemetry: Sentry owns errors, PostHog owns behaviour, and neither lies
 
-Full runbook, CLI recipes and traps: **[docs/observability.md](docs/observability.md)** — read it
-before touching Sentry config or triaging. The rules that bind while writing code:
+Full runbook, event registry, CLI recipes and traps: **[docs/telemetry.md](docs/telemetry.md)** —
+read it before touching Sentry config, adding a PostHog event, or triaging. **Telemetry** is the
+umbrella; **observability** (Sentry, Vercel) and **product analytics** (PostHog) stay named apart
+because rules like the first one below need two things to keep separate. The rules that bind while
+writing code:
 
 - **Sentry is the error tracker; PostHog is product analytics.** Never add a second error tracker.
   **Vercel Web Analytics (`<Analytics />`) is kept deliberately** despite overlapping PostHog — do
   not remove either as "redundant".
+- **Every `posthog.capture()` needs a row in the event registry, and CI enforces it both ways.**
+  A capture with no row fails; a row nothing sends fails too. Names are `[object] [verb]`
+  (`quote created`); properties are `snake_case` and describe the *shape* of the interaction —
+  counts, booleans, enums — **never the customer's business data**. A surface belongs in a property,
+  not the event name. Registry and convention:
+  [telemetry.md](docs/telemetry.md), guard: [`scripts/analyticsEventsCheck.ts`](scripts/analyticsEventsCheck.ts).
+- **The check cannot tell you that you forgot to instrument.** It compares code to the registry, so
+  a feature in neither passes green — that is exactly how the operator notes feature shipped
+  unmeasured for months. When a PR adds a user-facing write, it adds a row or says why not.
 - **A failed `.from()` read or write reports itself — don't report it again.** `lib/supabase.ts`
   installs Sentry's Supabase integration, so every `{ error }` is captured with its query
   attached. Adding a `captureException` for one files the same failure as two issues. You still

--- a/__tests__/standards/analyticsEvents.test.ts
+++ b/__tests__/standards/analyticsEvents.test.ts
@@ -34,7 +34,7 @@ describe('analyticsEventsCheck — doc parsing', () => {
   });
 
   /**
-   * GUARD 1. The registry now lives inside observability.md, which documents
+   * GUARD 1. The registry now lives inside telemetry.md, which documents
    * session-replay settings in a table of its own. Without the marker slice
    * those rows parse as events named `session_recording_opt_in`.
    */
@@ -57,7 +57,7 @@ describe('analyticsEventsCheck — doc parsing', () => {
       registry(
         'A surface is a property — see `stock updated` and `surface` above.\n' +
           '| Doc | What it is |\n' +
-          '| [observability.md](observability.md) | The runbook |\n' +
+          '| [telemetry.md](telemetry.md) | The runbook |\n' +
           '| `session_recording_opt_in` | `true` | a setting, not an event |\n' +
           '| `part created` | A part is created | `source` | [x](../x.ts) |',
       ),
@@ -179,7 +179,7 @@ describe('analyticsEventsCheck — comparison', () => {
 describe('analyticsEventsCheck — the live tree', () => {
   /**
    * The check that actually binds. If this fails, either a capture call was
-   * added without a registry row in docs/observability.md, or a row is
+   * added without a registry row in docs/telemetry.md, or a row is
    * describing an event that no longer exists.
    */
   it('every captured event matches the tracking plan', () => {

--- a/__tests__/standards/analyticsEvents.test.ts
+++ b/__tests__/standards/analyticsEvents.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import {
+  parseTrackingPlan,
+  extractCaptures,
+  compare,
+  scanProject,
+  DOC_PATH,
+  REGISTRY_START,
+  REGISTRY_END,
+} from '../../scripts/analyticsEventsCheck';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+/** Wraps a fixture in the markers the parser requires. */
+const registry = (body: string) => `${REGISTRY_START}\n${body}\n${REGISTRY_END}`;
+
+describe('analyticsEventsCheck — doc parsing', () => {
+  it('reads events and properties out of a registry row', () => {
+    const plan = parseTrackingPlan(
+      registry(
+        '| Event | Fires when | Properties | Call site |\n' +
+          '|---|---|---|---|\n' +
+          '| `quote created` | A quote is saved | `line_item_count`, `customer_id` | [x](../x.ts) |',
+      ),
+    );
+    expect([...plan.keys()]).toEqual(['quote created']);
+    expect([...plan.get('quote created')!]).toEqual(['line_item_count', 'customer_id']);
+  });
+
+  it('treats an em dash in the properties cell as no properties', () => {
+    const plan = parseTrackingPlan(registry('| `user signed in` | Login submitted | — | [x](../x.ts) |'));
+    expect(plan.get('user signed in')!.size).toBe(0);
+  });
+
+  /**
+   * GUARD 1. The registry now lives inside observability.md, which documents
+   * session-replay settings in a table of its own. Without the marker slice
+   * those rows parse as events named `session_recording_opt_in`.
+   */
+  it('ignores tables outside the markers', () => {
+    const plan = parseTrackingPlan(
+      '| `session_recording_opt_in` | `true` | The change itself |\n' +
+        registry('| `part created` | A part is created | `source` | [x](../x.ts) |') +
+        '\n| `capture_console_log_opt_in` | `false` | Console holds API responses |',
+    );
+    expect([...plan.keys()]).toEqual(['part created']);
+  });
+
+  /**
+   * GUARD 2. Prose inside the registry section is full of `code spans`; only a
+   * row whose first cell is exactly a backticked event name counts. Note the
+   * snake_case row is rejected — property-shaped names are not event names.
+   */
+  it('ignores prose and non-event rows inside the markers', () => {
+    const plan = parseTrackingPlan(
+      registry(
+        'A surface is a property — see `stock updated` and `surface` above.\n' +
+          '| Doc | What it is |\n' +
+          '| [observability.md](observability.md) | The runbook |\n' +
+          '| `session_recording_opt_in` | `true` | a setting, not an event |\n' +
+          '| `part created` | A part is created | `source` | [x](../x.ts) |',
+      ),
+    );
+    expect([...plan.keys()]).toEqual(['part created']);
+  });
+
+  it('throws rather than silently finding nothing when the markers are missing', () => {
+    expect(() => parseTrackingPlan('| `quote created` | x | — | y |')).toThrow(/markers not found/i);
+  });
+});
+
+describe('analyticsEventsCheck — source parsing', () => {
+  it('extracts the event name and literal property keys', () => {
+    const sites = extractCaptures(
+      `posthog.capture('shipment created', {\n` +
+        `  line_item_count: payload.line_items.length,\n` +
+        `  shipping_method: payload.shipping_method,\n` +
+        `});`,
+      'components/shipments/ShipmentForm.tsx',
+    );
+    expect(sites).toHaveLength(1);
+    expect(sites[0].event).toBe('shipment created');
+    expect(sites[0].properties).toEqual(['line_item_count', 'shipping_method']);
+  });
+
+  it('handles a capture with no properties', () => {
+    const sites = extractCaptures(`posthog.capture('user signed out');`, 'x.tsx');
+    expect(sites[0].properties).toEqual([]);
+  });
+
+  it('reads shorthand keys', () => {
+    const sites = extractCaptures(
+      `posthog.capture('stock updated', { surface: 'office', action, unit });`,
+      'x.tsx',
+    );
+    expect(sites[0].properties).toEqual(['surface', 'action', 'unit']);
+  });
+
+  /**
+   * A comma inside a nested call or a template literal must not be read as a
+   * key separator — that would invent property names out of argument lists.
+   */
+  it('does not split on commas nested inside calls, objects or template literals', () => {
+    const sites = extractCaptures(
+      `posthog.capture('job created from purchase order', {\n` +
+        `  part_count: lines.filter((l, i) => l.part).length,\n` +
+        `  label: \`\${a}, \${b}\`,\n` +
+        `  nested: { a: 1, b: 2 },\n` +
+        `});`,
+      'x.tsx',
+    );
+    expect(sites[0].properties).toEqual(['part_count', 'label', 'nested']);
+  });
+
+  it('records a 1-indexed line number', () => {
+    const sites = extractCaptures(`const a = 1;\n\nposthog.capture('part created');`, 'x.tsx');
+    expect(sites[0].line).toBe(3);
+  });
+
+  it('finds several captures in one file', () => {
+    const sites = extractCaptures(
+      `posthog.capture('quote created');\nposthog.capture('part created', { n: 1 });`,
+      'x.tsx',
+    );
+    expect(sites.map((s) => s.event)).toEqual(['quote created', 'part created']);
+  });
+});
+
+describe('analyticsEventsCheck — comparison', () => {
+  const site = (event: string, properties: string[] = []) => [
+    { event, properties, file: 'x.tsx', line: 1 },
+  ];
+
+  it('passes when code and doc agree', () => {
+    const plan = new Map([['quote created', new Set(['line_item_count'])]]);
+    expect(compare(plan, site('quote created', ['line_item_count']))).toEqual([]);
+  });
+
+  it('flags an event that is captured but undocumented', () => {
+    const v = compare(new Map(), site('note posted'));
+    expect(v.map((x) => x.kind)).toContain('undocumented-event');
+  });
+
+  /** The direction that keeps the registry trustworthy once a name changes. */
+  it('flags a documented event that nothing sends', () => {
+    const plan = new Map([['quote deleted', new Set<string>()]]);
+    expect(compare(plan, []).map((x) => x.kind)).toEqual(['stale-doc-entry']);
+  });
+
+  it('flags properties missing from the doc and missing from the code', () => {
+    const plan = new Map([['part created', new Set(['source', 'is_stocked'])]]);
+    const v = compare(plan, site('part created', ['source', 'colour']));
+    expect(v.map((x) => x.kind).sort()).toEqual(['stale-doc-property', 'undocumented-property']);
+  });
+
+  /**
+   * `stock updated` is sent from both the office and operator modals with
+   * different property sets, so the doc describes the union, not either call.
+   */
+  it('unions properties across call sites before judging the doc', () => {
+    const plan = new Map([['stock updated', new Set(['surface', 'location_id'])]]);
+    const sites = [
+      { event: 'stock updated', properties: ['surface'], file: 'a.tsx', line: 1 },
+      { event: 'stock updated', properties: ['surface', 'location_id'], file: 'b.tsx', line: 1 },
+    ];
+    expect(compare(plan, sites)).toEqual([]);
+  });
+
+  /** The old snake_case convention is now itself a violation. */
+  it('flags snake_case and capitalised event names', () => {
+    for (const bad of ['quote_created', 'Quote Created']) {
+      const v = compare(new Map([[bad, new Set<string>()]]), site(bad));
+      expect(v.map((x) => x.kind), bad).toContain('bad-event-name');
+    }
+  });
+});
+
+describe('analyticsEventsCheck — the live tree', () => {
+  /**
+   * The check that actually binds. If this fails, either a capture call was
+   * added without a registry row in docs/observability.md, or a row is
+   * describing an event that no longer exists.
+   */
+  it('every captured event matches the tracking plan', () => {
+    const violations = scanProject(REPO_ROOT);
+    const report = violations
+      .map((v) => `  [${v.kind}] ${v.file}${v.line ? `:${v.line}` : ''} — ${v.detail}`)
+      .join('\n');
+    expect(violations, `Tracking-plan drift (registry: ${DOC_PATH}):\n${report}`).toEqual([]);
+  });
+});

--- a/app/accept-invite/[invitationId]/page.tsx
+++ b/app/accept-invite/[invitationId]/page.tsx
@@ -357,7 +357,7 @@ export default function AcceptInvitePage() {
       await setLastCompany(userId, companyId);
 
       posthog.identify(userId, { email: invitation.email });
-      posthog.capture('invitation_accepted', {
+      posthog.capture('invitation accepted', {
         role: invitation.role,
         existing_user: isExistingUser,
       });

--- a/app/dashboard/[companyId]/jobs/page.tsx
+++ b/app/dashboard/[companyId]/jobs/page.tsx
@@ -383,7 +383,7 @@ export default function JobsPage() {
     setCancelling(true);
     try {
       await bulkCancelJobs(selectedIds);
-      posthog.capture('jobs_bulk_cancelled', { count: selectedIds.length });
+      posthog.capture('jobs bulk cancelled', { count: selectedIds.length });
       setSelectedIds([]);
       if (gridRef.current?.api) {
         gridRef.current.api.deselectAll();

--- a/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
+++ b/app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx
@@ -239,7 +239,7 @@ export default function OperatorOperationActionPage() {
       // Analytics fires here, beside the existing operator event and BEFORE the note capture
       // below: the completion is durable at this point, and a slow photo upload must not delay or
       // skip the measurement of the thing that already happened.
-      posthog.capture('operator_operation_completed', {
+      posthog.capture('operation completed', {
         job_operation_id: jobOperationId,
         quantity_good: qty,
         is_partial: qty < remaining,

--- a/components/auth/Login.tsx
+++ b/components/auth/Login.tsx
@@ -75,7 +75,7 @@ export default function Login({ expired, returnTo }: LoginProps) {
 
       if (data.user) {
         posthog.identify(data.user.id, { email: data.user.email });
-        posthog.capture('user_signed_in');
+        posthog.capture('user signed in');
         // If we have a valid returnTo path (e.g., from session expiry), go there
         if (returnTo && isValidReturnTo(returnTo)) {
           router.push(returnTo);

--- a/components/jobs/AcceptPurchaseOrderModal.tsx
+++ b/components/jobs/AcceptPurchaseOrderModal.tsx
@@ -278,7 +278,7 @@ export default function AcceptPurchaseOrderModal({
         }
       }
 
-      posthog.capture('job_created_from_po', {
+      posthog.capture('job created from purchase order', {
         part_count: lines.filter((l) => l.part).length,
         total_value: total,
         is_hot: hot,

--- a/components/operator/OperatorLocationActionModal.tsx
+++ b/components/operator/OperatorLocationActionModal.tsx
@@ -199,7 +199,8 @@ export default function OperatorLocationActionModal({
           photoPath,
         });
       }
-      posthog.capture('operator_inventory_stock_updated', {
+      posthog.capture('stock updated', {
+        surface: 'operator',
         action,
         part_id: partId,
         quantity: qty,

--- a/components/parts/PartLocationActionModal.tsx
+++ b/components/parts/PartLocationActionModal.tsx
@@ -245,7 +245,8 @@ export default function PartLocationActionModal({
           operatorId,
         });
       }
-      posthog.capture('inventory_stock_updated', {
+      posthog.capture('stock updated', {
+        surface: 'office',
         action,
         part_id: partId,
         quantity: qty,

--- a/components/parts/workspace/PartIdentitySection.tsx
+++ b/components/parts/workspace/PartIdentitySection.tsx
@@ -174,7 +174,7 @@ export default function PartIdentitySection({
       // Properties are the shape choices that drive later journeys (a stocked bought
       // part implies inventory + procurement; a made part implies a routing) — never
       // the part name, which is customer-identifying.
-      posthog.capture('part_created', {
+      posthog.capture('part created', {
         source: formData.source,
         is_stocked: formData.is_stocked,
         has_reorder_point: formData.reorder_point !== null,

--- a/components/providers/AuthProvider.tsx
+++ b/components/providers/AuthProvider.tsx
@@ -95,7 +95,7 @@ export default function AuthProvider({ children }: AuthProviderProps) {
 
         if (event === 'SIGNED_OUT') {
           intentionalSignOut.current = false;
-          posthog.capture('user_signed_out');
+          posthog.capture('user signed out');
           posthog.reset();
         }
       }

--- a/components/quotes/ConvertToJobModal.tsx
+++ b/components/quotes/ConvertToJobModal.tsx
@@ -301,7 +301,7 @@ export default function ConvertToJobModal({
           return;
         }
       }
-      posthog.capture('quote_converted_to_job', {
+      posthog.capture('quote converted to job', {
         quote_id: quote.id,
         part_count: includedGroups.length,
         is_hot: hot,

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -1077,7 +1077,7 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     try {
       if (mode === 'create') {
         const { quote } = await createQuote(companyId, payload);
-        posthog.capture('quote_created', {
+        posthog.capture('quote created', {
           line_item_count: payload.parts.length,
           customer_id: formData.customer_id,
         });

--- a/components/shipments/ShipmentForm.tsx
+++ b/components/shipments/ShipmentForm.tsx
@@ -624,7 +624,7 @@ export default function ShipmentForm({
 
     try {
       const result = await createShipment(companyId, payload);
-      posthog.capture('shipment_created', {
+      posthog.capture('shipment created', {
         line_item_count: payload.line_items.length,
         shipping_method: payload.shipping_method,
       });

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ the detail, including the doc-writing standard in [writing-docs.md](writing-docs
 | [architecture.md](architecture.md) | System architecture — the most-linked doc here; §8 (API standard) and §16 (soft-delete) are cited by number |
 | [design-system.md](design-system.md) | The visual spec: canvas, glass cards, buttons, scales, detail-page patterns |
 | [interaction-standards.md](interaction-standards.md) | Normative interaction rules, **machine-enforced** by `scripts/interactionStandardsCheck.ts` |
-| [observability.md](observability.md) | Sentry / PostHog / Vercel — the runbook and the traps |
+| [observability.md](observability.md) | Sentry / PostHog / Vercel — the runbook, the traps, and the **machine-enforced** analytics event registry |
 | [brand-guide.md](brand-guide.md) | Palette, logo, and the only writing-voice guidance in the repo |
 
 ## Modules

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ the detail, including the doc-writing standard in [writing-docs.md](writing-docs
 | [architecture.md](architecture.md) | System architecture — the most-linked doc here; §8 (API standard) and §16 (soft-delete) are cited by number |
 | [design-system.md](design-system.md) | The visual spec: canvas, glass cards, buttons, scales, detail-page patterns |
 | [interaction-standards.md](interaction-standards.md) | Normative interaction rules, **machine-enforced** by `scripts/interactionStandardsCheck.ts` |
-| [observability.md](observability.md) | Sentry / PostHog / Vercel — the runbook, the traps, and the **machine-enforced** analytics event registry |
+| [telemetry.md](telemetry.md) | Everything we collect: Sentry/Vercel observability, PostHog product analytics, the traps, and the **machine-enforced** event registry |
 | [brand-guide.md](brand-guide.md) | Palette, logo, and the only writing-voice guidance in the repo |
 
 ## Modules

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ else → `/dashboard/{companyId}`. Tested:
 
 [`AuthGuard.tsx`](../components/auth/AuthGuard.tsx) verifies auth + company access
 and stamps `last_company_id` on success. Two invariants it holds (rationale:
-[observability.md](observability.md)):
+[telemetry.md](telemetry.md)):
 
 - **"Couldn't check" is never "denied."** `verifyCompanyAccess` returns `false`
   only for PostgREST `PGRST116` (genuinely no membership row) and **throws**
@@ -409,7 +409,7 @@ Feature-scoped groups, each owned by its module doc rather than repeated here:
 `STRIPE_FOUNDING_PRICE_ID` ([modules/billing.md](modules/billing.md); note §8.4 —
 the restricted key deliberately has **no** fallback to `STRIPE_SECRET_KEY`),
 `QUICKBOOKS_*` + `APP_BASE_URL`, `RESEND_API_KEY` / `QUOTES_FROM_EMAIL`, and
-`SENTRY_DSN` ([observability.md](observability.md)).
+`SENTRY_DSN` ([telemetry.md](telemetry.md)).
 
 *(§10 Development Commands was removed 2026-08-03: CLAUDE.md genuinely does own it,
 and this copy said `pip install -r requirements.txt` / `python index.py` against the

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -51,6 +51,154 @@ correctly. **Keep both — neither is "redundant".**
 
 ---
 
+## PostHog session replay: on, and why it is configured this way
+
+**Enabled 2026-08-07.** Replay is the highest-value instrument at pilot scale: with three named
+users, watching three sessions beats any aggregate, and rate-based insights over an N that small
+are noise. There is **no code for this** — `instrumentation-client.ts` never sets
+`disable_session_recording`, so the project's remote config governs. The settings below live only
+in PostHog, which is why they are written down here.
+
+| Setting | Value | Why |
+|---|---|---|
+| `session_recording_opt_in` | `true` | The change itself |
+| `session_recording_masking_config` | `{ maskAllInputs: true }` | Never record keystrokes — passwords, prices, quantities. Rendered text stays visible, because a replay with every label masked cannot teach you anything |
+| `recording_domains` | `https://www.jigged.app` | Belt-and-braces production-only. The token already gates this, but a domain allowlist survives someone re-adding it to `.env.local` |
+| `capture_console_log_opt_in` | `false` | Console output routinely holds API responses and user objects. It was `true` and inert while replay was off — enabling replay is what would have armed it |
+| `capture_performance_opt_in` | `false` | **See below** |
+| `session_recording_retention_period` | `30d` | Shortest available |
+
+**`capture_performance` is deliberately off, and turning it on would break an argument made
+above.** Overlap 2 rests on PostHog having never ingested a `$web_vitals` event — that is what
+makes "deleting `<Analytics />` would end Web Vitals, not move them" true. Performance capture is
+part of replay, so enabling replay with it on would start producing `$web_vitals` here, and the
+next person to read that section would find its premise false and reasonably conclude Vercel
+Analytics is now redundant. The cost of keeping it off is network timing in replays, which is not
+worth a load-bearing invariant.
+
+**Not masked: rendered text**, which on admin screens means customer names and part numbers. That
+is the same exposure as autocapture ([#702](https://github.com/debola31/Jigged/issues/702)), traded
+deliberately — a replay is watched by us and expires in 30 days, where an event property is
+queried, exported and retained for a year. Revisit when the pilot ends.
+
+---
+
+## The tracking plan
+
+**Machine-enforced** by [`scripts/analyticsEventsCheck.ts`](../scripts/analyticsEventsCheck.ts):
+an event captured in code but absent from the registry below fails CI, and so does a registry row
+nobody sends. Both directions, because a table with one wrong row stops being read.
+
+### The convention
+
+**`[object] [verb]`, lowercase, spaces, past tense** — `quote created`, not `quote_created` or
+`Create Quote`. This is [PostHog's own recommendation](https://posthog.com/docs/product-analytics/capture-events)
+and what PostHog uses for its own custom events. The object leads so related events sort together.
+
+**Renamed from snake_case on 2026-08-07**, four days into collecting anything. The argument for
+keeping the old names was continuity of historical data; at three users and four days there was no
+history worth the inconsistency. **That argument gets stronger every week** — the disciplined way
+to rename later is to emit both names, migrate the insights, then retire the old one, and it is
+much more work than doing it now.
+
+**Properties describe the shape of the interaction, never the content of the record.** Counts,
+booleans and enums — not names, values or free text. `part created` is the model: it sends
+`has_reorder_point`, a boolean, not the reorder point.
+
+**Properties stay `snake_case`.** They are code identifiers read in filter expressions, not display
+labels.
+
+**A surface is a property, not a name.** Office and operator stock adjustments are one
+`stock updated` event with `surface`, not two events. Encoding a variable in the event name is what
+PostHog's high-cardinality guidance warns against, and it makes the two impossible to total.
+
+### The registry
+
+The properties column is exhaustive, unioned across call sites: a property passed but unlisted
+fails, and so does a listed property nothing passes.
+
+<!-- registry:start -->
+
+| Event | Fires when | Properties | Call site |
+|---|---|---|---|
+| `user signed in` | The login form is submitted successfully | — | [Login.tsx](../components/auth/Login.tsx) |
+| `user signed out` | Supabase emits `SIGNED_OUT` | — | [AuthProvider.tsx](../components/providers/AuthProvider.tsx) |
+| `invitation accepted` | An invitee completes acceptance | `role`, `existing_user` | [accept-invite/page.tsx](../app/accept-invite/[invitationId]/page.tsx) |
+| `quote created` | A new quote is saved | `line_item_count`, `customer_id` | [QuoteForm.tsx](../components/quotes/QuoteForm.tsx) |
+| `quote converted to job` | A quote is accepted and becomes a job | `quote_id`, `part_count`, `is_hot` | [ConvertToJobModal.tsx](../components/quotes/ConvertToJobModal.tsx) |
+| `job created from purchase order` | A job is created directly from a PO | `part_count`, `total_value`, `is_hot` | [AcceptPurchaseOrderModal.tsx](../components/jobs/AcceptPurchaseOrderModal.tsx) |
+| `jobs bulk cancelled` | Several jobs are cancelled in one action | `count` | [jobs/page.tsx](../app/dashboard/[companyId]/jobs/page.tsx) |
+| `shipment created` | A shipment is created | `line_item_count`, `shipping_method` | [ShipmentForm.tsx](../components/shipments/ShipmentForm.tsx) |
+| `part created` | A part is created in the parts workspace | `source`, `is_stocked`, `has_reorder_point`, `has_preferred_vendor` | [PartIdentitySection.tsx](../components/parts/workspace/PartIdentitySection.tsx) |
+| `stock updated` | Stock is adjusted. `surface` says which UI; `location_id` is operator-only | `surface`, `action`, `part_id`, `quantity`, `unit`, `location_id` | [PartLocationActionModal.tsx](../components/parts/PartLocationActionModal.tsx) · [OperatorLocationActionModal.tsx](../components/operator/OperatorLocationActionModal.tsx) |
+| `operation completed` | An operator completes an operation. Operator-only, so no `surface` | `job_operation_id`, `quantity_good`, `is_partial` | [operations/page.tsx](../app/operator/[companyId]/jobs/[jobId]/parts/[jobPartId]/operations/[jobOperationId]/page.tsx) |
+
+<!-- registry:end -->
+
+The markers are not decoration — the checker parses only between them, because this document
+contains other tables whose first cells are backticked identifiers.
+
+**Several properties carry customer business data and are scheduled for change** — `total_value`,
+`quantity`, `quantity_good`, and the raw `customer_id` / `part_id` / `quote_id` /
+`job_operation_id` identifiers ([#702](https://github.com/debola31/Jigged/issues/702)). This table
+records what we send, not what we have decided is right.
+
+### Known gap: notes and photos are not instrumented
+
+The operator activity feed — the notes-and-photos loop
+[modules/operator-view.md](modules/operator-view.md) treats as a core surface — sends **no event**.
+A pilot user posted a note on 2026-08-06 and it appeared nowhere in analytics; that is how the gap
+was found.
+
+Measurement today is a PostHog **action** (`Note posted (autocapture proxy)`, id 311795) matching
+autocapture clicks on the `Post` button. It works retroactively, which is why it was worth making,
+but it is text-matched and breaks silently if the label changes.
+
+**This blocks a fix we want.** `mask_all_text` — the remedy for autocapture capturing customer
+names — would also break the proxy. Instrument `note posted` properly and both resolve.
+
+### Autocapture is for discovery, not measurement
+
+Autocapture stays **on** and is the highest-volume event by an order of magnitude. Its job is to
+answer *"what are people doing that we never thought to measure"* — exactly what it did for notes.
+Its job is **not** to be the source of a metric anyone relies on.
+
+The loop: autocapture surfaces a behaviour → the behaviour earns an explicit `posthog.capture()` and
+a registry row → the metric now rests on a stable name. Never let a metric you care about depend on
+autocapture element text; it is fragile, and it is how customer names reach PostHog.
+
+### What the check cannot do
+
+**It cannot tell you that you forgot to instrument something.** It compares code against this
+document; a feature in neither passes green. Notes shipped, went unmeasured, and this check would
+have said nothing. The control is review: a PR adding a user-facing write adds a row or says why not.
+
+**It does not verify the event reaches PostHog.** A bad token, an ad blocker, or an `init` that
+never ran all produce silence indistinguishable from green.
+
+### Two lifecycles, one doc
+
+Analytics events and error signals are collected the same way and read at different times, and the
+difference that matters is **when you stop**.
+
+An observability signal is permanent. Errors and uptime matter for as long as the code runs, and
+nobody prunes them because a feature matured.
+
+An analytics event is a **question with an expiry**. Industry practice treats events as having
+explicit states — proposed, active, deprecated, removed — with periodic audits that retire events
+nobody queries, because unused events cost ingest and clutter the taxonomy. Once *"is anyone using
+Storage?"* is answered, `stock updated` may stop earning its keep.
+
+**Two caveats before pruning anything.** Growth events — activation, retention, the quote-to-cash
+spine — are never retired; they are the denominators everything else is measured against. And
+deleting an event ends the time series: you keep history but lose the future, so retire only what
+you would not miss in a year-over-year comparison.
+
+Nothing here is retired yet — we have days of data. The audit is worth running once there is a
+quarter of it.
+
+---
+
 ## Sentry: the CLI is the interface
 
 The `sentry` CLI is installed and authenticated (`sentry auth status`). Prefer it over the

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,4 +1,19 @@
-# Observability
+# Telemetry
+
+Everything we collect about the running system, and everything we collect about the people using
+it. **Telemetry is the umbrella; the two halves under it are different disciplines and stay named
+apart.**
+
+- **Observability** — inferring system state from its outputs. Sentry and the Vercel surfaces.
+  Permanent: an error signal matters for as long as the code runs.
+- **Product analytics** — what people did and where they dropped off. PostHog. Question-shaped:
+  an event can be retired once its question is answered ([two lifecycles](#two-lifecycles-one-doc)).
+
+They live in one document because they share tools, config surfaces and failure modes — the
+session-replay setting below reaches into the Web Vitals argument above, and splitting them is how
+you get a PR that changes one without noticing the other. They keep separate names because
+"observability" has a specific meaning (metrics, logs, traces) that product analytics is not, and
+because rules like *"Sentry owns errors, PostHog must not"* need two things to keep apart.
 
 Four surfaces across three vendors. They answer different questions, and the two places
 they *do* overlap are handled deliberately — one avoided, one knowingly accepted.

--- a/lib/supabaseErrors.ts
+++ b/lib/supabaseErrors.ts
@@ -149,7 +149,7 @@ export function isIndeterminateSingleError(error: unknown): boolean {
  *
  * Excluding these is not about quota, which has ample headroom. It is that an issue queue with
  * predictable non-failures in it is one people stop reading, which is the documented history of
- * this project's queue (docs/observability.md "Why any of this matters").
+ * this project's queue (docs/telemetry.md "Why any of this matters").
  */
 export function shouldReportSupabaseError(error: unknown): boolean {
   if (!error) return false;

--- a/scripts/analyticsEventsCheck.ts
+++ b/scripts/analyticsEventsCheck.ts
@@ -1,7 +1,7 @@
 /**
  * Tracking-plan drift checker.
  *
- * Parses the registry table in `docs/observability.md` to learn the
+ * Parses the registry table in `docs/telemetry.md` to learn the
  * canonical {event → properties} shape, then walks the source tree for
  * `posthog.capture('name', { … })` calls and asserts the two agree in both
  * directions:
@@ -83,7 +83,7 @@ export const REGISTRY_END = '<!-- registry:end -->';
  * Reads the registry table out of the tracking plan.
  *
  * TWO GUARDS, AND BOTH ARE LOAD-BEARING NOW THAT THE REGISTRY LIVES INSIDE THE
- * OBSERVABILITY DOC. That doc contains other tables — notably the session
+ * TELEMETRY DOC. That doc contains other tables — notably the session
  * replay settings, whose first cells are backticked identifiers like
  * `session_recording_opt_in`. Parsing the whole file would silently invent
  * those as events:
@@ -234,7 +234,7 @@ const SCAN_DIRS = ['app', 'components', 'lib', 'utils', 'hooks'];
 const SCAN_EXT = ['.ts', '.tsx'];
 const SKIP_DIRS = new Set(['node_modules', '.next', '__tests__', 'coverage']);
 
-export const DOC_PATH = 'docs/observability.md';
+export const DOC_PATH = 'docs/telemetry.md';
 
 function walk(dir: string, out: string[]): void {
   let entries: string[];

--- a/scripts/analyticsEventsCheck.ts
+++ b/scripts/analyticsEventsCheck.ts
@@ -1,0 +1,370 @@
+/**
+ * Tracking-plan drift checker.
+ *
+ * Parses the registry table in `docs/observability.md` to learn the
+ * canonical {event → properties} shape, then walks the source tree for
+ * `posthog.capture('name', { … })` calls and asserts the two agree in both
+ * directions:
+ *
+ *   - an event captured in code but missing from the doc  → undocumented-event
+ *   - an event in the doc that nothing sends              → stale-doc-entry
+ *   - a property passed but not documented                → undocumented-property
+ *   - a property documented but never passed              → stale-doc-property
+ *   - an event name that is not `[object] [verb]`         → bad-event-name
+ *
+ * WHY BOTH DIRECTIONS. A one-way check (code ⊆ doc) lets the doc accumulate
+ * events that were renamed or deleted, which is the failure mode that makes a
+ * registry untrustworthy: once one row is wrong, no reader believes any row.
+ * The reverse direction is what keeps the table worth reading.
+ *
+ * WHAT THIS DELIBERATELY CANNOT DO, so nobody mistakes green for coverage:
+ * it compares code against a document. A feature that is in NEITHER passes.
+ * The operator notes feature shipped, went unmeasured, and this check would
+ * have said nothing — see the "Known gap" section of the doc. The control for
+ * that is review, not CI.
+ *
+ * PROPERTY EXTRACTION IS LITERAL-ONLY, and that is a real limit rather than a
+ * shortcut. Keys are read from the object literal at the call site, so
+ * `{ ...spreadProps }` or a computed `[key]:` contributes nothing and the
+ * documented properties for that event become unverifiable. Every call site
+ * today uses plain literal keys; if that changes, prefer splitting the capture
+ * over silently losing the check.
+ *
+ * Driven through vitest like the repo's other source scanners —
+ * `pnpm exec vitest run __tests__/standards/analyticsEvents.test.ts`. There is
+ * a CLI block at the foot of this file, but note `tsx` is NOT a dependency of
+ * this repo, so `pnpm exec tsx scripts/…` does not work here despite what the
+ * header of docLinkCheck.ts claims. The vitest spec is the real entry point.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative, resolve } from 'path';
+
+// ============== Types ==============
+
+export type ViolationKind =
+  | 'undocumented-event'
+  | 'stale-doc-entry'
+  | 'undocumented-property'
+  | 'stale-doc-property'
+  | 'bad-event-name';
+
+export interface EventViolation {
+  kind: ViolationKind;
+  event: string;
+  detail: string;
+  /** Repo-relative path, or the doc path for doc-side violations. */
+  file: string;
+  /** 1-indexed. 0 when the violation is "nothing in code sends this". */
+  line: number;
+}
+
+export interface CaptureSite {
+  event: string;
+  properties: string[];
+  file: string;
+  line: number;
+}
+
+/** Documented event → its exhaustive property set. */
+export type TrackingPlan = Map<string, Set<string>>;
+
+// ============== Doc parsing ==============
+
+/** Event names are `[object] [verb]`: lowercase words separated by spaces. */
+const EVENT_CELL = /^`([a-z][a-z0-9 ]*)`$/;
+/** Property names stay snake_case — they are code identifiers, not display labels. */
+const BACKTICKED = /`([a-z][a-z0-9_]*)`/g;
+
+export const REGISTRY_START = '<!-- registry:start -->';
+export const REGISTRY_END = '<!-- registry:end -->';
+
+/**
+ * Reads the registry table out of the tracking plan.
+ *
+ * TWO GUARDS, AND BOTH ARE LOAD-BEARING NOW THAT THE REGISTRY LIVES INSIDE THE
+ * OBSERVABILITY DOC. That doc contains other tables — notably the session
+ * replay settings, whose first cells are backticked identifiers like
+ * `session_recording_opt_in`. Parsing the whole file would silently invent
+ * those as events:
+ *
+ *   1. Only content between the registry markers is considered.
+ *   2. Within it, only rows whose first cell is exactly a backticked
+ *      space-separated lowercase name count — which also excludes prose
+ *      containing `code spans`.
+ *
+ * Guard 1 alone would be enough today and guard 2 alone would be enough while
+ * every setting happens to be snake_case. Keeping both means neither a new
+ * table nor a renamed setting can quietly poison the registry.
+ */
+export function parseTrackingPlan(markdown: string): TrackingPlan {
+  const plan: TrackingPlan = new Map();
+
+  const from = markdown.indexOf(REGISTRY_START);
+  const to = markdown.indexOf(REGISTRY_END);
+  if (from === -1 || to === -1 || to < from) {
+    throw new Error(
+      `Registry markers not found in the tracking plan. Expected ${REGISTRY_START} … ${REGISTRY_END}.`,
+    );
+  }
+  const registry = markdown.slice(from + REGISTRY_START.length, to);
+
+  for (const rawLine of registry.split('\n')) {
+    const line = rawLine.trim();
+    if (!line.startsWith('|')) continue;
+
+    // Drop the empty leading/trailing cells produced by the outer pipes.
+    const cells = line.split('|').slice(1, -1).map((c) => c.trim());
+    if (cells.length < 3) continue;
+
+    const nameMatch = EVENT_CELL.exec(cells[0]);
+    if (!nameMatch) continue;
+
+    const properties = new Set<string>();
+    // An em dash means "no properties" and is left as an empty set.
+    for (const m of cells[2].matchAll(BACKTICKED)) properties.add(m[1]);
+
+    plan.set(nameMatch[1], properties);
+  }
+
+  return plan;
+}
+
+// ============== Source parsing ==============
+
+/**
+ * Splits an object-literal body on top-level commas, stepping over nested
+ * braces/brackets/parens and over string and template-literal contents so a
+ * comma inside `` `a, b` `` or `f(x, y)` does not split a key off.
+ */
+function splitTopLevel(body: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let quote: string | null = null;
+  let start = 0;
+
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+
+    if (quote) {
+      if (ch === '\\') i++;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === '`') quote = ch;
+    else if (ch === '{' || ch === '[' || ch === '(') depth++;
+    else if (ch === '}' || ch === ']' || ch === ')') depth--;
+    else if (ch === ',' && depth === 0) {
+      parts.push(body.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(body.slice(start));
+  return parts;
+}
+
+/** Finds the index just past the `}` matching an opening `{` at `open`. */
+function matchBrace(source: string, open: number): number {
+  let depth = 0;
+  let quote: string | null = null;
+
+  for (let i = open; i < source.length; i++) {
+    const ch = source[i];
+
+    if (quote) {
+      if (ch === '\\') i++;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === '`') quote = ch;
+    else if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+const CALL = 'posthog.capture(';
+const KEY = /^\s*(?:\/\/[^\n]*\n\s*)*([A-Za-z_$][A-Za-z0-9_$]*)\s*(?::|$)/;
+
+export function extractCaptures(source: string, relPath: string): CaptureSite[] {
+  const sites: CaptureSite[] = [];
+  let idx = source.indexOf(CALL);
+
+  while (idx !== -1) {
+    const afterCall = idx + CALL.length;
+    const nameMatch = /^\s*(['"`])([^'"`]+)\1/.exec(source.slice(afterCall));
+
+    if (nameMatch) {
+      const line = source.slice(0, idx).split('\n').length;
+      const properties: string[] = [];
+
+      // Optional second argument: an object literal of properties.
+      const rest = source.slice(afterCall + nameMatch[0].length);
+      const objStart = /^\s*,\s*\{/.exec(rest);
+      if (objStart) {
+        const openAbs = afterCall + nameMatch[0].length + objStart[0].length - 1;
+        const closeAbs = matchBrace(source, openAbs);
+        if (closeAbs !== -1) {
+          for (const segment of splitTopLevel(source.slice(openAbs + 1, closeAbs))) {
+            if (!segment.trim()) continue;
+            const key = KEY.exec(segment);
+            // A spread or computed key yields no name; see the header note.
+            if (key) properties.push(key[1]);
+          }
+        }
+      }
+
+      sites.push({ event: nameMatch[2], properties, file: relPath, line });
+    }
+
+    idx = source.indexOf(CALL, idx + CALL.length);
+  }
+
+  return sites;
+}
+
+// ============== Project scan ==============
+
+const SCAN_DIRS = ['app', 'components', 'lib', 'utils', 'hooks'];
+const SCAN_EXT = ['.ts', '.tsx'];
+const SKIP_DIRS = new Set(['node_modules', '.next', '__tests__', 'coverage']);
+
+export const DOC_PATH = 'docs/observability.md';
+
+function walk(dir: string, out: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (SCAN_EXT.some((e) => entry.endsWith(e)) && !entry.includes('.test.')) out.push(full);
+  }
+}
+
+export function collectCaptures(root: string): CaptureSite[] {
+  const files: string[] = [];
+  for (const dir of SCAN_DIRS) walk(join(root, dir), files);
+
+  const sites: CaptureSite[] = [];
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8');
+    if (!source.includes(CALL)) continue;
+    sites.push(...extractCaptures(source, relative(root, file)));
+  }
+  return sites;
+}
+
+export function compare(plan: TrackingPlan, sites: CaptureSite[]): EventViolation[] {
+  const violations: EventViolation[] = [];
+  const seen = new Map<string, Set<string>>();
+
+  for (const site of sites) {
+    if (!/^[a-z][a-z0-9 ]*$/.test(site.event)) {
+      violations.push({
+        kind: 'bad-event-name',
+        event: site.event,
+        detail: `"${site.event}" is not \`[object] [verb]\`: lowercase words separated by spaces, past tense.`,
+        file: site.file,
+        line: site.line,
+      });
+    }
+
+    const documented = plan.get(site.event);
+    if (!documented) {
+      violations.push({
+        kind: 'undocumented-event',
+        event: site.event,
+        detail: `Captured in code but absent from ${DOC_PATH}. Add a registry row.`,
+        file: site.file,
+        line: site.line,
+      });
+      continue;
+    }
+
+    // Union across call sites: the same event may be sent from more than one
+    // place, and the doc describes the event, not any single call.
+    const union = seen.get(site.event) ?? new Set<string>();
+    for (const p of site.properties) {
+      union.add(p);
+      if (!documented.has(p)) {
+        violations.push({
+          kind: 'undocumented-property',
+          event: site.event,
+          detail: `Property "${p}" is passed here but not listed for ${site.event} in ${DOC_PATH}.`,
+          file: site.file,
+          line: site.line,
+        });
+      }
+    }
+    seen.set(site.event, union);
+  }
+
+  for (const [event, documented] of plan) {
+    const actual = seen.get(event);
+    if (!actual) {
+      violations.push({
+        kind: 'stale-doc-entry',
+        event,
+        detail: `Documented but nothing calls posthog.capture('${event}'). Remove the row, or fix the name.`,
+        file: DOC_PATH,
+        line: 0,
+      });
+      continue;
+    }
+    for (const p of documented) {
+      if (!actual.has(p)) {
+        violations.push({
+          kind: 'stale-doc-property',
+          event,
+          detail: `Property "${p}" is documented for ${event} but no call site passes it.`,
+          file: DOC_PATH,
+          line: 0,
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+export function scanProject(root: string): EventViolation[] {
+  const plan = parseTrackingPlan(readFileSync(join(root, DOC_PATH), 'utf8'));
+  return compare(plan, collectCaptures(root));
+}
+
+// ============== CLI ==============
+
+// `require.main === module` does not hold under tsx/ESM, so compare argv
+// instead — the same shape the repo's other scanners use.
+const invokedDirectly =
+  typeof process !== 'undefined' &&
+  process.argv[1] !== undefined &&
+  process.argv[1].includes('analyticsEventsCheck');
+
+if (invokedDirectly) {
+  const root = resolve(__dirname, '..');
+  const violations = scanProject(root);
+
+  if (violations.length === 0) {
+    console.log(`✓ Tracking plan matches code (${DOC_PATH})`);
+  } else {
+    console.error(`✗ ${violations.length} tracking-plan violation(s):\n`);
+    for (const v of violations) {
+      const where = v.line ? `${v.file}:${v.line}` : v.file;
+      console.error(`  [${v.kind}] ${where}\n      ${v.detail}`);
+    }
+    console.error(`\nThe registry lives in ${DOC_PATH}.`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Why

Event definitions were implicit — spread across whichever PR introduced the feature — so the only way to answer *"what do we measure?"* was to grep. That is how the operator notes feature shipped, went unmeasured, and was only noticed when a pilot user's note appeared in the in-app Activity feed and nowhere in analytics.

## What this adds

**A registry that CI can falsify.** `docs/telemetry.md` gains a tracking-plan section listing all 11 events, their exhaustive properties and call sites, enforced by [`scripts/analyticsEventsCheck.ts`](scripts/analyticsEventsCheck.ts) as a named CI step.

Enforced **both directions**: a capture without a registry row fails, *and* a row nothing sends fails. One-way (code ⊆ doc) would let the table accumulate renamed events, and a table with one wrong row stops being read.

**Event names move to PostHog's `[object] [verb]`** — `quote created`, not `quote_created`. Four days into collecting anything, at three users, there was no history worth the inconsistency, and the disciplined way to rename later (emit both names, migrate insights, retire the old) is far more work than doing it now.

The two stock events collapse into one `stock updated` carrying `surface: 'office' | 'operator'`. Encoding a variable in the event name is what PostHog's high-cardinality guidance warns against, and it made the two impossible to total.

**`docs/observability.md` → `docs/telemetry.md`.** The doc now holds product analytics too, and "observability" has a specific meaning — inferring system state from metrics, logs and traces — that product analytics is not. Telemetry is the umbrella the industry uses for both. Git tracked the rename, so history follows the file.

Collapsing the vocabulary entirely was considered and rejected. The two halves keep their own names inside the doc, because rules like *"Sentry owns errors, PostHog must not"* need two things to keep apart, and so does the two-lifecycles section. Merging was about locality of content, not sameness of concept.

**CLAUDE.md now carries the rule.** It pointed at the runbook and never mentioned that a `posthog.capture()` without a registry row fails CI — invisible in the file agents read first. It now states the convention, the property-shape rule, and what the check *cannot* do.

## Reviewer notes

**The trends tiles will read zero until this deploys.** The code emits new names; production still emits the old ones. Self-corrects on deploy. The workflow-stages SQL insight matches both forms so it spans the rename.

**Eight PostHog insights were repointed** as part of this — they are not in the diff.

**The registry sits between `<!-- registry:start -->` / `<!-- registry:end -->` markers.** Not decoration: this doc has other tables whose first cells are backticked identifiers, so without the slice `session_recording_opt_in` parses as an event. A test covers that case.

**What the check cannot do**, recorded in its header so green is not mistaken for coverage:
- It compares code to a document, so a feature in **neither** passes. Notes would not have been caught. The control for forgotten instrumentation is review.
- Property extraction is literal-only; a spread or computed key contributes nothing.
- It does not verify events reach PostHog.

## Changes outside this diff

Applied to the PostHog project, none of it code:

- **Session replay enabled** — `maskAllInputs`, recording domains locked to `www.jigged.app`, console capture off, 30-day retention. Documented in the replay section.
- **`capture_performance_opt_in` turned off.** Performance capture is part of replay, so enabling replay with it on would start producing `$web_vitals` in PostHog and falsify the Overlap 2 argument that Vercel Analytics is not redundant — the exact conclusion CLAUDE.md forbids.
- **Internal-account filters extended** to exclude `@jigged.app` and `debola31@outlook.com`, the latter of which the domain filter missed and which was inflating pilot numbers.

## Deliberate trade-off worth a second opinion

Replay does **not** mask rendered text, so recordings show customer names and part numbers. Judged acceptable — a replay is watched by us and expires in 30 days, where an event property is queried, exported and kept for a year — but it is the same exposure as #702.

## Verification

- Negative control: reintroducing `posthog.capture('quote_created')` fails with both `bad-event-name` and `undocumented-event`, pointing at the exact file and line
- 56 standards tests pass (16 new), including the live-tree check
- docLinkCheck passes against all ten renamed references and the new intra-doc anchor
- `tsc --noEmit` clean; `pnpm lint` 16 warnings against the 17 cap, all pre-existing
- All 8 pilot-dashboard tiles re-run and resolve

Refs #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)
