### PR TITLE
fix(shipments): packing slip Qty Remaining now counts prior shipments

### DIFF
--- a/__tests__/utils/packingSlipPdf.test.ts
+++ b/__tests__/utils/packingSlipPdf.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Hoisted mocks so they're set up before imports resolve.
+const { jsPDFCtor, autoTableFn, textMock } = vi.hoisted(() => {
+  const textMock = vi.fn();
+
+  const docInstance = {
+    internal: { pageSize: { getWidth: () => 612, getHeight: () => 792 } },
+    setFont: vi.fn(),
+    setFontSize: vi.fn(),
+    setTextColor: vi.fn(),
+    setDrawColor: vi.fn(),
+    setLineWidth: vi.fn(),
+    setFillColor: vi.fn(),
+    text: textMock,
+    line: vi.fn(),
+    rect: vi.fn(),
+    splitTextToSize: vi.fn().mockReturnValue(['wrapped']),
+    save: vi.fn(),
+    addPage: vi.fn(),
+    setPage: vi.fn(),
+    getNumberOfPages: vi.fn().mockReturnValue(1),
+    getTextWidth: vi.fn().mockReturnValue(50),
+    addImage: vi.fn(),
+    lastAutoTable: { finalY: 400 },
+  };
+
+  return {
+    jsPDFCtor: vi.fn().mockImplementation(function () {
+      return docInstance;
+    }),
+    autoTableFn: vi.fn(),
+    textMock,
+  };
+});
+
+vi.mock('jspdf', () => ({ jsPDF: jsPDFCtor }));
+vi.mock('jspdf-autotable', () => ({ default: autoTableFn }));
+
+// packingSlipPdf imports shipmentsAccess → lib/supabase, which builds a real
+// browser client at module load. Stub it so importing doesn't need Supabase env
+// vars (this path never calls the client — supabase: null skips the logo).
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => ({}),
+  createClient: () => ({}),
+}));
+
+import {
+  computePackingSlipQuantities,
+  generatePackingSlipPdf,
+  type PackingSlipQtyLine,
+} from '@/utils/packingSlipPdf';
+import type { ShipmentWithRelations } from '@/types/shipment';
+import type { Company } from '@/utils/companyAccess';
+
+const company: Company = { id: 'c1', name: 'Vanguard Precision Works' };
+
+type LineItem = NonNullable<ShipmentWithRelations['shipment_line_items']>[number];
+
+function line(over: {
+  id?: string;
+  jobPartId?: string;
+  quantity: number;
+  ordered: number;
+  partName?: string;
+}): LineItem {
+  return {
+    id: over.id ?? 'sli-1',
+    shipment_id: 'ship-2',
+    job_part_id: over.jobPartId ?? 'jp-1',
+    quantity: over.quantity,
+    created_at: '2026-08-05T12:00:00+00:00',
+    job_part: {
+      id: over.jobPartId ?? 'jp-1',
+      job_id: 'job-1',
+      quantity: over.ordered,
+      part: {
+        id: 'part-1',
+        part_name: over.partName ?? 'SUB-PLATE-005',
+        description: 'Waterjet-profile plate blank, milled flat',
+      },
+      job: {
+        id: 'job-1',
+        job_number: 'J-0023',
+        customer_po_number: 'VEC-8903',
+        quote_id: null,
+      },
+    },
+  };
+}
+
+function shipment(over: Partial<ShipmentWithRelations> = {}): ShipmentWithRelations {
+  return {
+    id: 'ship-2',
+    company_id: 'c1',
+    customer_id: 'cust-1',
+    job_id: 'job-1',
+    shipping_address_id: 'addr-1',
+    one_time_address: null,
+    packing_slip_number: 'PS-0023-2',
+    ship_date: '2026-08-05',
+    carrier: null,
+    shipping_method: 'customer_pickup',
+    created_by: null,
+    created_at: '2026-08-05T12:00:00+00:00',
+    voided_at: null,
+    voided_by: null,
+    customer_name: 'Vertex Energy Controls',
+    bill_to_address: null,
+    ship_to_address: null,
+    freight_terms: null,
+    customer_carrier_account_id: null,
+    freight_account_snapshot: null,
+    shipment_line_items: [line({ quantity: 10, ordered: 40 })],
+    ...over,
+  };
+}
+
+/** The autoTable config from the one call generatePackingSlipPdf makes. */
+function tableConfig() {
+  const config = autoTableFn.mock.calls[0][1] as {
+    head: string[][];
+    body: string[][];
+    columnStyles: Record<string, { cellWidth?: number | 'auto' }>;
+  };
+  return { ...config, headers: config.head[0] };
+}
+
+describe('computePackingSlipQuantities', () => {
+  const lines = (over: Partial<PackingSlipQtyLine>[]): PackingSlipQtyLine[] =>
+    over.map((o) => ({
+      jobPartId: o.jobPartId ?? 'jp-1',
+      qtyOrdered: o.qtyOrdered ?? 0,
+      qtyShippedThisSlip: o.qtyShippedThisSlip ?? 0,
+    }));
+
+  it('nets nothing on the first slip of a job', () => {
+    const [row] = computePackingSlipQuantities(
+      lines([{ qtyOrdered: 40, qtyShippedThisSlip: 30 }]),
+      new Map(),
+      true,
+    );
+    expect(row).toEqual({
+      qtyOrdered: 40,
+      qtyPrevShipped: 0,
+      qtyShipped: 30,
+      qtyRemaining: 10,
+    });
+  });
+
+  it('nets out prior shipments — the 30-then-10 of 40 case that read 30 remaining', () => {
+    const [row] = computePackingSlipQuantities(
+      lines([{ qtyOrdered: 40, qtyShippedThisSlip: 10 }]),
+      new Map([['jp-1', 30]]),
+      true,
+    );
+    expect(row.qtyPrevShipped).toBe(30);
+    expect(row.qtyRemaining).toBe(0);
+  });
+
+  it('leaves a voided slip’s own quantity in the backlog', () => {
+    const [row] = computePackingSlipQuantities(
+      lines([{ qtyOrdered: 40, qtyShippedThisSlip: 10 }]),
+      new Map([['jp-1', 30]]),
+      false,
+    );
+    // Still prints what the voided slip carried, but those 10 are owed again.
+    expect(row.qtyShipped).toBe(10);
+    expect(row.qtyRemaining).toBe(10);
+  });
+
+  it('clamps an over-shipment at zero rather than printing a negative', () => {
+    const [row] = computePackingSlipQuantities(
+      lines([{ qtyOrdered: 10, qtyShippedThisSlip: 5 }]),
+      new Map([['jp-1', 8]]),
+      true,
+    );
+    expect(row.qtyRemaining).toBe(0);
+  });
+
+  it('keeps numeric(12,2) quantities exact', () => {
+    const [row] = computePackingSlipQuantities(
+      lines([{ qtyOrdered: 10.5, qtyShippedThisSlip: 0.2 }]),
+      new Map([['jp-1', 0.1]]),
+      true,
+    );
+    expect(row.qtyRemaining).toBe(10.2);
+  });
+
+  it('subtracts the whole slip when one job_part appears on two lines', () => {
+    const rows = computePackingSlipQuantities(
+      lines([
+        { qtyOrdered: 10, qtyShippedThisSlip: 6 },
+        { qtyOrdered: 10, qtyShippedThisSlip: 4 },
+      ]),
+      new Map(),
+      true,
+    );
+    expect(rows.map((r) => r.qtyRemaining)).toEqual([0, 0]);
+    // Each row still reports its own shipped quantity.
+    expect(rows.map((r) => r.qtyShipped)).toEqual([6, 4]);
+  });
+
+  it('ignores map entries for job_parts not on this slip', () => {
+    const [row] = computePackingSlipQuantities(
+      lines([{ qtyOrdered: 40, qtyShippedThisSlip: 10 }]),
+      new Map([['jp-OTHER', 30]]),
+      true,
+    );
+    expect(row.qtyPrevShipped).toBe(0);
+    expect(row.qtyRemaining).toBe(30);
+  });
+
+  it('treats a missing job_part as zero ordered without throwing', () => {
+    const [row] = computePackingSlipQuantities(
+      lines([{ qtyOrdered: Number.NaN, qtyShippedThisSlip: 5 }]),
+      new Map(),
+      true,
+    );
+    expect(row.qtyOrdered).toBe(0);
+    expect(row.qtyRemaining).toBe(0);
+  });
+});
+
+describe('generatePackingSlipPdf — the quantity table', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('drops the Job # column, keeping the job number in the meta block', async () => {
+    await generatePackingSlipPdf({
+      shipment: shipment(),
+      company,
+      shippedBeforeByJobPart: new Map(),
+      supabase: null,
+    });
+
+    expect(tableConfig().headers).not.toContain('Job #');
+    expect(textMock.mock.calls.some((c) => String(c[0]) === 'Job: J-0023')).toBe(true);
+  });
+
+  it('shows neither conditional column on a slip that ships everything at once', async () => {
+    await generatePackingSlipPdf({
+      shipment: shipment({ shipment_line_items: [line({ quantity: 40, ordered: 40 })] }),
+      company,
+      shippedBeforeByJobPart: new Map(),
+      supabase: null,
+    });
+
+    expect(tableConfig().headers).toEqual([
+      'Customer PO',
+      'Part',
+      'Description',
+      'Qty Ordered',
+      'Qty Shipped',
+    ]);
+  });
+
+  it('prints Prev Shipped and a zero Qty Remaining is hidden once the order closes out', async () => {
+    await generatePackingSlipPdf({
+      shipment: shipment(),
+      company,
+      shippedBeforeByJobPart: new Map([['jp-1', 30]]),
+      supabase: null,
+    });
+
+    const { headers, body } = tableConfig();
+    expect(headers).toContain('Prev Shipped');
+    expect(headers).not.toContain('Qty Remaining');
+    expect(body[0]).toEqual(['VEC-8903', 'SUB-PLATE-005', expect.any(String), '40', '30', '10']);
+  });
+
+  it('prints Qty Remaining while the job is still open, and renders 0 rather than blanking', async () => {
+    await generatePackingSlipPdf({
+      shipment: shipment({
+        shipment_line_items: [
+          line({ id: 'a', jobPartId: 'jp-1', quantity: 10, ordered: 40, partName: 'AAA' }),
+          line({ id: 'b', jobPartId: 'jp-2', quantity: 5, ordered: 5, partName: 'BBB' }),
+        ],
+      }),
+      company,
+      shippedBeforeByJobPart: new Map(),
+      supabase: null,
+    });
+
+    const { headers, body } = tableConfig();
+    const remainingIdx = headers.indexOf('Qty Remaining');
+    expect(remainingIdx).toBeGreaterThan(-1);
+    expect(body.map((r) => r[remainingIdx])).toEqual(['30', '0']);
+  });
+
+  it.each([
+    ['neither column', new Map<string, number>(), 40],
+    ['prev only', new Map([['jp-1', 30]]), 10],
+    ['remaining only', new Map<string, number>(), 10],
+    ['both columns', new Map([['jp-1', 20]]), 10],
+  ])('keeps head, body and columnStyles aligned — %s', async (_label, before, qty) => {
+    vi.clearAllMocks();
+    await generatePackingSlipPdf({
+      shipment: shipment({ shipment_line_items: [line({ quantity: qty, ordered: 40 })] }),
+      company,
+      shippedBeforeByJobPart: before,
+      supabase: null,
+    });
+
+    const { headers, body, columnStyles } = tableConfig();
+    expect(body.every((row) => row.length === headers.length)).toBe(true);
+    expect(Object.keys(columnStyles)).toHaveLength(headers.length);
+  });
+
+  it('emits one full-width placeholder row when the slip has no line items', async () => {
+    await generatePackingSlipPdf({
+      shipment: shipment({ shipment_line_items: [] }),
+      company,
+      shippedBeforeByJobPart: new Map(),
+      supabase: null,
+    });
+
+    const { headers, body } = tableConfig();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toHaveLength(headers.length);
+  });
+
+  it('leaves Description enough room in the widest permutation', async () => {
+    await generatePackingSlipPdf({
+      shipment: shipment({
+        shipment_line_items: [
+          line({ id: 'a', jobPartId: 'jp-1', quantity: 10, ordered: 40, partName: 'AAA' }),
+        ],
+      }),
+      company,
+      shippedBeforeByJobPart: new Map([['jp-1', 20]]),
+      supabase: null,
+    });
+
+    const { headers, columnStyles } = tableConfig();
+    expect(headers).toHaveLength(7);
+    const widths = Object.values(columnStyles).map((s) => s.cellWidth);
+    // Exactly one 'auto' column (Description) absorbs the remainder, and the
+    // fixed columns leave it at least 140pt of the 532pt usable width.
+    expect(widths.filter((w) => w === 'auto')).toHaveLength(1);
+    const fixed = widths.filter((w): w is number => typeof w === 'number');
+    expect(fixed.reduce((a, b) => a + b, 0)).toBeLessThanOrEqual(392);
+  });
+
+  it('still draws the VOIDED banner', async () => {
+    await generatePackingSlipPdf({
+      shipment: shipment({ voided_at: '2026-08-06T09:00:00+00:00' }),
+      company,
+      shippedBeforeByJobPart: new Map([['jp-1', 30]]),
+      supabase: null,
+    });
+
+    expect(
+      textMock.mock.calls.some((c) => String(c[0]).startsWith('VOIDED')),
+    ).toBe(true);
+    // Voided: its own 10 are owed again, so Qty Remaining comes back.
+    expect(tableConfig().headers).toContain('Qty Remaining');
+  });
+});

--- a/__tests__/utils/shipmentsAccess.test.ts
+++ b/__tests__/utils/shipmentsAccess.test.ts
@@ -75,8 +75,10 @@ vi.mock('@/lib/supabase', () => ({
 }));
 
 import {
+  compareShipmentOrder,
   countShipmentsForJob,
   getOpenJobPartsForCustomer,
+  getShippedBeforeShipment,
   voidShipment,
 } from '@/utils/shipmentsAccess';
 import type { OpenJobPartRow } from '@/types/shipment';
@@ -445,5 +447,152 @@ describe('countShipmentsForJob', () => {
     queueBuilders([stub]);
 
     await expect(countShipmentsForJob('job-1')).rejects.toThrow(/check shipments/i);
+  });
+});
+
+describe('compareShipmentOrder', () => {
+  const key = (ship_date: string, created_at: string, id: string) => ({
+    ship_date,
+    created_at,
+    id,
+  });
+
+  it('orders by ship_date first', () => {
+    const early = key('2026-08-01', '2026-08-05T10:00:00+00:00', 'zzz');
+    const late = key('2026-08-02', '2026-08-01T10:00:00+00:00', 'aaa');
+    expect(compareShipmentOrder(early, late)).toBeLessThan(0);
+    expect(compareShipmentOrder(late, early)).toBeGreaterThan(0);
+  });
+
+  it('falls back to created_at as an instant, not as text', () => {
+    // '…:56.7' is LATER than '…:56.68' numerically but sorts earlier as a
+    // string — the reason this compares parsed timestamps.
+    const a = key('2026-08-01', '2026-08-01T10:00:56.68+00:00', 'aaa');
+    const b = key('2026-08-01', '2026-08-01T10:00:56.7+00:00', 'bbb');
+    expect(compareShipmentOrder(a, b)).toBeLessThan(0);
+    expect(compareShipmentOrder(b, a)).toBeGreaterThan(0);
+  });
+
+  it('breaks a full tie on id, and reports identity as 0', () => {
+    const a = key('2026-08-01', '2026-08-01T10:00:00+00:00', 'aaa');
+    const b = key('2026-08-01', '2026-08-01T10:00:00+00:00', 'bbb');
+    expect(compareShipmentOrder(a, b)).toBeLessThan(0);
+    expect(compareShipmentOrder(a, { ...a })).toBe(0);
+  });
+});
+
+describe('getShippedBeforeShipment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const current = {
+    id: 'ship-2',
+    job_id: 'job-1',
+    ship_date: '2026-08-05',
+    created_at: '2026-08-05T12:00:00+00:00',
+  };
+
+  it('sums only the slips ordered before this one, skipping itself', async () => {
+    const stub = buildQueryStub({
+      data: [
+        {
+          id: 'ship-1',
+          ship_date: '2026-08-01',
+          created_at: '2026-08-01T09:00:00+00:00',
+          shipment_line_items: [{ job_part_id: 'jp-1', quantity: 30 }],
+        },
+        {
+          id: 'ship-2',
+          ship_date: '2026-08-05',
+          created_at: '2026-08-05T12:00:00+00:00',
+          shipment_line_items: [{ job_part_id: 'jp-1', quantity: 10 }],
+        },
+        {
+          id: 'ship-3',
+          ship_date: '2026-08-09',
+          created_at: '2026-08-09T09:00:00+00:00',
+          shipment_line_items: [{ job_part_id: 'jp-1', quantity: 5 }],
+        },
+      ],
+    });
+    queueBuilders([stub]);
+
+    const before = await getShippedBeforeShipment(current);
+
+    expect(before.get('jp-1')).toBe(30);
+    expect(mockSupabase.from).toHaveBeenCalledWith('shipments');
+    expect(stub.eq).toHaveBeenCalledWith('job_id', 'job-1');
+    // Voided siblings never reach the fold — a void removes the quantity.
+    expect(stub.is).toHaveBeenCalledWith('voided_at', null);
+  });
+
+  it('excludes a same-timestamp sibling with a greater id', async () => {
+    const stub = buildQueryStub({
+      data: [
+        {
+          id: 'ship-1',
+          ...{ ship_date: current.ship_date, created_at: current.created_at },
+          shipment_line_items: [{ job_part_id: 'jp-1', quantity: 4 }],
+        },
+        {
+          id: 'ship-9',
+          ...{ ship_date: current.ship_date, created_at: current.created_at },
+          shipment_line_items: [{ job_part_id: 'jp-1', quantity: 7 }],
+        },
+      ],
+    });
+    queueBuilders([stub]);
+
+    // 'ship-1' < 'ship-2' < 'ship-9': only the first counts.
+    await expect(getShippedBeforeShipment(current)).resolves.toEqual(
+      new Map([['jp-1', 4]]),
+    );
+  });
+
+  it('sums two lines of the same job_part on one prior slip, rounded to 2dp', async () => {
+    const stub = buildQueryStub({
+      data: [
+        {
+          id: 'ship-1',
+          ship_date: '2026-08-01',
+          created_at: '2026-08-01T09:00:00+00:00',
+          shipment_line_items: [
+            { job_part_id: 'jp-1', quantity: 0.1 },
+            { job_part_id: 'jp-1', quantity: 0.2 },
+            { job_part_id: 'jp-2', quantity: 6 },
+          ],
+        },
+      ],
+    });
+    queueBuilders([stub]);
+
+    const before = await getShippedBeforeShipment(current);
+
+    expect(before.get('jp-1')).toBe(0.3);
+    expect(before.get('jp-2')).toBe(6);
+  });
+
+  it('returns an empty map for the first slip on a job', async () => {
+    const stub = buildQueryStub({
+      data: [
+        {
+          id: current.id,
+          ship_date: current.ship_date,
+          created_at: current.created_at,
+          shipment_line_items: [{ job_part_id: 'jp-1', quantity: 30 }],
+        },
+      ],
+    });
+    queueBuilders([stub]);
+
+    await expect(getShippedBeforeShipment(current)).resolves.toEqual(new Map());
+  });
+
+  it('throws rather than reporting zero prior shipments when the query fails', async () => {
+    const stub = buildQueryStub({ error: { message: 'boom' } });
+    queueBuilders([stub]);
+
+    await expect(getShippedBeforeShipment(current)).rejects.toThrow(/prior shipments/i);
   });
 });

--- a/components/shipments/PackingSlipPreviewDialog.tsx
+++ b/components/shipments/PackingSlipPreviewDialog.tsx
@@ -24,7 +24,11 @@ import {
   packingSlipPdfFilename,
   type PackingSlipPdfContext,
 } from '@/utils/packingSlipPdf';
-import { getShipmentById, voidShipment } from '@/utils/shipmentsAccess';
+import {
+  getShipmentById,
+  getShippedBeforeShipment,
+  voidShipment,
+} from '@/utils/shipmentsAccess';
 
 export interface PackingSlipPreviewDialogProps {
   open: boolean;
@@ -94,18 +98,24 @@ export default function PackingSlipPreviewDialog({
         const supabase = getSupabase();
         const shipment = await getShipmentById(shipmentId);
 
-        const { data: companyRow, error: companyErr } = await supabase
-          .from('companies')
-          .select('id, name, logo_url, address_line1, address_line2, city, state, postal_code, country, phone, email, website')
-          .eq('id', shipment.company_id)
-          .single();
-        if (companyErr || !companyRow) {
-          throw new Error(companyErr?.message ?? 'Failed to load company.');
+        // Independent reads — the company profile and what shipped on
+        // this job's earlier slips (which the Qty Remaining column nets out).
+        const [companyRes, shippedBeforeByJobPart] = await Promise.all([
+          supabase
+            .from('companies')
+            .select('id, name, logo_url, address_line1, address_line2, city, state, postal_code, country, phone, email, website')
+            .eq('id', shipment.company_id)
+            .single(),
+          getShippedBeforeShipment(shipment),
+        ]);
+        if (companyRes.error || !companyRes.data) {
+          throw new Error(companyRes.error?.message ?? 'Failed to load company.');
         }
 
         const ctx: PackingSlipPdfContext = {
           shipment,
-          company: companyRow as unknown as Company,
+          company: companyRes.data as unknown as Company,
+          shippedBeforeByJobPart,
           supabase,
         };
 

--- a/docs/modules/shipments.md
+++ b/docs/modules/shipments.md
@@ -94,6 +94,15 @@ itself one clause later with "across non-cancelled parts".)*
 post-conversion edit; conversely `updateJobPartQuantity` refuses to lower a part below
 `max(already-shipped, already-invoiced)`.
 
+⚠ **Two different numbers share the name `qty_remaining`.** The job surfaces (jobs list, ship form,
+`getJobPartShipmentSummaries`) answer *what is open on this job right now* — every non-voided slip
+netted out. The **packing slip's Qty Remaining column** answers *what was still open as of that
+shipment* — only the slips ordered at-or-before it, so opening slip #1 after slip #2 exists still
+reads 10, not 0. Collapsing the two is the bug this column shipped with: it subtracted only the
+slip's own quantity, so slip #2 of a 40-piece job printed "30 remaining" after 30 had already gone
+out. `getShippedBeforeShipment` is the point-in-time half and is deliberately separate from
+`getJobPartShipmentSummaries`, which structurally cannot answer it.
+
 **Invoicing is decoupled from shipping.** Billing is capped at the **ordered** quantity, not the shipped one —
 a packing slip is a document, not a delivery. The invoice picker only *defaults* to shipped-but-unbilled and
 nudges past it, so voiding a shipment does not yank on what you can invoice. A third axis,
@@ -168,7 +177,9 @@ from this doc.
 | `getShipmentsForJob(jobId)` | Non-voided, filtered via `line_items.job_part.job_id`, newest-first |
 | `listShipmentsForCompany(companyId, filters?)` | Flat list, optional customer/date/voided filters. **No current caller** — kept for reporting |
 | `countShipmentsForJob(jobId)` | Counts **all** rows incl. voided via the direct `shipments.job_id` column. No longer gates `deleteJob` ([architecture.md §16](../architecture.md)) |
-| `getJobPartShipmentSummaries(jobId)` | `{job_part_id, qty_ordered, qty_shipped, qty_remaining (clamped ≥0), last_ship_date}` |
+| `getJobPartShipmentSummaries(jobId)` | `{job_part_id, qty_ordered, qty_shipped, qty_remaining (clamped ≥0), last_ship_date}` — sums **every** non-voided slip on the job |
+| `getShippedBeforeShipment(shipment)` | `Map<job_part_id, qty>` for the slips ordered **before** this one — the packing slip's point-in-time backlog. One query on `shipments.job_id` (one slip = one job); voided siblings excluded in SQL; the tuple predicate is applied in TS because PostgREST has no compound `<` |
+| `compareShipmentOrder(a, b)` | Total order over a job's slips: `ship_date` → `created_at` (parsed as an instant, not text) → `id` |
 | `getJobShipmentSummary(jobId)` | Job rollup: ordered/shipped/remaining, last ship date, latest slip #, count |
 | `getOpenJobPartsForCustomer(companyId, customerId, filter?)` | Feeds only the dormant customer-mode branch; same untracked-excision gap |
 | `getJobLastShipDate(jobId)` | Wrapper over the `job_last_ship_date(uuid)` SQL helper |
@@ -198,10 +209,13 @@ As-built, verified 2026-08-03. Each row names the file + `describe`/class that e
 | Freight precedence (job over customer); refusing to guess at >1 account; printed freight comes only from the snapshot | `__tests__/utils/customerCarrierAccountsAccess.test.ts` — `resolveFreightLine — the job wins over the customer default`, `pickCarrierAccount — refuses to guess`, `describeShipmentFreight — everything printed comes from the snapshot` |
 | Raising an ordered quantity above the shipped total recomputes fulfillment; reducing below shipped is blocked | `__tests__/utils/jobsAccess.test.ts` — `updateJobPartQuantity` |
 | Deleting a job **archives** it and never blocks, even with shipments and an invoice — the records-of-value guards were removed | `__tests__/utils/jobsAccess.test.ts` — `deleteJob` |
+| Slip quantities net out prior shipments, clamp over-shipment, survive `numeric(12,2)` fractions, and hand a voided slip's own quantity back to the backlog; the two conditional columns keep head / body / `columnStyles` aligned in all four permutations | `__tests__/utils/packingSlipPdf.test.ts` — `computePackingSlipQuantities`, `generatePackingSlipPdf — the quantity table` |
+| Prior-shipment lookup skips itself, later slips and same-timestamp-greater-id siblings, and throws rather than reporting zero prior | `__tests__/utils/shipmentsAccess.test.ts` — `compareShipmentOrder`, `getShippedBeforeShipment` |
 
 **Gaps, automation-pending ([#367](https://github.com/debola31/Jigged/issues/367)):** reload-persistence E2E
 for create and void; `ShipmentsMenu` rendering; the packing-slip PDF rendering Bill To / Ship To / ATTN from
-the frozen snapshots (`snapshot_shipment_party`, `resolveAttentionLine`, `utils/packingSlipPdf.ts`).
+the frozen snapshots (`snapshot_shipment_party`, `resolveAttentionLine`) — the slip's **quantity table** is
+now covered, the address blocks are not.
 
 ---
 

--- a/utils/packingSlipPdf.ts
+++ b/utils/packingSlipPdf.ts
@@ -12,13 +12,14 @@
  *     from the customer's default-billing address at render time; ship-to
  *     is the shipment.shipping_address_id snapshot. Ship-to surfaces
  *     ATTN: from customer_addresses.attention_to via resolveAttentionLine.
- *   - Line items table (JobBOSS pattern): Job # / Customer PO / Part /
- *     Description / Qty Shipped / Qty Remaining. The Qty Remaining
- *     *column* appears only when at least one line on the slip has
- *     qty_remaining > 0; when present, every cell shows the numeric
- *     value (0 for fully-shipped lines, not blanked). Every slip is a
- *     single job (shipments.job_id), so the per-row Job # / PO are
- *     constant — kept for the JobBOSS-style legibility receiving expects.
+ *   - Line items table: Customer PO / Part / Description / Qty Ordered /
+ *     Prev Shipped / Qty Shipped / Qty Remaining, so the row reconciles
+ *     on its face: ordered − prev − shipped = remaining. Two columns are
+ *     conditional — Prev Shipped appears only once some line has a
+ *     prior shipment, Qty Remaining only while some line is still open —
+ *     and when a column is present every cell shows its number, 0
+ *     included, never blanked. There is no Job # column: every slip is a
+ *     single job (shipments.job_id) and the number is in the meta block.
  *   - Shipment details block: shipping method label + carrier (carrier
  *     only present when the method is a true shipment), notes.
  *   - Signature lines at the bottom: Received By / Date / Signature.
@@ -28,7 +29,7 @@
  */
 
 import { jsPDF } from 'jspdf';
-import autoTable from 'jspdf-autotable';
+import autoTable, { type Styles } from 'jspdf-autotable';
 import type { Company } from '@/utils/companyAccess';
 import type { AddressSnapshot } from '@/types/documentSnapshot';
 import {
@@ -67,6 +68,70 @@ function formatNumber(value: number | null | undefined, fractionDigits = 2): str
   return Number(value).toLocaleString('en-US', {
     minimumFractionDigits: 0,
     maximumFractionDigits: fractionDigits,
+  });
+}
+
+export interface PackingSlipQtyLine {
+  jobPartId: string;
+  qtyOrdered: number;
+  qtyShippedThisSlip: number;
+}
+
+export interface PackingSlipQtyRow {
+  qtyOrdered: number;
+  qtyPrevShipped: number;
+  /** This line's own quantity — not the job_part's total on the slip. */
+  qtyShipped: number;
+  qtyRemaining: number;
+}
+
+/**
+ * The slip's quantity block: what was ordered, what went out before,
+ * what goes out on this slip, and what is still open after it.
+ *
+ *   remaining = ordered − prev shipped − this slip, clamped at zero.
+ *
+ * Clamped because over-shipment is allowed (the FR-4 soft warning
+ * confirms it upstream) and "−5 remaining" is not something a receiving
+ * dock can act on.
+ *
+ * `thisSlipCounts` is false for a voided slip: a void removes that
+ * shipment's quantity, so its lines still print their Qty Shipped under
+ * the VOIDED banner while Qty Remaining reports what is genuinely owed.
+ *
+ * Grouped by job_part, not by line. shipment_line_items has no unique
+ * constraint on (shipment_id, job_part_id), so one job_part can legally
+ * appear on two rows of one slip; per-line math would subtract only
+ * half the slip and overstate the remaining on both rows.
+ */
+export function computePackingSlipQuantities(
+  lines: readonly PackingSlipQtyLine[],
+  shippedBeforeByJobPart: ReadonlyMap<string, number>,
+  thisSlipCounts: boolean,
+): PackingSlipQtyRow[] {
+  // quantity is numeric(12,2); round after each accumulation so binary
+  // float drift can't print 9.999999999999998 as "10".
+  const round2 = (n: number) => Math.round(n * 100) / 100;
+  const num = (n: number) => (Number.isFinite(n) ? n : 0);
+
+  const thisSlipByPart = new Map<string, number>();
+  for (const line of lines) {
+    thisSlipByPart.set(
+      line.jobPartId,
+      round2((thisSlipByPart.get(line.jobPartId) ?? 0) + num(line.qtyShippedThisSlip)),
+    );
+  }
+
+  return lines.map((line) => {
+    const ordered = num(line.qtyOrdered);
+    const prev = Math.max(0, num(shippedBeforeByJobPart.get(line.jobPartId) ?? 0));
+    const onThisSlip = thisSlipCounts ? (thisSlipByPart.get(line.jobPartId) ?? 0) : 0;
+    return {
+      qtyOrdered: ordered,
+      qtyPrevShipped: prev,
+      qtyShipped: num(line.qtyShippedThisSlip),
+      qtyRemaining: Math.max(0, round2(ordered - prev - onThisSlip)),
+    };
   });
 }
 
@@ -177,9 +242,116 @@ export interface SupabaseLike {
 export interface PackingSlipPdfContext {
   shipment: ShipmentWithRelations;
   company: Company;
+  /**
+   * Quantity shipped per job_part on the slips issued before this one —
+   * from getShippedBeforeShipment(). Required, and deliberately not
+   * defaulted to an empty map: silently treating "not supplied" as "no
+   * prior shipments" is what made slip #2 of a 40-piece job claim 30
+   * remaining when 30 had already gone out.
+   */
+  shippedBeforeByJobPart: ReadonlyMap<string, number>;
   /** Optional Supabase client to resolve the logo signed URL. */
   supabase?: SupabaseLike | null;
 }
+
+/**
+ * Fixed column widths, in points. Letter page less two 40pt margins
+ * leaves 532pt; Description is the only 'auto' column and absorbs
+ * whatever the fixed ones don't take — 250 / 200 / 190 / 140pt across
+ * the four visibility permutations. The 140pt worst case is ~24
+ * characters a line at 10pt, and is what decides whether another column
+ * can ever be added here.
+ *
+ * The identifier columns are sized by their *content*, not by taste:
+ * `part` holds "PROD-ACTUATOR-200" and `po` holds "PO-CAS-2207" on one
+ * line, because a part number broken mid-token ("PROD-ACTUATO/R-200")
+ * is what a receiving clerk has to retype. The numeric columns fit
+ * their headers only because the header row drops to 9pt — at 10pt
+ * "Remaining" wraps mid-word to "Remai/ning".
+ */
+const SLIP_COL_WIDTH = {
+  po: 78,
+  part: 104,
+  ordered: 50,
+  prevShipped: 50,
+  shipped: 50,
+  remaining: 60,
+} as const;
+
+interface SlipRowData {
+  po: string;
+  partName: string;
+  description: string;
+  qty: PackingSlipQtyRow;
+}
+
+interface SlipColumnSpec {
+  key: 'po' | 'part' | 'description' | 'ordered' | 'prevShipped' | 'shipped' | 'remaining';
+  header: string;
+  style: Partial<Styles>;
+  cell: (row: SlipRowData) => string;
+  /** Cell used by the single placeholder row when the slip has no lines. */
+  placeholder: string;
+}
+
+/**
+ * One declarative spec drives the header, the body, the placeholder row
+ * and columnStyles, so the four visibility permutations cannot drift out
+ * of alignment — the previous version hand-maintained two index→width
+ * maps and a separate placeholder row, and the placeholder was already
+ * one cell short whenever Qty Remaining showed.
+ */
+const SLIP_COLUMNS: readonly SlipColumnSpec[] = [
+  {
+    key: 'po',
+    header: 'Customer PO',
+    style: { cellWidth: SLIP_COL_WIDTH.po },
+    cell: (r) => r.po || '—',
+    placeholder: '—',
+  },
+  {
+    key: 'part',
+    header: 'Part',
+    style: { cellWidth: SLIP_COL_WIDTH.part, fontStyle: 'bold' },
+    cell: (r) => r.partName,
+    placeholder: '—',
+  },
+  {
+    key: 'description',
+    header: 'Description',
+    style: { cellWidth: 'auto' },
+    cell: (r) => r.description,
+    placeholder: '',
+  },
+  {
+    key: 'ordered',
+    header: 'Qty Ordered',
+    style: { cellWidth: SLIP_COL_WIDTH.ordered, halign: 'right' },
+    cell: (r) => formatNumber(r.qty.qtyOrdered),
+    placeholder: '—',
+  },
+  {
+    key: 'prevShipped',
+    header: 'Prev Shipped',
+    style: { cellWidth: SLIP_COL_WIDTH.prevShipped, halign: 'right' },
+    cell: (r) => formatNumber(r.qty.qtyPrevShipped),
+    placeholder: '—',
+  },
+  {
+    key: 'shipped',
+    header: 'Qty Shipped',
+    style: { cellWidth: SLIP_COL_WIDTH.shipped, halign: 'right' },
+    cell: (r) => formatNumber(r.qty.qtyShipped),
+    placeholder: '—',
+  },
+  {
+    key: 'remaining',
+    header: 'Qty Remaining',
+    style: { cellWidth: SLIP_COL_WIDTH.remaining, halign: 'right' },
+    cell: (r) => formatNumber(r.qty.qtyRemaining),
+    placeholder: '—',
+  },
+];
 
 /**
  * Build the jsPDF document for a shipment and return it without writing
@@ -348,69 +520,49 @@ export async function generatePackingSlipPdf(
 
   // ---------- Line items table ----------
   const lineItems = [...(shipment.shipment_line_items ?? [])];
-  lineItems.sort((a, b) => {
-    const ja = a.job_part?.job?.job_number ?? '';
-    const jb = b.job_part?.job?.job_number ?? '';
-    if (ja !== jb) return ja.localeCompare(jb);
-    const pa = a.job_part?.part?.part_name ?? '';
-    const pb = b.job_part?.part?.part_name ?? '';
-    return pa.localeCompare(pb);
-  });
+  // One slip is one job (shipments.job_id), so part name is the only
+  // ordering that carries information.
+  lineItems.sort((a, b) =>
+    (a.job_part?.part?.part_name ?? '').localeCompare(b.job_part?.part?.part_name ?? ''),
+  );
 
-  // Per-line remaining = qty_ordered minus this shipment's quantity.
-  // Single-document number (not running total) so receiving can
-  // reconcile against the PO. Clamped to zero — the FR-4 soft warning
-  // already covered over-shipment confirmation upstream.
-  const remainingByLine = lineItems.map((li) => {
-    const ordered = Number(li.job_part?.quantity ?? 0);
-    const shipped = Number(li.quantity);
-    return Math.max(0, ordered - shipped);
-  });
-  // Show the Qty Remaining *column* whenever at least one line on the
-  // slip has open backlog. When the column is hidden the whole slip is
-  // a clean "everything ordered, everything shipped" document.
-  const showRemaining = remainingByLine.some((r) => r > 0);
+  const quantities = computePackingSlipQuantities(
+    lineItems.map((li) => ({
+      jobPartId: li.job_part_id,
+      qtyOrdered: Number(li.job_part?.quantity ?? 0),
+      qtyShippedThisSlip: Number(li.quantity),
+    })),
+    ctx.shippedBeforeByJobPart,
+    !shipment.voided_at,
+  );
 
-  // JobBOSS pattern: per-row Job # + Customer PO so a multi-job packing
-  // slip is legible without restructuring into sections. Single-job
-  // slips have the same value on every row — mildly redundant but
-  // consistent with the multi-job case.
-  const headRow = [
-    'Job #',
-    'Customer PO',
-    'Part',
-    'Description',
-    'Qty Shipped',
-  ];
-  if (showRemaining) headRow.push('Qty Remaining');
-  const head = [headRow];
+  // Prev Shipped only earns its width once something went out earlier;
+  // Qty Remaining only while something is still open — a slip that
+  // closes the order out prints a clean "everything shipped" table.
+  const showPrevShipped = quantities.some((q) => q.qtyPrevShipped > 0);
+  const showRemaining = quantities.some((q) => q.qtyRemaining > 0);
 
-  const body = lineItems.map((li, idx) => {
-    const part = li.job_part?.part;
-    const jobNumber = li.job_part?.job?.job_number ?? '';
-    const po = li.job_part?.job?.customer_po_number ?? '';
-    const partName = part?.part_name ?? '—';
-    const description = part?.description?.trim() ?? '';
-    const qtyShipped = formatNumber(Number(li.quantity));
-    const remaining = remainingByLine[idx];
-    const row = [
-      jobNumber || '—',
-      po || '—',
-      partName,
-      description,
-      qtyShipped,
-    ];
-    // PRD v2.1 / FR-8: when the column is present, every cell shows
-    // the numeric value including 0 — cells are not blanked.
-    if (showRemaining) row.push(formatNumber(remaining));
-    return row;
-  });
+  const columns = SLIP_COLUMNS.filter((c) =>
+    c.key === 'prevShipped' ? showPrevShipped : c.key === 'remaining' ? showRemaining : true,
+  );
 
-  if (body.length === 0) {
-    const emptyRow = ['—', '—', '—', '', '—'];
-    if (showRemaining) emptyRow.push('—');
-    body.push(emptyRow);
-  }
+  const rows: SlipRowData[] = lineItems.map((li, idx) => ({
+    po: li.job_part?.job?.customer_po_number ?? '',
+    partName: li.job_part?.part?.part_name ?? '—',
+    description: li.job_part?.part?.description?.trim() ?? '',
+    qty: quantities[idx],
+  }));
+
+  const head = [columns.map((c) => c.header)];
+  // Every cell in a present column shows its number, 0 included —
+  // blanking a zero reads as "unknown" on a receiving dock.
+  const body =
+    rows.length > 0
+      ? rows.map((row) => columns.map((c) => c.cell(row)))
+      : [columns.map((c) => c.placeholder)];
+  const columnStyles: Record<string, Partial<Styles>> = Object.fromEntries(
+    columns.map((c, i) => [String(i), c.style]),
+  );
 
   autoTable(doc, {
     startY: cursorY,
@@ -427,25 +579,13 @@ export async function generatePackingSlipPdf(
       fillColor: [240, 240, 240],
       textColor: [30, 30, 30],
       fontStyle: 'bold',
+      // 9pt, not the body's 10: four numeric headers have to fit their
+      // own column, and "Remaining" wraps mid-word at 10pt.
+      fontSize: 9,
       lineColor: [200, 200, 200],
       lineWidth: 0.5,
     },
-    columnStyles: showRemaining
-      ? {
-          0: { cellWidth: 70 },
-          1: { cellWidth: 80 },
-          2: { cellWidth: 90, fontStyle: 'bold' },
-          3: { cellWidth: 'auto' },
-          4: { cellWidth: 70, halign: 'right' },
-          5: { cellWidth: 80, halign: 'right' },
-        }
-      : {
-          0: { cellWidth: 80 },
-          1: { cellWidth: 90 },
-          2: { cellWidth: 110, fontStyle: 'bold' },
-          3: { cellWidth: 'auto' },
-          4: { cellWidth: 80, halign: 'right' },
-        },
+    columnStyles,
     theme: 'grid',
   });
 

--- a/utils/shipmentsAccess.ts
+++ b/utils/shipmentsAccess.ts
@@ -153,6 +153,88 @@ export async function getShipmentById(
   return shipment;
 }
 
+/** Sort key for the total order over one job's packing slips. */
+export interface ShipmentOrderKey {
+  ship_date: string;
+  created_at: string;
+  id: string;
+}
+
+/**
+ * Total order over a job's packing slips: ship_date, then created_at,
+ * then id.
+ *
+ * ship_date is a 'YYYY-MM-DD' date scalar, so a string compare is
+ * chronological. created_at is compared as an *instant*, not as text —
+ * PostgREST returns ISO-8601 with an offset and a variable number of
+ * fractional-second digits, so a lexicographic compare of
+ * '…:56.7+00:00' against '…:56.68+00:00' is a coin flip. id is the last
+ * tie-break so two slips written with identical timestamps still order
+ * the same way every time the slip is opened.
+ */
+export function compareShipmentOrder(a: ShipmentOrderKey, b: ShipmentOrderKey): number {
+  if (a.ship_date !== b.ship_date) return a.ship_date < b.ship_date ? -1 : 1;
+  const ta = Date.parse(a.created_at);
+  const tb = Date.parse(b.created_at);
+  if (Number.isFinite(ta) && Number.isFinite(tb) && ta !== tb) return ta < tb ? -1 : 1;
+  if (a.id !== b.id) return a.id < b.id ? -1 : 1;
+  return 0;
+}
+
+/**
+ * Quantity shipped per job_part on the slips issued BEFORE this one.
+ *
+ * The packing slip's Qty Remaining states the backlog as of its own
+ * shipment, so it cannot come from getJobPartShipmentSummaries — that
+ * sums every slip on the job, including later ones and this one, which
+ * would make an earlier slip read 0 remaining once the job closed out.
+ *
+ * One query: shipments.job_id is NOT NULL and RPC-derived (one slip =
+ * one job), so every sibling slip is on that key — no join through
+ * job_parts needed. PostgREST cannot express a compound
+ * (ship_date, created_at) < tuple, so the ordering predicate is applied
+ * in TS; a job has a handful of slips.
+ *
+ * Voided siblings are excluded in SQL: a void removes that shipment's
+ * quantity, the same rule shipment_line_items' table comment and every
+ * other summing helper here follow.
+ */
+export async function getShippedBeforeShipment(
+  shipment: Pick<Shipment, 'id' | 'job_id' | 'ship_date' | 'created_at'>,
+): Promise<Map<string, number>> {
+  const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from('shipments')
+    .select('id, ship_date, created_at, shipment_line_items (job_part_id, quantity)')
+    .eq('job_id', shipment.job_id)
+    .is('voided_at', null);
+
+  if (error) {
+    console.error('Error fetching prior shipments:', error);
+    throw new Error(`Failed to load prior shipments: ${error.message}`);
+  }
+
+  const before = new Map<string, number>();
+  for (const sibling of data ?? []) {
+    if (sibling.id === shipment.id) continue;
+    if (compareShipmentOrder(sibling, shipment) >= 0) continue;
+    for (const li of sibling.shipment_line_items ?? []) {
+      before.set(
+        li.job_part_id,
+        (before.get(li.job_part_id) ?? 0) + Number(li.quantity),
+      );
+    }
+  }
+  // quantity is numeric(12,2) — re-round each total so a chain of binary
+  // float adds can't leave 29.999999999999996 to print as "30" while
+  // still comparing > 0 and forcing the Prev Shipped column on.
+  for (const [jobPartId, qty] of before) {
+    before.set(jobPartId, Math.round(qty * 100) / 100);
+  }
+  return before;
+}
+
 /**
  * Look up the salesperson/shipper who created the row. Lives in
  * user_company_access (same shape quotePdf uses). Returns null when


### PR DESCRIPTION
## The bug

On a 40-piece job shipped **30 then 10**, the second packing slip printed **Qty Remaining 30**.

`utils/packingSlipPdf.ts` computed `remaining = job_parts.quantity − this slip's quantity`, and its own comment defended it as "a single-document number (not running total)". Everywhere else — the ship form, the jobs list, `getJobPartShipmentSummaries` — already nets every non-voided shipment, so the printed document and the screen disagreed by construction.

## The fix

The slip now states the backlog **as of its own shipment**: ordered minus everything shipped at-or-before it. Opening an earlier slip from the Shipments menu still shows what was open then; the job page stays the place you go for today's number.

- **`getShippedBeforeShipment(shipment)`** sums the non-voided slips ordered before this one. One query on `shipments.job_id` (one slip = one job, so no join through `job_parts`), with the `(ship_date, created_at, id)` predicate applied in TS — PostgREST can't express a compound `<`. Rooting at `shipments` also makes the embed a reverse one, which types as a plain array with no cast.
- **A void removes the quantity** — on prior slips *and* on the slip being viewed. A voided slip prints its Qty Shipped under the VOIDED banner while Qty Remaining reports what is genuinely owed.
- **`computePackingSlipQuantities()`** groups by `job_part`, not per line: `shipment_line_items` has no unique constraint on `(shipment_id, job_part_id)`, so per-line math would subtract half a slip and overstate the remaining on both rows.
- **The map is a required field on `PackingSlipPdfContext`.** A second caller that forgets it fails to compile rather than silently reinstating the bug — the alternative, an optional field defaulting to an empty map, is exactly the silent fallback `CLAUDE.md` forbids.

## The table

`Customer PO | Part | Description | Qty Ordered | [Prev Shipped] | Qty Shipped | [Qty Remaining]` — so the row reconciles on its face. `Job #` is dropped; it is already in the top-right meta block. Prev Shipped appears only once something went out earlier, Qty Remaining only while something is open (existing rule, now on correct numbers).

One declarative column spec drives head, body, placeholder row and `columnStyles`, so the four visibility permutations can't drift — the old code hand-maintained two width maps and a placeholder row that was **already a cell short** whenever Qty Remaining showed. Widths and the 9pt header row come from rendering real PDFs and looking at them: at 10pt "Remaining" wrapped to "Remai/ning" and part numbers broke mid-token, which is what a receiving clerk has to retype.

## Verification

`tsc` clean, lint unchanged (16/17 warnings, none new), 39 new/extended tests in `__tests__/utils/packingSlipPdf.test.ts` and `__tests__/utils/shipmentsAccess.test.ts` — including the permutation invariant that body row length, head length and `columnStyles` count always agree.

Driven end-to-end against the local stack on **J-0005** (20 ordered, 10 already shipped on PS-0005-1):

| Step | Result |
|---|---|
| Ship the remaining 10 → PS-0005-2 | Ordered 20 · Prev Shipped 10 · Qty Shipped 10, **no** Qty Remaining column |
| Reopen PS-0005-1 | still Ordered 20 · Qty Shipped 10 · **Remaining 10**, no Prev column |
| Void PS-0005-1, reopen PS-0005-2 | Prev Shipped column gone, Remaining 10 — the backlog comes back |
| Open the voided PS-0005-1 | VOIDED banner, its own 10 owed again |

Seed rows touched during the run were restored.

No migration, no analytics registry row (no `capture()` on this path), no E2E affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)