### PR TITLE
fix(quotes): quote the tier's listed price, not a price recomputed at order qty

### DIFF
--- a/__tests__/components/quotes/QuoteForm.test.tsx
+++ b/__tests__/components/quotes/QuoteForm.test.tsx
@@ -25,11 +25,15 @@ vi.mock('@/utils/quotesAccess', () => ({
 
 // Parts: hydrating initial part_ids on edit + by-id lookup
 const getPartsForSelectByIds = vi.fn();
+// The form must NOT reach for the cost engine: a row's price is the matched
+// tier's listed price, already carried on the tiers loaded with the part. Kept
+// mocked (rather than deleted) so the guard test below can assert it stays
+// uncalled — costing per order-qty here is what made a quote disagree with the
+// part page it was priced from.
+const getComputedPartCost = vi.fn(async () => 40);
 vi.mock('@/utils/partsAccess', () => ({
   getPartsForSelectByIds: (...args: unknown[]) => getPartsForSelectByIds(...args),
-  // The form prices each row at base(orderQty) × markup; base comes from here.
-  // 40 × 25% markup = $50, matching the resolver stub below.
-  getComputedPartCost: vi.fn(async () => 40),
+  getComputedPartCost: (...args: unknown[]) => getComputedPartCost(...args),
 }));
 
 // Customers: dropdown + defaults. The pick* resolvers are the real ones in
@@ -757,6 +761,27 @@ describe('QuoteForm', () => {
       expect(screen.getByText('Price options quote')).toBeInTheDocument();
     });
     expect(screen.queryByText('Quote total')).not.toBeInTheDocument();
+  });
+
+  it('prices rows off the loaded tiers — never re-costs at the order quantity', async () => {
+    // Regression guard. Pricing a row as base(orderQty) × markup makes the
+    // number slide with quantity (setup amortizes over whatever qty the cost
+    // engine is handed), so a quote silently undercuts the price the shop set
+    // on the part page everywhere except the exact break. A row's price is the
+    // matched tier's LISTED price, so nothing here may call the cost engine.
+    render(<QuoteForm mode="edit" quoteId="q-1" initialData={initialPopulated} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+
+    const user = userEvent.setup();
+    const qtyInput = (await screen.findAllByLabelText('Order quantity'))[0];
+    await user.clear(qtyInput);
+    await user.type(qtyInput, '180');
+
+    await waitFor(() => expect(qtyInput).toHaveValue('180'));
+    expect(getComputedPartCost).not.toHaveBeenCalled();
   });
 
   it('blocks save when the same quantity is entered twice for one part', async () => {

--- a/__tests__/utils/quoteLineItemsAccess.test.ts
+++ b/__tests__/utils/quoteLineItemsAccess.test.ts
@@ -61,8 +61,9 @@ function makeTier(partial: Partial<ComputedPartPricingTier>): ComputedPartPricin
   };
 }
 
-// A frozen snapshot carrying one markup tier (t100 @ qty 100, 20% markup) — the
-// edit path resolves markup from here, then re-costs base live at the new qty.
+// A frozen snapshot carrying one priced tier (t100 @ qty 100, listed 45.50).
+// The edit path reads the LISTED price straight off this ladder — a quantity
+// move walks the frozen price list, it does not re-cost.
 const SNAPSHOT: PricingBasisSnapshot = {
   tiers: [{ id: 't100', quantity: 100, unit_price: 45.5, markup_percent: 20 }],
   resolved_tier_id: 't100',
@@ -86,33 +87,11 @@ beforeEach(() => {
   buildPricingBasisSnapshotMock.mockReturnValue(SNAPSHOT_SENTINEL);
 });
 
-describe('insertLineItemForPart — single-source pricing (base@qty × markup)', () => {
-  // One tier: markup 25% for orders >= 10.
-  const tiers = [makeTier({ id: 't10', quantity: 10, markup_percent: 25 })];
+describe('insertLineItemForPart — the matched tier’s listed price', () => {
+  // One tier: orders >= 10 list at 50.00 (base 40 × 1.25 at qty 10).
+  const tiers = [makeTier({ id: 't10', quantity: 10, markup_percent: 25, unit_price: 50 })];
 
-  it('prices at base(orderQty) × markup, rounds unit and total to cents', async () => {
-    // base 26.6664 × 1.25 = 33.3330 → 33.33; total = 33.33 × 3 = 99.99.
-    getComputedPartCostMock.mockResolvedValue(26.6664);
-    mockQueryBuilder.data = { id: 'li-1' };
-
-    await insertLineItemForPart('q1', 'co-1', 'part-1', 3, tiers, 0);
-
-    expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        unit_price: 33.33,
-        quantity: 3,
-        total_price: 99.99,
-        base_cost_per_unit: 26.6664,
-        markup_percent: 25,
-        source_tier_id: 't10',
-        is_quote_override: false,
-        basis_unknown: false,
-      }),
-    );
-  });
-
-  it('base × markup with the tier that applies at the order qty', async () => {
-    // qty 12 >= 10 → tier t10, markup 25; base 40 × 1.25 = 50; total 600.
+  it('quotes the tier’s listed price and rounds the total to cents', async () => {
     getComputedPartCostMock.mockResolvedValue(40);
     mockQueryBuilder.data = { id: 'li-1' };
 
@@ -121,11 +100,54 @@ describe('insertLineItemForPart — single-source pricing (base@qty × markup)',
     expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
       expect.objectContaining({
         unit_price: 50,
-        source_tier_id: 't10',
-        markup_percent: 25,
+        quantity: 12,
         total_price: 600,
-        base_cost_per_unit: 40,
+        markup_percent: 25,
+        source_tier_id: 't10',
+        is_quote_override: false,
+        basis_unknown: false,
       }),
+    );
+  });
+
+  it('quotes the SAME price well above the break — setup is not re-amortized', async () => {
+    // The regression this whole rule exists for: a part listing 50.00 at its
+    // qty-10 break quotes 50.00 at 500, not a cheaper number recomputed at 500.
+    getComputedPartCostMock.mockResolvedValue(40);
+    mockQueryBuilder.data = { id: 'li-1' };
+
+    await insertLineItemForPart('q1', 'co-1', 'part-1', 500, tiers, 0);
+
+    expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ unit_price: 50, total_price: 25000, source_tier_id: 't10' }),
+    );
+  });
+
+  it('snapshots base_cost_per_unit at the BREAK qty, so the row’s arithmetic holds', async () => {
+    // unit_price = base_cost_per_unit × (1 + markup/100) is what the column
+    // records, so the base must come from the qty the price was derived at (10)
+    // — never the order qty (500), where setup amortizes differently.
+    getComputedPartCostMock.mockResolvedValue(40);
+    mockQueryBuilder.data = { id: 'li-1' };
+
+    await insertLineItemForPart('q1', 'co-1', 'part-1', 500, tiers, 0);
+
+    expect(getComputedPartCostMock).toHaveBeenCalledWith('part-1', 10);
+    const written = (mockQueryBuilder.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(written.base_cost_per_unit).toBe(40);
+    expect(
+      Math.round(written.base_cost_per_unit * (1 + written.markup_percent / 100) * 100) / 100,
+    ).toBe(written.unit_price);
+  });
+
+  it('below the lowest break, snaps to that break’s listed price', async () => {
+    getComputedPartCostMock.mockResolvedValue(40);
+    mockQueryBuilder.data = { id: 'li-1' };
+
+    await insertLineItemForPart('q1', 'co-1', 'part-1', 3, tiers, 0);
+
+    expect(mockQueryBuilder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ unit_price: 50, total_price: 150, source_tier_id: 't10' }),
     );
   });
 
@@ -149,7 +171,7 @@ describe('insertLineItemForPart — single-source pricing (base@qty × markup)',
     );
   });
 
-  it('throws when no markup tier applies and no override is supplied', async () => {
+  it('throws when no priced tier applies and no override is supplied', async () => {
     getComputedPartCostMock.mockResolvedValue(40);
     await expect(
       insertLineItemForPart('q1', 'co-1', 'part-1', 5, [makeTier({ markup_percent: null })], 0),
@@ -157,9 +179,9 @@ describe('insertLineItemForPart — single-source pricing (base@qty × markup)',
     expect(mockQueryBuilder.insert).not.toHaveBeenCalled();
   });
 
-  it('falls back to the resolved tier price when the live base cost is null', async () => {
-    // base null (cost can't compute) → fall back to the ladder's priced tier so
-    // the line still gets a sensible price instead of NaN.
+  it('still writes the tier price when the base cost cannot be computed', async () => {
+    // The price comes off the ladder, so a part that momentarily can't cost
+    // still quotes correctly — only the base_cost_per_unit snapshot goes null.
     getComputedPartCostMock.mockResolvedValue(null);
     mockQueryBuilder.data = { id: 'li-1' };
 
@@ -178,8 +200,8 @@ describe('insertLineItemForPart — single-source pricing (base@qty × markup)',
   });
 });
 
-describe('updateLineItemQuantity — re-cost base at new qty × frozen markup', () => {
-  it('recomputes unit_price from base(newQty) × the snapshot markup', async () => {
+describe('updateLineItemQuantity — walks the frozen price list', () => {
+  it('takes unit_price from the snapshot tier, without re-costing', async () => {
     mockQueryBuilder.data = {
       id: 'li-1',
       part_id: 'part-1',
@@ -189,19 +211,37 @@ describe('updateLineItemQuantity — re-cost base at new qty × frozen markup', 
       unit_price: 99,
       source_tier_id: 't1',
     };
-    // base(100) = 40; markup from snapshot tier t100 = 20% → unit 48; total 4800.
-    getComputedPartCostMock.mockResolvedValue(40);
 
     await updateLineItemQuantity('li-1', 100);
 
-    expect(getComputedPartCostMock).toHaveBeenCalledWith('part-1', 100);
+    // The frozen ladder lists 45.50 at t100 → 45.50 × 100 = 4550. No cost call:
+    // a quantity move reads the price list, it does not re-derive a price.
+    expect(getComputedPartCostMock).not.toHaveBeenCalled();
     expect(mockQueryBuilder.update).toHaveBeenCalledWith(
       expect.objectContaining({
         quantity: 100,
-        unit_price: 48,
+        unit_price: 45.5,
         source_tier_id: 't100',
-        total_price: 4800,
+        total_price: 4550,
       }),
+    );
+  });
+
+  it('holds that price above the break instead of drifting below it', async () => {
+    mockQueryBuilder.data = {
+      id: 'li-1',
+      part_id: 'part-1',
+      is_quote_override: false,
+      basis_unknown: false,
+      pricing_basis_snapshot: SNAPSHOT,
+      unit_price: 45.5,
+      source_tier_id: 't100',
+    };
+
+    await updateLineItemQuantity('li-1', 400);
+
+    expect(mockQueryBuilder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ quantity: 400, unit_price: 45.5, total_price: 18200 }),
     );
   });
 
@@ -244,8 +284,10 @@ describe('updateLineItemQuantity — re-cost base at new qty × frozen markup', 
   });
 });
 
-describe('repriceLineItemToCurrent — base(lineQty) × current markup', () => {
-  const currentTiers = [makeTier({ id: 't50', quantity: 50, markup_percent: 30 })];
+describe('repriceLineItemToCurrent — the current ladder’s listed price', () => {
+  const currentTiers = [
+    makeTier({ id: 't50', quantity: 50, markup_percent: 30, unit_price: 41.11 }),
+  ];
 
   it('throws for override rows', async () => {
     mockQueryBuilder.data = { id: 'li-1', part_id: 'part-1', is_quote_override: true, quantity: 50 };
@@ -263,9 +305,9 @@ describe('repriceLineItemToCurrent — base(lineQty) × current markup', () => {
     ).rejects.toThrow(/no priced tiers/);
   });
 
-  it('recomputes base(lineQty) × current markup, total, and rebuilds the snapshot', async () => {
+  it('takes the current tier’s listed price, refreshes the base and the snapshot', async () => {
     mockQueryBuilder.data = { id: 'li-1', part_id: 'part-1', is_quote_override: false, quantity: 50 };
-    // base(50) = 31.62; markup 30% → 41.106 → 41.11; total 41.11 × 50 = 2055.5.
+    // t50 lists 41.11 (base 31.62 × 1.30 at qty 50); total 41.11 × 50 = 2055.5.
     getComputedPartCostMock.mockResolvedValue(31.62);
 
     await repriceLineItemToCurrent('li-1', currentTiers);
@@ -276,10 +318,25 @@ describe('repriceLineItemToCurrent — base(lineQty) × current markup', () => {
         unit_price: 41.11,
         source_tier_id: 't50',
         markup_percent: 30,
+        base_cost_per_unit: 31.62,
         total_price: 2055.5,
         pricing_basis_snapshot: SNAPSHOT_SENTINEL,
         basis_unknown: false,
       }),
+    );
+  });
+
+  it('re-costs at the matched BREAK, not the line qty, when they differ', async () => {
+    // Line sits at 500 but the ladder tops out at 50: the price is t50's listed
+    // price, so the refreshed base must be the one behind it (qty 50).
+    mockQueryBuilder.data = { id: 'li-1', part_id: 'part-1', is_quote_override: false, quantity: 500 };
+    getComputedPartCostMock.mockResolvedValue(31.62);
+
+    await repriceLineItemToCurrent('li-1', currentTiers);
+
+    expect(getComputedPartCostMock).toHaveBeenCalledWith('part-1', 50);
+    expect(mockQueryBuilder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ unit_price: 41.11, total_price: 20555 }),
     );
   });
 });

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -50,8 +50,7 @@ import {
   pickFobPoint,
 } from '@/utils/customerAccess';
 import { getTiersWithComputedPrices } from '@/utils/partPricingTiersAccess';
-import { resolveTier, resolveMarkupAtQty, unitPriceFromBase } from '@/utils/quotePricingResolver';
-import { getComputedPartCost } from '@/utils/partsAccess';
+import { resolveTier } from '@/utils/quotePricingResolver';
 import { isValidQuantityInput } from '@/lib/quantityInput';
 import { quantityUnitSuffix, unitShortLabel } from '@/lib/standardUnits';
 import type { ComputedPartPricingTier } from '@/types/partPricing';
@@ -852,58 +851,12 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     setCustomerModalOpen(false);
   };
 
-  // Base cost per (part | order-qty), from the ONE canonical engine
-  // (compute_part_cost_at_qty) at the ACTUAL order quantity. The row price is
-  // base × the markup tier that applies at that qty — the same single-source
-  // rule the persisted line uses — so the form shows exactly what gets saved,
-  // and a ceiling/batch part is priced exactly at any qty (not snapped to a
-  // tier breakpoint). Keyed by `${partId}|${qty}`; a stored `null` means the
-  // part can't currently be costed. Debounced so typing a qty doesn't refetch
-  // on every keystroke.
-  const [orderQtyBaseCosts, setOrderQtyBaseCosts] = useState<Map<string, number | null>>(new Map());
-  const inFlightBaseKeys = useRef<Set<string>>(new Set());
-
-  useEffect(() => {
-    const wanted: Array<{ key: string; partId: string; qty: number }> = [];
-    for (const block of partBlocks) {
-      if (!block.part) continue;
-      for (const row of block.rows) {
-        const qty = Number(row.quantity);
-        if (!Number.isFinite(qty) || qty <= 0) continue;
-        wanted.push({ key: `${block.part.id}|${qty}`, partId: block.part.id, qty });
-      }
-    }
-    const missing = wanted.filter(
-      (w) => !orderQtyBaseCosts.has(w.key) && !inFlightBaseKeys.current.has(w.key),
-    );
-    if (missing.length === 0) return;
-
-    let cancelled = false;
-    const handle = setTimeout(() => {
-      for (const { key, partId, qty } of missing) {
-        inFlightBaseKeys.current.add(key);
-        getComputedPartCost(partId, qty)
-          .catch(() => null)
-          .then((base) => {
-            inFlightBaseKeys.current.delete(key);
-            if (cancelled) return;
-            setOrderQtyBaseCosts((prev) => {
-              const next = new Map(prev);
-              next.set(key, base);
-              return next;
-            });
-          });
-      }
-    }, 300);
-    return () => {
-      cancelled = true;
-      clearTimeout(handle);
-    };
-  }, [partBlocks, orderQtyBaseCosts]);
-
-  /** Per-row live preview: blockPreviews[block][row] = { resolved, total, loading }.
-   *  `resolved.unit_price` = base(orderQty) × markup(orderQty) — the single
-   *  source of truth. `loading` is true while the base cost is being fetched.
+  /** Per-row live preview: blockPreviews[block][row] = { resolved, total }.
+   *  `resolved.unit_price` is the price the matched tier LISTS — the same number
+   *  the part page shows for that break — because the tier ladder is a price
+   *  list and a break's price holds for its whole band. `block.tiers` already
+   *  carries those prices (getTiersWithComputedPrices, fetched when the part is
+   *  picked), so this is synchronous: no per-quantity round trip.
    *  A part-level custom price (block.override_*) applies to every row. */
   const blockPreviews = useMemo(() => {
     return partBlocks.map((block) => {
@@ -918,39 +871,24 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
         const empty = {
           resolved: null as ReturnType<typeof resolveTier>,
           total: null as number | null,
-          loading: false,
         };
         if (!Number.isFinite(orderQty) || orderQty <= 0) return empty;
         if (overrideValid) {
           return {
             resolved: null as ReturnType<typeof resolveTier>,
             total: Math.round((overridePrice as number) * orderQty * 100) / 100,
-            loading: false,
           };
         }
         if (!block.part) return empty;
-        const markup = resolveMarkupAtQty(block.tiers, orderQty);
-        if (!markup) return empty;
-        const key = `${block.part.id}|${orderQty}`;
-        const loading = !orderQtyBaseCosts.has(key);
-        const base = orderQtyBaseCosts.get(key) ?? null;
-        const unitPrice = unitPriceFromBase(base, markup.markup_percent);
+        const resolved = resolveTier(block.tiers, orderQty);
+        if (!resolved) return empty;
         return {
-          resolved:
-            unitPrice !== null
-              ? {
-                  unit_price: unitPrice,
-                  source_tier_id: markup.source_tier_id,
-                  matched_tier_quantity: markup.matched_tier_quantity,
-                  below_min: markup.below_min,
-                }
-              : null,
-          total: unitPrice !== null ? Math.round(unitPrice * orderQty * 100) / 100 : null,
-          loading,
+          resolved,
+          total: Math.round(resolved.unit_price * orderQty * 100) / 100,
         };
       });
     });
-  }, [partBlocks, orderQtyBaseCosts]);
+  }, [partBlocks]);
 
   /**
    * Firm order = every part has exactly one quantity → show a grand total.
@@ -1562,10 +1500,6 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                                       : `Tier ${matched.matched_tier_quantity} ${tierUnitLabel}`}
                                   </Typography>
                                 </>
-                              ) : preview?.loading ? (
-                                <Typography variant="caption" color="text.secondary">
-                                  Pricing…
-                                </Typography>
                               ) : (
                                 <Typography variant="caption" color="warning.main">
                                   No priced tier — add a tier or use a custom price

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -33,6 +33,18 @@ against tiers of 1/10/20). Each price resolves by **snapping to the highest tier
 breakpoint is ≤ the quantity** ([`resolveTier`](../../utils/quotePricingResolver.ts)); there is
 **no interpolation**.
 
+> **A tier's listed price holds for its whole band, and the quote never recomputes it.** Quoting
+> 180 of a part whose tier-80 break lists $33.40 quotes $33.40 — the same number
+> [`PartPricing`](../../components/parts/PartPricing.tsx) shows. This is load-bearing rather than
+> incidental: base cost is a *function of quantity* (setup amortizes over whatever quantity
+> `compute_part_cost_at_qty` is handed), so pricing as `base(order qty) × the tier's markup`
+> yields a different number at every quantity and quotes the shop's chosen price only at the exact
+> break. That shipped between 2026-07-13 and 2026-08-07 and read as a bug the first time a
+> salesperson compared a quote line against the part page. **The part page decides a price; the
+> quote reads it.** Reaching for `resolveMarkupAtQty` + `unitPriceFromBase` on a quote path
+> reintroduces it — those two are the *costing* pair that builds a tier's listed price, not the
+> quote-time price path.
+
 **Firm vs price-options is implicit — decided by quantity count, with no mode toggle:**
 
 | Shape | Detail view + PDF |
@@ -157,8 +169,10 @@ detail page (`quotes/[quoteId]/page.tsx`), gated on the quote being active and u
 **Parts card** — one block per part, plus **+ Add part**. Each block: a part picker (with **+ New
 Part** inline create), an editable **list of quantity rows** (one per quoted quantity, **Add
 quantity** appends, every row past the first can be deleted), each row showing its resolved
-price inline as `Tier {n} ea · {unit price} / unit` plus Total (firm) or Extended (options). A
+price stacked over a `Tier {n} {unit}` caption, plus Total (firm) or Extended (options). A
 row below the lowest tier shows a "below minimum break" hint and snaps to the lowest tier price.
+Prices resolve synchronously off the tiers already loaded with the part — no per-quantity round
+trip, so typing a quantity updates the row immediately.
 The block warns when the part has no priced tiers, linking to the part page.
 
 There is **no separate "Pricing tiers (reference)" section** — the editable quantity rows
@@ -288,8 +302,10 @@ procurement tiers via `compute_part_cost_at_qty`, so they resolve a real tier pr
 need a manual per-line override.
 
 On the quote, `createQuote` inserts one row per (part, quantity), with `unit_price` from
-`resolveTier`, `base_cost_per_unit` from `getComputedPartCost` (historical record),
-`source_tier_id` as a soft reference, and `pricing_basis_snapshot` as the frozen tier table. A
+`resolveTier`, `base_cost_per_unit` from `getComputedPartCost` **at the matched break's quantity**
+— not the order quantity, so the row's own `unit_price = base_cost_per_unit × (1 + markup/100)`
+still holds — `source_tier_id` as a soft reference, and `pricing_basis_snapshot` as the frozen
+tier table. A
 quantity below the lowest tier snaps to it and is flagged `below_min` in the UI. A typed custom
 price instead sets that row's `unit_price` with `is_quote_override = true`, leaving the tier
 untouched.

--- a/utils/quoteLineItemsAccess.ts
+++ b/utils/quoteLineItemsAccess.ts
@@ -7,7 +7,6 @@ import {
   resolveTier,
   resolveTierFromSnapshot,
   resolveMarkupAtQty,
-  unitPriceFromBase,
   buildPricingBasisSnapshot,
 } from '@/utils/quotePricingResolver';
 import { getComputedPartCost } from '@/utils/partsAccess';
@@ -73,53 +72,50 @@ export async function insertLineItemForPart(
 ): Promise<QuoteLineItem> {
   const supabase = getSupabase();
 
-  // Base cost live at the ACTUAL order quantity, from the one canonical engine.
-  // This is both the frozen `base_cost_per_unit` and the basis for the selling
-  // price below — so `unit_price = base_cost_per_unit × (1 + markup/100)` holds
-  // on the row itself, and the quote form (which prices the same way) shows the
-  // identical number.
+  let unitPrice: number;
+  let markupPercent: number | null;
+  let sourceTierId: string | null;
+  // Quantity the price basis was evaluated at — the matched tier's break, not
+  // the order quantity (see `basisQuantity` below).
+  let basisQuantity: number;
+
+  if (override) {
+    unitPrice = override.unit_price;
+    markupPercent = override.markup_percent;
+    const resolvedMarkup = resolveMarkupAtQty(tiers, orderQuantity);
+    sourceTierId = resolvedMarkup?.source_tier_id ?? null;
+    basisQuantity = resolvedMarkup?.matched_tier_quantity ?? orderQuantity;
+  } else {
+    // The tier ladder is the shop's declared price list: the price listed at a
+    // break holds for that break's whole band. `resolveTier` returns exactly
+    // the number the part page shows for the matched tier, so a quote can never
+    // disagree with the part it was priced from.
+    const resolved = resolveTier(tiers, orderQuantity);
+    if (!resolved) {
+      throw new Error(
+        'Cannot create quote line item: this part has no priced pricing tiers. Add tiers on the part page first.',
+      );
+    }
+    unitPrice = resolved.unit_price;
+    sourceTierId = resolved.source_tier_id;
+    const matchedTier = tiers.find((t) => t.id === resolved.source_tier_id);
+    markupPercent = matchedTier?.markup_percent ?? null;
+    basisQuantity = resolved.matched_tier_quantity ?? orderQuantity;
+  }
+
+  // Base cost at the quantity the PRICE was derived from — the matched tier's
+  // break, not the order quantity. Setup amortization makes the base a function
+  // of quantity, so snapshotting it at the order qty would break the row's own
+  // arithmetic: `unit_price = base_cost_per_unit × (1 + markup/100)` is the
+  // invariant this column exists to record.
   let baseCost: number | null;
   try {
-    baseCost = await getComputedPartCost(partId, orderQuantity);
+    baseCost = await getComputedPartCost(partId, basisQuantity);
   } catch {
     // Cost RAISES on missing labor rates / external pricing / unit
     // conversions. Snapshot a null so the breakdown view can fall through
     // to its computed-live fallback rather than persisting wrong data.
     baseCost = null;
-  }
-
-  let unitPrice: number;
-  let markupPercent: number | null;
-  let sourceTierId: string | null;
-
-  if (override) {
-    unitPrice = override.unit_price;
-    markupPercent = override.markup_percent;
-    sourceTierId = resolveMarkupAtQty(tiers, orderQuantity)?.source_tier_id ?? null;
-  } else {
-    // Resolve the markup that applies at the order qty; price = base(orderQty)
-    // × markup — the single-source computation. Fall back to the tier ladder's
-    // breakpoint price only when the live base can't be computed (so a part
-    // that momentarily can't cost still gets a sensible price rather than
-    // failing the quote).
-    const resolvedMarkup = resolveMarkupAtQty(tiers, orderQuantity);
-    const fromBase = unitPriceFromBase(baseCost, resolvedMarkup?.markup_percent);
-    if (fromBase !== null && resolvedMarkup) {
-      unitPrice = fromBase;
-      markupPercent = resolvedMarkup.markup_percent;
-      sourceTierId = resolvedMarkup.source_tier_id;
-    } else {
-      const resolved = resolveTier(tiers, orderQuantity);
-      if (!resolved) {
-        throw new Error(
-          'Cannot create quote line item: this part has no priced pricing tiers. Add tiers on the part page first.',
-        );
-      }
-      unitPrice = resolved.unit_price;
-      sourceTierId = resolved.source_tier_id;
-      const matchedTier = tiers.find((t) => t.id === resolved.source_tier_id);
-      markupPercent = matchedTier?.markup_percent ?? null;
-    }
   }
 
   const totalPrice = Math.round(unitPrice * orderQuantity * 100) / 100;
@@ -195,27 +191,15 @@ export async function updateLineItemQuantity(
   if (!row.is_quote_override) {
     const snapshot = row.pricing_basis_snapshot;
     if (snapshot && !row.basis_unknown) {
-      // Markup stays frozen from the snapshot ladder (selling policy); the base
-      // cost is recomputed live at the NEW qty and the price recombined — the
-      // same single-source rule as insert. Falls back to the snapshot's frozen
-      // breakpoint price if the live base can't be computed.
-      const resolvedMarkup = resolveMarkupAtQty(snapshot.tiers, newQuantity);
-      let base: number | null;
-      try {
-        base = await getComputedPartCost(row.part_id, newQuantity);
-      } catch {
-        base = null;
-      }
-      const fromBase = unitPriceFromBase(base, resolvedMarkup?.markup_percent);
-      if (fromBase !== null && resolvedMarkup) {
-        newUnitPrice = fromBase;
-        newSourceTierId = resolvedMarkup.source_tier_id;
-      } else {
-        const resolved = resolveTierFromSnapshot(snapshot, newQuantity);
-        if (resolved) {
-          newUnitPrice = resolved.unit_price;
-          newSourceTierId = resolved.source_tier_id;
-        }
+      // Walk the FROZEN ladder captured at quote time, not the part's current
+      // tiers — moving to another quantity is quantity-curve movement, not a
+      // reprice, so a tier edit since creation must not leak in here. The
+      // snapshot stores each tier's listed price, which is the price the band
+      // carries, so this lands on the same number the part page shows.
+      const resolved = resolveTierFromSnapshot(snapshot, newQuantity);
+      if (resolved) {
+        newUnitPrice = resolved.unit_price;
+        newSourceTierId = resolved.source_tier_id;
       }
     }
     // basis_unknown rows keep the stored unit_price — there's no
@@ -295,30 +279,24 @@ export async function repriceLineItemToCurrent(
     throw new Error('Override line items cannot be repriced — clear the override first.');
   }
 
-  const resolvedMarkup = resolveMarkupAtQty(currentTiers, row.quantity);
-  if (!resolvedMarkup) {
+  // Reprice onto the part's CURRENT ladder — the listed price at the break this
+  // quantity falls in, which is the number the part page shows today.
+  const resolved = resolveTier(currentTiers, row.quantity);
+  if (!resolved) {
     throw new Error('Cannot reprice: this part has no priced tiers in the current tier table.');
   }
-  const newMarkup = resolvedMarkup.markup_percent;
+  const newUnitPrice = resolved.unit_price;
+  const newSourceTierId: string | null = resolved.source_tier_id;
+  const matchedTier = currentTiers.find((t) => t.id === resolved.source_tier_id);
+  const newMarkup = matchedTier?.markup_percent ?? null;
 
-  // Single-source reprice: base cost live at the line's own qty × the current
-  // tier's markup. Falls back to the ladder's breakpoint price if base can't
-  // be computed.
+  // Base at the matched break — the quantity the new price was derived from, so
+  // `unit_price = base_cost_per_unit × (1 + markup/100)` still holds on the row.
   let base: number | null;
   try {
-    base = await getComputedPartCost(row.part_id, row.quantity);
+    base = await getComputedPartCost(row.part_id, resolved.matched_tier_quantity ?? row.quantity);
   } catch {
     base = null;
-  }
-  let newUnitPrice = unitPriceFromBase(base, newMarkup);
-  let newSourceTierId: string | null = resolvedMarkup.source_tier_id;
-  if (newUnitPrice === null) {
-    const resolved = resolveTier(currentTiers, row.quantity);
-    if (!resolved) {
-      throw new Error('Cannot reprice: this part has no priced tiers in the current tier table.');
-    }
-    newUnitPrice = resolved.unit_price;
-    newSourceTierId = resolved.source_tier_id;
   }
 
   const newSnapshot = buildPricingBasisSnapshot(
@@ -334,6 +312,10 @@ export async function repriceLineItemToCurrent(
       unit_price: newUnitPrice,
       source_tier_id: newSourceTierId,
       markup_percent: newMarkup,
+      // Refreshed alongside the price it belongs to — leaving the create-time
+      // base here would leave the row asserting an arithmetic that no longer
+      // holds, and it is what cost-vs-sell reporting reads.
+      base_cost_per_unit: base,
       total_price: newTotal,
       pricing_basis_snapshot: newSnapshot as unknown as Json,
       basis_unknown: false,

--- a/utils/quotePricingResolver.ts
+++ b/utils/quotePricingResolver.ts
@@ -18,16 +18,27 @@ export interface ResolvedMarkup {
 /**
  * SINGLE SOURCE OF TRUTH for a part's price at a quantity.
  *
- * Every surface (Pricing card tier rows, the Pricing "Cost at qty" preview, the
- * quote form's live price, and the persisted quote line) computes price the same
- * way: a base cost from the ONE canonical engine `compute_part_cost_at_qty`
- * (via `getComputedPartCost`) at the ACTUAL quantity, times the markup of the
- * tier that applies at that quantity. The markup ladder is a step function of
- * qty; the base cost is exact at qty — so the price is exact at every qty and
- * identical across screens (no per-breakpoint approximation, no TS/SQL engine
- * split on the money path).
+ * **A part's tier ladder is a price list, and the price listed at a break holds
+ * for that break's whole band.** Quoting 180 of a part whose tier-80 break lists
+ * $33.40 quotes $33.40 — not a number recomputed at 180.
  *
- * `resolveMarkupAtQty` picks the markup; `unitPriceFromBase` applies it.
+ * That matters because the base cost is a *function of quantity*: setup
+ * amortizes over whatever quantity `compute_part_cost_at_qty` is called with. So
+ * "base at the order qty × the tier's markup" produces a different number for
+ * every quantity, and the price a shop deliberately set on the part page would
+ * be quoted only at the exact break quantity — silently drifting below it
+ * everywhere else. The tier row is where a price is decided; a quote reads it.
+ *
+ * `resolveTier` is therefore the price path: it returns the matched tier's own
+ * listed `unit_price`, computed once per tier by `getTiersWithComputedPrices` at
+ * that tier's quantity — the same number `PartPricing` renders. Every pricing
+ * surface goes through it or through `resolveTierFromSnapshot` (the frozen
+ * equivalent, for lines already committed to a quote).
+ *
+ * `resolveMarkupAtQty` + `unitPriceFromBase` remain the *costing* pair: they
+ * build a tier's listed price from a base in `getTiersWithComputedPrices`, and
+ * resolve which tier an override borrows its `source_tier_id` from. They are not
+ * the quote-time price path — reaching for them there reintroduces the drift.
  */
 
 /**


### PR DESCRIPTION
## The bug

Part `JVD1035AS RGD (DMC)` lists **$33.40** at both its qty-50 and qty-80 breaks. Quoting **180** showed **$32.98**.

`part_pricing_tiers` stores only `(quantity, markup_percent)` — **there is no price column**. Every surface derives price as `base × (1 + markup/100)`, and `base` is a *function of quantity*: [`compute_part_cost_at_qty`](https://github.com/debola31/Jigged/blob/main/supabase/migrations/20260715150633_made_part_standard_costing_lot_size.sql#L117) amortizes setup over whatever quantity it is handed.

- Part page evaluated base at **the tier's own quantity** → tier 80: base $22.77 → **$33.40**
- Quote evaluated base at **the order quantity** → 180: base $22.48 → **$32.98**

Same markup, different base. The $0.42 gap is exactly `(41.33/80 − 41.33/180) × 1.4668`. The `Tier 80 ea` caption made it worse — it names *which markup was borrowed*, not which price was used.

The consequence is one-directional: the price a shop deliberately set was quoted **only at the exact break quantity**, and drifted below it everywhere above — further the larger the order.

## The rule

**A tier's listed price holds for its whole band. The part page decides a price; the quote reads it.**

The part page is correct and is **not** changed here. So every quote price now goes through `resolveTier` (live tiers) / `resolveTierFromSnapshot` (committed lines), which return the matched tier's own listed `unit_price` — the same number `PartPricing` renders.

This also puts the quote form back in line with the three surfaces that *already* priced this way: `AcceptPurchaseOrderModal`, `ConvertToJobModal` (via `resolveJobPartUnitPrice`), and job-part repricing. It was the odd one out — and [`docs/modules/quotes.md`](https://github.com/debola31/Jigged/blob/main/docs/modules/quotes.md) still described the tier-price behaviour, so the docs were never updated when the drift was introduced in `402c3d7f` (2026-07-13).

## Verified against production

Against the real part, same markup on both sides:

| order qty | matched tier | before | after |
|---|---|---|---|
| 50 | 50 | $33.40 | $33.40 |
| 80 | 80 | $33.40 | $33.40 |
| 100 | 80 | $33.25 | **$33.40** |
| 180 | 80 | **$32.98** | **$33.40** |
| 500 | 80 | $32.76 | **$33.40** |

Across all 29 existing lines quoting above their matched break, parts with a **real price break** move **+2.5% average / +7.8% max**.

**Existing quote lines are NOT repriced** — `unit_price` is frozen by design; the per-line *Update to current price* control remains the way to move one.

## Changes

- `insertLineItemForPart` — price from `resolveTier`; `base_cost_per_unit` snapshotted at the **matched break's** quantity so the row's own `unit_price = base_cost_per_unit × (1 + markup/100)` still holds.
- `updateLineItemQuantity` — walk the frozen snapshot ladder only. A quantity move reads the price list; it does not re-derive a price.
- `repriceLineItemToCurrent` — take the current ladder's listed price. **Also fixes a latent bug:** it computed a refreshed `base_cost_per_unit` and then dropped it, leaving the column asserting arithmetic that no longer held.
- `QuoteForm` — prices resolve synchronously off tiers already loaded with the part. Drops the debounced per-quantity `getComputedPartCost` fetch, its cache, its in-flight set and the `Pricing…` state: **no round trip per quantity typed.**

## Tests

Rewrote the cases that asserted base-at-order-qty. New coverage: quoting well above a break yields the same listed price; `base_cost_per_unit` is fetched at the break qty and the row's arithmetic holds; a qty change makes **no** cost call; a `QuoteForm` guard asserting the form never calls the cost engine at all.

`tsc` clean · lint 0 errors · doc-link + analytics guards pass · full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)