### PR TITLE
feat(quotes): make the unit price directly editable, per quantity

### DIFF
--- a/__tests__/components/quotes/QuoteForm.test.tsx
+++ b/__tests__/components/quotes/QuoteForm.test.tsx
@@ -804,25 +804,114 @@ describe('QuoteForm', () => {
     });
   });
 
-  it('shows a single part-level "Use custom price" control regardless of how many quantities', async () => {
+  it('gives every quantity its own editable price, seeded from its tier', async () => {
+    // There is no "Use custom price" toggle to discover any more: the price is
+    // just an editable field carrying the tier's listed price. One per row,
+    // because each (part, quantity) is its own line with its own price.
     render(<QuoteForm mode="edit" quoteId="q-1" initialData={initialPopulated} />);
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
     });
 
-    // One quantity row → exactly one custom-price toggle.
-    expect(screen.getAllByRole('button', { name: /use custom price/i })).toHaveLength(1);
+    expect(screen.queryByRole('button', { name: /use custom price/i })).toBeNull();
+    expect(screen.getAllByLabelText('Unit price')).toHaveLength(1);
+    expect(screen.getAllByLabelText('Unit price')[0]).toHaveValue('50');
 
     const user = userEvent.setup();
     await user.click(screen.getByRole('button', { name: /add quantity/i }));
     await user.click(screen.getByRole('button', { name: /add quantity/i }));
 
-    // Three quantity rows → STILL exactly one custom-price toggle (per part).
     await waitFor(() => {
       expect(screen.getAllByLabelText('Order quantity')).toHaveLength(3);
     });
-    expect(screen.getAllByRole('button', { name: /use custom price/i })).toHaveLength(1);
+    expect(screen.getAllByLabelText('Unit price')).toHaveLength(3);
+  });
+
+  it('flags a typed price as custom, keeps the tier price visible, and resets back to it', async () => {
+    render(<QuoteForm mode="edit" quoteId="q-1" initialData={initialPopulated} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+
+    const user = userEvent.setup();
+    const priceInput = screen.getAllByLabelText('Unit price')[0];
+    await user.clear(priceInput);
+    await user.type(priceInput, '42');
+
+    // The auto price stays on screen — the old toggle hid it, leaving the user
+    // nothing to compare their number against.
+    await waitFor(() => {
+      expect(screen.getByText(/Custom · Tier 1 ea is \$50\.00/)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('price-reset-0-0'));
+
+    await waitFor(() => expect(priceInput).toHaveValue('50'));
+    expect(screen.queryByText(/Custom · Tier/)).toBeNull();
+  });
+
+  it('keeps Reset reachable when the price field is emptied — the state that blocks save', async () => {
+    // Clearing the field blocks the save with "reset the row to its tier price".
+    // If Reset were gated on a *valid* custom price it would disappear at
+    // exactly the moment that message points at it, stranding the user.
+    render(<QuoteForm mode="edit" quoteId="q-1" initialData={initialPopulated} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+
+    const user = userEvent.setup();
+    await user.clear(screen.getAllByLabelText('Unit price')[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled();
+    });
+    expect(screen.getByTestId('price-reset-0-0')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('price-reset-0-0'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+    expect(screen.getAllByLabelText('Unit price')[0]).toHaveValue('50');
+  });
+
+  it('sends one override per row — and none for a row typed back to its tier price', async () => {
+    render(<QuoteForm mode="edit" quoteId="q-1" initialData={initialPopulated} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /add quantity/i }));
+    await waitFor(() => expect(screen.getAllByLabelText('Order quantity')).toHaveLength(2));
+
+    // Second row: qty 100 at a negotiated 42. First row: retype the tier's own
+    // price, which must NOT become an override — that would freeze the line out
+    // of drift detection and repricing for no reason.
+    await user.type(screen.getAllByLabelText('Order quantity')[1], '100');
+    const prices = screen.getAllByLabelText('Unit price');
+    await user.clear(prices[1]);
+    await user.type(prices[1], '42');
+    await user.clear(prices[0]);
+    await user.type(prices[0], '50');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(updateQuote).toHaveBeenCalled());
+    const payload = updateQuote.mock.calls[0][1] as QuoteFormData;
+    expect(payload.parts).toHaveLength(2);
+    expect(payload.parts[0].override).toBeUndefined();
+    expect(payload.parts[1]).toMatchObject({
+      order_quantity: 100,
+      override: { unit_price: 42, markup_percent: null },
+    });
   });
 });
 

--- a/__tests__/components/quotes/QuoteForm.test.tsx
+++ b/__tests__/components/quotes/QuoteForm.test.tsx
@@ -212,8 +212,7 @@ describe('QuoteForm', () => {
   });
 
   it('disables submit when validation passes initial guard but parts array is empty', async () => {
-    // Customer set, no part chosen → the pre-opened block has no part, so
-    // "Every part block must have a part selected." still blocks the save.
+    // Customer set, parts empty → "Add at least one part to the quote."
     render(
       <QuoteForm
         mode="create"
@@ -225,18 +224,16 @@ describe('QuoteForm', () => {
     });
   });
 
-  it('opens a new quote with one part block already there', async () => {
-    // Every quote has at least one part, so making the user click "Add part"
-    // to reach the form's whole point was a click that could never be wrong
-    // to spend. Edit mode keeps whatever blocks the quote already has.
+  it('starts a new quote with no part block — Add part is the way in', async () => {
+    // Deliberate: seeding a block saves no click (Add part autofocuses the
+    // picker it creates) and costs the signal that a quote can hold several
+    // parts. Guards the revert so nobody re-adds the seed as an "improvement".
     render(<QuoteForm mode="create" initialData={initialBlank} />);
 
-    // PartAutocomplete is mocked to null here, so the block's own Remove
-    // control is what proves a block rendered without anyone clicking Add part.
     await waitFor(() => {
-      expect(screen.getAllByRole('button', { name: /remove part/i })).toHaveLength(1);
+      expect(screen.getByText(/add at least one part to quote/i)).toBeInTheDocument();
     });
-    expect(screen.queryByText(/add at least one part to quote/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /remove part/i })).toBeNull();
   });
 
   it('enables submit when initial data is fully valid (populated edit mode)', async () => {

--- a/__tests__/components/quotes/QuoteForm.test.tsx
+++ b/__tests__/components/quotes/QuoteForm.test.tsx
@@ -212,7 +212,8 @@ describe('QuoteForm', () => {
   });
 
   it('disables submit when validation passes initial guard but parts array is empty', async () => {
-    // Customer set, parts empty → "Add at least one part to the quote."
+    // Customer set, no part chosen → the pre-opened block has no part, so
+    // "Every part block must have a part selected." still blocks the save.
     render(
       <QuoteForm
         mode="create"
@@ -222,6 +223,20 @@ describe('QuoteForm', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /create quote/i })).toBeDisabled();
     });
+  });
+
+  it('opens a new quote with one part block already there', async () => {
+    // Every quote has at least one part, so making the user click "Add part"
+    // to reach the form's whole point was a click that could never be wrong
+    // to spend. Edit mode keeps whatever blocks the quote already has.
+    render(<QuoteForm mode="create" initialData={initialBlank} />);
+
+    // PartAutocomplete is mocked to null here, so the block's own Remove
+    // control is what proves a block rendered without anyone clicking Add part.
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /remove part/i })).toHaveLength(1);
+    });
+    expect(screen.queryByText(/add at least one part to quote/i)).toBeNull();
   });
 
   it('enables submit when initial data is fully valid (populated edit mode)', async () => {
@@ -843,13 +858,16 @@ describe('QuoteForm', () => {
     // The auto price stays on screen — the old toggle hid it, leaving the user
     // nothing to compare their number against.
     await waitFor(() => {
-      expect(screen.getByText(/Custom · Tier 1 ea is \$50\.00/)).toBeInTheDocument();
+      // No unit in the caption: the Qty box beside it already carries one
+      // wherever a unit is meaningful, and the old `?? 'ea'` fallback invented
+      // one for parts whose Qty box shows none.
+      expect(screen.getByText(/Custom · tier 1 is \$50\.00/)).toBeInTheDocument();
     });
 
     await user.click(screen.getByTestId('price-reset-0-0'));
 
     await waitFor(() => expect(priceInput).toHaveValue('50'));
-    expect(screen.queryByText(/Custom · Tier/)).toBeNull();
+    expect(screen.queryByText(/Custom · tier/)).toBeNull();
   });
 
   it('keeps Reset reachable when the price field is emptied — the state that blocks save', async () => {

--- a/__tests__/utils/quoteLineItemsAccess.test.ts
+++ b/__tests__/utils/quoteLineItemsAccess.test.ts
@@ -43,6 +43,7 @@ vi.mock('@/utils/partsAccess', () => ({ getComputedPartCost: getComputedPartCost
 import {
   insertLineItemForPart,
   updateLineItemQuantity,
+  updateLineItemOverride,
   repriceLineItemToCurrent,
 } from '@/utils/quoteLineItemsAccess';
 
@@ -280,6 +281,70 @@ describe('updateLineItemQuantity — walks the frozen price list', () => {
     expect(getComputedPartCostMock).not.toHaveBeenCalled();
     expect(mockQueryBuilder.update).toHaveBeenCalledWith(
       expect.objectContaining({ quantity: 8, unit_price: 12.5, total_price: 100 }),
+    );
+  });
+});
+
+describe('updateLineItemOverride — set/clear a one-off price on a saved line', () => {
+  const saved = (over: Record<string, unknown> = {}) => ({
+    id: 'li-1',
+    part_id: 'part-1',
+    quantity: 10,
+    unit_price: 45.5,
+    source_tier_id: 't100',
+    markup_percent: 20,
+    is_quote_override: false,
+    basis_unknown: false,
+    pricing_basis_snapshot: SNAPSHOT,
+    ...over,
+  });
+
+  it('pins the typed price and flags the line as an override', async () => {
+    mockQueryBuilder.data = saved();
+
+    await updateLineItemOverride('li-1', 88);
+
+    expect(mockQueryBuilder.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unit_price: 88,
+        total_price: 880,
+        is_quote_override: true,
+        markup_percent: null,
+      }),
+    );
+  });
+
+  it('clearing returns the line to its FROZEN tier basis, not current tiers', async () => {
+    // Dropping an override is not an opt-in to a tier change made since the
+    // quote was written — that stays the explicit "Update to current price".
+    mockQueryBuilder.data = saved({ is_quote_override: true, unit_price: 88 });
+
+    await updateLineItemOverride('li-1', null);
+
+    expect(mockQueryBuilder.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unit_price: 45.5,
+        total_price: 455,
+        source_tier_id: 't100',
+        markup_percent: 20,
+        is_quote_override: false,
+      }),
+    );
+  });
+
+  it('clearing a line with no usable basis keeps the agreed price, just drops the flag', async () => {
+    // Pre-snapshot row: there is no basis to return to, so inventing one would
+    // be worse than keeping the number both parties already agreed on.
+    mockQueryBuilder.data = saved({
+      is_quote_override: true,
+      unit_price: 88,
+      basis_unknown: true,
+    });
+
+    await updateLineItemOverride('li-1', null);
+
+    expect(mockQueryBuilder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ unit_price: 88, total_price: 880, is_quote_override: false }),
     );
   });
 });

--- a/__tests__/utils/quotesAccess.test.ts
+++ b/__tests__/utils/quotesAccess.test.ts
@@ -87,6 +87,7 @@ const {
   insertLineItemForPartMock,
   updateLineItemQuantityMock,
   updateLineItemLeadTimeMock,
+  updateLineItemOverrideMock,
   repriceLineItemToCurrentMock,
   deleteLineItemMock,
   getTiersWithComputedPricesMock,
@@ -96,6 +97,7 @@ const {
   insertLineItemForPartMock: vi.fn(),
   updateLineItemQuantityMock: vi.fn(),
   updateLineItemLeadTimeMock: vi.fn(),
+  updateLineItemOverrideMock: vi.fn(),
   repriceLineItemToCurrentMock: vi.fn(),
   deleteLineItemMock: vi.fn(),
   getTiersWithComputedPricesMock: vi.fn(),
@@ -107,6 +109,7 @@ vi.mock('@/utils/quoteLineItemsAccess', () => ({
   insertLineItemForPart: insertLineItemForPartMock,
   updateLineItemQuantity: updateLineItemQuantityMock,
   updateLineItemLeadTime: updateLineItemLeadTimeMock,
+  updateLineItemOverride: updateLineItemOverrideMock,
   repriceLineItemToCurrent: repriceLineItemToCurrentMock,
   deleteLineItem: deleteLineItemMock,
   // clearLineItemsForQuote isn't exercised in these tests but the import
@@ -937,6 +940,7 @@ describe('quotesAccess utilities', () => {
       insertLineItemForPartMock.mockReset();
       updateLineItemQuantityMock.mockReset();
       updateLineItemLeadTimeMock.mockReset();
+      updateLineItemOverrideMock.mockReset();
       repriceLineItemToCurrentMock.mockReset();
       deleteLineItemMock.mockReset();
       getTiersWithComputedPricesMock.mockReset();
@@ -944,8 +948,129 @@ describe('quotesAccess utilities', () => {
       insertLineItemForPartMock.mockResolvedValue({});
       updateLineItemQuantityMock.mockResolvedValue({});
       updateLineItemLeadTimeMock.mockResolvedValue(undefined);
+      updateLineItemOverrideMock.mockResolvedValue({});
       repriceLineItemToCurrentMock.mockResolvedValue({});
       deleteLineItemMock.mockResolvedValue(undefined);
+    });
+
+    /**
+     * A custom price on an ALREADY-SAVED line. `reconcileQuoteLineItems` used to
+     * read `block.override` only on the insert paths, so setting, changing or
+     * clearing one on an existing line was accepted by the form and silently
+     * dropped. These lock the write in.
+     */
+    describe('custom price on an existing line', () => {
+      const savedLine = (over: Record<string, unknown> = {}) => ({
+        id: 'li-A',
+        quote_id: 'quote-1',
+        company_id: 'company-1',
+        part_id: 'part-A',
+        source_tier_id: 't1',
+        sequence: 10,
+        quantity: 10,
+        unit_price: 100,
+        total_price: 1000,
+        markup_percent: 50,
+        base_cost_per_unit: 66.67,
+        is_quote_override: false,
+        pricing_basis_snapshot: {
+          tiers: [{ id: 't1', quantity: 1, unit_price: 100, markup_percent: 50 }],
+          resolved_tier_id: 't1',
+          resolved_quantity: 10,
+          captured_at: '',
+        },
+        basis_unknown: false,
+        created_at: '2026-05-01T00:00:00Z',
+        ...over,
+      });
+
+      const editWith = async (part: QuoteFormData['parts'][number]) => {
+        stubUpdateQuoteHappyPath();
+        await updateQuote('quote-1', { ...baseFormData, parts: [part] });
+      };
+
+      it('sets a custom price on a line that had none', async () => {
+        getLineItemsForQuoteMock.mockResolvedValueOnce([savedLine()]);
+
+        await editWith({
+          part_id: 'part-A',
+          order_quantity: 10,
+          line_item_id: 'li-A',
+          override: { unit_price: 88, markup_percent: null },
+        });
+
+        expect(updateLineItemOverrideMock).toHaveBeenCalledWith('li-A', 88);
+      });
+
+      it('changes an existing custom price', async () => {
+        getLineItemsForQuoteMock.mockResolvedValueOnce([
+          savedLine({ is_quote_override: true, unit_price: 88 }),
+        ]);
+
+        await editWith({
+          part_id: 'part-A',
+          order_quantity: 10,
+          line_item_id: 'li-A',
+          override: { unit_price: 95, markup_percent: null },
+        });
+
+        expect(updateLineItemOverrideMock).toHaveBeenCalledWith('li-A', 95);
+      });
+
+      it('clears a custom price back to the tier basis when the form drops it', async () => {
+        getLineItemsForQuoteMock.mockResolvedValueOnce([
+          savedLine({ is_quote_override: true, unit_price: 88 }),
+        ]);
+
+        await editWith({ part_id: 'part-A', order_quantity: 10, line_item_id: 'li-A' });
+
+        expect(updateLineItemOverrideMock).toHaveBeenCalledWith('li-A', null);
+      });
+
+      it('writes nothing when the custom price is unchanged', async () => {
+        getLineItemsForQuoteMock.mockResolvedValueOnce([
+          savedLine({ is_quote_override: true, unit_price: 88 }),
+        ]);
+
+        await editWith({
+          part_id: 'part-A',
+          order_quantity: 10,
+          line_item_id: 'li-A',
+          override: { unit_price: 88, markup_percent: null },
+        });
+
+        expect(updateLineItemOverrideMock).not.toHaveBeenCalled();
+      });
+
+      it('leaves a plain tier-priced line alone', async () => {
+        getLineItemsForQuoteMock.mockResolvedValueOnce([savedLine()]);
+
+        await editWith({ part_id: 'part-A', order_quantity: 10, line_item_id: 'li-A' });
+
+        expect(updateLineItemOverrideMock).not.toHaveBeenCalled();
+      });
+
+      it('applies the override AFTER a quantity change, so the typed price wins', async () => {
+        getLineItemsForQuoteMock.mockResolvedValueOnce([savedLine()]);
+        const order: string[] = [];
+        updateLineItemQuantityMock.mockImplementation(async () => {
+          order.push('qty');
+          return {};
+        });
+        updateLineItemOverrideMock.mockImplementation(async () => {
+          order.push('override');
+          return {};
+        });
+
+        await editWith({
+          part_id: 'part-A',
+          order_quantity: 40,
+          line_item_id: 'li-A',
+          override: { unit_price: 77, markup_percent: null },
+        });
+
+        expect(order).toEqual(['qty', 'override']);
+      });
     });
 
     it('reconciles line items on edit — insert new, update qty, delete removed', async () => {

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -164,6 +164,16 @@ function formatCurrency(value: number | null | undefined): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
 }
 
+/**
+ * Height of one `size="small"` MUI input — the quantity-row baseline.
+ *
+ * The row is top-aligned so the Qty and Unit price boxes stay on one line no
+ * matter how much the price column grows beneath them (caption, custom-price
+ * notice, drift chip). Cells that carry no input use this to re-centre against
+ * that first line instead of riding the top of a tall row.
+ */
+const ROW_CONTROL_HEIGHT = 40;
+
 const newRowKey = () => `temp-qty-${crypto.randomUUID()}`;
 
 function emptyRow(): QtyRowState {
@@ -1463,7 +1473,15 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                             key={row.rowKey}
                             sx={{
                               display: 'flex',
-                              alignItems: 'center',
+                              // Top-aligned, NOT centred. The price column grows
+                              // downward — a tier caption, a custom-price notice,
+                              // a drift chip — and centring re-centres every other
+                              // cell against that growth, so the Qty box visibly
+                              // drifts down the moment a price is edited. Anchoring
+                              // to the top keeps the two inputs on one line
+                              // whatever appears beneath them; the trailing cells
+                              // re-centre themselves against ROW_CONTROL_HEIGHT.
+                              alignItems: 'flex-start',
                               gap: 2,
                               px: 0.5,
                               py: 0.75,
@@ -1670,22 +1688,41 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                               )}
                             </Box>
 
-                            <Typography
-                              variant="body2"
-                              sx={{ width: 110, textAlign: 'right', fontWeight: 600 }}
+                            {/* Trailing cells centre themselves inside one
+                                input's worth of height, so they read as level
+                                with the Qty and Unit price boxes rather than
+                                floating at the top of a tall row. */}
+                            <Box
+                              sx={{
+                                width: 110,
+                                minHeight: ROW_CONTROL_HEIGHT,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'flex-end',
+                              }}
                             >
-                              {hasOrderQty ? formatCurrency(preview?.total ?? null) : '—'}
-                            </Typography>
+                              <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                                {hasOrderQty ? formatCurrency(preview?.total ?? null) : '—'}
+                              </Typography>
+                            </Box>
 
-                            <IconButton
-                              color="error"
-                              size="small"
-                              onClick={() => removeRow(idx, rowIdx)}
-                              aria-label="Remove quantity"
-                              disabled={block.rows.length === 1}
+                            <Box
+                              sx={{
+                                minHeight: ROW_CONTROL_HEIGHT,
+                                display: 'flex',
+                                alignItems: 'center',
+                              }}
                             >
-                              <DeleteOutlineIcon fontSize="small" />
-                            </IconButton>
+                              <IconButton
+                                color="error"
+                                size="small"
+                                onClick={() => removeRow(idx, rowIdx)}
+                                aria-label="Remove quantity"
+                                disabled={block.rows.length === 1}
+                              >
+                                <DeleteOutlineIcon fontSize="small" />
+                              </IconButton>
+                            </Box>
                           </Box>
                         );
                       })}

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -253,14 +253,16 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   const companyId = params.companyId as string;
 
   const [formData, setFormData] = useState<QuoteFormData>(initialData);
-  // A new quote opens with one empty part block already there. Every quote has
-  // at least one part, so making the user click "Add part" to reach the form's
-  // whole point was a click that could never be the wrong thing to spend. Edit
-  // mode and any prefilled payload keep their own blocks untouched.
-  const [partBlocks, setPartBlocks] = useState<PartBlockState[]>(() => {
-    const blocks = groupPartsIntoBlocks(initialData.parts);
-    return blocks.length > 0 ? blocks : [emptyBlock()];
-  });
+  // A new quote starts with NO part block — the user clicks "Add part".
+  //
+  // Seeding one looks like a free click saved, and isn't: "Add part" autofocuses
+  // the picker it creates, so a pre-seeded block still needs the same click to
+  // open the selector. What the button does buy is teaching that a quote can
+  // hold several parts, which a form that opens mid-way through its first one
+  // never says. (Tried seeded, reverted — this comment is the reason.)
+  const [partBlocks, setPartBlocks] = useState<PartBlockState[]>(() =>
+    groupPartsIntoBlocks(initialData.parts),
+  );
   // Index of the part block whose part picker should grab focus after it
   // mounts — set when the user clicks "Add part" so the new (empty) entry
   // gets focus and scrolls into view. Cleared once consumed so later

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -52,7 +52,7 @@ import {
 import { getTiersWithComputedPrices } from '@/utils/partPricingTiersAccess';
 import { resolveTier } from '@/utils/quotePricingResolver';
 import { isValidQuantityInput } from '@/lib/quantityInput';
-import { quantityUnitSuffix, unitShortLabel } from '@/lib/standardUnits';
+import { quantityUnitSuffix } from '@/lib/standardUnits';
 import type { ComputedPartPricingTier } from '@/types/partPricing';
 import CustomerFormModal from '@/components/customers/CustomerFormModal';
 import CustomerAddressForm from '@/components/customers/CustomerAddressForm';
@@ -253,9 +253,14 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
   const companyId = params.companyId as string;
 
   const [formData, setFormData] = useState<QuoteFormData>(initialData);
-  const [partBlocks, setPartBlocks] = useState<PartBlockState[]>(() =>
-    groupPartsIntoBlocks(initialData.parts),
-  );
+  // A new quote opens with one empty part block already there. Every quote has
+  // at least one part, so making the user click "Add part" to reach the form's
+  // whole point was a click that could never be the wrong thing to spend. Edit
+  // mode and any prefilled payload keep their own blocks untouched.
+  const [partBlocks, setPartBlocks] = useState<PartBlockState[]>(() => {
+    const blocks = groupPartsIntoBlocks(initialData.parts);
+    return blocks.length > 0 ? blocks : [emptyBlock()];
+  });
   // Index of the part block whose part picker should grab focus after it
   // mounts — set when the user clicks "Add part" so the new (empty) entry
   // gets focus and scrolls into view. Cleared once consumed so later
@@ -1360,7 +1365,13 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
             const orderQtyUnitLabel = quantityUnitSuffix(block.part?.primary_unit);
             // Tier caption reads "Tier 0.5 in" / "Tier 1 ea" — always show a
             // unit here (full label, fallback "ea") so counts stay unchanged.
-            const tierUnitLabel = unitShortLabel(block.part?.primary_unit) ?? 'ea';
+            // NOTE: the tier caption deliberately carries NO unit. The Qty box
+            // beside it already shows one wherever a unit is meaningful
+            // (`quantityUnitSuffix` returns null for count units, where a bare
+            // number is the convention), so repeating it was redundant there —
+            // and worse, the old `?? 'ea'` fallback INVENTED one for parts whose
+            // Qty box shows none, which is how "Tier 1 ea" appeared next to a
+            // unitless quantity.
 
             return (
               <Box key={idx} sx={{ mb: idx === partBlocks.length - 1 ? 0 : 3 }}>
@@ -1541,7 +1552,26 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                                     <InputAdornment position="start">$</InputAdornment>
                                   ),
                                 }}
-                                sx={{ width: 130 }}
+                                sx={{
+                                  width: 130,
+                                  // Subordinate to Qty, but never hidden. Qty is
+                                  // the field you must fill; this one already
+                                  // holds the tier's answer, so it rests at a
+                                  // lighter border weight and comes up to full
+                                  // strength on hover and focus.
+                                  //
+                                  // The tempting move — no border until hover,
+                                  // Notion-style — is the one thing to avoid:
+                                  // that pattern's documented failure is nobody
+                                  // discovering the value is editable, which is
+                                  // exactly the bug the old "Use custom price"
+                                  // toggle had. Quieter, not invisible.
+                                  '& .MuiOutlinedInput-root:not(.Mui-disabled)': {
+                                    '& fieldset': { borderColor: 'divider' },
+                                    '&:hover fieldset': { borderColor: 'text.secondary' },
+                                    '&.Mui-focused fieldset': { borderColor: 'primary.main' },
+                                  },
+                                }}
                               />
                               {/* Reset is offered for the whole time the row is
                                   off its tier price — including when the field
@@ -1575,8 +1605,8 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                                         ? 'Custom price'
                                         : 'Enter a unit price'
                                       : isOverride
-                                        ? `Custom · Tier ${matched.matched_tier_quantity} ${tierUnitLabel} is ${formatCurrency(matched.unit_price)}`
-                                        : `Tier ${matched.matched_tier_quantity} ${tierUnitLabel}`}
+                                        ? `Custom · tier ${matched.matched_tier_quantity} is ${formatCurrency(matched.unit_price)}`
+                                        : `From tier ${matched.matched_tier_quantity}`}
                                   </Typography>
                                   {matched && (
                                     <Button
@@ -1602,8 +1632,8 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                                   sx={{ display: 'block', mt: 0.25 }}
                                 >
                                   {matched.below_min
-                                    ? `Below min · Tier ${matched.matched_tier_quantity} ${tierUnitLabel}`
-                                    : `Tier ${matched.matched_tier_quantity} ${tierUnitLabel}`}
+                                    ? `Below min · from tier ${matched.matched_tier_quantity}`
+                                    : `From tier ${matched.matched_tier_quantity}`}
                                 </Typography>
                               ) : (
                                 <Typography

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -1619,7 +1619,23 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                                           price_touched: false,
                                         })
                                       }
-                                      sx={{ minWidth: 'auto', p: 0, textTransform: 'none' }}
+                                      sx={{
+                                        minWidth: 'auto',
+                                        px: 0.5,
+                                        py: 0,
+                                        textTransform: 'none',
+                                        // Match the caption's type exactly. A
+                                        // Button's own line-height (1.75) and
+                                        // min-height are taller than the caption
+                                        // beside it, which both inflated this
+                                        // flex row — pushing the caption further
+                                        // below the field than on a plain row —
+                                        // and drew an oversized hover block
+                                        // around a one-word action. Collapsing
+                                        // it to caption type fixes both at once.
+                                        typography: 'caption',
+                                        minHeight: 0,
+                                      }}
                                     >
                                       Reset
                                     </Button>

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -85,14 +85,28 @@ interface CustomerOption {
  * One quoted quantity within a part block. A block with a single row is a firm
  * line; a block with several rows is a price-options menu for that part. Each
  * row carries (on edit) its own line item id + drift state, because each
- * (part, quantity) is an independent quote_line_items row. The custom-price
- * override is part-level (see PartBlockState), not per row.
+ * (part, quantity) is an independent quote_line_items row — and, for the same
+ * reason, its own price.
  */
 interface QtyRowState {
   /** Stable React key for the row (mirrors RoutingOperationsList temp ids). */
   rowKey: string;
   /** Working-copy string so the input can be empty mid-edit. */
   quantity: string;
+  /**
+   * Working-copy unit price. Always editable, seeded from the matched tier's
+   * listed price while untouched — so the common path is "the tier price is
+   * already there" and pricing one break differently is just typing over it.
+   * Empty means "not yet resolved" (no quantity, or the part has no tier).
+   */
+  unit_price: string;
+  /**
+   * True once the user types in the price field. Kept as a flag rather than
+   * inferred by comparing against the tier price, because the two are equal at
+   * the moment of typing an identical number, and because it is what stops the
+   * seed from overwriting a deliberate entry when the quantity changes.
+   */
+  price_touched: boolean;
   /** Set on edit-mode rows; absent on newly-added or create-mode rows. */
   line_item_id?: string;
   /** Pre-snapshot Option C — renders the "basis unknown" chip. */
@@ -103,13 +117,6 @@ interface PartBlockState {
   part: PartSelectOption | null;
   /** One row per quoted quantity; always at least one row. */
   rows: QtyRowState[];
-  /**
-   * Part-level custom price. When open, the typed unit price applies to
-   * EVERY quantity row of this part (bypassing tier resolution) and is
-   * written as an override onto each resulting line item.
-   */
-  override_open: boolean;
-  override_unit_price: string;
   /**
    * Part-level lead time (free text). Applies to every quantity row of this
    * part; on save it's written onto each resulting line item. Blank ⇒ the line
@@ -163,6 +170,8 @@ function emptyRow(): QtyRowState {
   return {
     rowKey: newRowKey(),
     quantity: '',
+    unit_price: '',
+    price_touched: false,
   };
 }
 
@@ -170,8 +179,6 @@ function emptyBlock(): PartBlockState {
   return {
     part: null,
     rows: [emptyRow()],
-    override_open: false,
-    override_unit_price: '',
     lead_time_text: '',
     tiers: [],
     loading: false,
@@ -183,6 +190,10 @@ function rowFromInitial(p: QuoteFormData['parts'][number]): QtyRowState {
   return {
     rowKey: newRowKey(),
     quantity: String(p.order_quantity),
+    // A saved override is a price someone typed — restore it as touched so the
+    // tier seed can't quietly overwrite it on the way back in.
+    unit_price: p.override ? String(p.override.unit_price) : '',
+    price_touched: !!p.override,
     line_item_id: p.line_item_id,
     basis_unknown: p.basis_unknown,
   };
@@ -194,9 +205,10 @@ function rowFromInitial(p: QuoteFormData['parts'][number]): QtyRowState {
  * part is a stub carrying only the id; loadData replaces it with the hydrated
  * option (the form renders a spinner until then, so the stub is never shown).
  *
- * The custom-price override is part-level: if any entry carries an override,
- * the whole part is treated as overridden at that unit price (on save every
- * entry for the part is written with the same override).
+ * Price is per row: each (part, quantity) is its own `quote_line_items` row with
+ * its own `unit_price` / `is_quote_override`, so quoting 50/100/250 can carry
+ * three different negotiated prices. (It used to be one price per part, which
+ * flattened exactly the quantity curve a price-options quote exists to show.)
  */
 function groupPartsIntoBlocks(parts: QuoteFormData['parts']): PartBlockState[] {
   const blocks: PartBlockState[] = [];
@@ -209,17 +221,11 @@ function groupPartsIntoBlocks(parts: QuoteFormData['parts']): PartBlockState[] {
       blocks.push({
         part: { id: p.part_id } as PartSelectOption,
         rows: [],
-        override_open: false,
-        override_unit_price: '',
         lead_time_text: '',
         tiers: [],
         loading: false,
         error: null,
       });
-    }
-    if (p.override && !blocks[idx].override_open) {
-      blocks[idx].override_open = true;
-      blocks[idx].override_unit_price = String(p.override.unit_price);
     }
     // Lead time is per-part; take it from the first entry that carries one
     // (all entries for a part share the same value on save).
@@ -851,40 +857,45 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     setCustomerModalOpen(false);
   };
 
-  /** Per-row live preview: blockPreviews[block][row] = { resolved, total }.
-   *  `resolved.unit_price` is the price the matched tier LISTS — the same number
-   *  the part page shows for that break — because the tier ladder is a price
-   *  list and a break's price holds for its whole band. `block.tiers` already
-   *  carries those prices (getTiersWithComputedPrices, fetched when the part is
-   *  picked), so this is synchronous: no per-quantity round trip.
-   *  A part-level custom price (block.override_*) applies to every row. */
+  /** Per-row live preview: blockPreviews[block][row].
+   *
+   *  `resolved` is the matched tier — `resolved.unit_price` is the price that
+   *  tier LISTS, the same number the part page shows, because the tier ladder is
+   *  a price list and a break's price holds for its whole band. `block.tiers`
+   *  already carries those prices (getTiersWithComputedPrices, fetched when the
+   *  part is picked), so this is synchronous: no per-quantity round trip.
+   *
+   *  `effectiveUnitPrice` is what the row will actually be quoted at — the typed
+   *  price once the user has touched the field, otherwise the tier price.
+   *  `isCustom` is the difference between the two, and drives the marker. */
   const blockPreviews = useMemo(() => {
     return partBlocks.map((block) => {
-      const overridePrice =
-        block.override_open && block.override_unit_price.trim() !== ''
-          ? Number(block.override_unit_price)
-          : null;
-      const overrideValid =
-        overridePrice !== null && Number.isFinite(overridePrice) && overridePrice >= 0;
       return block.rows.map((row) => {
         const orderQty = Number(row.quantity);
-        const empty = {
-          resolved: null as ReturnType<typeof resolveTier>,
-          total: null as number | null,
-        };
-        if (!Number.isFinite(orderQty) || orderQty <= 0) return empty;
-        if (overrideValid) {
-          return {
-            resolved: null as ReturnType<typeof resolveTier>,
-            total: Math.round((overridePrice as number) * orderQty * 100) / 100,
-          };
-        }
-        if (!block.part) return empty;
-        const resolved = resolveTier(block.tiers, orderQty);
-        if (!resolved) return empty;
+        const hasQty = Number.isFinite(orderQty) && orderQty > 0;
+        const resolved =
+          hasQty && block.part ? resolveTier(block.tiers, orderQty) : null;
+
+        const typed = row.price_touched && row.unit_price.trim() !== '' ? Number(row.unit_price) : null;
+        const typedValid = typed !== null && Number.isFinite(typed) && typed >= 0;
+
+        const effectiveUnitPrice = typedValid ? typed : resolved?.unit_price ?? null;
+        // Custom means "differs from what the ladder would charge" — typing the
+        // tier price back in is not an override, so it must not be flagged or
+        // written as one. Compared at cent precision, which is the precision
+        // both numbers are stored and displayed at.
+        const isCustom =
+          typedValid &&
+          (resolved === null || Math.round(typed * 100) !== Math.round(resolved.unit_price * 100));
+
         return {
           resolved,
-          total: Math.round(resolved.unit_price * orderQty * 100) / 100,
+          effectiveUnitPrice,
+          isCustom,
+          total:
+            hasQty && effectiveUnitPrice !== null
+              ? Math.round(effectiveUnitPrice * orderQty * 100) / 100
+              : null,
         };
       });
     });
@@ -946,17 +957,6 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
       seenParts.add(block.part.id);
       if (block.loading) return 'Loading pricing tiers…';
       if (block.rows.length === 0) return 'Every part needs at least one quantity.';
-      // Part-level custom price: validate once; when active it covers every row.
-      if (block.override_open) {
-        const overridePrice = Number(block.override_unit_price);
-        if (
-          block.override_unit_price.trim() === '' ||
-          !Number.isFinite(overridePrice) ||
-          overridePrice < 0
-        ) {
-          return 'Custom unit price must be a non-negative number.';
-        }
-      }
       const seenQty = new Set<number>();
       for (const row of block.rows) {
         const orderQty = Number(row.quantity);
@@ -965,11 +965,26 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
         }
         if (seenQty.has(orderQty)) return 'Each quantity can appear only once per part.';
         seenQty.add(orderQty);
-        if (!block.override_open) {
-          const resolved = resolveTier(block.tiers, orderQty);
-          if (!resolved) {
-            return 'At least one part has no priced tiers — add tiers on the part page or use a custom price.';
+
+        // Price is per row now. A row is priceable if the user typed a valid
+        // price OR the part's ladder resolves one — only the absence of both
+        // blocks the save.
+        const typedRaw = row.price_touched ? row.unit_price.trim() : '';
+        if (typedRaw !== '') {
+          const typed = Number(typedRaw);
+          if (!Number.isFinite(typed) || typed < 0) {
+            return 'Unit price must be a non-negative number.';
           }
+          continue;
+        }
+        if (row.price_touched) {
+          // Touched then cleared: the row has no price and no seed to fall back
+          // on until Reset restores the tier. Say so rather than silently
+          // quoting the tier price they just deleted.
+          return 'Enter a unit price, or reset the row to its tier price.';
+        }
+        if (!resolveTier(block.tiers, orderQty)) {
+          return 'At least one part has no priced tiers — add tiers on the part page, or type a unit price.';
         }
       }
     }
@@ -982,10 +997,8 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
 
     const payload: QuoteFormData = {
       ...formData,
-      parts: partBlocks.flatMap((b) => {
-        const overrideActive = b.override_open && b.override_unit_price.trim() !== '';
-        const overrideUnitPrice = overrideActive ? Number(b.override_unit_price) : null;
-        return b.rows.map((r) => {
+      parts: partBlocks.flatMap((b, bIdx) =>
+        b.rows.map((r, rIdx) => {
           const orderQty = Number(r.quantity);
           const entry: QuoteFormData['parts'][number] = {
             part_id: b.part?.id ?? '',
@@ -998,17 +1011,21 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
           // reconcile reads a missing value as "use the quote default" and
           // clears any lead time the line previously had.
           if (b.lead_time_text.trim() !== '') entry.lead_time_text = b.lead_time_text;
-          if (overrideUnitPrice !== null) {
-            // Part-level custom price → same override on every row of the part.
+          // Override only when the typed price actually DIFFERS from the tier's
+          // listed price — `isCustom` already draws that line. Typing the tier
+          // price back in must stay a normal tier-priced line, or it would be
+          // frozen out of drift detection and repricing for no reason.
+          const preview = blockPreviews[bIdx]?.[rIdx];
+          if (preview?.isCustom && preview.effectiveUnitPrice !== null) {
             entry.override = {
-              unit_price: overrideUnitPrice,
+              unit_price: preview.effectiveUnitPrice,
               // Markup % is no longer a quote-form input — leave it null on overrides.
               markup_percent: null,
             };
           }
           return entry;
-        });
-      }),
+        }),
+      ),
     };
 
     setLoading(true);
@@ -1017,6 +1034,10 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
         const { quote } = await createQuote(companyId, payload);
         posthog.capture('quote created', {
           line_item_count: payload.parts.length,
+          // How often the ladder gets overridden is the signal that says whether
+          // shops' tiers are actually carrying their pricing. A count, never a
+          // price — the amount is the customer's business data.
+          custom_priced_line_count: payload.parts.filter((p) => p.override).length,
           customer_id: formData.customer_id,
         });
         onSave?.();
@@ -1324,9 +1345,6 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
             // fires and the user isn't trapped typing a quantity that
             // can't resolve to a line price.
             const hasUsableTier = block.tiers.some((t) => t.unit_price !== null);
-            // Part-level custom price — when active it overrides every row.
-            const blockOverrideActive =
-              block.override_open && block.override_unit_price.trim() !== '';
             // Unit symbol for the order-qty field (e.g. "in") so a fractional
             // quantity isn't ambiguous. null for count/unitless parts.
             const orderQtyUnitLabel = quantityUnitSuffix(block.part?.primary_unit);
@@ -1421,8 +1439,16 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                         const hasOrderQty =
                           row.quantity !== '' && Number.isFinite(orderQtyNum) && orderQtyNum > 0;
                         const matched = preview?.resolved ?? null;
-                        // Override is part-level — it applies to every row.
-                        const isOverride = blockOverrideActive;
+                        const isOverride = preview?.isCustom ?? false;
+                        // The field shows the tier's listed price until the user
+                        // types over it. Derived rather than seeded into state by
+                        // an effect: there is no sync to get wrong, and a
+                        // quantity change re-reads the new tier automatically.
+                        const priceFieldValue = row.price_touched
+                          ? row.unit_price
+                          : matched
+                            ? String(matched.unit_price)
+                            : '';
                         // Drift state for this row, if any. Override lines never
                         // appear here (detectQuoteLineDrift filters them out).
                         const drift = row.line_item_id
@@ -1473,36 +1499,101 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                             />
 
                             <Box sx={{ flex: 1, minWidth: 120 }}>
-                              {!hasOrderQty ? (
-                                <Typography variant="body2" color="text.secondary">
-                                  —
-                                </Typography>
-                              ) : isOverride ? (
-                                <>
-                                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                                    {formatCurrency(Number(block.override_unit_price))}
-                                  </Typography>
-                                  <Typography variant="caption" color="text.secondary">
-                                    custom price
-                                  </Typography>
-                                </>
-                              ) : matched ? (
-                                <>
-                                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                                    {formatCurrency(matched.unit_price)}
-                                  </Typography>
+                              {/* Always an editable field — no toggle to find.
+                                  It holds the tier's listed price by default, so
+                                  the common path reads as a plain number and
+                                  pricing this break differently is just typing
+                                  over it. What was behind "Use custom price" is
+                                  now the absence of a control. */}
+                              <TextField
+                                size="small"
+                                value={priceFieldValue}
+                                onChange={(e) => {
+                                  const v = e.target.value;
+                                  if (v !== '' && !/^\d*\.?\d*$/.test(v)) return;
+                                  updateRow(idx, rowIdx, {
+                                    unit_price: v,
+                                    price_touched: true,
+                                  });
+                                }}
+                                disabled={!hasOrderQty}
+                                inputProps={{ 'aria-label': 'Unit price', inputMode: 'decimal' }}
+                                InputProps={{
+                                  startAdornment: (
+                                    <InputAdornment position="start">$</InputAdornment>
+                                  ),
+                                }}
+                                sx={{ width: 130 }}
+                              />
+                              {/* Reset is offered for the whole time the row is
+                                  off its tier price — including when the field
+                                  has been emptied, which is the state that
+                                  blocks the save. Gating it on a *valid* custom
+                                  price instead would take the way back off the
+                                  screen at exactly the moment the user needs it,
+                                  while validation told them to use it. */}
+                              {!hasOrderQty ? null : row.price_touched ? (
+                                <Box
+                                  sx={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 0.5,
+                                    flexWrap: 'wrap',
+                                    mt: 0.25,
+                                  }}
+                                >
+                                  {/* warning.main per the row status ladder —
+                                      "wants your attention, not wrong yet". An
+                                      override is deliberate, so never `error`.
+                                      The auto price stays on screen: the old
+                                      toggle hid it, leaving nothing to compare
+                                      against. */}
                                   <Typography
                                     variant="caption"
-                                    color={matched.below_min ? 'warning.main' : 'text.secondary'}
+                                    color={isOverride || !matched ? 'warning.main' : 'text.secondary'}
                                   >
-                                    {matched.below_min
-                                      ? `Below min · Tier ${matched.matched_tier_quantity} ${tierUnitLabel}`
-                                      : `Tier ${matched.matched_tier_quantity} ${tierUnitLabel}`}
+                                    {!matched
+                                      ? isOverride
+                                        ? 'Custom price'
+                                        : 'Enter a unit price'
+                                      : isOverride
+                                        ? `Custom · Tier ${matched.matched_tier_quantity} ${tierUnitLabel} is ${formatCurrency(matched.unit_price)}`
+                                        : `Tier ${matched.matched_tier_quantity} ${tierUnitLabel}`}
                                   </Typography>
-                                </>
+                                  {matched && (
+                                    <Button
+                                      size="small"
+                                      variant="text"
+                                      data-testid={`price-reset-${idx}-${rowIdx}`}
+                                      onClick={() =>
+                                        updateRow(idx, rowIdx, {
+                                          unit_price: '',
+                                          price_touched: false,
+                                        })
+                                      }
+                                      sx={{ minWidth: 'auto', p: 0, textTransform: 'none' }}
+                                    >
+                                      Reset
+                                    </Button>
+                                  )}
+                                </Box>
+                              ) : matched ? (
+                                <Typography
+                                  variant="caption"
+                                  color={matched.below_min ? 'warning.main' : 'text.secondary'}
+                                  sx={{ display: 'block', mt: 0.25 }}
+                                >
+                                  {matched.below_min
+                                    ? `Below min · Tier ${matched.matched_tier_quantity} ${tierUnitLabel}`
+                                    : `Tier ${matched.matched_tier_quantity} ${tierUnitLabel}`}
+                                </Typography>
                               ) : (
-                                <Typography variant="caption" color="warning.main">
-                                  No priced tier — add a tier or use a custom price
+                                <Typography
+                                  variant="caption"
+                                  color="warning.main"
+                                  sx={{ display: 'block', mt: 0.25 }}
+                                >
+                                  No priced tier — type a price, or add tiers on the part page
                                 </Typography>
                               )}
                               {row.basis_unknown && (
@@ -1600,24 +1691,18 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                       })}
                     </Box>
 
-                    {/* Part-level controls: add a quantity, and one custom-price
-                        toggle for the whole part (not per row). */}
+                    {/* Price now lives in each row's own field, so the only
+                        part-level control left is adding a quantity. The
+                        "estimate" caveat still belongs at the part: it is a
+                        property of the part having no cost basis, not of any one
+                        quantity. */}
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
                       <Button size="small" startIcon={<AddIcon />} onClick={() => addRow(idx)}>
                         Add quantity
                       </Button>
                       <Box sx={{ flex: 1 }} />
-                      {blockOverrideActive &&
-                        (hasUsableTier ? (
-                          <Chip
-                            size="small"
-                            label="adjusted for this quote"
-                            color="success"
-                            variant="outlined"
-                            sx={{ height: 20 }}
-                          />
-                        ) : (
-                          // Override on a not-yet-costed part: it's an estimate.
+                      {!hasUsableTier &&
+                        (blockPreviews[idx] ?? []).some((p) => p?.isCustom) && (
                           <Chip
                             size="small"
                             label="estimate — needs cost setup"
@@ -1625,49 +1710,8 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                             variant="outlined"
                             sx={{ height: 20 }}
                           />
-                        ))}
-                      <Button
-                        size="small"
-                        onClick={() =>
-                          updateBlock(idx, (prev) => {
-                            const firstResolved =
-                              (blockPreviews[idx] ?? [])
-                                .map((p) => p?.resolved)
-                                .find(Boolean) ?? null;
-                            return {
-                              override_open: !prev.override_open,
-                              override_unit_price:
-                                !prev.override_open &&
-                                prev.override_unit_price === '' &&
-                                firstResolved
-                                  ? String(firstResolved.unit_price)
-                                  : prev.override_unit_price,
-                            };
-                          })
-                        }
-                      >
-                        {block.override_open ? 'Cancel custom price' : '✏ Use custom price'}
-                      </Button>
+                        )}
                     </Box>
-                    {block.override_open && (
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-                        <TextField
-                          size="small"
-                          label="Custom unit price"
-                          value={block.override_unit_price}
-                          onChange={(e) => {
-                            const v = e.target.value;
-                            if (v !== '' && !/^\d*\.?\d*$/.test(v)) return;
-                            updateBlock(idx, { override_unit_price: v });
-                          }}
-                          sx={{ width: 180 }}
-                          inputMode="decimal"
-                        />
-                        <Typography variant="caption" color="text.secondary">
-                          Applies to every quantity of this part
-                        </Typography>
-                      </Box>
-                    )}
 
                     {/* Per-item lead time (per-part — applies to every quantity
                         of this part). Blank ⇒ the quote-level lead time is used.

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -178,10 +178,27 @@ The block warns when the part has no priced tiers, linking to the part page.
 There is **no separate "Pricing tiers (reference)" section** — the editable quantity rows
 replaced it, on the form and on the detail view.
 
-- **Per-part price override:** one **✏ Use custom price** toggle per part (not per quantity)
-  revealing a Custom unit price that applies to **every** quantity of that part. Each row gets
-  `is_quote_override = true`; the part's tier is never touched. Markup % is no longer a
-  quote-form input.
+- **Per-quantity price, always editable.** Each quantity row's **Unit price** is a plain text
+  field carrying the matched tier's listed price. Typing over it prices that break differently;
+  the row then reads `Custom · Tier {n} {unit} is {auto price}` in `warning.main` with a
+  **Reset** beside it, and saves with `is_quote_override = true`. The part's tier is never
+  touched, and markup % is not a quote-form input.
+
+  Three things this shape is deliberate about, all of which the previous
+  **✏ Use custom price** toggle got wrong:
+  - **No control to discover.** The toggle sat at the foot of the part block, away from the price
+    it changed ([NN/g — icon discoverability](https://www.nngroup.com/articles/how-to-test-digital-icons/)).
+    An editable field is its own affordance, and this is the shape already shipped in
+    [`AcceptPurchaseOrderModal`](../../components/jobs/AcceptPurchaseOrderModal.tsx).
+  - **The auto price stays on screen.** The toggle replaced it, so the moment you overrode a
+    price you lost the number you were overriding — and the only way back was to re-click the
+    toggle. Naming the tier price in the caption is what makes **Reset** meaningful.
+  - **Per row, not per part.** Price lives on `quote_line_items` per (part, quantity), so
+    50/100/250 can carry three negotiated prices. One price for the whole part flattened exactly
+    the quantity curve a price-options quote exists to show.
+
+  A typed price equal to the tier's is **not** an override — it saves as a normal tier-priced
+  line, so it stays inside drift detection and repricing.
 - **Per-part lead time:** an optional free-text field so one item can read "2–3 weeks" and
   another "3–4 weeks" **without splitting the quote in two**. When *any* item has its own, the
   detail view and PDF move lead time under each item; when none do, one quote-level line shows.
@@ -207,8 +224,9 @@ added on the part page. **+ Add new address** on the shipping/billing selectors 
 `CustomerAddressForm` inline in a `Collapse` rather than navigating away.
 
 **Guards:** at least one part block, each with a part; a part may appear in only one block; every
-quantity a number > 0 (fractional allowed) and unique within its part; each non-override row must
-resolve to a priced tier or carry a custom price; lead time and payment terms required.
+quantity a number > 0 (fractional allowed) and unique within its part; every row must either
+resolve to a priced tier or carry a typed unit price ≥ 0 — only the absence of *both* blocks the
+save; lead time and payment terms required.
 
 ### Detail — `/dashboard/{companyId}/quotes/{id}`
 

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -166,11 +166,24 @@ a per-row total misleads. Totals live on the detail page and PDF, for firm quote
 detail page (`quotes/[quoteId]/page.tsx`), gated on the quote being active and unconverted.
 *(This doc described an `/quotes/{id}/edit` route that never existed.)*
 
-**Parts card** — one block per part, plus **+ Add part**. Each block: a part picker (with **+ New
-Part** inline create), an editable **list of quantity rows** (one per quoted quantity, **Add
-quantity** appends, every row past the first can be deleted), each row showing its resolved
-price stacked over a `Tier {n} {unit}` caption, plus Total (firm) or Extended (options). A
-row below the lowest tier shows a "below minimum break" hint and snaps to the lowest tier price.
+**Parts card** — **a new quote opens with one part block already there** (every quote has at least
+one part, so the click could never be the wrong one to spend), plus **+ Add part** for the rest.
+Each block: a part picker (with **+ New Part** inline create), an editable **list of quantity rows**
+(one per quoted quantity, **Add quantity** appends, every row past the first can be deleted), each
+row showing its resolved price stacked over a `From tier {n}` caption, plus Total (firm) or Extended
+(options). A row below the lowest tier shows a "below minimum break" hint and snaps to the lowest
+tier price.
+
+> **The tier caption carries no unit, deliberately.** The Qty box beside it already shows one
+> wherever a unit is meaningful — `quantityUnitSuffix` returns null for count units, where a bare
+> number is the convention ("10 brackets", not "10 ea"). Repeating it was redundant there, and the
+> old `?? 'ea'` fallback **invented** one for parts whose Qty box shows none, which is how
+> "Tier 1 ea" came to sit beside a unitless quantity.
+
+The quantity row is **top-aligned, not centred**: the price column grows downward (caption, custom
+notice, drift chip) and centring re-centred every other cell against that growth, visibly pushing
+the Qty box out of line with the Unit price box the moment a price was edited. Trailing cells
+re-centre themselves against one input's height instead.
 Prices resolve synchronously off the tiers already loaded with the part — no per-quantity round
 trip, so typing a quantity updates the row immediately.
 The block warns when the part has no priced tiers, linking to the part page.
@@ -180,9 +193,16 @@ replaced it, on the form and on the detail view.
 
 - **Per-quantity price, always editable.** Each quantity row's **Unit price** is a plain text
   field carrying the matched tier's listed price. Typing over it prices that break differently;
-  the row then reads `Custom · Tier {n} {unit} is {auto price}` in `warning.main` with a
+  the row then reads `Custom · tier {n} is {auto price}` in `warning.main` with a
   **Reset** beside it, and saves with `is_quote_override = true`. The part's tier is never
   touched, and markup % is not a quote-form input.
+
+  The field is **subordinate to Qty but never hidden** — it rests at `divider` border weight
+  against Qty's default, rising to `text.secondary` on hover and `primary.main` on focus. Qty is
+  the field you must fill; this one already holds the tier's answer, and the `From tier {n}`
+  caption says so. **Do not take the border away entirely** (Notion-style reveal-on-hover): that
+  pattern's [documented failure](https://webapphuddle.com/inline-edit-design/) is nobody
+  discovering the value is editable — precisely the bug the old toggle had. Quieter, not invisible.
 
   Three things this shape is deliberate about, all of which the previous
   **✏ Use custom price** toggle got wrong:

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -166,13 +166,17 @@ a per-row total misleads. Totals live on the detail page and PDF, for firm quote
 detail page (`quotes/[quoteId]/page.tsx`), gated on the quote being active and unconverted.
 *(This doc described an `/quotes/{id}/edit` route that never existed.)*
 
-**Parts card** — **a new quote opens with one part block already there** (every quote has at least
-one part, so the click could never be the wrong one to spend), plus **+ Add part** for the rest.
-Each block: a part picker (with **+ New Part** inline create), an editable **list of quantity rows**
-(one per quoted quantity, **Add quantity** appends, every row past the first can be deleted), each
-row showing its resolved price stacked over a `From tier {n}` caption, plus Total (firm) or Extended
-(options). A row below the lowest tier shows a "below minimum break" hint and snaps to the lowest
-tier price.
+**Parts card** — one block per part, plus **+ Add part**. Each block: a part picker (with **+ New
+Part** inline create), an editable **list of quantity rows** (one per quoted quantity, **Add
+quantity** appends, every row past the first can be deleted), each row showing its resolved price
+stacked over a `From tier {n}` caption, plus Total (firm) or Extended (options). A row below the
+lowest tier shows a "below minimum break" hint and snaps to the lowest tier price.
+
+> **A new quote deliberately starts with NO part block.** Seeding one looks like a free click
+> saved and isn't — **+ Add part** autofocuses the picker it creates, so a pre-seeded block still
+> costs the same click to open the selector. What the button buys is teaching that a quote can hold
+> **several** parts, which a form that opens mid-way through its first one never says. Tried and
+> reverted 2026-08-08; `QuoteForm.test.tsx` guards it.
 
 > **The tier caption carries no unit, deliberately.** The Qty box beside it already shows one
 > wherever a unit is meaningful — `quantityUnitSuffix` returns null for count units, where a bare

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -139,7 +139,7 @@ fails, and so does a listed property nothing passes.
 | `user signed in` | The login form is submitted successfully | — | [Login.tsx](../components/auth/Login.tsx) |
 | `user signed out` | Supabase emits `SIGNED_OUT` | — | [AuthProvider.tsx](../components/providers/AuthProvider.tsx) |
 | `invitation accepted` | An invitee completes acceptance | `role`, `existing_user` | [accept-invite/page.tsx](../app/accept-invite/[invitationId]/page.tsx) |
-| `quote created` | A new quote is saved | `line_item_count`, `customer_id` | [QuoteForm.tsx](../components/quotes/QuoteForm.tsx) |
+| `quote created` | A new quote is saved | `line_item_count`, `custom_priced_line_count`, `customer_id` | [QuoteForm.tsx](../components/quotes/QuoteForm.tsx) |
 | `quote converted to job` | A quote is accepted and becomes a job | `quote_id`, `part_count`, `is_hot` | [ConvertToJobModal.tsx](../components/quotes/ConvertToJobModal.tsx) |
 | `job created from purchase order` | A job is created directly from a PO | `part_count`, `total_value`, `is_hot` | [AcceptPurchaseOrderModal.tsx](../components/jobs/AcceptPurchaseOrderModal.tsx) |
 | `jobs bulk cancelled` | Several jobs are cancelled in one action | `count` | [jobs/page.tsx](../app/dashboard/[companyId]/jobs/page.tsx) |

--- a/e2e/fractional-quote-to-job.spec.ts
+++ b/e2e/fractional-quote-to-job.spec.ts
@@ -57,8 +57,9 @@ test.describe('Fractional quote to job workflow', () => {
     // tier is qty 0.5 in, so ordering 0.5 resolves to it deterministically.
     const orderQty = page.getByRole('textbox', { name: /Order quantity/i });
     await orderQty.fill('0.5');
-    // Tier caption carries the part's unit now (not a hardcoded "ea") — "Tier 0.5 in".
-    await expect(page.getByText(/Tier 0\.5 in/i).first()).toBeVisible({
+    // The caption states provenance and carries NO unit — the Qty box beside it
+    // already shows "in". A fractional break still reads exactly: "From tier 0.5".
+    await expect(page.getByText(/From tier 0\.5/i).first()).toBeVisible({
       timeout: 10_000,
     });
 

--- a/e2e/quote-edit.spec.ts
+++ b/e2e/quote-edit.spec.ts
@@ -183,7 +183,7 @@ test.describe('Quote edit — reload contract', () => {
     // Wait for tier resolution before submitting — see quote-to-job.spec.ts.
     // The Create Quote button stays disabled until the tier query returns
     // and resolveTier produces a usable unit price.
-    await expect(page.getByText(/Tier \d+ ea/i).first()).toBeVisible({
+    await expect(page.getByText(/From tier \d+/i).first()).toBeVisible({
       timeout: 10_000,
     });
     await page.getByRole('textbox', { name: 'Lead time', exact: true }).fill('2 weeks');
@@ -522,7 +522,7 @@ test.describe('Quote edit — reload contract', () => {
       .first()
       .click();
     await page.getByRole('textbox', { name: /Order quantity/i }).fill('1');
-    await expect(page.getByText(/Tier \d+ ea/i).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/From tier \d+/i).first()).toBeVisible({ timeout: 10_000 });
 
     // Force a past expiration date (the form otherwise defaults to today + 10),
     // so the quote is expired-by-date the moment it's created.

--- a/e2e/quote-edit.spec.ts
+++ b/e2e/quote-edit.spec.ts
@@ -223,12 +223,10 @@ test.describe('Quote edit — reload contract', () => {
       .click();
     // The second order-qty input is the new block's.
     await orderQtyInputs.nth(1).fill('2');
-    // Open custom price for the SECOND block only — both blocks render a
-    // single part-level "Use custom price" button, so the unscoped locator
-    // hits a strict-mode violation. nth(1) targets the new block.
-    await page.getByRole('button', { name: /Use custom price/i }).nth(1).click();
-    // The "Custom unit price" input only exists after override is opened.
-    await page.getByRole('textbox', { name: /^Custom unit price$/i }).fill('25');
+    // Price the new line at a negotiated 25. There is no toggle to open: every
+    // quantity row carries its own always-editable Unit price, pre-filled with
+    // the tier's listed price. nth(1) is the new block's row.
+    await page.getByRole('textbox', { name: /^Unit price$/i }).nth(1).fill('25');
 
     // Wait for the Save button to become enabled before clicking. With
     // qty + override price filled, validation passes; the button enables
@@ -252,6 +250,11 @@ test.describe('Quote edit — reload contract', () => {
     // per line item — we match by part name + the new quantity.
     await expect(page.getByText('E2E-MFG-001').first()).toBeVisible();
     await expect(page.getByText('E2E-RAW-001').first()).toBeVisible();
+    // The negotiated price actually persisted. Asserting only that the part is
+    // present would pass even if the price silently fell back to the tier —
+    // which is exactly what the reconcile gap did to a custom price on an
+    // already-saved line.
+    await expect(page.getByText('$25.00').first()).toBeVisible();
 
     // ── Second edit pass: remove the just-added part. After reload, only
     //    the original line should remain.

--- a/e2e/quote-to-job.spec.ts
+++ b/e2e/quote-to-job.spec.ts
@@ -76,10 +76,10 @@ test.describe('Quote to Job workflow', () => {
     // tier deterministically.
     const orderQty = page.getByRole('textbox', { name: /Order quantity/i });
     await orderQty.fill('1');
-    // Confirm the tier resolved — the form renders a "Tier N ea" caption
+    // Confirm the tier resolved — the form renders a "From tier N" caption
     // under the unit price when the match succeeds. If this assertion fails,
     // the seeded part is missing pricing tiers (check e2e/global-setup.ts).
-    await expect(page.getByText(/Tier \d+ ea/i).first()).toBeVisible({
+    await expect(page.getByText(/From tier \d+/i).first()).toBeVisible({
       timeout: 10_000,
     });
 

--- a/utils/quoteLineItemsAccess.ts
+++ b/utils/quoteLineItemsAccess.ts
@@ -251,6 +251,87 @@ export async function updateLineItemLeadTime(
 }
 
 /**
+ * Set or clear a one-off price on an EXISTING line item.
+ *
+ * `unitPrice` non-null pins that price and flags `is_quote_override`; null
+ * clears the override and returns the line to its frozen tier basis (the price
+ * the snapshot ladder lists at this quantity).
+ *
+ * This exists because `reconcileQuoteLineItems` used to read `block.override`
+ * only on the INSERT paths: on an existing line, setting, changing or clearing a
+ * custom price was accepted by the form and silently dropped on save. The old
+ * part-level toggle made that easy to miss; an always-editable price field would
+ * have made it a lie on every keystroke.
+ *
+ * `markup_percent` is deliberately nulled on override and left null on clear —
+ * the quote form has no markup input, and the row's markup is only meaningful
+ * when the price came off the ladder.
+ */
+export async function updateLineItemOverride(
+  lineItemId: string,
+  unitPrice: number | null,
+): Promise<QuoteLineItem> {
+  const supabase = getSupabase();
+
+  const { data: existing, error: fetchError } = await supabase
+    .from('quote_line_items')
+    .select('*')
+    .eq('id', lineItemId)
+    .single();
+  if (fetchError) {
+    console.error('Error loading line item for override update:', fetchError);
+    throw fetchError;
+  }
+  const row = existing as unknown as QuoteLineItem;
+
+  let newUnitPrice: number;
+  let newSourceTierId = row.source_tier_id;
+  let newMarkup: number | null = null;
+
+  if (unitPrice !== null) {
+    newUnitPrice = unitPrice;
+  } else {
+    // Clearing: fall back to the FROZEN ladder, not current tiers — dropping an
+    // override is not an opt-in to a tier change made since the quote was
+    // written. That stays the explicit "Update to current price" action.
+    const snapshot = row.pricing_basis_snapshot;
+    const resolved =
+      snapshot && !row.basis_unknown ? resolveTierFromSnapshot(snapshot, row.quantity) : null;
+    if (!resolved) {
+      // No basis to return to (pre-snapshot row, or a part that had no priced
+      // tier when quoted). Keep the agreed price and just drop the flag rather
+      // than inventing one or refusing the edit.
+      newUnitPrice = row.unit_price;
+    } else {
+      newUnitPrice = resolved.unit_price;
+      newSourceTierId = resolved.source_tier_id;
+      newMarkup =
+        snapshot?.tiers.find((t) => t.id === resolved.source_tier_id)?.markup_percent ?? null;
+    }
+  }
+
+  const newTotal = Math.round(newUnitPrice * row.quantity * 100) / 100;
+
+  const { data, error } = await supabase
+    .from('quote_line_items')
+    .update({
+      unit_price: newUnitPrice,
+      source_tier_id: newSourceTierId,
+      markup_percent: newMarkup,
+      total_price: newTotal,
+      is_quote_override: unitPrice !== null,
+    })
+    .eq('id', lineItemId)
+    .select('*')
+    .single();
+  if (error) {
+    console.error('Error updating line item override:', error);
+    throw toFriendlyError(error, { entity: 'line item' });
+  }
+  return data as unknown as QuoteLineItem;
+}
+
+/**
  * Reprice an existing line item against the part's CURRENT tier table —
  * used when the user clicks "Update to current price" on a drifted line.
  * Refreshes both the resolved price and the frozen snapshot so the row

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -31,6 +31,7 @@ import {
   getLineItemsForQuote,
   updateLineItemQuantity,
   updateLineItemLeadTime,
+  updateLineItemOverride,
   repriceLineItemToCurrent,
   deleteLineItem,
 } from '@/utils/quoteLineItemsAccess';
@@ -684,6 +685,19 @@ async function reconcileQuoteLineItems(
 
     if (existing.quantity !== block.order_quantity) {
       await updateLineItemQuantity(existing.id, block.order_quantity);
+    }
+
+    // A custom price set, changed or cleared on an ALREADY-SAVED line. This
+    // used to be dropped on the floor — `block.override` was only read on the
+    // insert paths above — so editing a quote's price appeared to work and
+    // silently did nothing. Runs after the quantity update so it wins: an
+    // override is a price the user typed, not one derived from the new qty.
+    const nextOverridePrice = block.override ? block.override.unit_price : null;
+    const overrideChanged = existing.is_quote_override
+      ? nextOverridePrice === null || nextOverridePrice !== existing.unit_price
+      : nextOverridePrice !== null;
+    if (overrideChanged) {
+      await updateLineItemOverride(existing.id, nextOverridePrice);
     }
 
     // Persist a per-item lead-time edit even when the quantity is unchanged


### PR DESCRIPTION
> **Stacked on #735** — review that one first. This PR targets `fix/quote-price-uses-tier-price`, so the diff here is only the editable-price work. GitHub retargets it to `main` automatically once #735 merges.

## The problem

The custom price hid behind a **✏ Use custom price** toggle at the foot of the part block, away from the price it changed. Two things were worse than the discoverability:

- **Opening it REPLACED the auto price on screen.** The moment you overrode a price you lost the number you were overriding, and the only way back was to re-click the toggle.
- **One price applied to every quantity of the part** — flattening exactly the quantity curve a price-options quote exists to show. Quoting 50/100/250 could not carry three negotiated prices.

## The shape

The unit price is now just an editable field carrying the matched tier's listed price. **There is no control to discover** — an editable field is its own affordance.

```
Qty          Unit price                        Total
 50    $ 33.40   Tier 50 ea                   $1,670
100    $ 32.00   Custom · Tier 80 ea is       $3,200
                 $33.40   [Reset]
250    $ 31.00   Custom · Tier 80 ea is       $7,750
                 $33.40   [Reset]
```

Grounding, in order of weight:

- **This is already shipped here.** [`AcceptPurchaseOrderModal`](https://github.com/debola31/Jigged/blob/main/components/jobs/AcceptPurchaseOrderModal.tsx#L429-L481) has an always-editable unit price, seeded from the resolved price, with an "Expected $X" caption that turns amber plus a **Reset** when it diverges. Same pattern, same repo.
- **The row status ladder** in [`docs/interaction-standards.md`](https://github.com/debola31/Jigged/blob/main/docs/interaction-standards.md) — `warning.main` is *"wants your attention, not wrong yet"*. An override is deliberate, so never `error`.
- [NN/g on icon discoverability](https://www.nngroup.com/articles/how-to-test-digital-icons/) — actions parked away from what they act on are the discoverability failure. Paperless Parts, in this exact domain, highlights manual overrides for the same reason.

## Details worth reviewing

- **Per row, not per part.** `quote_line_items` already stores `unit_price` + `is_quote_override` per (part, quantity), so **no schema change** — the work is in `QuoteForm` state.
- **The field's value derives from the tier price while untouched**, rather than being seeded into state by an effect. Nothing to keep in sync, a quantity change re-reads the new tier for free, and it adds no `set-state-in-effect` warning against the lint ratchet.
- **Typing a price equal to the tier's is not an override.** It saves as a normal tier-priced line, so it stays inside drift detection and repricing instead of being frozen out for no reason.
- **Reset stays reachable while the field is empty** — that is the state that blocks the save, and gating Reset on a *valid* custom price would take the way back off screen exactly when validation points at it.

## Bug fixed in the same change

`reconcileQuoteLineItems` read `block.override` **only on the INSERT paths**. On an already-saved line, setting, changing or clearing a custom price was accepted by the form and **silently dropped on save**. The old toggle made that easy to miss; an always-editable field would have made it a lie on every keystroke.

New `updateLineItemOverride` writes it. Clearing falls back to the **frozen** snapshot ladder — dropping an override is not an opt-in to a tier change made since the quote was written, which stays the explicit *Update to current price* action. A pre-snapshot row with no basis to return to keeps its agreed price and just drops the flag.

The e2e spec previously filled the custom price and asserted only that the part still existed after reload — it now asserts **the price survived**, which is what the reconcile gap was breaking.

## Telemetry

Adds `custom_priced_line_count` to `quote created` (+ its registry row) — a count, never the amount. How often the ladder gets overridden is the signal for whether shops' tiers are actually carrying their pricing.

`tsc` clean · lint 0 errors · doc-link + analytics guards pass · full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)