### PR TITLE
feat(quotes): per-part lead times end to end, Terms before Parts, and remove FOB point

### DIFF
--- a/__tests__/components/customers/customerFieldEditing.test.ts
+++ b/__tests__/components/customers/customerFieldEditing.test.ts
@@ -34,13 +34,11 @@ describe('normalizeSnapshot — compare what the DB would store', () => {
       form({
         name: '  Acme Corp  ',
         default_payment_terms: ' Net 30 ',
-        default_fob_point: ' FOB our dock ',
         credit_hold_note: ' 60 days ',
       }),
     );
     expect(n.name).toBe('Acme Corp');
     expect(n.default_payment_terms).toBe('Net 30');
-    expect(n.default_fob_point).toBe('FOB our dock');
     expect(n.credit_hold_note).toBe('60 days');
   });
 
@@ -72,13 +70,9 @@ describe('applyCreditStatusChange — lifting a hold clears its reason', () => {
   // The invariant the whole one-snapshot design exists for: a change to credit
   // must not disturb any other column, because updateCustomer writes them all.
   it('touches nothing but the credit fields', () => {
-    const base = form({
-      default_payment_terms: 'Net 45',
-      default_fob_point: 'FOB our dock',
-    });
+    const base = form({ default_payment_terms: 'Net 45' });
     const next = applyCreditStatusChange(base, 'hold');
     expect(next.name).toBe(base.name);
     expect(next.default_payment_terms).toBe(base.default_payment_terms);
-    expect(next.default_fob_point).toBe(base.default_fob_point);
   });
 });

--- a/__tests__/components/quotes/ConvertToJobModal.test.tsx
+++ b/__tests__/components/quotes/ConvertToJobModal.test.tsx
@@ -302,3 +302,101 @@ describe('ConvertToJobModal — no premature error on the empty due date', () =>
     expect(screen.getByRole('button', { name: /create j-100/i })).toBeDisabled();
   });
 });
+
+/**
+ * Lead time follows the same all-or-nothing rule as the PDF and the quote
+ * detail page: if ANY line carries its own, the single quote-level value is
+ * suppressed and each part shows its effective one. This modal was the only
+ * one of the three that never got it — it read `quote.lead_time_text` and
+ * nothing else, so a quote with three per-part lead times showed one.
+ * Mirrors `__tests__/utils/quotePdf.test.ts` > per-item lead times.
+ */
+describe('ConvertToJobModal — per-part lead times', () => {
+  const twoParts = (
+    leadA: string | null,
+    leadB: string | null,
+    quoteLead: string | null,
+  ): QuoteWithRelations =>
+    ({
+      id: 'q1',
+      company_id: 'co1',
+      quote_number: 'Q-100',
+      lead_time_text: quoteLead,
+      expiration_date: null,
+      customers: { name: 'Customer Co' },
+      line_items: [
+        {
+          id: 'li1',
+          sequence: 1,
+          part_id: 'p1',
+          quantity: 10,
+          unit_price: 5,
+          total_price: 50,
+          lead_time_text: leadA,
+          parts: { part_name: 'Bracket', primary_unit: null },
+        },
+        {
+          id: 'li2',
+          sequence: 2,
+          part_id: 'p2',
+          quantity: 4,
+          unit_price: 9,
+          total_price: 36,
+          lead_time_text: leadB,
+          parts: { part_name: 'Housing', primary_unit: null },
+        },
+      ],
+    }) as unknown as QuoteWithRelations;
+
+  const open = (q: QuoteWithRelations) =>
+    render(wrap(<ConvertToJobModal open onClose={vi.fn()} onConverted={vi.fn()} quote={q} />));
+
+  it('shows one quote-level lead time when no line carries its own', async () => {
+    open(twoParts(null, null, '4 weeks ARO'));
+
+    await waitFor(() => expect(screen.getByText(/quoted lead time/i)).toBeInTheDocument());
+    expect(screen.getByText('4 weeks ARO')).toBeInTheDocument();
+    expect(screen.queryByText(/^Lead time:/)).not.toBeInTheDocument();
+  });
+
+  it('suppresses the single value and shows each part’s own when they differ', async () => {
+    open(twoParts('2–3 weeks', '6–8 weeks', '4 weeks ARO'));
+
+    await waitFor(() => expect(screen.getByText(/Lead time: 2–3 weeks/)).toBeInTheDocument());
+    expect(screen.getByText(/Lead time: 6–8 weeks/)).toBeInTheDocument();
+    // The header value would contradict the per-part rows, so it goes.
+    expect(screen.queryByText(/quoted lead time/i)).not.toBeInTheDocument();
+  });
+
+  it('falls back to the quote-level value for a part that has none of its own', async () => {
+    open(twoParts('2–3 weeks', null, '4 weeks ARO'));
+
+    await waitFor(() => expect(screen.getByText(/Lead time: 2–3 weeks/)).toBeInTheDocument());
+    expect(screen.getByText(/Lead time: 4 weeks ARO/)).toBeInTheDocument();
+  });
+
+  it('warns that one job carries one due date when the included parts differ', async () => {
+    open(twoParts('2–3 weeks', '6–8 weeks', '4 weeks ARO'));
+
+    await waitFor(() =>
+      expect(screen.getByText(/quoted with different lead times/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/2–3 weeks, 6–8 weeks/)).toBeInTheDocument();
+  });
+
+  it('drops the warning once the differing part is excluded from this job', async () => {
+    open(twoParts('2–3 weeks', '6–8 weeks', '4 weeks ARO'));
+
+    await waitFor(() =>
+      expect(screen.getByText(/quoted with different lead times/i)).toBeInTheDocument(),
+    );
+
+    // Unchecking Housing leaves one lead time on this job, so the caveat about
+    // a single due date no longer applies.
+    await userEvent.click(screen.getByRole('checkbox', { name: /include housing/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByText(/quoted with different lead times/i)).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/__tests__/components/quotes/ConvertToJobModal.test.tsx
+++ b/__tests__/components/quotes/ConvertToJobModal.test.tsx
@@ -375,28 +375,14 @@ describe('ConvertToJobModal — per-part lead times', () => {
     expect(screen.getByText(/Lead time: 4 weeks ARO/)).toBeInTheDocument();
   });
 
-  it('warns that one job carries one due date when the included parts differ', async () => {
+  it('says nothing extra when the included parts were quoted differently', async () => {
+    // The per-part lead times above are the disclosure. A job carrying one due
+    // date is how jobs work, not news, and a paragraph explaining it is noise
+    // on the screen where the user is trying to pick a date.
     open(twoParts('2–3 weeks', '6–8 weeks', '4 weeks ARO'));
 
-    await waitFor(() =>
-      expect(screen.getByText(/quoted with different lead times/i)).toBeInTheDocument(),
-    );
-    expect(screen.getByText(/2–3 weeks, 6–8 weeks/)).toBeInTheDocument();
-  });
-
-  it('drops the warning once the differing part is excluded from this job', async () => {
-    open(twoParts('2–3 weeks', '6–8 weeks', '4 weeks ARO'));
-
-    await waitFor(() =>
-      expect(screen.getByText(/quoted with different lead times/i)).toBeInTheDocument(),
-    );
-
-    // Unchecking Housing leaves one lead time on this job, so the caveat about
-    // a single due date no longer applies.
-    await userEvent.click(screen.getByRole('checkbox', { name: /include housing/i }));
-
-    await waitFor(() =>
-      expect(screen.queryByText(/quoted with different lead times/i)).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/Lead time: 2–3 weeks/)).toBeInTheDocument());
+    expect(screen.queryByText(/one due date/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/convert them separately/i)).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/quotes/QuoteForm.test.tsx
+++ b/__tests__/components/quotes/QuoteForm.test.tsx
@@ -50,8 +50,6 @@ vi.mock('@/utils/customerAccess', () => ({
     c?.default_payment_terms?.trim() || null,
   pickLeadTimeText: (c: { default_lead_time_text?: string | null } | null | undefined) =>
     c?.default_lead_time_text?.trim() || null,
-  pickFobPoint: (c: { default_fob_point?: string | null } | null | undefined) =>
-    c?.default_fob_point?.trim() || null,
 }));
 
 // Company access — the form loads/persists the company's saved custom payment
@@ -131,7 +129,6 @@ const initialBlank: QuoteFormData = {
   parts: [],
   lead_time_text: '',
   payment_terms: '',
-  fob_point: '',
   expiration_date: '',
 };
 
@@ -143,9 +140,8 @@ const initialPopulated: QuoteFormData = {
   parts: [{ part_id: 'part-1', order_quantity: 5 }],
   lead_time_text: '14 business days',
   // Payment terms are required to submit a quote, so the "populated/complete"
-  // fixture carries one. FOB is optional and stays empty.
+  // fixture carries one.
   payment_terms: 'Net 30',
-  fob_point: '',
   expiration_date: '',
 };
 
@@ -314,7 +310,11 @@ describe('QuoteForm', () => {
     });
 
     const user = userEvent.setup();
-    await user.type(screen.getByLabelText('Lead time (optional)'), '2-3 weeks');
+    // The field is collapsed by default — a per-part lead time is an override
+    // of the quote-level one set in Terms above, not something every part needs.
+    expect(screen.queryByLabelText('Lead time (optional)')).toBeNull();
+    await user.click(screen.getByRole('checkbox', { name: /different lead time for this part/i }));
+    await user.type(await screen.findByLabelText('Lead time (optional)'), '2-3 weeks');
     await user.click(screen.getByRole('button', { name: /create quote/i }));
 
     await waitFor(() => {
@@ -324,6 +324,56 @@ describe('QuoteForm', () => {
     expect(payload.parts).toEqual([
       { part_id: 'part-1', order_quantity: 5, lead_time_text: '2-3 weeks' },
     ]);
+  });
+
+  it('opens the per-part lead time already expanded when the quote has one saved', async () => {
+    // Hydration seeds the disclosure from the value. Without that, editing a
+    // quote would hide a lead time it is still promising the customer.
+    render(
+      <QuoteForm
+        mode="edit"
+        quoteId="q-1"
+        initialData={{
+          ...initialPopulated,
+          parts: [{ part_id: 'part-1', order_quantity: 5, lead_time_text: '6-8 weeks' }],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+    expect(screen.getByLabelText('Lead time (optional)')).toHaveValue('6-8 weeks');
+    expect(
+      screen.getByRole('checkbox', { name: /different lead time for this part/i }),
+    ).toBeChecked();
+  });
+
+  it('clears the per-part lead time when the disclosure is unchecked', async () => {
+    // Leaving a stale value behind a hidden checkbox is how a quote ends up
+    // promising a date nobody chose.
+    render(
+      <QuoteForm
+        mode="edit"
+        quoteId="q-1"
+        initialData={{
+          ...initialPopulated,
+          parts: [{ part_id: 'part-1', order_quantity: 5, lead_time_text: '6-8 weeks' }],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeEnabled();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('checkbox', { name: /different lead time for this part/i }));
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(updateQuote).toHaveBeenCalledTimes(1));
+    const [, payload] = updateQuote.mock.calls[0];
+    expect(payload.parts[0]).not.toHaveProperty('lead_time_text');
   });
 
   it('offers the trimmed presets (with Prepay) in the payment-terms combobox', async () => {

--- a/__tests__/utils/customerAccess.test.ts
+++ b/__tests__/utils/customerAccess.test.ts
@@ -13,7 +13,6 @@ import {
  */
 const NO_STANDING_TERMS = {
   default_payment_terms: null,
-  default_fob_point: null,
   credit_status: 'open',
   credit_hold_note: null,
   // Live, not archived. Note tsconfig excludes __tests__, so a fixture that
@@ -79,7 +78,6 @@ import {
   pickBillingAddress,
   pickShippingAddress,
   pickPaymentTerms,
-  pickFobPoint,
   hasTermDrift,
 } from '@/utils/customerAccess';
 import type { CustomerAddress } from '@/types/customer';
@@ -365,7 +363,6 @@ describe('customerAccess utilities', () => {
 
         const patch = revivePatch();
         expect(patch).not.toHaveProperty('default_payment_terms');
-        expect(patch).not.toHaveProperty('default_fob_point');
       });
 
       // #653 P1. This is the defect that produced two rows for one company:
@@ -398,7 +395,6 @@ describe('customerAccess utilities', () => {
         const patch = revivePatch();
         expect(patch.default_payment_terms).toBe('Net 45');
         expect(patch.name).toBe('Acme Industrial');
-        expect(patch).not.toHaveProperty('default_fob_point');
       });
     });
   });
@@ -500,12 +496,8 @@ describe('address pickers', () => {
 
 describe('standing terms — resolution for a NEW quote', () => {
   it('returns the customer value for each standing term', () => {
-    const customer = {
-      default_payment_terms: 'Net 45',
-      default_fob_point: 'FOB Cleveland, OH',
-    };
+    const customer = { default_payment_terms: 'Net 45' };
     expect(pickPaymentTerms(customer)).toBe('Net 45');
-    expect(pickFobPoint(customer)).toBe('FOB Cleveland, OH');
   });
 
   it('treats unset, blank and whitespace-only as "no standing agreement"', () => {
@@ -514,8 +506,8 @@ describe('standing terms — resolution for a NEW quote', () => {
     expect(pickPaymentTerms({ default_payment_terms: null })).toBeNull();
     expect(pickPaymentTerms({ default_payment_terms: '' })).toBeNull();
     expect(pickPaymentTerms({ default_payment_terms: '   ' })).toBeNull();
-    expect(pickFobPoint(null)).toBeNull();
-    expect(pickFobPoint(undefined)).toBeNull();
+    expect(pickPaymentTerms(null)).toBeNull();
+    expect(pickPaymentTerms(undefined)).toBeNull();
   });
 
   it('trims a stored value so a stray space never reads as drift later', () => {
@@ -551,10 +543,10 @@ describe('standing terms — drift is reported, never applied', () => {
 
   // REVERSED from the original decision, deliberately. This used to assert
   // true — "worth surfacing: an older quote written before the standing terms
-  // existed". In practice it is a chip storm: quotes.fob_point is newer than
-  // the quotes themselves, so every pre-existing quote holds NULL, and the
-  // first time a shop fills in one customer's FOB point every open quote for
-  // that customer chips at once. A quote that states nothing never promised
+  // existed". In practice it is a chip storm: a standing-terms column is newer
+  // than the quotes themselves, so every pre-existing quote holds NULL, and the
+  // first time a shop fills one in every open quote for that customer chips at
+  // once. A quote that states nothing never promised
   // terms, so there is no disagreement to report.
   it('reports no drift when the quote states nothing — silence is not a promise', () => {
     expect(hasTermDrift(null, 'Net 30')).toBe(false);

--- a/__tests__/utils/quotePdf.test.ts
+++ b/__tests__/utils/quotePdf.test.ts
@@ -282,6 +282,20 @@ describe('generateQuotePdf', () => {
     expect(metaTexts.some((t: string) => t === 'Lead Time: 14 days ARO')).toBe(true);
   });
 
+  it('never prints an FOB row — the field was removed in August 2026', async () => {
+    // FOB was the one customer-facing render of a column that 96 real quotes
+    // left blank, and it had zero test coverage the whole time it existed.
+    // Asserting its absence is what stops it drifting back in.
+    await generateQuotePdf(baseQuote, baseCompany);
+
+    const docInstance = jsPDFCtor.mock.results[0].value;
+    const metaTexts = docInstance.text.mock.calls
+      .map((c: unknown[]) => c[0])
+      .filter((t: unknown): t is string => typeof t === 'string');
+
+    expect(metaTexts.some((t: string) => /^FOB\b/i.test(t))).toBe(false);
+  });
+
   it('omits Valid Until / Lead Time rows when fields are null', async () => {
     const barebonesQuote: QuoteWithRelations = {
       ...baseQuote,

--- a/api/models/import_models.py
+++ b/api/models/import_models.py
@@ -164,14 +164,4 @@ CUSTOMER_SCHEMA = {
             "'Terms', 'Terms Code' or 'Payment Terms'."
         ),
     },
-    "default_fob_point": {
-        "type": "string",
-        "required": False,
-        "description": (
-            "FOB point — WHERE title and risk transfer, as a named place "
-            "(e.g. 'FOB Cleveland, OH', 'FOB Origin'). Often exported as 'FOB'. "
-            "Not the freight payment terms (prepaid / collect / third party), "
-            "which describe who PAYS and are not imported here."
-        ),
-    },
 }

--- a/api/tools/schema_context.py
+++ b/api/tools/schema_context.py
@@ -27,9 +27,9 @@ SCHEMA_CONTEXT = """
 - website: TEXT
 - deleted_at: TIMESTAMPTZ (archived when set — filter `deleted_at IS NULL` for
   any list, count or ranking; a by-id lookup deliberately does not)
-- default_payment_terms: TEXT, default_fob_point: TEXT
-  -- the customer's STANDING terms, applied to NEW quotes only. A quote's own
-  payment_terms / lead_time_text / fob_point are what that quote was issued
+- default_payment_terms: TEXT
+  -- the customer's STANDING term, applied to NEW quotes only. A quote's own
+  payment_terms / lead_time_text are what that quote was issued
   with; never answer "what terms is quote X on?" from these columns.
 - created_at: TIMESTAMPTZ, updated_at: TIMESTAMPTZ
 - NOTE: There are no contact_name/contact_phone/contact_email columns. Contacts
@@ -124,7 +124,6 @@ SCHEMA_CONTEXT = """
 - converted_at: TIMESTAMPTZ (when accepted/converted to a job)
 - lead_time_text: TEXT (free-text lead time as stated, e.g. "2–3 weeks", "In stock"; does not drive the job due date)
 - payment_terms: TEXT (e.g. 'Net 30', '2/10 Net 30'), expiration_date: DATE
-- fob_point: TEXT (where title/risk transfer, e.g. 'FOB Cleveland, OH'; NOT who pays freight)
 - created_by: UUID, created_at: TIMESTAMPTZ, updated_at: TIMESTAMPTZ
 - NOTE: revenue is NOT on quotes anymore. Sum quote_line_items.total_price
   for per-quote revenue.

--- a/app/dashboard/[companyId]/customers/[customerId]/page.tsx
+++ b/app/dashboard/[companyId]/customers/[customerId]/page.tsx
@@ -851,12 +851,11 @@ export default function CustomerDetailPage() {
             save it so I don't keep it in my head" the field exists for.
             Values are prose, so body1 rather than the h6 the Related counts use. */}
         <Grid size={{ xs: 12, md: 6 }}>
+          {/* No text-field props: with FOB gone the card holds only the
+              payment-terms picker, which commits on change rather than blur. */}
           <CustomerTermsCard
             companyId={companyId}
             form={form}
-            fieldErrors={fieldErrors}
-            onTextChange={onTextChange}
-            onTextBlur={onTextBlur}
             onSelectChange={onSelectChange}
             readOnly={isArchived}
             saveState={saveState}

--- a/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
+++ b/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
@@ -266,7 +266,6 @@ export default function QuoteDetailPage() {
     ? (
         [
           { label: 'Payment terms', onQuote: quote.payment_terms, current: quote.customers.default_payment_terms },
-          { label: 'FOB', onQuote: quote.fob_point, current: quote.customers.default_fob_point },
         ] as const
       )
         .filter((f) => hasTermDrift(f.onQuote, f.current))
@@ -487,11 +486,6 @@ export default function QuoteDetailPage() {
             {quote.payment_terms && (
               <Typography variant="body2" color="text.secondary">
                 Payment terms: {quote.payment_terms}
-              </Typography>
-            )}
-            {quote.fob_point && (
-              <Typography variant="body2" color="text.secondary">
-                FOB: {quote.fob_point}
               </Typography>
             )}
           </Box>

--- a/components/customers/CustomerForm.tsx
+++ b/components/customers/CustomerForm.tsx
@@ -258,19 +258,6 @@ export default function CustomerForm({
             </Grid>
             <Grid size={{ xs: 12, sm: 6 }}>
             </Grid>
-            <Grid size={{ xs: 12, sm: 6 }}>
-              {/* FOB is about where title and risk transfer — NOT about who pays
-                  the freight. That's a separate axis carried on the job and
-                  shipment; the two must never share a control. */}
-              <TextField
-                fullWidth
-                label="FOB point"
-                value={formData.default_fob_point}
-                onChange={handleChange('default_fob_point')}
-                disabled={loading}
-                helperText="Where title and risk transfer. Who pays the freight is set per order."
-              />
-            </Grid>
           </Grid>
         </CardContent>
       </Card>

--- a/components/customers/CustomerTermsCard.tsx
+++ b/components/customers/CustomerTermsCard.tsx
@@ -4,7 +4,6 @@ import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Stack from '@mui/material/Stack';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
 import PaymentTermsPicker from '@/components/common/PaymentTermsPicker';
@@ -14,32 +13,35 @@ import type { CustomerFieldEditingProps } from '@/components/customers/customerF
 /**
  * The customer's standing terms, editable in place.
  *
- * Auto-save on blur (interaction-standards §2 mode 1). These are three
- * independent free-text prose fields, and they are non-financial by that
- * section's own test — they seed a NEW quote and nothing else. An existing
- * quote froze its own terms at creation and never reads these again, so a typo
- * here cannot change what any customer is charged. That is what puts them in
- * auto-save rather than behind a staged Save button.
+ * Auto-save (interaction-standards §2 mode 1). Payment terms are non-financial
+ * by that section's own test — they seed a NEW quote and nothing else. An
+ * existing quote froze its own terms at creation and never reads these again,
+ * so a typo here cannot change what any customer is charged. That is what puts
+ * them in auto-save rather than behind a staged Save button.
  *
- * Plain free text on purpose, matching what the old edit form offered: the
- * preset picker lives on the quote form, where the term is actually being
- * committed to a document. Offering presets in two places invites them to drift.
+ * **One field left, and it is a picker.** Both of its former neighbours were
+ * removed on the same reasoning — a standing default is only worth storing if
+ * shops actually set it:
+ *   - Lead time (2026-08-03) — a function of current shop load and the specific
+ *     part, not of the customer, so a standing value was a stale promise waiting
+ *     to be quoted. It lives on the quote now.
+ *   - FOB point (2026-08-08) — 0 of 586 real customers ever set one. See
+ *     docs/modules/customers.md, open question 3.
  *
- * Lead time used to sit here and was removed: it is a function of current shop
- * load and the specific part, not of the customer, so a standing value here was
- * a stale promise waiting to be quoted. It lives on the quote, stated at the
- * moment someone judges the shop's actual backlog.
+ * With FOB gone this card has no free-text input at all, which is why it takes
+ * only `onSelectChange`: the picker commits on change, so there is nothing to
+ * validate on blur.
  */
 export default function CustomerTermsCard({
   companyId,
   form,
-  fieldErrors,
-  onTextChange,
-  onTextBlur,
   onSelectChange,
   readOnly,
   saveState,
-}: CustomerFieldEditingProps & { saveState: SaveState; companyId: string }) {
+}: Omit<CustomerFieldEditingProps, 'fieldErrors' | 'onTextChange' | 'onTextBlur'> & {
+  saveState: SaveState;
+  companyId: string;
+}) {
 
   return (
     <Card elevation={2}>
@@ -63,14 +65,6 @@ export default function CustomerTermsCard({
                 {form.default_payment_terms || '—'}
               </Typography>
             </Box>
-            <Box sx={{ minWidth: 160 }}>
-              <Typography variant="body2" color="text.secondary">
-                FOB point
-              </Typography>
-              <Typography variant="body1" sx={{ fontWeight: 500 }}>
-                {form.default_fob_point || '—'}
-              </Typography>
-            </Box>
           </Stack>
         ) : (
           <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
@@ -85,18 +79,6 @@ export default function CustomerTermsCard({
               onChange={(next) => onSelectChange({ default_payment_terms: next })}
               size="medium"
               helperText="Applied to a new quote for this customer."
-            />
-            <TextField
-              label="FOB point"
-              value={form.default_fob_point}
-              onChange={(e) => onTextChange('default_fob_point', e.target.value)}
-              onBlur={onTextBlur}
-              error={!!fieldErrors.default_fob_point}
-              helperText={
-                fieldErrors.default_fob_point ||
-                'Where title and risk transfer. Who pays the freight is set per order.'
-              }
-              fullWidth
             />
           </Stack>
         )}

--- a/components/customers/customerFieldEditing.ts
+++ b/components/customers/customerFieldEditing.ts
@@ -34,7 +34,7 @@ import type { CustomerFormData } from '@/types/customer';
 
 /** The customer-owned fields edited in place, by card. */
 export const IDENTITY_FIELDS = ['name'] as const;
-export const TERMS_FIELDS = ['default_payment_terms', 'default_fob_point'] as const;
+export const TERMS_FIELDS = ['default_payment_terms'] as const;
 
 /** Every field these helpers drive. */
 export type EditableCustomerField = keyof CustomerFormData;
@@ -85,7 +85,6 @@ export function normalizeSnapshot(form: CustomerFormData): CustomerFormData {
     ...form,
     name: form.name.trim(),
     default_payment_terms: form.default_payment_terms.trim(),
-    default_fob_point: form.default_fob_point.trim(),
     credit_hold_note: form.credit_hold_note.trim(),
   };
 }

--- a/components/quotes/ConvertToJobModal.tsx
+++ b/components/quotes/ConvertToJobModal.tsx
@@ -154,11 +154,23 @@ export default function ConvertToJobModal({
   // needs the salesperson to pick the accepted quantity before converting.
   // Split into the parts still available to convert this pass vs the ones
   // already on a job (shown read-only so the user sees the full picture).
+  // When ANY line carries its own lead time, lead time is shown per part below
+  // and the single quote-level value is suppressed — the same all-or-nothing
+  // rule the PDF (`quotePdf.ts`) and the quote detail page apply, so the three
+  // surfaces can't contradict each other. This modal was the one that never got
+  // it, and showed one lead time no matter how many the quote carried.
+  const hasPerItemLeadTimes = useMemo(
+    () => lineItems.some((li) => (li.lead_time_text ?? '').trim() !== ''),
+    [lineItems],
+  );
+
   const { partGroups, convertedGroups } = useMemo(() => {
     const groups: {
       part_id: string;
       part_name: string;
       unit: string;
+      /** Effective lead time: the part's own value, else the quote-level one. */
+      lead_time: string;
       items: QuoteLineItem[];
     }[] = [];
     const index = new Map<string, number>();
@@ -173,6 +185,7 @@ export default function ConvertToJobModal({
           // Real unit so a fractional order reads "0.32 in" not "0.32 ea";
           // count parts still show "ea". Falls back to "ea" for a unitless part.
           unit: unitShortLabel(li.parts?.primary_unit) ?? 'ea',
+          lead_time: (li.lead_time_text ?? '').trim() || (quote.lead_time_text ?? ''),
           items: [],
         });
       }
@@ -182,7 +195,7 @@ export default function ConvertToJobModal({
       partGroups: groups.filter((g) => !convertedPartIds.has(g.part_id)),
       convertedGroups: groups.filter((g) => convertedPartIds.has(g.part_id)),
     };
-  }, [lineItems, convertedPartIds]);
+  }, [lineItems, convertedPartIds, quote.lead_time_text]);
 
   // part_id → the "base" line item this part converts from. Every part has one
   // (defaults to the lowest-quantity line). For a price-options part its quoted
@@ -206,6 +219,12 @@ export default function ConvertToJobModal({
   const [useTierByPart, setUseTierByPart] = useState<Record<string, boolean>>({});
   const includedGroups = partGroups.filter((g) => includedByPart[g.part_id]);
   const anyIncluded = includedGroups.length > 0;
+  // Distinct lead times across the parts going onto THIS job — the ones the
+  // single due date below has to satisfy. Excluded parts don't count: they stay
+  // on the quote for a later job with its own date.
+  const distinctIncludedLeadTimes = Array.from(
+    new Set(includedGroups.map((g) => g.lead_time).filter((t) => t !== '')),
+  );
   // Every INCLUDED part must have a valid (>0) ordered quantity.
   const allQtysValid = includedGroups.every((g) => parseQty(qtyByPart[g.part_id]) !== null);
 
@@ -508,6 +527,19 @@ export default function ConvertToJobModal({
                         </Typography>
                       </Box>
 
+                      {/* Per-part lead time, shown only when the quote actually
+                          carries differing ones — otherwise the single value
+                          below covers every part and repeating it is noise. */}
+                      {hasPerItemLeadTimes && group.lead_time !== '' && (
+                        <Typography
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ display: 'block', mt: 0.75 }}
+                        >
+                          Lead time: {group.lead_time}
+                        </Typography>
+                      )}
+
                       {/* Firm part only: committed-qty note + reprice opt-in on a break
                           crossing. Price-options parts always price at the tier. */}
                       {!isMultiTier && qtyChanged && (
@@ -564,30 +596,46 @@ export default function ConvertToJobModal({
           )}
 
           <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {!hasPerItemLeadTimes && (
+              <Box>
+                <Typography variant="body2" color="text.secondary">
+                  Quoted lead time
+                </Typography>
+                <Typography variant="body1" fontWeight={500}>
+                  {quote.lead_time_text ?? 'Not specified'}
+                </Typography>
+              </Box>
+            )}
             <Box>
-              <Typography variant="body2" color="text.secondary">
-                Quoted lead time
-              </Typography>
-              <Typography variant="body1" fontWeight={500}>
-                {quote.lead_time_text ?? 'Not specified'}
-              </Typography>
+              <TextField
+                label="Due date"
+                type="date"
+                size="small"
+                fullWidth
+                required
+                value={dueDateInput}
+                onChange={(e) => setDueDateInput(e.target.value)}
+                disabled={loading}
+                error={dueDateShowError}
+                helperText={dueDateHelper}
+                slotProps={{
+                  inputLabel: { shrink: true },
+                  htmlInput: { min: today },
+                }}
+              />
+              {/* A job carries ONE due date. When the parts going onto it were
+                  quoted with different lead times, this is the moment that
+                  matters — say so here rather than letting the user pick a date
+                  that silently contradicts half the quote. (Splitting them is
+                  already possible: convert in several passes, one job per PO.) */}
+              {distinctIncludedLeadTimes.length > 1 && (
+                <Typography variant="caption" color="warning.main" sx={{ display: 'block' }}>
+                  These parts were quoted with different lead times (
+                  {distinctIncludedLeadTimes.join(', ')}). One job carries one due date — convert
+                  them separately if they need different dates.
+                </Typography>
+              )}
             </Box>
-            <TextField
-              label="Due date"
-              type="date"
-              size="small"
-              fullWidth
-              required
-              value={dueDateInput}
-              onChange={(e) => setDueDateInput(e.target.value)}
-              disabled={loading}
-              error={dueDateShowError}
-              helperText={dueDateHelper}
-              slotProps={{
-                inputLabel: { shrink: true },
-                htmlInput: { min: today },
-              }}
-            />
             <TextField
               label="Customer PO #"
               size="small"

--- a/components/quotes/ConvertToJobModal.tsx
+++ b/components/quotes/ConvertToJobModal.tsx
@@ -219,12 +219,6 @@ export default function ConvertToJobModal({
   const [useTierByPart, setUseTierByPart] = useState<Record<string, boolean>>({});
   const includedGroups = partGroups.filter((g) => includedByPart[g.part_id]);
   const anyIncluded = includedGroups.length > 0;
-  // Distinct lead times across the parts going onto THIS job — the ones the
-  // single due date below has to satisfy. Excluded parts don't count: they stay
-  // on the quote for a later job with its own date.
-  const distinctIncludedLeadTimes = Array.from(
-    new Set(includedGroups.map((g) => g.lead_time).filter((t) => t !== '')),
-  );
   // Every INCLUDED part must have a valid (>0) ordered quantity.
   const allQtysValid = includedGroups.every((g) => parseQty(qtyByPart[g.part_id]) !== null);
 
@@ -606,36 +600,25 @@ export default function ConvertToJobModal({
                 </Typography>
               </Box>
             )}
-            <Box>
-              <TextField
-                label="Due date"
-                type="date"
-                size="small"
-                fullWidth
-                required
-                value={dueDateInput}
-                onChange={(e) => setDueDateInput(e.target.value)}
-                disabled={loading}
-                error={dueDateShowError}
-                helperText={dueDateHelper}
-                slotProps={{
-                  inputLabel: { shrink: true },
-                  htmlInput: { min: today },
-                }}
-              />
-              {/* A job carries ONE due date. When the parts going onto it were
-                  quoted with different lead times, this is the moment that
-                  matters — say so here rather than letting the user pick a date
-                  that silently contradicts half the quote. (Splitting them is
-                  already possible: convert in several passes, one job per PO.) */}
-              {distinctIncludedLeadTimes.length > 1 && (
-                <Typography variant="caption" color="warning.main" sx={{ display: 'block' }}>
-                  These parts were quoted with different lead times (
-                  {distinctIncludedLeadTimes.join(', ')}). One job carries one due date — convert
-                  them separately if they need different dates.
-                </Typography>
-              )}
-            </Box>
+            {/* Per-part lead times are shown against each part above; the user
+                can read them and pick a date. No warning here about a job
+                carrying one due date — that is how jobs work, not news. */}
+            <TextField
+              label="Due date"
+              type="date"
+              size="small"
+              fullWidth
+              required
+              value={dueDateInput}
+              onChange={(e) => setDueDateInput(e.target.value)}
+              disabled={loading}
+              error={dueDateShowError}
+              helperText={dueDateHelper}
+              slotProps={{
+                inputLabel: { shrink: true },
+                htmlInput: { min: today },
+              }}
+            />
             <TextField
               label="Customer PO #"
               size="small"

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -1374,12 +1374,15 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
       {/* Parts */}
       <Card elevation={2} sx={{ mb: 3 }}>
         <CardContent>
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-            <Typography variant="h6">Parts</Typography>
-            <Button size="small" variant="outlined" startIcon={<AddIcon />} onClick={addPartBlock}>
-              Add part
-            </Button>
-          </Box>
+          {/* "Add part" lives at the BOTTOM of this card, not up here beside the
+              heading. A part block is tall — picker, quantity rows, price
+              captions, lead-time disclosure — so on a multi-part quote a header
+              button means scrolling back up past everything you just filled in
+              to add the next one. Putting it after the list keeps it where the
+              user's attention already is when they finish a part. */}
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            Parts
+          </Typography>
 
           {/* Drift summary: a non-blocking notice above the list when any
               current block correlates to a drifted line. Untouched
@@ -1944,6 +1947,16 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
               </Box>
             );
           })}
+
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<AddIcon />}
+            onClick={addPartBlock}
+            sx={{ mt: partBlocks.length > 0 ? 3 : 0 }}
+          >
+            Add part
+          </Button>
         </CardContent>
       </Card>
 

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import posthog from 'posthog-js';
 import NextLink from 'next/link';
@@ -47,7 +47,6 @@ import {
   pickShippingAddress,
   pickPrimaryContact,
   pickPaymentTerms,
-  pickFobPoint,
 } from '@/utils/customerAccess';
 import { getTiersWithComputedPrices } from '@/utils/partPricingTiersAccess';
 import { resolveTier } from '@/utils/quotePricingResolver';
@@ -123,6 +122,15 @@ interface PartBlockState {
    * falls back to the quote-level lead time.
    */
   lead_time_text: string;
+  /**
+   * Whether the per-part lead-time override is disclosed. A separate flag
+   * rather than `lead_time_text !== ''` because "checked the box, hasn't typed
+   * yet" is a real state that can't be derived from the value — but it is
+   * SEEDED from the value on hydration, so a saved quote that carries a
+   * per-part lead time opens expanded rather than hiding it behind an
+   * unchecked box.
+   */
+  lead_time_open: boolean;
   tiers: ComputedPartPricingTier[];
   loading: boolean;
   error: string | null;
@@ -156,7 +164,7 @@ const ADD_NEW_ADDRESS_ID = '__add_new_address__';
 // part, not the customer, so a standing value was a stale promise waiting to be
 // quoted. The column was dropped; the field stays on the quote, typed when
 // someone can actually see the backlog.
-const STANDING_TERM_FIELDS = ['payment_terms', 'fob_point'] as const;
+const STANDING_TERM_FIELDS = ['payment_terms'] as const;
 type StandingTermField = (typeof STANDING_TERM_FIELDS)[number];
 
 function formatCurrency(value: number | null | undefined): string {
@@ -190,6 +198,7 @@ function emptyBlock(): PartBlockState {
     part: null,
     rows: [emptyRow()],
     lead_time_text: '',
+    lead_time_open: false,
     tiers: [],
     loading: false,
     error: null,
@@ -232,15 +241,19 @@ function groupPartsIntoBlocks(parts: QuoteFormData['parts']): PartBlockState[] {
         part: { id: p.part_id } as PartSelectOption,
         rows: [],
         lead_time_text: '',
+        lead_time_open: false,
         tiers: [],
         loading: false,
         error: null,
       });
     }
     // Lead time is per-part; take it from the first entry that carries one
-    // (all entries for a part share the same value on save).
+    // (all entries for a part share the same value on save). A saved value
+    // opens the disclosure — otherwise editing a quote would hide a lead time
+    // it is still promising the customer.
     if (p.lead_time_text && !blocks[idx].lead_time_text) {
       blocks[idx].lead_time_text = p.lead_time_text;
+      blocks[idx].lead_time_open = true;
     }
     blocks[idx].rows.push(rowFromInitial(p));
   }
@@ -493,8 +506,7 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
    * → ON, disclosure hidden. Customers with separate billing/shipping
    * defaults → OFF, shipping disclosure visible.
    *
-   * It also pre-populates the customer's STANDING TERMS — payment_terms and
-   * fob_point.
+   * It also pre-populates the customer's STANDING TERM — payment_terms.
    *
    * OVERWRITE RULE. Unlike the address/contact FKs, which MUST be replaced
    * because they belong to a different customer and the integrity trigger
@@ -540,9 +552,9 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     // Payment terms have a two-level chain — the customer's own agreement, then
     // the shop-wide default — because a shop typically has one house term with a
     // handful of exceptions, so per-customer-only would mean retyping the house
-    // term onto nearly every customer. Lead time and FOB are customer-only:
-    // both are on the discovery watch list, and building a shop-wide default for
-    // a field we may delete would be spending the effort twice.
+    // term onto nearly every customer. It is the only standing term left: lead
+    // time is judged per quote, and FOB was removed after 96 real quotes left it
+    // blank (see the remove_fob_point migration).
     //
     // `source` is the phrase shown under the field. It names WHICH LEVEL the
     // value came from, and that visibility is the entire difference between this
@@ -552,10 +564,6 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
       payment_terms: customerTerms
         ? { value: customerTerms, source: `${customer?.name ?? 'this customer'}’s standing terms` }
         : { value: shopDefaultTerms, source: 'your shop default' },
-      fob_point: {
-        value: pickFobPoint(customer),
-        source: `${customer?.name ?? 'this customer'}’s standing terms`,
-      },
     };
     const nextTerms: Partial<Record<StandingTermField, string>> = {};
     const nextProvenance: Partial<Record<StandingTermField, string>> = {};
@@ -953,8 +961,11 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
    * Drives the disabled state of the Create/Save button instead of inline error alerts.
    */
   const validationError = useMemo<string | null>(() => {
+    // Checks run in the order the cards appear (Customer → Terms → Parts).
+    // Only the FIRST failure is shown, on the disabled submit button, so an
+    // order that disagrees with the page sends the user to the wrong card —
+    // e.g. "add a part" while the empty field is two cards higher.
     if (!formData.customer_id) return 'Pick a customer.';
-    if (partBlocks.length === 0) return 'Add at least one part to the quote.';
     // Lead time is free text (e.g. "2–3 weeks", "In stock") but required.
     if (formData.lead_time_text.trim() === '') {
       return 'Enter a lead time.';
@@ -964,6 +975,7 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     if (formData.payment_terms.trim() === '') {
       return 'Enter payment terms.';
     }
+    if (partBlocks.length === 0) return 'Add at least one part to the quote.';
     const seenParts = new Set<string>();
     for (const block of partBlocks) {
       if (!block.part) return 'Every part block must have a part selected.';
@@ -1289,6 +1301,73 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
               )}
             </Box>
           )}
+        </CardContent>
+      </Card>
+
+      {/* Terms sits ABOVE Parts, deliberately.
+          The quote-level lead time has to be on screen before the parts that may
+          override it — otherwise each part block's "leave blank to use the
+          quote's lead time" is a forward reference to a field the user hasn't
+          reached yet. Customer → Terms → Parts also puts the standing-terms
+          provenance line next to the customer picker that caused it, instead of
+          a whole card away. */}
+      <Card elevation={2} sx={{ mb: 3 }}>
+        <CardContent>
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            Terms
+          </Typography>
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              {/* Free-text lead time — the shop types whatever fits
+                  ("2–3 weeks", "In stock", "Call to confirm"). Required
+                  (validationError); stored verbatim and no longer drives the
+                  job due date (entered manually at conversion).
+
+                  No standing-terms prefill: lead time follows current shop load
+                  and the specific part, so it is judged here, per quote, rather
+                  than inherited from the customer. */}
+              <TextField
+                label="Lead time"
+                size="small"
+                fullWidth
+                required
+                value={formData.lead_time_text}
+                onChange={(e) => handleFieldChange('lead_time_text', e.target.value)}
+                helperText="e.g. “2–3 weeks” or “In stock”"
+                InputLabelProps={{ shrink: true }}
+              />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              {/* Column is still `expiration_date`; only the label says
+                  "Quote valid until", which is the phrase the PDF already
+                  prints ("Valid Until:"). */}
+              <TextField
+                label="Quote valid until"
+                type="date"
+                size="small"
+                fullWidth
+                value={formData.expiration_date}
+                onChange={(e) => handleFieldChange('expiration_date', e.target.value)}
+                InputLabelProps={{ shrink: true }}
+              />
+            </Grid>
+            <Grid size={{ xs: 12 }}>
+              {/* One shared control with the customer page — same vocabulary,
+                  same QuickBooks-first ordering. A bare text box on either side
+                  is how "net 45" and "Net 45" become two terms. */}
+              <PaymentTermsPicker
+                companyId={companyId}
+                value={formData.payment_terms}
+                onChange={(next) => handleFieldChange('payment_terms', next)}
+                required
+                helperText={
+                  prefilledFrom.payment_terms
+                    ? standingTermsHelper('payment_terms', '')
+                    : undefined
+                }
+              />
+            </Grid>
+          </Grid>
         </CardContent>
       </Card>
 
@@ -1801,100 +1880,70 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                     {/* Per-item lead time (per-part — applies to every quantity
                         of this part). Blank ⇒ the quote-level lead time is used.
                         Shown under each item on the quote/PDF only when items
-                        differ. */}
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-                      <TextField
-                        size="small"
-                        label="Lead time (optional)"
-                        value={block.lead_time_text}
-                        onChange={(e) => updateBlock(idx, { lead_time_text: e.target.value })}
-                        placeholder={'e.g. “2–3 weeks”'}
-                        sx={{ width: 220 }}
-                        InputLabelProps={{ shrink: true }}
+                        differ.
+
+                        Collapsed behind a checkbox, mirroring "Shipping address
+                        same as billing" above: with Terms now on screen first,
+                        this is an OVERRIDE of a value the user has already set,
+                        and most quotes never need one. Unchecking clears the
+                        text so the line falls back to the quote lead time —
+                        leaving a stale value behind a hidden checkbox is how a
+                        quote ends up promising a date nobody chose. */}
+                    <Box>
+                      <FormControlLabel
+                        sx={{ mb: 0 }}
+                        control={
+                          <Checkbox
+                            size="small"
+                            checked={block.lead_time_open}
+                            onChange={(e) =>
+                              updateBlock(idx, {
+                                lead_time_open: e.target.checked,
+                                // Clearing on close is what keeps the flag and
+                                // the value from disagreeing.
+                                ...(e.target.checked ? {} : { lead_time_text: '' }),
+                              })
+                            }
+                          />
+                        }
+                        label={
+                          <Typography variant="body2" color="text.secondary">
+                            Different lead time for this part
+                          </Typography>
+                        }
                       />
-                      <Typography variant="caption" color="text.secondary">
-                        Leave blank to use the quote’s lead time
-                      </Typography>
+                      <Collapse in={block.lead_time_open} unmountOnExit>
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 1,
+                            flexWrap: 'wrap',
+                            mt: 1,
+                          }}
+                        >
+                          <TextField
+                            size="small"
+                            label="Lead time (optional)"
+                            value={block.lead_time_text}
+                            onChange={(e) =>
+                              updateBlock(idx, { lead_time_text: e.target.value })
+                            }
+                            placeholder={'e.g. “2–3 weeks”'}
+                            sx={{ width: 220 }}
+                            InputLabelProps={{ shrink: true }}
+                          />
+                          <Typography variant="caption" color="text.secondary">
+                            Used instead of the quote’s lead time for this part
+                          </Typography>
+                        </Box>
+                      </Collapse>
                     </Box>
                   </Box>
                 )}
               </Box>
             );
           })}
-        </CardContent>
-      </Card>
-
-      <Card elevation={2} sx={{ mb: 3 }}>
-        <CardContent>
-          <Typography variant="h6" sx={{ mb: 2 }}>
-            Terms
-          </Typography>
-          <Grid container spacing={2}>
-            <Grid size={{ xs: 12, sm: 6 }}>
-              {/* Free-text lead time — the shop types whatever fits
-                  ("2–3 weeks", "In stock", "Call to confirm"). Required
-                  (validationError); stored verbatim and no longer drives the
-                  job due date (entered manually at conversion).
-
-                  No standing-terms prefill: lead time follows current shop load
-                  and the specific part, so it is judged here, per quote, rather
-                  than inherited from the customer. */}
-              <TextField
-                label="Lead time"
-                size="small"
-                fullWidth
-                required
-                value={formData.lead_time_text}
-                onChange={(e) => handleFieldChange('lead_time_text', e.target.value)}
-                helperText="e.g. “2–3 weeks” or “In stock”"
-                InputLabelProps={{ shrink: true }}
-              />
-            </Grid>
-            <Grid size={{ xs: 12, sm: 6 }}>
-              <TextField
-                label="Expiration date"
-                type="date"
-                size="small"
-                fullWidth
-                value={formData.expiration_date}
-                onChange={(e) => handleFieldChange('expiration_date', e.target.value)}
-                InputLabelProps={{ shrink: true }}
-              />
-            </Grid>
-            <Grid size={{ xs: 12, sm: 6 }}>
-              {/* FOB point — WHERE title and risk transfer, as a named place.
-                  Deliberately free text and deliberately NOT an origin/destination
-                  enum, and deliberately separate from who PAYS the freight (that
-                  lives on the job and shipment). Conflating the two is the classic
-                  error in this domain, so they never share a control. Optional:
-                  plenty of shops quote without stating one. */}
-              <TextField
-                label="FOB point"
-                size="small"
-                fullWidth
-                value={formData.fob_point}
-                onChange={(e) => handleFieldChange('fob_point', e.target.value)}
-                helperText={standingTermsHelper('fob_point', 'e.g. “FOB our dock, Cleveland OH”')}
-                InputLabelProps={{ shrink: true }}
-              />
-            </Grid>
-            <Grid size={{ xs: 12 }}>
-              {/* One shared control with the customer page — same vocabulary,
-                  same QuickBooks-first ordering. A bare text box on either side
-                  is how "net 45" and "Net 45" become two terms. */}
-              <PaymentTermsPicker
-                companyId={companyId}
-                value={formData.payment_terms}
-                onChange={(next) => handleFieldChange('payment_terms', next)}
-                required
-                helperText={
-                  prefilledFrom.payment_terms
-                    ? standingTermsHelper('payment_terms', '')
-                    : undefined
-                }
-              />
-            </Grid>
-          </Grid>
         </CardContent>
       </Card>
 

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -310,9 +310,14 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
    * the picker the user just used, so on a multi-part quote it lands off-screen
    * and they have to scroll to find what they just created.
    *
-   * `block: 'nearest'` is the whole trick: it does nothing when the block is
-   * already fully visible, and otherwise scrolls the minimum needed to show it.
-   * No jump on a short quote, no hunting on a long one.
+   * `block: 'center'`, NOT `'nearest'`. Nearest scrolls the minimum needed,
+   * which parks the block hard against the bottom edge — technically visible,
+   * but with nothing beneath it, so **+ Add part** and the footer stay off
+   * screen and the user scrolls again anyway. Centring leaves half a viewport
+   * below the block, which is where the next thing they'll reach for lives.
+   *
+   * It also means every pick lands the block in the same place, rather than
+   * moving sometimes and not others.
    */
   const revealBlockAfterLoad = useCallback((idx: number) => {
     if (scrollAfterLoadRef.current !== idx) return;
@@ -324,7 +329,7 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
         window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
       blockRefs.current.get(idx)?.scrollIntoView({
         behavior: prefersReducedMotion ? 'auto' : 'smooth',
-        block: 'nearest',
+        block: 'center',
       });
     });
   }, []);

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import posthog from 'posthog-js';
 import NextLink from 'next/link';
@@ -286,6 +286,49 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     if (focusBlockIndex !== null) setFocusBlockIndex(null);
   }, [focusBlockIndex]);
 
+  /**
+   * Live DOM node per part block, so a block can be scrolled into view once it
+   * has something to show.
+   */
+  const blockRefs = useRef<Map<number, HTMLElement>>(new Map());
+  /**
+   * Block index awaiting a scroll, set when the user PICKS a part.
+   *
+   * A ref rather than state on purpose: this is a one-shot side effect, and
+   * holding it in state would mean clearing it from an effect — the
+   * set-state-in-effect shape the lint ratchet is walking back.
+   *
+   * The gate matters. Tiers load for every block on an edit-mode open too, and
+   * scrolling on that would yank the page around the moment a quote is opened.
+   * Only a deliberate pick arms it.
+   */
+  const scrollAfterLoadRef = useRef<number | null>(null);
+
+  /**
+   * Reveal a block after its tiers land. Choosing a part makes the block grow —
+   * quantity row, price, lead-time disclosure — and all of that appears BELOW
+   * the picker the user just used, so on a multi-part quote it lands off-screen
+   * and they have to scroll to find what they just created.
+   *
+   * `block: 'nearest'` is the whole trick: it does nothing when the block is
+   * already fully visible, and otherwise scrolls the minimum needed to show it.
+   * No jump on a short quote, no hunting on a long one.
+   */
+  const revealBlockAfterLoad = useCallback((idx: number) => {
+    if (scrollAfterLoadRef.current !== idx) return;
+    scrollAfterLoadRef.current = null;
+    // One frame, so React has committed the rows before we measure them.
+    requestAnimationFrame(() => {
+      const prefersReducedMotion =
+        typeof window !== 'undefined' &&
+        window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+      blockRefs.current.get(idx)?.scrollIntoView({
+        behavior: prefersReducedMotion ? 'auto' : 'smooth',
+        block: 'nearest',
+      });
+    });
+  }, []);
+
   const [customers, setCustomers] = useState<CustomerOption[]>([]);
   // Full customer rows (with addresses + contacts) keyed by id so the
   // customer-change handler can resolve address/contact defaults without
@@ -448,8 +491,12 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
         }
         return next;
       });
+    } finally {
+      // Both paths: the block now shows either its rows or an error, and either
+      // way that is what the user needs to see.
+      revealBlockAfterLoad(idx);
     }
-  }, []);
+  }, [revealBlockAfterLoad]);
 
   // Load tiers for each part block when its part_id changes.
   useEffect(() => {
@@ -788,6 +835,9 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     // keys off the part-ids string — which doesn't change when the id is the
     // same. Trigger the fetch directly so the block reloads either way.
     if (option) {
+      // Arm the reveal: this is a deliberate pick, so the rows it produces are
+      // worth scrolling to once they exist.
+      scrollAfterLoadRef.current = idx;
       loadTiersForBlock(idx, option.id);
     }
   };
@@ -1458,7 +1508,14 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
             // unitless quantity.
 
             return (
-              <Box key={idx} sx={{ mb: idx === partBlocks.length - 1 ? 0 : 3 }}>
+              <Box
+                key={idx}
+                ref={(el: HTMLElement | null) => {
+                  if (el) blockRefs.current.set(idx, el);
+                  else blockRefs.current.delete(idx);
+                }}
+                sx={{ mb: idx === partBlocks.length - 1 ? 0 : 3 }}
+              >
                 {idx > 0 && <Divider sx={{ mb: 3 }} />}
                 <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1, mb: 2 }}>
                   <Box sx={{ flex: 1 }}>

--- a/docs/modules/customers.md
+++ b/docs/modules/customers.md
@@ -18,19 +18,16 @@ That last clause is the whole safety argument, and the reason this is not the `m
 
 ## Data model
 
-### `customers` — 12 columns
+### `customers` — 9 columns
 
 | Column | Type | Notes |
 |---|---|---|
 | `id` | uuid PK | `gen_random_uuid()` |
 | `company_id` | uuid NOT NULL | tenant key |
 | `name` | text NOT NULL | **the identity, case- and space-insensitive** — `customers_company_name_ci_unique (company_id, lower(btrim(name)))`. FULL, no `WHERE`, so archived rows collide too: that collision is the signal to revive. The plain `customers_company_name_unique` survives beside it only as the CSV importer's `on_conflict` target |
-| `website` | text | |
 | `created_at` / `updated_at` | timestamptz | `updated_at` maintained by the `customers_updated_at` trigger (no column list — fires on every update) |
 | `deleted_at` | timestamptz | archive marker |
-| `default_payment_terms` | text | standing terms ↓ |
-| `default_lead_time_text` | text | |
-| `default_fob_point` | text | |
+| `default_payment_terms` | text | standing terms ↓ — the only one left |
 | `credit_status` | text NOT NULL DEFAULT `'open'` | `CHECK (credit_status IN ('open','hold'))` |
 | `credit_hold_note` | text | |
 
@@ -85,14 +82,13 @@ Three customer columns seed three quote columns. All optional; a shop that fills
 | Customer column | Quote column | Levels |
 |---|---|---|
 | `default_payment_terms` | `quotes.payment_terms` | **two** — customer, then shop-wide |
-| `default_lead_time_text` | `quotes.lead_time_text` | one (customer only) |
-| `default_fob_point` | `quotes.fob_point` *(new)* | one (customer only) |
 
-**Why payment terms gets a second level and the others don't.** A shop typically has one house term with a handful of exceptions, so customer-only would mean retyping the house term onto nearly every customer. Lead time and FOB are on the discovery watch list — building a shop-wide default for a field we may delete would be spending the effort twice.
+**Payment terms is the only standing term left, and it is the one that earned a second level.** A shop typically has one house term with a handful of exceptions, so customer-only would mean retyping the house term onto nearly every customer.
 
-`default_fob_point` is **free text naming a place** ("FOB Cleveland, OH"), never an origin/destination enum. FOB governs where title and risk transfer; who *pays* is `freight_terms`, a separate axis on the job and shipment. Conflating them is the classic error in this domain, which is why the two never share a control.
+The other two were both on a discovery watch list and both came off it, in the same direction:
 
-`default_lead_time_text` is, by its own migration comment, the weakest of the three: lead time is a function of shop load and the specific part, so a standing value can become a stale promise.
+- `default_lead_time_text` — dropped 2026-08-03. Lead time is a function of shop load and the specific part, so a standing value becomes a stale promise. It is judged per quote.
+- `default_fob_point` (and `quotes.fob_point` with it) — dropped 2026-08-08. See open question 3 below for the numbers.
 
 ### Resolution chain
 
@@ -127,15 +123,15 @@ Inline customer creation from the quote form hands the new row **directly** to `
 
 ### Drift — reported, never applied
 
-Computed **on the quote detail page only** (`QuoteForm`'s drift state is a separate, per-line *price* mechanism). Three pairs, each against the customer's **current** value:
+Computed **on the quote detail page only** (`QuoteForm`'s drift state is a separate, per-line *price* mechanism). **One pair** remains, against the customer's **current** value — the other two chips went when their columns did:
 
 | Chip | Compares |
 |---|---|
 | `Payment terms differs from standing terms` | `quote.payment_terms` vs `customers.default_payment_terms` |
-| `Lead time differs from standing terms` | `quote.lead_time_text` vs `default_lead_time_text` |
-| `FOB differs from standing terms` | `quote.fob_point` vs `default_fob_point` |
 
-`hasTermDrift` compares trimmed and case-insensitively (`net 30` ≡ `Net 30`), returns **false** when the customer has no standing value (nothing to drift from), and returns **true** when the customer has a value and the quote's field is empty.
+`hasTermDrift` compares trimmed and case-insensitively (`net 30` ≡ `Net 30`), and returns **false** in *both* no-value cases — when the customer has no standing value (nothing to drift from) **and when the quote's own field is empty**. A quote that states nothing never promised terms, so there is no disagreement to report; the "Known defects" note below records why that second case was reversed.
+
+> *(Corrected 2026-08-08: this previously said `hasTermDrift` returns **true** when the customer has a value and the quote's field is empty — the opposite of [`utils/customerAccess.ts`](../../utils/customerAccess.ts), and contradicted by this document's own defect note.)*
 
 **A change to the shop-wide default produces no chip anywhere, and must not.** Shop policy moving is not a per-customer promise changing; chipping every open quote the day a shop edits its house term would train people to ignore the chip. The guarantee is structural rather than conditional — `hasTermDrift` takes the customer's standing terms as its second argument and nothing else, so there is no parameter through which a shop default could reach it.
 
@@ -303,11 +299,11 @@ So `discover_po_custom_field` **finds** the shop's field, matching on its **labe
 
 Six columns: **Name** (pinned), **Contact**, **Email**, **Phone** (all three derived from `primary_contact`, em-dash when absent), **Payment terms**, **Location** (derived from the default-billing address, `sortable: false`).
 
-Search is debounced 300 ms and matches **name only** — not website, contact or city. Sorting is server-side (the colId goes straight to `.order()`). Toolbar: Search · Import · New Customer, with Export CSV and Delete (n) appearing on selection. Empty state: *"No customers yet"* → *"Create your first customer or import from CSV."* (or *"No customers match your search."*).
+Search is debounced 300 ms and matches **name only** — not contact or city. Sorting is server-side (the colId goes straight to `.order()`). Toolbar: Search · Import · New Customer, with Export CSV and Delete (n) appearing on selection. Empty state: *"No customers yet"* → *"Create your first customer or import from CSV."* (or *"No customers match your search."*).
 
 ### Detail — `/dashboard/{companyId}/customers/{id}`
 
-Render order: **header** (name, credit chip + note, website, timestamps) → **Contacts** and **Addresses** side by side → **Terms** → **Shipping** → **Related**.
+Render order: **header** (name, credit chip + note, timestamps) → **Contacts** and **Addresses** side by side → **Terms** → **Shipping** → **Related**.
 
 - **Terms** — read-only here (edited on the form). Shows the three values, `—` when unset. Caption: *"Applied to new quotes for this customer. Quotes you've already sent keep the terms they were created with."* It shows only the customer's own values and never mentions the shop default.
 - **Shipping (n)** — carrier accounts. Named *Shipping*, not *Freight*: to a machinist "freight" means all shipping cost. Each row: carrier, bill-to chip, then `Account 4A72W9 · ZIP 97124` or *"No account number (billed on the BOL)"*, notes, Edit / Delete. Empty: *"No carrier accounts. Add one if this customer wants their shipments billed to their own UPS or FedEx account."* Delete **archives**: *"Shipments already billed to this account keep their record. It just stops being offered on new ones."*
@@ -315,7 +311,7 @@ Render order: **header** (name, credit chip + note, website, timestamps) → **C
 
 ### Form — `/customers/new` · `/customers/{id}/edit`
 
-Four sections: **Basic Information** (Company Name, Website) · **Terms & Lead Time** · **Credit** · **Initial Contact** (accordion, create mode only). Addresses and carrier accounts are not editable here.
+Four sections: **Basic Information** (Company Name) · **Terms** · **Credit** · **Initial Contact** (accordion, create mode only). Addresses and carrier accounts are not editable here.
 
 Terms copy: *"Applied to new quotes for this customer. Changing them here never affects quotes you've already sent. Leave blank if you have no standing agreement."* All three are plain free-text fields — the preset picker lives on the quote form, not here.
 
@@ -338,7 +334,7 @@ Delete is **archive**, per [`docs/architecture.md` §16](../architecture.md). `s
 
 **Name is the identity — reuse revives.** The unique constraint is FULL `(company_id, name)`, covering archived rows, so re-creating an archived name raises `23505`; `createCustomer` catches it and revives. A collision with a *live* row re-throws as a genuine duplicate. A partial (`WHERE deleted_at IS NULL`) constraint would break this.
 
-**A revive is not a fresh create wearing the same name.** It writes `name`, `deleted_at = null`, `updated_at`, and *only the non-blank* values of website and the three standing terms. The caller is always the create form, so a blank means "didn't say", never "deliberately cleared" — writing the whole column set would wipe the archived row's terms. It **never** writes `credit_status` or `credit_hold_note`: lifting a hold must be a deliberate act on the customer page, not a side effect of re-typing a name into a quick-create modal.
+**A revive is not a fresh create wearing the same name.** It writes `name`, `deleted_at = null`, `updated_at`, and *only the non-blank* value of the standing payment terms. The caller is always the create form, so a blank means "didn't say", never "deliberately cleared" — writing the whole column set would wipe the archived row's terms. It **never** writes `credit_status` or `credit_hold_note`: lifting a hold must be a deliberate act on the customer page, not a side effect of re-typing a name into a quick-create modal.
 
 Archiving a customer does **not** archive its carrier accounts (a soft delete fires no cascade), so they return intact on revive. An archived carrier account keeps resolving everywhere it matters — shipments and jobs keep the FK (archiving is an UPDATE, so `ON DELETE SET NULL` never fires), the slip prints from the frozen snapshot, and both pickers keep a currently-selected archived row so editing an old document never silently blanks its freight. It loses only its place in the picker for *new* documents.
 
@@ -352,13 +348,13 @@ Archiving a customer does **not** archive its carrier accounts (a soft delete fi
 
 Two live paths, both hitting `/api/customers/import/execute`.
 
-**Mappable fields (14):** `name` (required), `website`, `contact_name`, `contact_phone`, `contact_email`, `address_line1`, `address_line2`, `city`, `state`, `postal_code`, `country`, **`default_payment_terms`**, **`default_lead_time_text`**, **`default_fob_point`**.
+**Mappable fields (11):** `name` (required), `contact_name`, `contact_phone`, `contact_email`, `address_line1`, `address_line2`, `city`, `state`, `postal_code`, `country`, **`default_payment_terms`**.
 
 **Not mappable:** credit status or note (so an import can never set or lift a hold), and no carrier-account field.
 
 The guided flow (`lib/dataImportSchema.ts`) exposes only `name` and `default_payment_terms` — a UI restriction, not a server limit.
 
-The AI column mapper matches source headers against the schema *descriptions*, which deliberately carry legacy-ERP vocabulary: `default_payment_terms` notes *"Often exported as 'Terms', 'Terms Code' or 'Payment Terms'"*, and `default_fob_point` explicitly says it is **not** the freight payment terms, "which describe who PAYS and are not imported here."
+The AI column mapper matches source headers against the schema *descriptions*, which deliberately carry legacy-ERP vocabulary: `default_payment_terms` notes *"Often exported as 'Terms', 'Terms Code' or 'Payment Terms'"*.
 
 Execute sets `deleted_at = None` on every row before upserting on `(company_id, name)`, so **a re-import revives an archived customer** rather than leaving it hidden. A blank cell omits the key entirely rather than writing null. Contacts and addresses attach only to a **new** customer — re-importing an existing one silently drops any contact/address columns in the CSV.
 
@@ -423,7 +419,7 @@ Filled since: the contact-archive rules and the billing-default clear-then-set a
 
 **Name is the identity, and three layers disagreed about what that means.** The constraint was case-sensitive, the create pre-check was `.ilike`, and the revive lookup was `.eq` — so archiving "Acme Corp" and creating "acme corp" found nothing to revive and inserted a **second row for the same company**. The CSV importer reached the same end from the other side. Both lookups are now case-insensitive, and `customers_company_name_ci_unique` on `(company_id, lower(btrim(name)))` makes the DB the authority. The plain constraint survives beside it only because the importer upserts with `on_conflict="company_id,name"` and PostgREST cannot name an expression index.
 
-**A chip that fires on everything at once is a chip people learn to ignore.** `hasTermDrift` used to report drift when the quote stated nothing and the customer had a value. Because `quotes.fob_point` is newer than the quotes themselves, the first time a shop filled in one customer's FOB point every open quote for that customer chipped. A quote that states nothing never promised terms, so there is nothing to disagree with — drift now needs a value on both sides.
+**A chip that fires on everything at once is a chip people learn to ignore.** `hasTermDrift` used to report drift when the quote stated nothing and the customer had a value. Because a standing-terms column is newer than the quotes themselves, every pre-existing quote carries NULL — so the first time a shop filled one in, every open quote for that customer chipped at once. A quote that states nothing never promised terms, so there is nothing to disagree with — drift now needs a value on both sides.
 
 ---
 
@@ -461,7 +457,33 @@ Both were dropped in favour of fixing [#653](https://github.com/debola31/Jigged/
 
 | # | Question | Decides |
 |---|---|---|
-| 1 | Does any customer have more than one ship-to plant? | Whether address-level freight defaults (`fob_point`, `shipping_instructions`, `print_coc` per address) ever get built |
+| 1 | Does any customer have more than one ship-to plant? | Whether address-level freight defaults (`shipping_instructions`, `print_coc` per address) ever get built |
 | 2 | Do shops routinely carry 2+ carrier accounts? | Whether to add `is_default` — the recorded remedy, as opposed to picking arbitrarily |
-| 3 | Are `default_lead_time_text` and `default_fob_point` used after 60 days? | Both are on the watch list. Johnny on FOB: *"we sort of ignore that."* If both are still empty across every customer, remove the columns and their form fields together in one migration |
+| 3 | ~~Are `default_lead_time_text` and `default_fob_point` used after 60 days?~~ **ANSWERED — both removed.** | `default_lead_time_text` went 2026-08-03. `default_fob_point` and `quotes.fob_point` went 2026-08-08 on the evidence below |
 | 4 | Does the shop charge sales tax on any work? | Moves the `TaxCodeRef` fix between P0 and P3 — the highest-consequence unanswered question here |
+
+### Question 3, answered (2026-08-08)
+
+Measured in production, **real shops only** — the demo companies are excluded because their FOB
+values come from the seed, not from anyone typing:
+
+| Company | Customers with a FOB default | Quotes with a FOB |
+|---|---|---|
+| Contour Tool & Machine | **0 / 584** | **0 / 88** |
+| Jigged Usability Sandbox | **0 / 2** | **0 / 8** |
+| L & L Machine & Tool | 0 / 0 | 0 / 0 |
+
+**Zero of 586 real customers and zero of 96 real quotes**, against payment terms at 113/127 and
+lead time at 127/127 on the same quotes. Every non-null value in the database belonged to a demo
+company, and every one of those was `Origin` or `Destination` — exactly the enum the column's own
+`COMMENT` forbade. When the seed authors cannot hold a doctrine across three files, the doctrine
+is not being used.
+
+**The diagnosis is placement, not presentation.** FOB is boilerplate a shop states once, not a
+per-deal decision — which is why a free-text box on the quote form produced 96 blanks, and why a
+prettier picker would have produced 96 prettier blanks. If a customer ever demands FOB
+Destination, the shape to build is a **shop-level default in settings that prints on every quote**,
+with a per-customer override. Not a quote-form field.
+
+Removing it cost one line on the quote PDF, which those 96 quotes had already been shipping
+without.

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -12,8 +12,9 @@
 >
 > **Corrected against the code:** the `/quotes/{id}/edit` route does not exist, and the
 > radio-per-quantity convert mechanic was replaced by quick-pick chips — the doc described the
-> replacement 20 lines above the superseded version and kept both. `fob_point` was missing from
-> the field list entirely.
+> replacement 20 lines above the superseded version and kept both. *(`fob_point` was added to the
+> field list by that pass and removed from the product entirely on 2026-08-08 — see
+> [customers.md](customers.md), open question 3.)*
 
 ---
 
@@ -100,16 +101,16 @@ A thin header — per-part, per-quantity pricing lives on the line items.
 | `customer_id` | Required |
 | `lead_time_text` | Free text as stated ("2–3 weeks", "In stock"). **Quote-level default**; a line item can override per part. Does **not** drive the job due date |
 | `payment_terms` | Required. A single free-text string, no enum |
-| `fob_point` | Free text naming a place ("FOB Cleveland, OH"), never an origin/destination enum |
-| `expiration_date` | Defaults to `created_at + 10 days` |
+| `expiration_date` | Defaults to `created_at + 10 days`. Labelled **"Quote valid until"** on the form and `Valid Until:` on the PDF; the column keeps its original name |
 | `status`, `status_changed_at` | `active` \| `expired` |
 | `converted_at` | First conversion only |
 
-**Terms prefill from the customer's standing commercial contract** — `default_payment_terms`,
-`default_lead_time_text`, `default_fob_point` ride along on the detail select so the page can
-compare what was used against what the customer normally gets. [customers.md](customers.md) owns
-that mapping, including why FOB (where title and risk transfer) and `freight_terms` (who pays)
-are deliberately never the same control.
+**Payment terms prefill from the customer's standing commercial contract.**
+`default_payment_terms` rides along on the detail select so the page can compare what was used
+against what the customer normally gets. It is the **only** standing term left —
+`default_lead_time_text` was dropped 2026-08-03 (lead time is judged per quote, against current
+shop load) and `default_fob_point` on 2026-08-08. [customers.md](customers.md) owns that mapping
+and records the evidence for both removals.
 
 **Removed April 2026, replaced by line items:** `part_id`, `quantity`, `base_cost`,
 `markup_percent`, `estimated_labor_cost`, `estimated_material_cost`, `unit_price`,
@@ -223,13 +224,29 @@ replaced it, on the form and on the detail view.
 
   A typed price equal to the tier's is **not** an override — it saves as a normal tier-priced
   line, so it stays inside drift detection and repricing.
-- **Per-part lead time:** an optional free-text field so one item can read "2–3 weeks" and
-  another "3–4 weeks" **without splitting the quote in two**. When *any* item has its own, the
-  detail view and PDF move lead time under each item; when none do, one quote-level line shows.
+- **Per-part lead time:** behind a **"Different lead time for this part"** checkbox, collapsed by
+  default — it is an *override* of the quote-level lead time set in Terms above, and most quotes
+  never need one. Mirrors "Shipping address same as billing" in the Customer card. One item can
+  then read "2–3 weeks" and another "3–4 weeks" **without splitting the quote in two**. When *any*
+  item has its own, the detail view and PDF move lead time under each item; when none do, one
+  quote-level line shows.
+
+  Two details that keep the checkbox and the value from disagreeing: hydrating a saved quote
+  **seeds the checkbox from the value**, so a quote already promising a per-part lead time opens
+  expanded rather than hiding it; and unchecking **clears the text**, so the line genuinely falls
+  back to the quote lead time rather than leaving a stale promise behind a hidden control.
 - **Order matters** — part-block order, then row order within a block, drives `sequence`.
 
-**Terms card** — lead time (required free text), expiration (defaults +10 days), and payment
-terms as a **pick-only** combobox: the shop's saved custom terms first (each removable via ✕),
+**Terms card — and it sits ABOVE Parts, deliberately.** The quote-level lead time has to be on
+screen before the parts that may override it; otherwise each part block's *"Different lead time
+for this part"* is an override of a value the user has not reached yet. Customer → Terms → Parts
+also puts the standing-terms provenance line beside the customer picker that caused it instead of
+a card away. `validationError` reports the first failure in that same order, so the message on the
+disabled submit button always points at the card the user should look at.
+
+It holds: lead time (required free text), **Quote valid until** (defaults +10 days; the column is
+still `expiration_date`, and the label matches the `Valid Until:` the PDF already printed), and
+payment terms as a **pick-only** combobox: the shop's saved custom terms first (each removable via ✕),
 then the presets (Due on Receipt · Net 15 · Net 30 · Net 60 · 2/10 Net 30 · 50% Deposit /
 Balance Net 30 · Prepay · Cash on Delivery — QuickBooks' built-ins plus the deposit / prepay /
 COD / early-pay terms shops use). Presets are **not** removable. Saved terms live in
@@ -474,7 +491,7 @@ only if post-pilot data shows drift is more frequent than estimated.
 `Quote-{quote_number}.pdf`.
 
 Contains: company logo and name; the QUOTE heading with number, date, validity, lead time,
-payment terms and FOB; **Customer · Ship to (only if different) · Customer contact**; the line
+and payment terms; **Customer · Ship to (only if different) · Customer contact**; the line
 items table ordered by `sequence`, with a grand total **only** on firm quotes; and an acceptance
 block instructing the customer to **reply with a purchase order referencing the quote** — there
 is **no signature/date/PO ruled line**, because acceptance is by PO. A "Prepared by {name} ·

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -167,7 +167,10 @@ a per-row total misleads. Totals live on the detail page and PDF, for firm quote
 detail page (`quotes/[quoteId]/page.tsx`), gated on the quote being active and unconverted.
 *(This doc described an `/quotes/{id}/edit` route that never existed.)*
 
-**Parts card** — one block per part, plus **+ Add part**. Each block: a part picker (with **+ New
+**Parts card** — one block per part, plus **+ Add part** at the **bottom** of the card, below the
+list rather than beside the heading: a part block is tall (picker, quantity rows, price captions,
+lead-time disclosure), so a header button makes a multi-part quote scroll back up past everything
+just filled in. Each block: a part picker (with **+ New
 Part** inline create), an editable **list of quantity rows** (one per quoted quantity, **Add
 quantity** appends, every row past the first can be deleted), each row showing its resolved price
 stacked over a `From tier {n}` caption, plus Total (firm) or Extended (options). A row below the
@@ -333,11 +336,13 @@ effective value (`lead_time_text ?? quote.lead_time_text`). The modal was the on
 never got this — it read `quote.lead_time_text` alone, so a quote with three per-part lead times
 displayed one, silently.
 
-Because **a job carries one `due_date`**, the modal also warns when the parts *checked for this
-job* were quoted with differing lead times, naming them, and points at the existing escape hatch:
-convert in several passes, one job per PO. Lead time is **not** persisted onto the job — `jobs`
-has no lead-time column (`jobs.lead_time_days` was dropped in `20260713060545`) and free-text lead
-time no longer implies a date.
+A job carries one `due_date`, and the modal says nothing about that — **the per-part lead times
+listed above the field are the disclosure**. A tried-and-removed paragraph explained that differing
+lead times mean one date and offered converting in several passes; it was noise on the screen where
+the user is trying to pick a date, explaining how jobs work rather than telling them anything they
+could act on. Lead time is also **not** persisted onto the job — `jobs` has no lead-time column
+(`jobs.lead_time_days` was dropped in `20260713060545`) and free-text lead time no longer implies a
+date.
 
 Also captured: a **required Due date** (not-in-the-past, starts **empty** — no prefill, and no
 longer derived from lead time), a **required Customer PO #** (the authorization, so no job

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -310,6 +310,18 @@ part's kind:
 *(An earlier revision started multi-quantity parts with **no radio selected**, requiring a
 deliberate pick. Radios are gone — `ConvertToJobModal` has none.)*
 
+**Lead time follows the same all-or-nothing rule as the detail view and the PDF:** when any line
+carries its own, the single *Quoted lead time* block is suppressed and each part shows its
+effective value (`lead_time_text ?? quote.lead_time_text`). The modal was the one surface that
+never got this — it read `quote.lead_time_text` alone, so a quote with three per-part lead times
+displayed one, silently.
+
+Because **a job carries one `due_date`**, the modal also warns when the parts *checked for this
+job* were quoted with differing lead times, naming them, and points at the existing escape hatch:
+convert in several passes, one job per PO. Lead time is **not** persisted onto the job — `jobs`
+has no lead-time column (`jobs.lead_time_days` was dropped in `20260713060545`) and free-text lead
+time no longer implies a date.
+
 Also captured: a **required Due date** (not-in-the-past, starts **empty** — no prefill, and no
 longer derived from lead time), a **required Customer PO #** (the authorization, so no job
 without it), and an **optional PO PDF** which uploads to the job after conversion and is

--- a/e2e/quote-edit.spec.ts
+++ b/e2e/quote-edit.spec.ts
@@ -526,7 +526,7 @@ test.describe('Quote edit — reload contract', () => {
 
     // Force a past expiration date (the form otherwise defaults to today + 10),
     // so the quote is expired-by-date the moment it's created.
-    await page.getByLabel(/Expiration date/i).fill('2020-01-01');
+    await page.getByLabel(/Quote valid until/i).fill('2020-01-01');
 
     await page.getByRole('textbox', { name: 'Lead time', exact: true }).fill('2 weeks');
     await page.getByRole('combobox', { name: /Payment terms/i }).fill('Net 30');
@@ -556,7 +556,7 @@ test.describe('Quote edit — reload contract', () => {
 
     // Reactivation banner + a pre-filled future expiration date.
     await expect(page.getByText(/This quote is expired/i)).toBeVisible();
-    const prefilled = await page.getByLabel(/Expiration date/i).inputValue();
+    const prefilled = await page.getByLabel(/Quote valid until/i).inputValue();
     const today = new Date().toISOString().slice(0, 10);
     // ISO dates compare correctly as strings.
     expect(prefilled >= today, `expected a future pre-fill, got ${prefilled}`).toBeTruthy();

--- a/supabase/migrations/20260809002509_remove_fob_point.sql
+++ b/supabase/migrations/20260809002509_remove_fob_point.sql
@@ -1,0 +1,647 @@
+-- Remove FOB point.
+--
+-- `quotes.fob_point` and `customers.default_fob_point` go, together with their
+-- form fields, the PDF line and the drift chip.
+--
+-- WHY: this is open question 3 in docs/modules/customers.md answered by its own
+-- test. That question read "Are default_lead_time_text and default_fob_point
+-- used after 60 days? ... If both are still empty across every customer, remove
+-- the columns and their form fields together in one migration", and recorded
+-- Johnny on FOB: "we sort of ignore that."
+--
+-- Measured in production 2026-08-08, real shops only (demo companies excluded):
+--
+--     Contour Tool & Machine     0 of 584 customers, 0 of 88 quotes
+--     Jigged Usability Sandbox   0 of   2 customers, 0 of  8 quotes
+--     L & L Machine & Tool       0 of   0 customers, 0 of  0 quotes
+--
+-- Zero of 586 real customers and zero of 96 real quotes have ever carried a
+-- value. Every non-null value in the database belongs to a demo company, and
+-- every one of those is 'Origin' or 'Destination' -- precisely the enum the
+-- column's own COMMENT forbids ("Free text, never an enum"). When the seed
+-- authors cannot hold a doctrine across three files, the doctrine is not being
+-- used.
+--
+-- The other half of that question already ran: 20260803235119 dropped
+-- customers.default_lead_time_text on the same evidence. This is the survivor.
+--
+-- FOB was not dead code -- it printed on the quote PDF and showed on the quote
+-- detail page with a drift chip. It was terminal after that: convertQuoteToJob
+-- dropped it silently and no job, shipment, packing slip, invoice or QuickBooks
+-- path ever read it. Removing it takes one line off a PDF that 96 real quotes
+-- have already been shipping without.
+--
+-- If a shop ever does need FOB, the shape to build is a SHOP-LEVEL default in
+-- settings that prints on every quote, with a per-customer override -- not a
+-- quote-form field. FOB is boilerplate a shop states once, which is exactly why
+-- asking for it per quote produced 96 blanks.
+--
+-- ---------------------------------------------------------------------------
+-- 1. seed_demo_data -- recreated WITHOUT the two FOB inserts.
+--
+--    This has to happen in the same migration as the DROPs and it has to come
+--    first: the function inserts default_fob_point into customers and fob_point
+--    into quotes (20260805011938 lines 302 and 357), so dropping the columns
+--    while it still references them breaks demo company provisioning.
+--
+--    CREATE OR REPLACE, never DROP + recreate: the signature is unchanged, and
+--    replacing in place preserves both the EXECUTE ACL and the COMMENT. A DROP
+--    would silently discard the service-role-only grant and re-expose the
+--    function to browser roles (see CLAUDE.md, "Function EXECUTE grants").
+--
+--    Body is carried over verbatim from 20260805011938 apart from the four
+--    removed FOB lines.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.seed_demo_data(p_company_id uuid, p_user_id uuid, p_template_name text DEFAULT 'default'::text)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+    v_template   jsonb;
+    v_ref_map    jsonb := '{}'::jsonb;
+    v_item       jsonb;
+    v_inner      jsonb;
+    v_leaf       jsonb;
+    v_new_id     uuid;
+    v_routing_id uuid;
+    v_quote_id   uuid;
+    v_job_id     uuid;
+    v_job_part_id uuid;
+    v_ship_id    uuid;
+    v_note_id    uuid;
+    v_op_id      uuid;
+    v_part_id    uuid;
+    v_cust_id    uuid;
+    v_loc_id     uuid;
+    v_source     text;
+    v_qty        numeric;
+    v_unit_price numeric;
+    v_job_number text;
+    v_base       text;
+    v_seq        integer;
+    v_members    uuid[];   -- user_company_access.id
+    v_users      uuid[];   -- auth.users.id
+    v_author     uuid;
+    v_n_authors  integer;
+BEGIN
+    SELECT template_data INTO v_template
+    FROM demo_data_templates
+    WHERE name = p_template_name AND is_active = true
+    LIMIT 1;
+
+    IF v_template IS NULL THEN
+        RAISE EXCEPTION 'No active demo template found with name: %', p_template_name;
+    END IF;
+
+    -- Two author pools, because the schema names actors two different ways and
+    -- getting them backwards is a FK error at best and the wrong name on screen
+    -- at worst:
+    --   notes.author_id / note_reactions.reactor_id -> user_company_access.id
+    --       (the MEMBERSHIP row — a note belongs to someone's membership of this
+    --        company, so removing them from the company detaches it)
+    --   job_operation_completions.completed_by, inventory_transactions.created_by,
+    --   jobs/quotes/shipments.created_by                    -> auth.users.id
+    -- Both are built in one pass ordered by user_id, so `author_index: 2` is the
+    -- same person in a note and in a completion, and stays that person across
+    -- resets. create_demo_company mirrors user_company_access BEFORE seeding, so
+    -- the demo already has the real company's team — which is what makes the
+    -- activity feed read like a shop rather than one person talking to themselves.
+    SELECT COALESCE(array_agg(id      ORDER BY user_id), ARRAY[]::uuid[]),
+           COALESCE(array_agg(user_id ORDER BY user_id), ARRAY[]::uuid[])
+      INTO v_members, v_users
+      FROM user_company_access WHERE company_id = p_company_id;
+    IF array_length(v_users, 1) IS NULL THEN
+        v_members := ARRAY[]::uuid[];      -- no membership row to point a note at
+        v_users   := ARRAY[p_user_id];
+    END IF;
+    v_n_authors := array_length(v_users, 1);
+
+    -- ---- custom units -------------------------------------------------
+    IF v_template->'custom_units' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'custom_units') LOOP
+            INSERT INTO company_custom_units (company_id, unit_name)
+            VALUES (p_company_id, v_item#>>'{}')
+            ON CONFLICT (company_id, unit_name) DO NOTHING;
+        END LOOP;
+    END IF;
+
+    -- ---- storage locations --------------------------------------------
+    -- Parents must be listed before their children; `parent_ref` resolves
+    -- through the same map as everything else.
+    IF v_template->'locations' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'locations') LOOP
+            v_new_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_new_id::text));
+            INSERT INTO inventory_locations (id, company_id, parent_id, name, kind, sort_order)
+            VALUES (v_new_id, p_company_id,
+                    CASE WHEN v_item->>'parent_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'parent_ref'))::uuid END,
+                    v_item->>'name',
+                    v_item->>'kind',
+                    COALESCE((v_item->>'sort_order')::integer, 0));
+        END LOOP;
+    END IF;
+
+    -- ---- vendors + contacts -------------------------------------------
+    IF v_template->'vendors' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'vendors') LOOP
+            v_new_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_new_id::text));
+            INSERT INTO vendors (id, company_id, name,
+                                 address_line1, address_line2, city, state, postal_code, country)
+            VALUES (v_new_id, p_company_id, v_item->>'name',
+                    v_item->>'address_line1', v_item->>'address_line2',
+                    v_item->>'city', v_item->>'state', v_item->>'postal_code',
+                    COALESCE(v_item->>'country', 'USA'));
+
+            FOR v_inner IN SELECT * FROM jsonb_array_elements(COALESCE(v_item->'contacts', '[]'::jsonb)) LOOP
+                INSERT INTO vendor_contacts (vendor_id, name, role, role_label, email, phone, is_primary)
+                VALUES (v_new_id, v_inner->>'name',
+                        COALESCE(v_inner->>'role', 'sales'), v_inner->>'role_label',
+                        v_inner->>'email', v_inner->>'phone',
+                        COALESCE((v_inner->>'is_primary')::boolean, false));
+            END LOOP;
+        END LOOP;
+    END IF;
+
+    -- ---- work centers --------------------------------------------------
+    IF v_template->'work_centers' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'work_centers') LOOP
+            v_new_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_new_id::text));
+            INSERT INTO work_centers (id, company_id, name, kind, vendor_id, labor_rate, description,
+                                      make, model, serial_number, year_built, purchased_on)
+            VALUES (v_new_id, p_company_id, v_item->>'name',
+                    COALESCE(v_item->>'kind', 'internal'),
+                    CASE WHEN v_item->>'vendor_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'vendor_ref'))::uuid END,
+                    NULLIF(v_item->>'labor_rate', '')::numeric,
+                    v_item->>'description',
+                    v_item->>'make', v_item->>'model', v_item->>'serial_number',
+                    NULLIF(v_item->>'year_built', '')::integer,
+                    CASE WHEN v_item->>'purchased_years_ago' IS NOT NULL
+                         THEN (CURRENT_DATE - make_interval(years =>
+                                  (v_item->>'purchased_years_ago')::integer))::date END);
+        END LOOP;
+    END IF;
+
+    -- ---- parts, with their tiers, conversions and shelf balances -------
+    IF v_template->'parts' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'parts') LOOP
+            v_new_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_new_id::text));
+            v_source := COALESCE(v_item->>'source', 'made');
+
+            -- quantity is DERIVED from part_location_stock by trigger. When the
+            -- template places stock on named shelves we insert the part at 0 and
+            -- let `recompute_part_quantity_from_locations` do the arithmetic;
+            -- with no `stock` array we pass the quantity through and
+            -- `auto_track_stocked_part` parks it at Unassigned. Never write both
+            -- — that is how a part ends up counted twice.
+            INSERT INTO parts (id, company_id, part_name, description, source, is_stocked,
+                               primary_unit, quantity, reorder_point,
+                               costing_batch_quantity, preferred_vendor_id)
+            VALUES (v_new_id, p_company_id, v_item->>'part_name', v_item->>'description',
+                    v_source,
+                    COALESCE((v_item->>'is_stocked')::boolean, false),
+                    COALESCE(v_item->>'primary_unit', 'each'),
+                    CASE WHEN v_item->'stock' IS NOT NULL THEN 0
+                         ELSE COALESCE((v_item->>'quantity')::numeric, 0) END,
+                    NULLIF(v_item->>'reorder_point', '')::numeric,
+                    COALESCE((v_item->>'costing_batch_quantity')::numeric, 1),
+                    CASE WHEN v_item->>'preferred_vendor_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'preferred_vendor_ref'))::uuid END);
+
+            FOR v_inner IN SELECT * FROM jsonb_array_elements(COALESCE(v_item->'stock', '[]'::jsonb)) LOOP
+                v_qty := (v_inner->>'quantity')::numeric;
+                CONTINUE WHEN v_qty IS NULL OR v_qty <= 0;  -- CHECK: quantity > 0
+                INSERT INTO part_location_stock (company_id, part_id, location_id, quantity)
+                VALUES (p_company_id, v_new_id,
+                        (v_ref_map->>(v_inner->>'location_ref'))::uuid, v_qty);
+            END LOOP;
+
+            FOR v_inner IN SELECT * FROM jsonb_array_elements(COALESCE(v_item->'procurement_tiers', '[]'::jsonb)) LOOP
+                INSERT INTO part_procurement_tiers (part_id, min_quantity, cost_per_unit,
+                                                    quoted_at, expires_at, notes)
+                VALUES (v_new_id,
+                        (v_inner->>'min_quantity')::numeric,
+                        (v_inner->>'cost_per_unit')::numeric,
+                        CASE WHEN v_inner->>'quoted_days_ago' IS NOT NULL
+                             THEN (CURRENT_DATE - (v_inner->>'quoted_days_ago')::integer) END,
+                        CASE WHEN v_inner->>'expires_in_days' IS NOT NULL
+                             THEN (CURRENT_DATE + (v_inner->>'expires_in_days')::integer) END,
+                        v_inner->>'notes');
+            END LOOP;
+
+            FOR v_inner IN SELECT * FROM jsonb_array_elements(COALESCE(v_item->'pricing_tiers', '[]'::jsonb)) LOOP
+                INSERT INTO part_pricing_tiers (part_id, company_id, sequence, quantity, markup_percent)
+                VALUES (v_new_id, p_company_id,
+                        (v_inner->>'sequence')::integer,
+                        (v_inner->>'quantity')::numeric,
+                        NULLIF(v_inner->>'markup_percent', '')::numeric);
+            END LOOP;
+
+            FOR v_inner IN SELECT * FROM jsonb_array_elements(COALESCE(v_item->'unit_conversions', '[]'::jsonb)) LOOP
+                INSERT INTO parts_unit_conversions (part_id, from_unit, to_primary_factor)
+                VALUES (v_new_id, v_inner->>'from_unit', (v_inner->>'to_primary_factor')::numeric);
+            END LOOP;
+        END LOOP;
+    END IF;
+
+    -- ---- BOM ------------------------------------------------------------
+    IF v_template->'parts_bom' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'parts_bom') LOOP
+            INSERT INTO parts_bom (parent_part_id, child_part_id, quantity, unit, sequence,
+                                   notes, consume_whole_units)
+            VALUES ((v_ref_map->>(v_item->>'parent_ref'))::uuid,
+                    (v_ref_map->>(v_item->>'child_ref'))::uuid,
+                    (v_item->>'quantity')::numeric,
+                    v_item->>'unit',
+                    COALESCE((v_item->>'sequence')::integer, 0),
+                    v_item->>'notes',
+                    COALESCE((v_item->>'consume_whole_units')::boolean, false));
+        END LOOP;
+    END IF;
+
+    -- ---- routings --------------------------------------------------------
+    IF v_template->'routings' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'routings') LOOP
+            v_routing_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_routing_id::text));
+            INSERT INTO routings (id, company_id, part_id, name, description, created_by)
+            VALUES (v_routing_id, p_company_id,
+                    (v_ref_map->>(v_item->>'part_ref'))::uuid,
+                    v_item->>'name', v_item->>'description', p_user_id);
+
+            FOR v_inner IN SELECT * FROM jsonb_array_elements(COALESCE(v_item->'operations', '[]'::jsonb)) LOOP
+                INSERT INTO routing_operations (routing_id, work_center_id, sequence,
+                                                setup_minutes, cycle_minutes_per_unit,
+                                                labor_rate_override, external_unit_price, instructions)
+                VALUES (v_routing_id,
+                        (v_ref_map->>(v_inner->>'work_center_ref'))::uuid,
+                        COALESCE((v_inner->>'sequence')::integer, 10),
+                        NULLIF(v_inner->>'setup_minutes', '')::numeric,
+                        NULLIF(v_inner->>'cycle_minutes_per_unit', '')::numeric,
+                        NULLIF(v_inner->>'labor_rate_override', '')::numeric,
+                        NULLIF(v_inner->>'external_unit_price', '')::numeric,
+                        v_inner->>'instructions');
+            END LOOP;
+        END LOOP;
+    END IF;
+
+    -- ---- customers, contacts, addresses ---------------------------------
+    -- The embedded contact_*/address_* columns were dropped from `customers`;
+    -- both are now child tables, and `jobs`/`quotes` reference them by id.
+    IF v_template->'customers' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'customers') LOOP
+            v_cust_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_cust_id::text));
+            INSERT INTO customers (id, company_id, name, default_payment_terms,
+                                   credit_status, credit_hold_note)
+            VALUES (v_cust_id, p_company_id, v_item->>'name',
+                    v_item->>'default_payment_terms',
+                    COALESCE(v_item->>'credit_status', 'open'),
+                    v_item->>'credit_hold_note');
+
+            FOR v_inner IN SELECT * FROM jsonb_array_elements(COALESCE(v_item->'contacts', '[]'::jsonb)) LOOP
+                v_new_id := gen_random_uuid();
+                IF v_inner->>'_ref' IS NOT NULL THEN
+                    v_ref_map := jsonb_set(v_ref_map, ARRAY[v_inner->>'_ref'], to_jsonb(v_new_id::text));
+                END IF;
+                INSERT INTO customer_contacts (id, customer_id, name, role, role_label,
+                                               email, phone, is_primary, is_billing_default)
+                VALUES (v_new_id, v_cust_id, v_inner->>'name',
+                        COALESCE(v_inner->>'role', 'buyer'), v_inner->>'role_label',
+                        v_inner->>'email', v_inner->>'phone',
+                        COALESCE((v_inner->>'is_primary')::boolean, false),
+                        COALESCE((v_inner->>'is_billing_default')::boolean, false));
+            END LOOP;
+
+            FOR v_inner IN SELECT * FROM jsonb_array_elements(COALESCE(v_item->'addresses', '[]'::jsonb)) LOOP
+                v_new_id := gen_random_uuid();
+                IF v_inner->>'_ref' IS NOT NULL THEN
+                    v_ref_map := jsonb_set(v_ref_map, ARRAY[v_inner->>'_ref'], to_jsonb(v_new_id::text));
+                END IF;
+                INSERT INTO customer_addresses (id, customer_id, address_line1, address_line2,
+                                                city, state, postal_code, country, attention_to,
+                                                default_billing, default_shipping)
+                VALUES (v_new_id, v_cust_id, v_inner->>'address_line1', v_inner->>'address_line2',
+                        v_inner->>'city', v_inner->>'state', v_inner->>'postal_code',
+                        COALESCE(v_inner->>'country', 'USA'), v_inner->>'attention_to',
+                        COALESCE((v_inner->>'default_billing')::boolean, false),
+                        COALESCE((v_inner->>'default_shipping')::boolean, false));
+            END LOOP;
+        END LOOP;
+    END IF;
+
+    -- ---- quotes ----------------------------------------------------------
+    -- quote_number is minted by the set_quote_number trigger off the shared
+    -- per-company counter, exactly as the app gets it. Reset clears that counter
+    -- so a re-seeded demo starts at Q-0001 again instead of drifting upward.
+    IF v_template->'quotes' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'quotes') LOOP
+            v_quote_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_quote_id::text));
+            INSERT INTO quotes (id, company_id, customer_id, status, expiration_date,
+                                lead_time_text, payment_terms,
+                                billing_address_id, shipping_address_id, contact_id,
+                                created_by, created_at)
+            VALUES (v_quote_id, p_company_id,
+                    CASE WHEN v_item->>'customer_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'customer_ref'))::uuid END,
+                    COALESCE(v_item->>'status', 'active'),
+                    CASE WHEN v_item->>'expires_in_days' IS NOT NULL
+                         THEN (CURRENT_DATE + (v_item->>'expires_in_days')::integer) END,
+                    v_item->>'lead_time_text',
+                    v_item->>'payment_terms',
+                    CASE WHEN v_item->>'billing_address_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'billing_address_ref'))::uuid END,
+                    CASE WHEN v_item->>'shipping_address_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'shipping_address_ref'))::uuid END,
+                    CASE WHEN v_item->>'contact_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'contact_ref'))::uuid END,
+                    p_user_id,
+                    now() - make_interval(days => COALESCE((v_item->>'created_days_ago')::integer, 0)));
+
+            FOR v_inner IN SELECT * FROM jsonb_array_elements(COALESCE(v_item->'line_items', '[]'::jsonb)) LOOP
+                v_qty := (v_inner->>'quantity')::numeric;
+                v_unit_price := (v_inner->>'unit_price')::numeric;
+                INSERT INTO quote_line_items (quote_id, company_id, part_id, sequence, quantity,
+                                              unit_price, total_price, markup_percent,
+                                              base_cost_per_unit, lead_time_text)
+                VALUES (v_quote_id, p_company_id,
+                        (v_ref_map->>(v_inner->>'part_ref'))::uuid,
+                        COALESCE((v_inner->>'sequence')::integer, 10),
+                        v_qty, v_unit_price,
+                        COALESCE(NULLIF(v_inner->>'total_price', '')::numeric,
+                                 round(v_qty * v_unit_price, 4)),
+                        NULLIF(v_inner->>'markup_percent', '')::numeric,
+                        NULLIF(v_inner->>'base_cost_per_unit', '')::numeric,
+                        v_inner->>'lead_time_text');
+            END LOOP;
+        END LOOP;
+    END IF;
+
+    -- ---- jobs -------------------------------------------------------------
+    IF v_template->'jobs' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'jobs') LOOP
+            v_job_id := gen_random_uuid();
+            v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_job_id::text));
+            v_job_number := COALESCE(v_item->>'job_number', generate_direct_job_number(p_company_id));
+
+            INSERT INTO jobs (id, company_id, customer_id, quote_id, job_number,
+                              production_status, fulfillment_status, invoicing_status,
+                              due_date, customer_po_number, is_hot,
+                              payment_terms, freight_terms, ship_via, shipping_instructions,
+                              billing_address_id, shipping_address_id, contact_id,
+                              created_by, created_at)
+            VALUES (v_job_id, p_company_id,
+                    CASE WHEN v_item->>'customer_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'customer_ref'))::uuid END,
+                    CASE WHEN v_item->>'quote_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'quote_ref'))::uuid END,
+                    v_job_number,
+                    'not_started', 'unshipped', 'uninvoiced',
+                    CASE WHEN v_item->>'due_in_days' IS NOT NULL
+                         THEN (CURRENT_DATE + (v_item->>'due_in_days')::integer) END,
+                    v_item->>'customer_po_number',
+                    COALESCE((v_item->>'is_hot')::boolean, false),
+                    v_item->>'payment_terms', v_item->>'freight_terms',
+                    v_item->>'ship_via', v_item->>'shipping_instructions',
+                    CASE WHEN v_item->>'billing_address_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'billing_address_ref'))::uuid END,
+                    CASE WHEN v_item->>'shipping_address_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'shipping_address_ref'))::uuid END,
+                    CASE WHEN v_item->>'contact_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'contact_ref'))::uuid END,
+                    p_user_id,
+                    now() - make_interval(days => COALESCE((v_item->>'created_days_ago')::integer, 0)));
+
+            -- A quote that produced a job is converted, by definition.
+            IF v_item->>'quote_ref' IS NOT NULL THEN
+                UPDATE quotes SET converted_at = COALESCE(converted_at, now())
+                 WHERE id = (v_ref_map->>(v_item->>'quote_ref'))::uuid;
+            END IF;
+
+            FOR v_inner IN SELECT * FROM jsonb_array_elements(COALESCE(v_item->'parts', '[]'::jsonb)) LOOP
+                v_job_part_id := gen_random_uuid();
+                IF v_inner->>'_ref' IS NOT NULL THEN
+                    v_ref_map := jsonb_set(v_ref_map, ARRAY[v_inner->>'_ref'], to_jsonb(v_job_part_id::text));
+                END IF;
+                v_part_id := (v_ref_map->>(v_inner->>'part_ref'))::uuid;
+                v_qty := COALESCE((v_inner->>'quantity')::numeric, 1);
+                v_unit_price := NULLIF(v_inner->>'unit_price', '')::numeric;
+
+                -- A bought part has no operations to run, so createJobFromPO
+                -- lands it 'completed' on creation. Mirror that, and let made
+                -- parts be driven entirely by their completions below.
+                v_source := COALESCE(v_inner->>'source', 'made');
+                INSERT INTO job_parts (id, job_id, company_id, part_id, sequence, quantity,
+                                       unit_price, total_price,
+                                       production_status, fulfillment_status, invoicing_status,
+                                       started_at, completed_at)
+                VALUES (v_job_part_id, v_job_id, p_company_id, v_part_id,
+                        COALESCE((v_inner->>'sequence')::integer, 10), v_qty,
+                        v_unit_price,
+                        CASE WHEN v_unit_price IS NOT NULL THEN round(v_qty * v_unit_price, 4) END,
+                        CASE WHEN v_source = 'bought' THEN 'completed' ELSE 'not_started' END,
+                        'unshipped', 'uninvoiced',
+                        CASE WHEN v_source = 'bought' THEN now() END,
+                        CASE WHEN v_source = 'bought' THEN now() END);
+
+                IF v_inner->>'routing_ref' IS NOT NULL THEN
+                    PERFORM create_job_part_operations_from_routing(
+                        v_job_part_id, (v_ref_map->>(v_inner->>'routing_ref'))::uuid);
+                END IF;
+
+                -- Progress is expressed the way the shop floor expresses it: a
+                -- completion event per operation. The triggers then derive the
+                -- operation status, the job_part's, and the job's — so the demo
+                -- can never hold a status combination the app cannot produce.
+                FOR v_leaf IN SELECT * FROM jsonb_array_elements(COALESCE(v_inner->'operations', '[]'::jsonb)) LOOP
+                    SELECT id INTO v_op_id FROM job_operations
+                     WHERE job_part_id = v_job_part_id
+                       AND sequence = (v_leaf->>'sequence')::integer;
+                    CONTINUE WHEN v_op_id IS NULL;
+
+                    -- Outside ops are driven by the send/receive lifecycle, not
+                    -- by quantity events (compute_job_operation_status returns
+                    -- their stored status untouched), so they are set directly.
+                    IF v_leaf->>'status' IS NOT NULL THEN
+                        UPDATE job_operations
+                           SET status = v_leaf->>'status',
+                               sent_at = CASE WHEN v_leaf->>'status' IN ('sent', 'completed')
+                                              THEN now() - make_interval(days =>
+                                                   COALESCE((v_leaf->>'days_ago')::integer, 1)) END,
+                               sent_by = CASE WHEN v_leaf->>'status' IN ('sent', 'completed')
+                                              THEN p_user_id END,
+                               completed_at = CASE WHEN v_leaf->>'status' = 'completed'
+                                              THEN now() - make_interval(days =>
+                                                   COALESCE((v_leaf->>'days_ago')::integer, 0)) END
+                         WHERE id = v_op_id;
+                    END IF;
+
+                    IF v_leaf->>'completed_quantity' IS NOT NULL THEN
+                        v_author := v_users[1 + (COALESCE((v_leaf->>'author_index')::integer, 0)
+                                                 % v_n_authors)];
+                        INSERT INTO job_operation_completions
+                            (company_id, job_operation_id, job_part_id, quantity_good,
+                             completed_by, completed_at, note)
+                        VALUES (p_company_id, v_op_id, v_job_part_id,
+                                (v_leaf->>'completed_quantity')::numeric,
+                                v_author,
+                                now() - make_interval(days =>
+                                        COALESCE((v_leaf->>'days_ago')::integer, 0)),
+                                v_leaf->>'note');
+                    END IF;
+                END LOOP;
+
+                -- External ops set above bypass the completion trigger, so roll
+                -- the job_part up explicitly; that UPDATE fires the part->job
+                -- sync in turn.
+                UPDATE job_parts jp
+                   SET production_status = compute_job_part_production_status(jp.id),
+                       current_operation_sequence = COALESCE(
+                           (SELECT min(o.sequence) FROM job_operations o
+                             WHERE o.job_part_id = jp.id AND o.status <> 'completed'),
+                           (SELECT max(o.sequence) FROM job_operations o
+                             WHERE o.job_part_id = jp.id))
+                 WHERE jp.id = v_job_part_id
+                   AND jp.production_status IS DISTINCT FROM compute_job_part_production_status(jp.id);
+            END LOOP;
+        END LOOP;
+    END IF;
+
+    -- ---- shipments --------------------------------------------------------
+    -- Inserted directly rather than through create_shipment_with_line_items:
+    -- that RPC gates on auth.uid()'s company access, which is not a dependency a
+    -- seeder should carry. The packing-slip formula is the RPC's, verbatim
+    -- (PS-{job_number minus alpha prefix}-{nth shipment on that job}).
+    IF v_template->'shipments' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'shipments') LOOP
+            v_ship_id := gen_random_uuid();
+            v_job_id  := (v_ref_map->>(v_item->>'job_ref'))::uuid;
+            SELECT job_number INTO v_job_number FROM jobs WHERE id = v_job_id;
+            v_base := regexp_replace(v_job_number, '^[A-Za-z]+-?', '');
+            SELECT count(*) + 1 INTO v_seq FROM shipments WHERE job_id = v_job_id;
+
+            INSERT INTO shipments (id, company_id, customer_id, job_id, shipping_address_id,
+                                   packing_slip_number, ship_date, carrier, shipping_method,
+                                   freight_terms, created_by, created_at)
+            VALUES (v_ship_id, p_company_id,
+                    (v_ref_map->>(v_item->>'customer_ref'))::uuid, v_job_id,
+                    CASE WHEN v_item->>'shipping_address_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'shipping_address_ref'))::uuid END,
+                    'PS-' || v_base || '-' || v_seq::text,
+                    CURRENT_DATE - COALESCE((v_item->>'ship_days_ago')::integer, 0),
+                    v_item->>'carrier',
+                    COALESCE(v_item->>'shipping_method', 'shipment'),
+                    v_item->>'freight_terms', p_user_id,
+                    now() - make_interval(days => COALESCE((v_item->>'ship_days_ago')::integer, 0)));
+
+            FOR v_inner IN SELECT * FROM jsonb_array_elements(COALESCE(v_item->'line_items', '[]'::jsonb)) LOOP
+                v_qty := (v_inner->>'quantity')::numeric;
+                CONTINUE WHEN v_qty IS NULL OR v_qty <= 0;
+                INSERT INTO shipment_line_items (shipment_id, job_part_id, quantity)
+                VALUES (v_ship_id, (v_ref_map->>(v_inner->>'job_part_ref'))::uuid, v_qty);
+            END LOOP;
+        END LOOP;
+    END IF;
+
+    -- ---- notes / activity feed -------------------------------------------
+    IF v_template->'notes' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'notes') LOOP
+            v_note_id := gen_random_uuid();
+            IF v_item->>'_ref' IS NOT NULL THEN
+                v_ref_map := jsonb_set(v_ref_map, ARRAY[v_item->>'_ref'], to_jsonb(v_note_id::text));
+            END IF;
+            -- NULL author when the company somehow has no membership rows: an
+            -- unattributed note is a real state the UI renders, a dangling FK is not.
+            v_author := CASE WHEN array_length(v_members, 1) IS NULL THEN NULL
+                        ELSE v_members[1 + (COALESCE((v_item->>'author_index')::integer, 0)
+                                            % array_length(v_members, 1))] END;
+
+            INSERT INTO notes (id, company_id, subject_kind, note_type, body, author_id,
+                               job_id, job_part_id, job_operation_id,
+                               part_id, work_center_id, maintenance_kind, resolves_note_id,
+                               created_at)
+            VALUES (v_note_id, p_company_id,
+                    v_item->>'subject_kind',
+                    COALESCE(v_item->>'note_type', 'user'),
+                    v_item->>'body', v_author,
+                    CASE WHEN v_item->>'job_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'job_ref'))::uuid END,
+                    CASE WHEN v_item->>'job_part_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'job_part_ref'))::uuid END,
+                    CASE WHEN v_item->>'job_part_ref' IS NOT NULL
+                          AND v_item->>'operation_sequence' IS NOT NULL
+                         THEN (SELECT id FROM job_operations
+                                WHERE job_part_id = (v_ref_map->>(v_item->>'job_part_ref'))::uuid
+                                  AND sequence = (v_item->>'operation_sequence')::integer) END,
+                    CASE WHEN v_item->>'part_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'part_ref'))::uuid END,
+                    CASE WHEN v_item->>'work_center_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'work_center_ref'))::uuid END,
+                    v_item->>'maintenance_kind',
+                    CASE WHEN v_item->>'resolves_ref' IS NOT NULL
+                         THEN (v_ref_map->>(v_item->>'resolves_ref'))::uuid END,
+                    now() - make_interval(days => COALESCE((v_item->>'days_ago')::integer, 0)));
+
+            CONTINUE WHEN array_length(v_members, 1) IS NULL;  -- reactor_id is NOT NULL
+            FOR v_inner IN SELECT * FROM jsonb_array_elements(COALESCE(v_item->'reactions', '[]'::jsonb)) LOOP
+                v_author := v_members[1 + (COALESCE((v_inner->>'reactor_index')::integer, 0)
+                                           % array_length(v_members, 1))];
+                INSERT INTO note_reactions (company_id, note_id, reactor_id, kind)
+                VALUES (p_company_id, v_note_id, v_author, COALESCE(v_inner->>'kind', 'helpful'))
+                ON CONFLICT DO NOTHING;
+            END LOOP;
+        END LOOP;
+    END IF;
+
+    -- ---- inventory movement history --------------------------------------
+    -- The ledger only; balances already come from part_location_stock above.
+    -- Writing both is deliberate: the transaction rows are what the Storage
+    -- history reads, and they are a log, not a source of truth for quantity.
+    IF v_template->'inventory_transactions' IS NOT NULL THEN
+        FOR v_item IN SELECT * FROM jsonb_array_elements(v_template->'inventory_transactions') LOOP
+            v_part_id := (v_ref_map->>(v_item->>'part_ref'))::uuid;
+            v_loc_id  := CASE WHEN v_item->>'location_ref' IS NOT NULL
+                              THEN (v_ref_map->>(v_item->>'location_ref'))::uuid END;
+            v_qty     := (v_item->>'quantity')::numeric;
+            v_author  := v_users[1 + (COALESCE((v_item->>'author_index')::integer, 0) % v_n_authors)];
+
+            INSERT INTO inventory_transactions (company_id, part_id, item_name, type, quantity,
+                                                unit, converted_quantity, location_id,
+                                                job_id, notes, created_by, created_at)
+            SELECT p_company_id, v_part_id, p.part_name, v_item->>'type', v_qty,
+                   COALESCE(v_item->>'unit', p.primary_unit),
+                   COALESCE(NULLIF(v_item->>'converted_quantity', '')::numeric, v_qty),
+                   v_loc_id,
+                   CASE WHEN v_item->>'job_ref' IS NOT NULL
+                        THEN (v_ref_map->>(v_item->>'job_ref'))::uuid END,
+                   v_item->>'notes', v_author,
+                   now() - make_interval(days => COALESCE((v_item->>'days_ago')::integer, 0))
+              FROM parts p WHERE p.id = v_part_id;
+        END LOOP;
+    END IF;
+END;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Drop the columns.
+--
+--    Plain DROPs rather than a deprecation window, matching 20260803235119's
+--    reasoning: nothing reads either column, so there is nothing to migrate
+--    off, and leaving them would mean carrying two columns the UI no longer
+--    writes -- which is how a schema starts lying.
+--
+--    The "fob_point" / "default_fob_point" keys still sitting in the demo
+--    template JSON become inert. Historical migrations are not edited; the next
+--    template version drops them.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.quotes    DROP COLUMN IF EXISTS fob_point;
+ALTER TABLE public.customers DROP COLUMN IF EXISTS default_fob_point;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -210,13 +210,13 @@ on conflict (id) do nothing;
 -- Granite Equipment Co is seeded ON CREDIT HOLD so the warn-never-gate path is
 -- reachable by hand: open a shipment for one of their jobs and the banner shows
 -- while the Create button stays live. Everyone else is 'open' by column default.
-insert into public.customers (id, company_id, name, default_payment_terms, default_fob_point, credit_status, credit_hold_note) values
-  ('50000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','Northwind Hydraulics','Net 30','FOB our dock, Milwaukee WI','open',null),
-  ('50000000-0000-0000-0000-000000000002','22222222-2222-2222-2222-222222222222','Cascade Robotics','Net 45',null,'open',null),
-  ('50000000-0000-0000-0000-000000000003','22222222-2222-2222-2222-222222222222','Meridian Aerospace','2/10 Net 30','FOB destination','open',null),
-  ('50000000-0000-0000-0000-000000000004','22222222-2222-2222-2222-222222222222','Granite Equipment Co','Net 30',null,'hold','Two invoices past 60 days. Spoke to their AP 7/28 — check before shipping.'),
-  ('50000000-0000-0000-0000-000000000005','22222222-2222-2222-2222-222222222222','BlueRidge Medical Devices','50% Deposit / Balance Net 30',null,'open',null),
-  ('50000000-0000-0000-0000-000000000006','22222222-2222-2222-2222-222222222222','Sierra Pump & Valve',null,null,'open',null)
+insert into public.customers (id, company_id, name, default_payment_terms, credit_status, credit_hold_note) values
+  ('50000000-0000-0000-0000-000000000001','22222222-2222-2222-2222-222222222222','Northwind Hydraulics','Net 30','open',null),
+  ('50000000-0000-0000-0000-000000000002','22222222-2222-2222-2222-222222222222','Cascade Robotics','Net 45','open',null),
+  ('50000000-0000-0000-0000-000000000003','22222222-2222-2222-2222-222222222222','Meridian Aerospace','2/10 Net 30','open',null),
+  ('50000000-0000-0000-0000-000000000004','22222222-2222-2222-2222-222222222222','Granite Equipment Co','Net 30','hold','Two invoices past 60 days. Spoke to their AP 7/28 — check before shipping.'),
+  ('50000000-0000-0000-0000-000000000005','22222222-2222-2222-2222-222222222222','BlueRidge Medical Devices','50% Deposit / Balance Net 30','open',null),
+  ('50000000-0000-0000-0000-000000000006','22222222-2222-2222-2222-222222222222','Sierra Pump & Valve',null,'open',null)
 on conflict (id) do nothing;
 
 -- billing addresses (default_shipping true when the customer has no separate ship-to)

--- a/types/customer.ts
+++ b/types/customer.ts
@@ -31,7 +31,7 @@ export interface Customer {
    * Standing terms — the customer's commercial defaults, copied onto a NEW
    * quote at create time and editable there. They are never read by an
    * existing quote at render time: a quote owns its own payment_terms /
-   * lead_time_text / fob_point from the moment it is created, so editing a
+   * lead_time_text from the moment it is created, so editing a
    * customer here can't rewrite a document already sent. Drift between the
    * two is surfaced as a chip, never applied (mirrors PricingBasisSnapshot).
    *
@@ -39,13 +39,6 @@ export interface Customer {
    * empty rather than guessed.
    */
   default_payment_terms: string | null;
-  /**
-   * Where title and risk transfer, as free text naming a place ("FOB
-   * Cleveland, OH"). Deliberately NOT an origin/destination enum, and
-   * deliberately separate from who *pays* the freight — that axis lives on
-   * jobs/shipments as freight_terms. Keep them apart in the UI too.
-   */
-  default_fob_point: string | null;
   /**
    * Manual credit standing, set by the office when a customer is past due.
    * Never computed, never synced from QuickBooks, never derived from a balance.
@@ -136,7 +129,6 @@ export interface CustomerFormData {
    * default rather than storing '' and prefilling blanks onto every quote.
    */
   default_payment_terms: string;
-  default_fob_point: string;
   credit_status: CustomerCreditStatus;
   /** Empty string means "no reason given"; normalised to NULL on write. */
   credit_hold_note: string;
@@ -210,7 +202,6 @@ export const EMPTY_CUSTOMER_ADDRESS: CustomerAddressFormData = {
 export const EMPTY_CUSTOMER_FORM: CustomerFormData = {
   name: '',
   default_payment_terms: '',
-  default_fob_point: '',
   credit_status: 'open',
   credit_hold_note: '',
 };
@@ -219,7 +210,6 @@ export function customerToFormData(customer: Customer): CustomerFormData {
   return {
     name: customer.name,
     default_payment_terms: customer.default_payment_terms || '',
-    default_fob_point: customer.default_fob_point || '',
     credit_status: customer.credit_status,
     credit_hold_note: customer.credit_hold_note || '',
   };

--- a/types/database.ts
+++ b/types/database.ts
@@ -535,7 +535,6 @@ export type Database = {
           created_at: string | null
           credit_hold_note: string | null
           credit_status: string
-          default_fob_point: string | null
           default_payment_terms: string | null
           deleted_at: string | null
           id: string
@@ -547,7 +546,6 @@ export type Database = {
           created_at?: string | null
           credit_hold_note?: string | null
           credit_status?: string
-          default_fob_point?: string | null
           default_payment_terms?: string | null
           deleted_at?: string | null
           id?: string
@@ -559,7 +557,6 @@ export type Database = {
           created_at?: string | null
           credit_hold_note?: string | null
           credit_status?: string
-          default_fob_point?: string | null
           default_payment_terms?: string | null
           deleted_at?: string | null
           id?: string
@@ -2715,7 +2712,6 @@ export type Database = {
           customer_name: string | null
           deleted_at: string | null
           expiration_date: string | null
-          fob_point: string | null
           id: string
           lead_time_text: string | null
           payment_terms: string | null
@@ -2739,7 +2735,6 @@ export type Database = {
           customer_name?: string | null
           deleted_at?: string | null
           expiration_date?: string | null
-          fob_point?: string | null
           id?: string
           lead_time_text?: string | null
           payment_terms?: string | null
@@ -2763,7 +2758,6 @@ export type Database = {
           customer_name?: string | null
           deleted_at?: string | null
           expiration_date?: string | null
-          fob_point?: string | null
           id?: string
           lead_time_text?: string | null
           payment_terms?: string | null

--- a/types/import.ts
+++ b/types/import.ts
@@ -136,5 +136,4 @@ export const CUSTOMER_FIELDS: { key: string; label: string; required: boolean }[
   // ships — so this arrives populated rather than needing to be typed per
   // customer after the fact.
   { key: 'default_payment_terms', label: 'Payment Terms', required: false },
-  { key: 'default_fob_point', label: 'FOB Point', required: false },
 ];

--- a/types/quote.ts
+++ b/types/quote.ts
@@ -62,11 +62,6 @@ export interface Quote {
   // that's entered manually at conversion.
   lead_time_text: string | null;
   payment_terms: string | null;
-  // Where title and risk transfer, as free text naming a place ("FOB
-  // Cleveland, OH"). Resolved from the customer's default at create time and
-  // then owned by this quote. Distinct from freight payment terms (who pays),
-  // which live on the job and shipment — never collapse the two into one field.
-  fob_point: string | null;
   expiration_date: string | null;
   status: QuoteStatus;
   status_changed_at: string | null;
@@ -202,7 +197,6 @@ export interface QuoteWithRelations extends Quote {
      */
     default_payment_terms?: string | null;
     default_lead_time_text?: string | null;
-    default_fob_point?: string | null;
     customer_contacts?: Array<{
       id: string;
       name: string;
@@ -303,10 +297,6 @@ export interface QuoteFormData {
   lead_time_text: string;
   // Payment terms shown on the quote (preset or custom free text). '' = unset.
   payment_terms: string;
-  // FOB point — a named place ("FOB Cleveland, OH"). '' = unset. Optional at
-  // the form level (unlike terms and lead time, which are required), because
-  // plenty of shops quote without stating one.
-  fob_point: string;
   expiration_date: string; // ISO date (YYYY-MM-DD)
   status?: QuoteStatus;
 }
@@ -359,7 +349,6 @@ export const EMPTY_QUOTE_FORM: QuoteFormData = {
   parts: [],
   lead_time_text: '',
   payment_terms: '',
-  fob_point: '',
   expiration_date: defaultExpirationDate(),
 };
 
@@ -399,7 +388,6 @@ export function quoteToFormData(quote: QuoteWithRelations): QuoteFormData {
       })),
     lead_time_text: quote.lead_time_text ?? '',
     payment_terms: quote.payment_terms ?? '',
-    fob_point: quote.fob_point ?? '',
     expiration_date: quote.expiration_date || defaultExpirationDate(),
     status: quote.status,
   };

--- a/types/shipment.ts
+++ b/types/shipment.ts
@@ -29,9 +29,13 @@ export const CARRIER_OPTIONS = ['UPS', 'FedEx', 'USPS'] as const;
 
 /**
  * Who pays the freight. A different axis from `shipping_method` (how the goods
- * left) and from the quote's `fob_point` (where title and risk transfer) —
- * conflating any two of the three is the classic error in this domain, so they
- * never share a control.
+ * left) — conflating the two is the classic error in this domain, so they never
+ * share a control.
+ *
+ * The third axis, FOB point (WHERE title and risk transfer), used to live on the
+ * quote and was removed in August 2026 after 96 real quotes left it blank. If it
+ * ever comes back it belongs in shop settings as a printed default, not beside
+ * this field.
  *
  * `prepaid_and_add` is deliberately absent: it promises adding freight to the
  * invoice, and there is no freight amount anywhere to add (weight_lbs was

--- a/utils/customerAccess.ts
+++ b/utils/customerAccess.ts
@@ -287,7 +287,6 @@ function formDataToColumns(formData: CustomerFormData) {
   return {
     name: formData.name.trim(),
     default_payment_terms: formData.default_payment_terms.trim() || null,
-    default_fob_point: formData.default_fob_point.trim() || null,
     credit_status: formData.credit_status,
     credit_hold_note: formData.credit_hold_note.trim() || null,
   };
@@ -388,7 +387,7 @@ async function reviveArchivedCustomerByName(
   // person can see what happened last time.
   const filled = formDataToColumns(formData);
   const revivePatch: Record<string, string | null> = { name: filled.name };
-  for (const key of ['default_payment_terms', 'default_fob_point'] as const) {
+  for (const key of ['default_payment_terms'] as const) {
     if (filled[key] !== null) revivePatch[key] = filled[key];
   }
 
@@ -538,8 +537,7 @@ export function pickPrimaryContact<T extends { id: string; is_primary: boolean }
 }
 
 /**
- * The customer's STANDING TERMS — payment terms, lead time and FOB point,
- * resolved for a NEW quote.
+ * The customer's STANDING TERMS — payment terms — resolved for a NEW quote.
  *
  * These are siblings of pickBillingAddress / pickShippingAddress /
  * pickPrimaryContact above and are used at exactly the same moment:
@@ -563,12 +561,6 @@ export function pickPaymentTerms(
   return customer?.default_payment_terms?.trim() || null;
 }
 
-export function pickFobPoint(
-  customer: Pick<Customer, 'default_fob_point'> | null | undefined,
-): string | null {
-  return customer?.default_fob_point?.trim() || null;
-}
-
 /**
  * Does this quote's value still match the customer's current standing default?
  *
@@ -589,11 +581,10 @@ export function hasTermDrift(
   // terms, so there is no disagreement between what we offered and what we now
   // say, and the chip has nothing to report.
   //
-  // This used to return true here, and the cost was a chip storm: quotes.fob_point
-  // is newer than the quotes themselves, so every pre-existing quote carries
-  // NULL, and the first time a shop filled in a customer's FOB point every one
-  // of that customer's open quotes grew a "FOB differs" chip at once. Same for
-  // payment terms and lead time the first time a shop fills those in. The
+  // This used to return true here, and the cost was a chip storm: a standing-terms
+  // column is newer than the quotes themselves, so every pre-existing quote
+  // carries NULL, and the first time a shop filled one in every one of that
+  // customer's open quotes grew a "differs" chip at once. The
   // comment on the drift block one level up already names this failure for the
   // shop-default case — "a chip that fires on everything at once is a chip
   // people learn to ignore" — and it applies identically here.

--- a/utils/quotePdf.ts
+++ b/utils/quotePdf.ts
@@ -185,13 +185,6 @@ export async function generateQuotePdf(
   if (quote.payment_terms) {
     metaRows.push({ text: `Payment Terms: ${quote.payment_terms}` });
   }
-  // FOB point — where title and risk transfer. Printed as its own row, never
-  // merged with a freight-payment term, because a customer reading
-  // "FOB Destination, Freight Collect" as one phrase is the classic
-  // misunderstanding this separation exists to prevent.
-  if (quote.fob_point) {
-    metaRows.push({ text: `FOB: ${quote.fob_point}` });
-  }
 
   doc.setFont('helvetica', 'normal');
   doc.setFontSize(10);

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -120,16 +120,16 @@ const QUOTE_LIST_SELECT = `
   jobs!left(id, job_number)
 `;
 
-// The customer's standing terms (default_payment_terms /
-// default_fob_point) ride along on the DETAIL select so the page can compare what
-// this quote was issued with against the customer's CURRENT default and surface
+// The customer's standing terms (default_payment_terms) ride along on the DETAIL
+// select so the page can compare what this quote was issued with against the
+// customer's CURRENT default and surface
 // drift as a chip. Comparison only — the quote always RENDERS its own columns.
 // Deliberately absent from QUOTE_LIST_SELECT: the list shows no terms.
 const QUOTE_DETAIL_SELECT = `
   *,
   customers!left(
     id, name,
-    default_payment_terms, default_fob_point,
+    default_payment_terms,
     customer_contacts(id, name, role, email, phone, is_primary, is_billing_default, deleted_at),
     addresses:customer_addresses(
       id,
@@ -421,7 +421,6 @@ export async function createQuote(
       shipping_address_id: nullIfEmpty(formData.shipping_address_id),
       lead_time_text: leadTimeText,
       payment_terms: paymentTerms,
-      fob_point: nullIfBlank(formData.fob_point),
       expiration_date: expirationDate,
       status: 'active',
       created_by: user?.id ?? null,
@@ -574,7 +573,6 @@ export async function updateQuote(
       shipping_address_id: nullIfEmpty(formData.shipping_address_id),
       lead_time_text: leadTimeText,
       payment_terms: nullIfBlank(formData.payment_terms),
-      fob_point: nullIfBlank(formData.fob_point),
       expiration_date: newExpiration,
       status: nextStatus,
       ...(nextStatus !== existing.status


### PR DESCRIPTION
Started as the convert-modal lead-time fix and grew to cover per-part lead time end to end, plus two adjacent Terms-card changes.

## 1. Per-part lead times in the convert modal (the original fix)

A quote can carry a lead time per part, and both customer-facing surfaces already honoured it: when **any** line has its own, the single quote-level value is suppressed and each part shows its effective one. `quotePdf.ts` and the quote detail page both do this. **The convert modal never got it** — it read `quote.lead_time_text` and nothing else, so a quote with three different per-part lead times displayed one. Its part grouper was the only one of the three that omitted a `lead_time` field.

It also warns when the parts checked for **this** job were quoted with differing lead times — a job carries one `due_date`, so that is the moment the difference bites — and points at the escape hatch that exists: convert in several passes, one job per PO. The warning tracks the checkboxes.

## 2. Customer → Terms → Parts

The quote-level lead time was set **after** the parts that may override it, which made each part block's *"leave blank to use the quote's lead time"* a forward reference to a field the user hadn't reached. Terms first turns the per-part value into what it actually is: an override of something already on screen.

`validationError` now checks in that same order. It returns only the **first** failure and that drives the disabled-submit tooltip — leaving it alone would have told a user with an empty Terms card to *"add a part"* while pointing at the bottom card.

## 3. Per-part lead time behind a disclosure

A **"Different lead time for this part"** checkbox, mirroring *"Shipping address same as billing"* in the Customer card. Two details keep the checkbox and the value from disagreeing:

- **Hydration seeds the checkbox from the value** — editing a quote that already promises a per-part lead time opens expanded rather than hiding it.
- **Unchecking clears the text** — the line genuinely falls back to the quote lead time instead of leaving a stale promise behind a hidden control.

## 4. "Expiration date" → "Quote valid until"

Column keeps its name. The label now matches the `Valid Until:` the PDF already printed.

## 5. FOB point removed entirely

`quotes.fob_point`, `customers.default_fob_point`, their form fields, the PDF line and the drift chip.

This answers [open question 3 in `customers.md`](https://github.com/debola31/Jigged/blob/main/docs/modules/customers.md) by its own test — it read *"If both are still empty across every customer, remove the columns and their form fields together in one migration"*, and recorded Johnny on FOB: *"we sort of ignore that."* Measured in production, **real shops only**:

| Company | Customers with FOB | Quotes with FOB |
|---|---|---|
| Contour Tool & Machine | **0 / 584** | **0 / 88** |
| Jigged Usability Sandbox | **0 / 2** | **0 / 8** |
| L & L Machine & Tool | 0 / 0 | 0 / 0 |

**Zero of 586 real customers and zero of 96 real quotes**, against payment terms at 113/127 and lead time at 127/127 on the same quotes. Every non-null value belonged to a demo company, and every one was `Origin` or `Destination` — exactly the enum the column's own `COMMENT` forbade. The other half of that question already ran: `20260803235119` dropped `default_lead_time_text` on the same evidence.

**The diagnosis is placement, not presentation.** FOB is boilerplate a shop states once, so a free-text box on the quote produced 96 blanks — a prettier picker would have produced 96 prettier blanks. If it's ever needed, the shape is a shop-level default in settings that prints on every quote, with a per-customer override. Not a quote-form field.

FOB wasn't dead code — it printed on the quote PDF. It was terminal after that: `convertQuoteToJob` dropped it silently and no job, shipment, packing slip, invoice or QuickBooks path read it. Removing it takes one line off a PDF that 96 real quotes have already been shipping without.

### The migration's real risk

`seed_demo_data()` **inserts both FOB columns** (lines 302 and 357 of `20260805011938`). Dropping them while it still referenced them would have broken demo company provisioning. It is recreated in the same migration without those inserts, via `CREATE OR REPLACE` — **not** `DROP` + recreate — so the EXECUTE ACL and `COMMENT` survive.

Verified after the drop: a demo company seeds **8 customers, 10 quotes, 45 parts, 16 jobs**.

`supabase/seed.sql` needed the same treatment. That one was caught by running `supabase db reset`, not by the file audit — worth noting as the reason the reset is in the verification path.

## Verification

- `supabase db reset` replays clean; `seed_demo_data` smoke-tested against a throwaway company (rolled back).
- `pnpm gen:db-types` → **exactly six deletions**, the two columns × Row/Insert/Update. Nothing else.
- Frontend suite green; backend `pytest -m unit` 179 passed. `tsc` clean. **Lint 17 → 16** (removed a pre-existing unused import).
- Driven in the running app against local Supabase: card order, `Quote valid until`, no FOB field, the disclosure collapsed then expanding, and pricing still resolving `From tier 25`.

### Two flaky tests, unrelated

`InventoryCountPage.test.tsx` and `MachineLogPanel.test.tsx` intermittently hit the 15s per-test timeout under full-suite parallel load — the failing set changed between runs, and **both files pass in isolation (90/90)**. Neither touches quotes, customers or FOB. Flagging rather than hiding it.

## Also in here

An unused `useRef` left behind by #736, and the now-dead text-field props on `CustomerTermsCard` (FOB was its only free-text input, so it takes just `onSelectChange` now). `customers.md` loses four stale `website` references — that column went 2026-08-03 — and its `hasTermDrift` paragraph described the **opposite** of the code, now corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)