### PR TITLE
fix(errors): a network blip tells the truth, and stops paging us

### DIFF
--- a/__tests__/lib/supabaseErrors.test.ts
+++ b/__tests__/lib/supabaseErrors.test.ts
@@ -7,6 +7,7 @@ import {
   isBillingWriteBlocked,
   isFriendlyError,
   isTransientAbortError,
+  isNetworkFailureError,
   shouldReportSupabaseError,
   toError,
   isIndeterminateSingleError,
@@ -372,6 +373,95 @@ describe('isTransientAbortError', () => {
     expect(isTransientAbortError(null)).toBe(false);
     expect(isTransientAbortError(undefined)).toBe(false);
     expect(isTransientAbortError('a string')).toBe(false);
+  });
+
+  /**
+   * Pins the branch that survives a dependency bump.
+   *
+   * Today an abort is recognised by postgrest-js's `hint: 'Request was aborted…'`, which
+   * `PostgrestBuilder` sets only for `AbortError`. That hint is a convenience of the current
+   * version, not a contract — but the `message` is, because the same `catch` always builds it as
+   * `` `${fetchError.name}: ${fetchError.message}` ``. So the name is in the message regardless,
+   * and the `aborterror` branch keeps working with no hint at all.
+   */
+  it('still recognises an abort when the hint is gone', () => {
+    expect(
+      isTransientAbortError({
+        code: '',
+        details: '',
+        hint: '',
+        message: 'AbortError: The user aborted a request.',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('isNetworkFailureError', () => {
+  /**
+   * The exact shapes postgrest-js resolves with when the browser's fetch rejects — it does not
+   * reject the promise, it converts the failure into an ordinary `{ error }` response. Recovered
+   * from Sentry JAVASCRIPT-NEXTJS-2R (Safari) and the operator note-save issue (Chrome).
+   */
+  const safari = {
+    code: '',
+    details: 'TypeError: Load failed\n    at ...',
+    hint: '',
+    message: 'TypeError: Load failed (fgwwlinwvsfcdizkqfau.supabase.co)',
+  };
+  const chrome = {
+    code: '',
+    details: 'TypeError: Failed to fetch\n    at ...',
+    hint: '',
+    message: 'TypeError: Failed to fetch (umurkvuxkikfrjojkadv.supabase.co)',
+  };
+  const firefox = {
+    code: '',
+    details: '',
+    hint: '',
+    message: 'TypeError: NetworkError when attempting to fetch resource.',
+  };
+
+  it('recognises the browsers that matter', () => {
+    expect(isNetworkFailureError(safari)).toBe(true);
+    expect(isNetworkFailureError(chrome)).toBe(true);
+    expect(isNetworkFailureError(firefox)).toBe(true);
+  });
+
+  /**
+   * THE DANGEROUS DIRECTION, and the reason `code` is checked at all.
+   *
+   * The message on the network path is the browser's, so nothing stops a Postgres error raised
+   * FOR the user from containing the same words. Classifying one of those as transient would drop
+   * a real failure with no trace anywhere — the worst outcome this module can produce. A SQLSTATE
+   * means PostgREST answered, and postgrest-js never sets one on a client-side failure.
+   */
+  it('does NOT drop a Postgres error whose message merely contains the words', () => {
+    expect(
+      isNetworkFailureError({
+        code: 'P0001',
+        details: '',
+        hint: '',
+        message: 'Failed to fetch the latest cost for this part',
+      }),
+    ).toBe(false);
+    expect(
+      isNetworkFailureError({ code: '42501', message: 'permission denied for table parts' }),
+    ).toBe(false);
+    expect(isNetworkFailureError({ code: 'PGRST116', message: 'no rows' })).toBe(false);
+  });
+
+  it('is not fooled by an unrelated failure with no code', () => {
+    expect(isNetworkFailureError({ code: '', message: 'Something else went wrong' })).toBe(false);
+    expect(isNetworkFailureError(null)).toBe(false);
+    expect(isNetworkFailureError(undefined)).toBe(false);
+    expect(isNetworkFailureError('a string')).toBe(false);
+  });
+
+  it('keeps these out of the issue queue', () => {
+    // The whole point: JAVASCRIPT-NEXTJS-2R paged the founder for one Safari network blip.
+    expect(shouldReportSupabaseError(safari)).toBe(false);
+    expect(shouldReportSupabaseError(chrome)).toBe(false);
+    expect(shouldReportSupabaseError(firefox)).toBe(false);
   });
 });
 

--- a/__tests__/lib/supabaseSentryIntegration.test.ts
+++ b/__tests__/lib/supabaseSentryIntegration.test.ts
@@ -60,6 +60,30 @@ function failingClient(body: Record<string, unknown>) {
   });
 }
 
+/**
+ * A client whose fetch REJECTS, the way a browser reports an offline or dropped connection.
+ *
+ * Wired like `lib/supabase.ts` in the one respect this exercises: the rpc span attribute is
+ * stamped BEFORE the request is awaited. Stamping it afterwards — which is what the real client
+ * did until this change — leaves the marker unset on exactly this path, because the throw skips
+ * everything below it.
+ */
+function rejectingClient(message: string) {
+  return createClient('https://example.supabase.co', 'anon-key', {
+    global: {
+      fetch: async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes('/rest/v1/rpc/')) {
+          Sentry.getActiveSpan()?.setAttribute(RPC_SPAN_ATTRIBUTE, true);
+        }
+        const err = new TypeError(message);
+        throw err;
+      },
+    },
+  });
+}
+
 const PG_RAISED = { code: 'P0001', message: 'work center 853e is not in company 7523' };
 
 beforeAll(() => {
@@ -112,6 +136,43 @@ describe('the net: what the Supabase integration captures on its own', () => {
     expect(captured[0].dbTable).toBe('transfer_stock');
     expect(captured[0].isRpc).toBe(true);
   });
+
+  /**
+   * postgrest-js does NOT reject when the browser's fetch does — it converts the failure into an
+   * ordinary resolved `{ error }`, so the net captures it like any database error. This is why a
+   * Safari network blip became Sentry issue JAVASCRIPT-NEXTJS-2R.
+   */
+  it('captures a network failure, because postgrest resolves it rather than rejecting', async () => {
+    const client = rejectingClient('Load failed');
+    Sentry.instrumentSupabaseClient(client);
+
+    await client.from('parts').select('id');
+    await Sentry.flush(200);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].message).toContain('Load failed');
+  });
+
+  /**
+   * The ordering regression. If the rpc marker is stamped after the await, the throw skips it and
+   * `beforeSend` cannot tell this is an rpc — so the failure files twice, once from the net and
+   * once from the access layer that owns rpc reporting.
+   */
+  it('still marks an .rpc() as rpc when the network fails', async () => {
+    const client = rejectingClient('Failed to fetch');
+    Sentry.instrumentSupabaseClient(client);
+
+    // Warm the lazy prototype patch, the way any real page load does.
+    await client.from('parts').select('id');
+    await Sentry.flush(200);
+    captured.length = 0;
+
+    await client.rpc('log_operator_event', { p_kind: 'app_opened' });
+    await Sentry.flush(200);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].isRpc).toBe(true);
+  });
 });
 
 describe('the policy: what survives beforeSend', () => {
@@ -158,6 +219,10 @@ describe('the policy: what survives beforeSend', () => {
     ['a .single() that matched nothing', { code: 'PGRST116', message: 'no rows' }],
     ['a cancelled request', { message: 'FetchError', hint: 'Request was aborted (timeout or manual cancellation)' }],
     ['an expired session', { code: 'PGRST301', message: 'JWT expired' }],
+    [
+      'a browser that could not reach Supabase',
+      { code: '', hint: '', details: '', message: 'TypeError: Load failed (abc.supabase.co)' },
+    ],
   ])('drops %s', (_label, originalException) => {
     const event = {
       exception: {

--- a/app/dashboard/[companyId]/customers/[customerId]/page.tsx
+++ b/app/dashboard/[companyId]/customers/[customerId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import LoadFailedState from '@/components/common/LoadFailedState';
 import { useParams, useRouter } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
@@ -139,6 +140,7 @@ export default function CustomerDetailPage() {
   const {
     data,
     loading,
+    error: loadError,
     reload: fetchAll,
   } = useLoad(
     async () => {
@@ -384,6 +386,17 @@ export default function CustomerDetailPage() {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 400 }}>
         <CircularProgress />
+      </Box>
+    );
+  }
+
+  // A failed load also leaves `customer` null, and "Customer not found" would then assert the
+  // record is gone when we simply never heard back. Tested first, so only a load that SUCCEEDED
+  // and returned nothing reaches the not-found branch.
+  if (loadError) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 6 }}>
+        <LoadFailedState error={loadError} entity="this customer" onRetry={fetchAll} />
       </Box>
     );
   }

--- a/app/dashboard/[companyId]/parts/page.tsx
+++ b/app/dashboard/[companyId]/parts/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import ImportAllDataLink from '@/components/import/ImportAllDataLink';
+import LoadFailedState from '@/components/common/LoadFailedState';
+import { friendlyErrorMessage } from '@/lib/supabaseErrors';
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useRouter, useParams, useSearchParams } from 'next/navigation';
@@ -156,6 +158,10 @@ export default function PartsPage() {
     return () => clearTimeout(timer);
   }, [search]);
 
+  // Whether rows are already on screen, for the reload-vs-first-load split in `onError` below.
+  // Written from an effect, never in the render body (the react-hooks/refs rule).
+  const hasRowsRef = useRef(false);
+
   // Pull every part the company owns (made + bought, stocked or not). The
   // source filter narrows this client-side; the inventory page handles the
   // stocked-only view. The priceable-id set is fetched in parallel — an
@@ -165,6 +171,7 @@ export default function PartsPage() {
   const {
     data: partsData,
     loading,
+    error: loadError,
     reload: fetchParts,
   } = useLoad(
     () =>
@@ -179,17 +186,29 @@ export default function PartsPage() {
     // useLoad wants primitive deps (see the warning in hooks/useLoad.ts).
     [companyId, searchDebounced, sortModel.field, sortModel.sort],
     {
+      /**
+       * The snackbar is for a RELOAD that failed — a search or sort change whose result never
+       * arrived, where `useLoad` keeps the previous rows so the grid still shows stale data and
+       * nothing else would say so.
+       *
+       * A FIRST load that fails has no rows to keep, and `LoadFailedState` takes over the whole
+       * card below. Firing here too would say the same thing twice.
+       */
       onError: (error) => {
         console.error('Error fetching parts:', error);
+        if (!hasRowsRef.current) return;
         setSnackbar({
           open: true,
-          message: error instanceof Error ? error.message : 'Failed to load parts',
+          message: friendlyErrorMessage(error, { fallback: 'Failed to load parts' }),
           severity: 'error',
         });
       },
     },
   );
   const rows = partsData?.[0] ?? EMPTY_PARTS;
+  useEffect(() => {
+    hasRowsRef.current = rows.length > 0;
+  });
   // Set of part ids the quote form accepts without warning (≥1 tier with a
   // non-null computed cost) — single source of truth (get_priceable_part_ids
   // RPC), matching QuoteForm.hasUsableTier so the Pricing column and the quote
@@ -682,8 +701,19 @@ export default function PartsPage() {
       {!loading && filteredRows.length === 0 ? (
         <Card elevation={2}>
           <CardContent sx={{ p: 6, textAlign: 'center' }}>
-            <CategoryIcon sx={{ fontSize: 64, color: 'text.secondary', mb: 2 }} />
-            {renderEmptyState()}
+            {/*
+              Nothing to show has two causes, and they are opposite: the shop genuinely has no
+              parts, or the load failed and we do not know what it has. Rendering "No parts yet.
+              Add your first part" for the second is the bug this branch exists to prevent.
+            */}
+            {loadError ? (
+              <LoadFailedState error={loadError} entity="parts" onRetry={fetchParts} />
+            ) : (
+              <>
+                <CategoryIcon sx={{ fontSize: 64, color: 'text.secondary', mb: 2 }} />
+                {renderEmptyState()}
+              </>
+            )}
           </CardContent>
         </Card>
       ) : (

--- a/app/dashboard/[companyId]/vendors/[vendorId]/page.tsx
+++ b/app/dashboard/[companyId]/vendors/[vendorId]/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
+import LoadFailedState from '@/components/common/LoadFailedState';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -97,6 +98,7 @@ export default function VendorDetailPage() {
   const {
     data,
     loading,
+    error: loadError,
     reload: fetchAll,
   } = useLoad(
     async () => {
@@ -196,6 +198,17 @@ export default function VendorDetailPage() {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 400 }}>
         <CircularProgress />
+      </Box>
+    );
+  }
+
+  // A failed load also leaves `vendor` null, and "Vendor not found" would then assert the record
+  // is gone when we simply never heard back. Tested first, so only a load that SUCCEEDED and
+  // returned nothing reaches the not-found branch.
+  if (loadError) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 6 }}>
+        <LoadFailedState error={loadError} entity="this vendor" onRetry={fetchAll} />
       </Box>
     );
   }

--- a/components/auth/Login.tsx
+++ b/components/auth/Login.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import * as Sentry from "@sentry/nextjs";
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
@@ -87,8 +86,18 @@ export default function Login({ expired, returnTo }: LoginProps) {
         router.push(redirectRoute);
       }
     } catch (err) {
+      /**
+       * No `Sentry.captureException` here: `signInWithPassword` is in the Supabase integration's
+       * `AUTH_OPERATIONS_TO_INSTRUMENT`, so since the net went in (#708) it files this itself, as
+       * `auto.db.supabase.auth`. Capturing again filed every sign-in failure twice under two
+       * fingerprints.
+       *
+       * This is NOT true of every auth call — `updateUser`, `resetPasswordForEmail` and
+       * `getSession` are absent from that list, so ForgotPassword, ResetPassword, ChangePassword
+       * and AuthProvider keep their manual captures, which are their only reporter. Check the
+       * list before removing another one.
+       */
       console.error('Login error:', err);
-      Sentry.captureException(err);
       setError(err instanceof Error ? err.message : 'An error occurred during sign in');
     } finally {
       setLoading(false);

--- a/components/auth/SignUp.tsx
+++ b/components/auth/SignUp.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import * as Sentry from "@sentry/nextjs";
 import { useState } from 'react';
 import Link from 'next/link';
 import Card from '@mui/material/Card';
@@ -85,8 +84,10 @@ export default function SignUp() {
 
       setSuccess(true);
     } catch (err) {
+      // No `Sentry.captureException`: `signUp` is instrumented by the Supabase integration, which
+      // files this as `auto.db.supabase.auth`. See the note in Login.tsx — the sibling auth
+      // screens call operations that are NOT instrumented and keep their captures.
       console.error('Sign up error:', err);
-      Sentry.captureException(err);
       setError(err instanceof Error ? err.message : 'An error occurred during sign up');
     } finally {
       setLoading(false);

--- a/components/common/LoadFailedState.tsx
+++ b/components/common/LoadFailedState.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import CloudOffIcon from '@mui/icons-material/CloudOff';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import { friendlyErrorMessage, isNetworkFailureError } from '@/lib/supabaseErrors';
+
+interface LoadFailedStateProps {
+  /** Whatever the loader rejected with. */
+  error: unknown;
+  /** What failed to load, for the copy: "parts", "this vendor", "this customer". */
+  entity: string;
+  /** Re-runs the load. Wire `useLoad`'s `reload` straight to this. */
+  onRetry: () => void;
+}
+
+/**
+ * "We couldn't load this" — the state a failed READ needs, and the one this app was missing.
+ *
+ * WHY THIS EXISTS. `useLoad` keeps its previous `data` when a load rejects, so the FIRST load
+ * failing leaves `data` null and the page falls through to its empty state. On the parts page
+ * that rendered *"No parts yet. Add your first part"* with Import CSV and Add Part buttons — a
+ * shop with three hundred parts, on a dropped connection, told its shop was empty and invited to
+ * start over. A failure that renders as a successful empty result is the worst shape an error can
+ * take, because nothing about it looks wrong.
+ *
+ * NOT `ErrorAlert`, which is for WRITE failures: its job is to explain why a save was refused
+ * (chiefly the billing write-gate) and it offers no way to try again. A failed read needs the
+ * opposite — little explanation, and a button.
+ *
+ * The copy splits on cause because the two have different remedies:
+ *   - a network failure is the user's connection, and "try again" is genuinely the fix;
+ *   - anything else came back from Postgres, so `friendlyErrorMessage` has something specific to
+ *     say and we say it rather than guessing.
+ *
+ * `friendlyErrorMessage` rather than `error.message`: the access layer rejects with Supabase's
+ * raw `{ code, details, hint, message }` object, so an `instanceof Error` check — which is what
+ * these pages did — always misses and degrades to a generic string.
+ */
+export default function LoadFailedState({ error, entity, onRetry }: LoadFailedStateProps) {
+  const isNetwork = isNetworkFailureError(error);
+  const Icon = isNetwork ? CloudOffIcon : ErrorOutlineIcon;
+
+  const detail = isNetwork
+    ? 'Check your connection and try again. Nothing has been lost.'
+    : friendlyErrorMessage(error, { fallback: `Something went wrong loading ${entity}.` });
+
+  return (
+    <>
+      <Icon sx={{ fontSize: 64, color: 'text.secondary', mb: 2 }} />
+      <Typography variant="h6" color="text.secondary" gutterBottom>
+        Couldn&apos;t load {entity}.
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        {detail}
+      </Typography>
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Button variant="contained" startIcon={<RefreshIcon />} onClick={onRetry}>
+          Try Again
+        </Button>
+      </Box>
+    </>
+  );
+}

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -234,10 +234,17 @@ sentry issue plan JAVASCRIPT-NEXTJS-9          # Seer AI fix plan
 sentry issue archive JAVASCRIPT-NEXTJS-9 --until auto
 ```
 
-An MCP server also exists — `https://mcp.sentry.dev/mcp/jigged/javascript-nextjs`, wired in
-the gitignored `.mcp.json`. Its entry **needs `"type": "http"`** or Claude Code silently
-skips it. Authorise via `/mcp` in an interactive session. The CLI does everything the MCP
-does, so this is convenience, not a prerequisite.
+An MCP server also exists — `https://mcp.sentry.dev/mcp/jigged`, wired in the gitignored
+`.mcp.json`. Its entry **needs `"type": "http"`** or Claude Code silently skips it. Authorise
+via `/mcp` in an interactive session. The CLI does everything the MCP does, so this is
+convenience, not a prerequisite.
+
+**Scope it to the org, not a project.** The URL takes an optional trailing project
+(`…/mcp/jigged/javascript-nextjs`), and a session opened that way can read *only* that project —
+`python-fastapi` issues come back as "outside the active project constraint", which reads like a
+permissions error rather than a scoping one. Two consequences worth knowing: half a triage can be
+silently invisible, and **the constraint is fixed when the connection is established**, so
+widening the URL takes a `/mcp reconnect` (or a new session) before it takes effect.
 
 ### Environments, and how to filter by them
 
@@ -495,6 +502,7 @@ a table name; the list needed to tell them apart is not available at runtime, si
 |---|---|
 | `PGRST116` | A `.single()` that matched nothing. The caller asked "is there one?" and got "no" |
 | Transient aborts | Superseded, not failed. **Load-bearing:** postgrest-js does not reject on a cancelled request, it resolves `{ error }` with `hint: 'Request was aborted…'`, so without this every navigation-away becomes an issue |
+| Network failures | The browser never reached Supabase — offline, DNS, a dropped connection. Same resolved-`{ error }` mechanism as an abort, but with no hint: postgrest-js only fills `hint` for `AbortError`, so Safari's `TypeError: Load failed` and Chrome's `Failed to fetch` used to slip through and page somebody. **Matched on the message AND an empty `code`** — a SQLSTATE means PostgREST answered, so a `P0001` raised for the user can never be dropped by a coincidental word match. Operators are on personal phones on cellular, so this class scales with adoption. The user still sees it: the read path renders `LoadFailedState` |
 | Auth errors | Session expiry is already handled by the refresh-and-retry in `lib/supabase.ts` |
 
 Add to this list only with a recorded reason, exactly as with `ignoreErrors` below.

--- a/hooks/useNoteDwell.ts
+++ b/hooks/useNoteDwell.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef } from 'react';
 import * as Sentry from '@sentry/nextjs';
 import { getSupabase } from '@/lib/supabase';
+import { shouldReportSupabaseError, toError } from '@/lib/supabaseErrors';
 
 /**
  * Logs that a note was actually READ.
@@ -80,8 +81,11 @@ export function useNoteDwell(
         p_job_id: jobId ?? undefined,
       })
       .then(({ error }) => {
-        if (error) {
-          Sentry.captureException(error, {
+        // Same reasoning as `logOperatorEvent`: rpc is outside the net, so this site owns both
+        // the reporting and the expected-negative filtering, and `toError` is what makes the
+        // issue readable. A phone losing signal mid-flush is not a defect.
+        if (error && shouldReportSupabaseError(error)) {
+          Sentry.captureException(toError(error, 'Failed to log note views'), {
             level: 'warning',
             tags: { area: 'note_views' },
           });

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -43,8 +43,6 @@ export function createClient() {
   const client = createBrowserClient<Database>(supabaseUrl, supabaseAnonKey, {
     global: {
       fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
-        const response = await fetch(input, init);
-
         // Extract URL for endpoint detection
         const url = typeof input === 'string'
           ? input
@@ -62,10 +60,17 @@ export function createClient() {
          * `db.table`, which for an rpc holds the *function* name and is otherwise
          * indistinguishable from a table name. The integration starts its span around the whole
          * request, so the span is still active here.
+         *
+         * STAMPED BEFORE THE FETCH, and the order is load-bearing: when the network fails the
+         * `await` below throws, so anything after it never runs. Stamping afterwards left exactly
+         * the network-failure case unmarked, `beforeSend` unable to recognise the rpc, and the
+         * one failure filed twice — once by the net, once by the access layer's own capture.
          */
         if (url.includes('/rest/v1/rpc/')) {
           Sentry.getActiveSpan()?.setAttribute(RPC_SPAN_ATTRIBUTE, true);
         }
+
+        const response = await fetch(input, init);
 
         // Check if this is already a retry to prevent infinite loops
         const headers = new Headers(init?.headers);

--- a/lib/supabaseErrors.ts
+++ b/lib/supabaseErrors.ts
@@ -108,6 +108,46 @@ export function isTransientAbortError(error: unknown): boolean {
 }
 
 /**
+ * The browser's fetch itself failed — offline, DNS, a dropped connection, or the tab navigating
+ * away mid-request. Not the same thing as an abort, and deliberately a separate predicate.
+ *
+ * `postgrest-js` does not reject on a failed fetch; it resolves `{ error }` built in
+ * `PostgrestBuilder`'s `res.catch` as `` { message: `${name}: ${message}`, details: <stack>,
+ * hint: '', code: '' } ``. The `hint` is only filled in for `AbortError` and undici's header
+ * overflow, so a plain network failure carries none of the text `isTransientAbortError` looks
+ * for — which is exactly how Safari's `TypeError: Load failed` became a paging alert.
+ *
+ * WHY `code` IS CHECKED, and it is not belt-and-braces: the message is the browser's, so a
+ * Postgres error raised deliberately FOR the user (`P0001`, "Could not fetch…") could contain
+ * one of these substrings by coincidence, and dropping that would hide a real failure silently —
+ * the worst outcome this module can produce. postgrest-js hard-codes `code = ''` on every
+ * client-side network path, and says why: "We don't populate code/hint for client-side network
+ * errors since those fields are meant for upstream service errors (PostgREST/PostgreSQL)." So an
+ * empty `code` means the request never reached Postgres, and anything with a SQLSTATE is
+ * upstream and reports normally.
+ *
+ * NOT keyed on `status: 0`, which the same `res.catch` also sets: that lives on the *response*
+ * object, a sibling of `error`, and never reaches the error value handed to `beforeSend`.
+ */
+export function isNetworkFailureError(error: unknown): boolean {
+  if (!error) return false;
+
+  const err = asRecord(error);
+
+  // A SQLSTATE or PGRST code means PostgREST answered. Only a client-side failure has none.
+  if (err.code !== '' && err.code !== undefined && err.code !== null) return false;
+
+  const message = typeof err.message === 'string' ? err.message.toLowerCase() : '';
+
+  return (
+    message.includes('load failed') || // Safari
+    message.includes('failed to fetch') || // Chrome, Edge
+    message.includes('networkerror') || // Firefox: "NetworkError when attempting to fetch resource"
+    message.includes('network request failed')
+  );
+}
+
+/**
  * `PGRST116` — PostgREST's "no rows returned" from `.single()`. A definitive answer, not a
  * failure: the row genuinely is not there. Callers branch on it deliberately.
  */
@@ -229,6 +269,22 @@ export function shouldReportSupabaseError(error: unknown): boolean {
    * coincidence rather than a designed contract, which is why the test pins it.
    */
   if (isTransientAbortError(error)) return false;
+
+  /**
+   * The browser could not reach Supabase at all — offline, a dropped connection, a tab navigating
+   * away mid-request. Indistinguishable from each other from here, and none of them a defect in
+   * this application.
+   *
+   * The cost of keeping them is not quota, it is that operators work from personal phones on
+   * cellular (see CLAUDE.md's device model), so this class scales with adoption rather than down.
+   * One issue per flaky-signal moment is how a queue becomes one nobody reads.
+   *
+   * WHAT THIS GIVES UP, deliberately: per-event visibility of a genuine Supabase outage. That is
+   * the right trade — an outage announces itself through every other error class at once, and the
+   * uptime monitors are the thing built to notice it. The user is still told: the read path
+   * renders a retry state (`LoadFailedState`), so a dropped report is never a silent failure.
+   */
+  if (isNetworkFailureError(error)) return false;
 
   // Session expiry is not a bug and is already handled: the custom fetch in lib/supabase.ts
   // refreshes and retries, and `redirectToSessionExpiry` covers the rest.

--- a/utils/operatorEventsAccess.ts
+++ b/utils/operatorEventsAccess.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/nextjs';
 import { getSupabase } from '@/lib/supabase';
+import { shouldReportSupabaseError, toError } from '@/lib/supabaseErrors';
 
 /**
  * Capture-funnel instrumentation.
@@ -80,8 +81,20 @@ export function logOperatorEvent(
         p_context: context,
       })
       .then(({ error }) => {
-        if (error) {
-          Sentry.captureException(error, {
+        /**
+         * `.rpc()` is excluded from the Supabase integration's net, so this call site is the
+         * only reporter — which also means the expected negatives it drops in `beforeSend` have
+         * to be dropped here by hand. `shouldReportSupabaseError` is that same judgement.
+         *
+         * It matters most on this surface: operators are on personal phones on cellular, and a
+         * lost signal while a funnel event is in flight is not a defect worth an issue.
+         *
+         * `toError` because Supabase rejects with a plain object, and Sentry cannot fingerprint
+         * one — it files as "Object captured as exception with keys: code, details, hint,
+         * message" with the real text buried in an extra.
+         */
+        if (error && shouldReportSupabaseError(error)) {
+          Sentry.captureException(toError(error, 'Failed to log operator event'), {
             level: 'warning',
             tags: { area: 'operator_events', kind },
           });


### PR DESCRIPTION
A Safari network blip on the parts page filed [JAVASCRIPT-NEXTJS-2R](https://jigged.sentry.io/issues/7657947942/) and sent a high-priority alert. **The blip was nothing** — one production event, on my own Mac. What it exposed was not.

## The user-facing bug

[`useLoad`](https://github.com/debola31/Jigged/blob/main/hooks/useLoad.ts#L105-L109) keeps its previous `data` when a load rejects, so a **first** load failing leaves it `null` and the page falls through to its empty state. On the parts page that rendered:

> **No parts yet.**
> Add your first part — made in-house or bought from a vendor.
> `[Import CSV]` `[Add Part]`

A shop with three hundred parts, on a dropped connection, is told its shop is empty and invited to start over. The page never destructured `useLoad`'s `error` at all. Vendor and customer detail have the same shape with a different lie — **"Vendor not found"**, asserting the record is gone when we simply never heard back.

`LoadFailedState` is the state these pages were missing: a message and a **Try Again** wired to `reload`. Deliberately not `ErrorAlert`, which exists for *write* failures (chiefly the billing gate) and offers no way to retry. Its copy splits on cause, because the remedies differ — a network failure is the user's connection and "try again" genuinely is the fix; anything else came back from Postgres and `friendlyErrorMessage` has something specific to say.

That also fixes the snackbar, which tested `instanceof Error` against an error the access layer throws as a **raw object**, so it always degraded to the generic "Failed to load parts". It now fires only for a *reload* failure, where stale rows stay on screen and nothing else would say so — the card owns the first-load case, so the two can't say the same thing twice.

## Why these were reported at all

The net ([#708](https://github.com/debola31/Jigged/issues/708)) drops aborts, but postgrest-js sets its `hint: 'Request was aborted…'` **only** when `fetchError.name === 'AbortError'`. A genuine network failure carries `name: 'TypeError'`, so it matched no branch of `isTransientAbortError` and became an alert.

`isNetworkFailureError` is a **separate** predicate — the abort semantics AuthGuard retries on are not these.

**It requires an empty `code` as well as a message match.** The message is the browser's, so a `P0001` raised deliberately for the user could contain the same words by coincidence, and dropping that would hide a real failure with no trace anywhere — the worst outcome this module can produce. postgrest-js hard-codes `code = ''` on every client-side path and says why: *"those fields are meant for upstream service errors (PostgREST/PostgreSQL)."* A SQLSTATE means PostgREST answered. Not keyed on `status: 0`, which sits on the response *wrapper* and never reaches the error value `beforeSend` sees.

**What this gives up, deliberately:** per-event visibility of a genuine Supabase outage. An outage announces itself through every other error class at once, the events were already `handled: true`, and the user is still told — the read path now renders a retry state instead of a lie.

## Also here

- **The rpc span marker was stamped after `await fetch`**, so the throw skipped it on exactly the network-failure path. `beforeSend` couldn't tell the call was an rpc, and the one failure filed **twice** — once from the net, once from the access layer that owns rpc reporting. The test inverts the ordering to prove it fails.
- **`operatorEventsAccess` and `useNoteDwell` passed raw Supabase objects to `captureException`** — the cause of the unreadable *"Object captured as exception with keys: code, details, hint, message"* issues. Both now wrap with `toError` and filter through `shouldReportSupabaseError`; rpc sits outside the net, so these call sites own the expected negatives too. That matters most here: operators are on personal phones on cellular.
- **Login and SignUp captured errors the integration has filed itself since 2026-08-06** — `signInWithPassword` and `signUp` are both in `AUTH_OPERATIONS_TO_INSTRUMENT`. Removed. The sibling screens are **not** duplicates and keep theirs: `updateUser`, `resetPasswordForEmail` and `getSession` are absent from that list, so ForgotPassword, ResetPassword, ChangePassword and AuthProvider are their errors' only reporter. Worth checking that list before removing another.
- **`telemetry.md`** gains the drop-policy row, and its MCP URL loses the project scope — a project-scoped session can read only `javascript-nextjs` (`python-fastapi` comes back as "outside the active project constraint"), and the constraint is fixed at connect time, so widening it needs a reconnect.

## Tests

Safari/Chrome/Firefox network shapes; **the negative case** — a Postgres error carrying a SQLSTATE whose message contains "failed to fetch" must still report; an abort recognised **with `hint: ''`**, pinning the message-prefix branch so a future postgrest-js bump that drops the hint can't silently un-classify aborts; and a rejecting-fetch client asserting both that the event is dropped and that an `.rpc()` is still marked as rpc.

`tsc` clean · lint 0 errors, 17 warnings (unchanged ratchet, none from these files) · full suite green.

> Verified by hand still owed: throttle to offline on all three pages, and confirm `2R` stops recurring after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)