### PR TITLE
fix(jobs): the search cap cuts the right rows, and says when it cut

### DIFF
--- a/__tests__/components/operator/OperatorBinView.test.tsx
+++ b/__tests__/components/operator/OperatorBinView.test.tsx
@@ -50,7 +50,7 @@ vi.mock('@/utils/storageHelpers', () => ({
 }));
 
 vi.mock('@/utils/jobsAccess', () => ({
-  getAllJobs: vi.fn().mockResolvedValue([]),
+  getAllJobs: vi.fn().mockResolvedValue({ jobs: [], total: 0, truncated: false }),
 }));
 
 const loc = (over: { id: string; name: string; code?: string | null; parent_id?: string | null }) => ({

--- a/__tests__/components/operator/OperatorLocationActionModal.test.tsx
+++ b/__tests__/components/operator/OperatorLocationActionModal.test.tsx
@@ -70,10 +70,14 @@ const renderModal = (props: Partial<React.ComponentProps<typeof OperatorLocation
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (getAllJobs as ReturnType<typeof vi.fn>).mockResolvedValue([
-    job({ id: 'j1', job_number: 'JOB-001', parts: ['Bracket', 'Pin'] }),
-    job({ id: 'j2', job_number: 'JOB-002', parts: ['Flange'] }),
-  ]);
+  (getAllJobs as ReturnType<typeof vi.fn>).mockResolvedValue({
+    jobs: [
+      job({ id: 'j1', job_number: 'JOB-001', parts: ['Bracket', 'Pin'] }),
+      job({ id: 'j2', job_number: 'JOB-002', parts: ['Flange'] }),
+    ],
+    total: 2,
+    truncated: false,
+  });
   (depleteStockAtLocation as ReturnType<typeof vi.fn>).mockResolvedValue({ location_balance: 7, part_quantity: 7 });
 });
 

--- a/__tests__/components/parts/PartLocationActionModal.test.tsx
+++ b/__tests__/components/parts/PartLocationActionModal.test.tsx
@@ -30,7 +30,9 @@ vi.mock('@/utils/operatorAccess', () => ({
 
 // The Remove action embeds JobTagPicker, which imports jobsAccess -> lib/supabase. Stubbed so
 // the module graph never evaluates a real Supabase client.
-vi.mock('@/utils/jobsAccess', () => ({ getAllJobs: vi.fn(async () => []) }));
+vi.mock('@/utils/jobsAccess', () => ({
+  getAllJobs: vi.fn(async () => ({ jobs: [], total: 0, truncated: false })),
+}));
 
 const ALL: LocationOption[] = [
   { id: 'l1', label: 'Left' },

--- a/__tests__/components/parts/PartTransactionJobTag.test.tsx
+++ b/__tests__/components/parts/PartTransactionJobTag.test.tsx
@@ -51,7 +51,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 
 beforeEach(() => {
   vi.clearAllMocks();
-  asMock(getAllJobs).mockResolvedValue(JOBS);
+  asMock(getAllJobs).mockResolvedValue({ jobs: JOBS, total: JOBS.length, truncated: false });
   asMock(depleteStockAtLocation).mockResolvedValue({});
 });
 

--- a/__tests__/types/job.test.ts
+++ b/__tests__/types/job.test.ts
@@ -6,6 +6,7 @@ import {
   isJobOverdue,
   JOB_LIFECYCLE_STAGE_CONFIG,
   STAGE_TO_JOB_FILTERS,
+  stagesToStatusPairs,
   type JobLifecycleStage,
   type ProductionStatus,
   type FulfillmentStatus,
@@ -196,5 +197,52 @@ describe('isJobOverdue', () => {
     expect(
       isJobOverdue({ due_date: null, production_status: 'in_progress', fulfillment_status: 'unshipped' }),
     ).toBe(false);
+  });
+});
+
+// The structural guarantee behind the jobs list's "showing 120 of 843" banner:
+// if these pairs were ever a SUPERSET of the ticked stages, the search RPC would
+// count rows the user can't see and the banner would overstate (#688).
+describe('stagesToStatusPairs', () => {
+  const pairOf = (c: (typeof CASES)[number]) => `${c.production}:${c.fulfillment}`;
+
+  it.each(Object.keys(JOB_LIFECYCLE_STAGE_CONFIG) as JobLifecycleStage[])(
+    'returns exactly the combinations getJobLifecycleStage maps to %s',
+    (stage) => {
+      expect(stagesToStatusPairs([stage]).sort()).toEqual(
+        CASES.filter((c) => c.stage === stage).map(pairOf).sort(),
+      );
+    },
+  );
+
+  it('is total — the union over every stage is all 12 combinations', () => {
+    const all = stagesToStatusPairs(
+      Object.keys(JOB_LIFECYCLE_STAGE_CONFIG) as JobLifecycleStage[],
+    );
+    expect(all.sort()).toEqual(CASES.map(pairOf).sort());
+    expect(all).toHaveLength(12);
+  });
+
+  it('is disjoint — no combination belongs to two stages', () => {
+    const seen = new Set<string>();
+    for (const stage of Object.keys(JOB_LIFECYCLE_STAGE_CONFIG) as JobLifecycleStage[]) {
+      for (const pair of stagesToStatusPairs([stage])) {
+        expect(seen.has(pair)).toBe(false);
+        seen.add(pair);
+      }
+    }
+  });
+
+  it('maps a multi-select to the union, and never widens past it', () => {
+    // The case STAGE_TO_JOB_FILTERS gets wrong: ANDing its two .in() lists would
+    // also admit in_progress:unshipped, which the user did not tick.
+    const pairs = stagesToStatusPairs(['not_started', 'partially_shipped']);
+    expect(pairs).toContain('not_started:unshipped');
+    expect(pairs).toContain('in_progress:partially_shipped');
+    expect(pairs).not.toContain('in_progress:unshipped');
+  });
+
+  it('returns nothing for an empty selection — "None" matches no jobs', () => {
+    expect(stagesToStatusPairs([])).toEqual([]);
   });
 });

--- a/__tests__/utils/jobsAccess.test.ts
+++ b/__tests__/utils/jobsAccess.test.ts
@@ -52,6 +52,7 @@ import {
   updateJobPartPrice,
   updateJobPartQuantity,
 } from '@/utils/jobsAccess';
+import { JOB_SEARCH_LIMIT } from '@/lib/queryLimits';
 import { getJobPartShipmentSummaries, countShipmentsForJob } from '@/utils/shipmentsAccess';
 import {
   getQuickBooksInvoiceLinkForJob,
@@ -295,21 +296,74 @@ describe('jobsAccess', () => {
   describe('searchJobsByIdentifier', () => {
     it('short-circuits on empty/whitespace queries', async () => {
       const result = await searchJobsByIdentifier('co-1', '   ');
-      expect(result).toEqual([]);
+      expect(result).toEqual({ matches: [], total: 0 });
       expect(mockSupabase.rpc).not.toHaveBeenCalled();
     });
 
     it('passes the trimmed query to the RPC and returns its rows', async () => {
       (mockSupabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({
-        data: [{ job_id: 'j1', match_source: 'job_number' }],
+        data: [{ job_id: 'j1', match_source: 'job_number', total_matches: 1 }],
         error: null,
       });
       const result = await searchJobsByIdentifier('co-1', '  ADP-001  ');
-      expect(mockSupabase.rpc).toHaveBeenCalledWith('search_jobs_by_identifier', {
-        p_company_id: 'co-1',
-        p_query: 'ADP-001',
+      expect(mockSupabase.rpc).toHaveBeenCalledWith(
+        'search_jobs_by_identifier',
+        expect.objectContaining({ p_company_id: 'co-1', p_query: 'ADP-001' }),
+      );
+      expect(result.matches).toEqual([{ job_id: 'j1', match_source: 'job_number' }]);
+    });
+
+    it('caps the RPC at JOB_SEARCH_LIMIT — the ids ride back in a .in() URL', async () => {
+      (mockSupabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({ data: [], error: null });
+      await searchJobsByIdentifier('co-1', 'x');
+      const args = (mockSupabase.rpc as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(args.p_limit).toBe(JOB_SEARCH_LIMIT);
+    });
+
+    it('forwards the filters so the cap applies AFTER them, not before (#688)', async () => {
+      (mockSupabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({ data: [], error: null });
+      await searchJobsByIdentifier('co-1', 'apex', {
+        stages: ['not_started'],
+        customerId: 'cust-9',
+        overdue: true,
       });
-      expect(result).toEqual([{ job_id: 'j1', match_source: 'job_number' }]);
+      const args = (mockSupabase.rpc as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      // Exact pairs, not the AND-of-two-.in() superset STAGE_TO_JOB_FILTERS would give.
+      expect(args.p_stage_pairs).toEqual(['not_started:unshipped']);
+      expect(args.p_customer_id).toBe('cust-9');
+      expect(args.p_overdue).toBe(true);
+      // Local date, so the overdue boundary matches applyOverdueJobsFilter's.
+      expect(args.p_today).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('omits p_stage_pairs when no stages are given, but sends [] for an empty selection', async () => {
+      (mockSupabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({ data: [], error: null });
+      await searchJobsByIdentifier('co-1', 'x');
+      expect(
+        (mockSupabase.rpc as ReturnType<typeof vi.fn>).mock.calls[0][1].p_stage_pairs,
+      ).toBeUndefined();
+
+      (mockSupabase.rpc as ReturnType<typeof vi.fn>).mockClear();
+      await searchJobsByIdentifier('co-1', 'x', { stages: [] });
+      // "The user ticked nothing" is a real answer that matches nothing — it must
+      // not collapse into "no stage narrowing".
+      expect((mockSupabase.rpc as ReturnType<typeof vi.fn>).mock.calls[0][1].p_stage_pairs).toEqual(
+        [],
+      );
+    });
+
+    it('reads total_matches off the first row, and 0 when there are none', async () => {
+      (mockSupabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: [
+          { job_id: 'j1', match_source: 'job_number', total_matches: 843 },
+          { job_id: 'j2', match_source: 'customer', total_matches: 843 },
+        ],
+        error: null,
+      });
+      expect((await searchJobsByIdentifier('co-1', 'x')).total).toBe(843);
+
+      (mockSupabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValue({ data: [], error: null });
+      expect((await searchJobsByIdentifier('co-1', 'x')).total).toBe(0);
     });
 
     it('throws when the RPC returns an error', async () => {
@@ -844,7 +898,7 @@ describe('jobsAccess', () => {
     it('hides closed jobs (done + cancelled) by default', async () => {
       mockQueryBuilder.data = rows;
       const result = await getAllJobs('co-1');
-      const ids = result.map((j) => j.id);
+      const ids = result.jobs.map((j) => j.id);
       expect(ids).toEqual(['active-ns', 'active-ip', 'ready']);
       // Behavior change: the cancelled-but-unshipped job is now hidden too,
       // alongside the fully-shipped done job.
@@ -855,7 +909,14 @@ describe('jobsAccess', () => {
     it('keeps closed jobs when excludeClosed is false (Show completed & cancelled)', async () => {
       mockQueryBuilder.data = rows;
       const result = await getAllJobs('co-1', { excludeClosed: false });
-      expect(result.map((j) => j.id)).toEqual(rows.map((r) => r.id));
+      expect(result.jobs.map((j) => j.id)).toEqual(rows.map((r) => r.id));
+    });
+
+    it('reports no truncation off the search path — nothing is capped there', async () => {
+      mockQueryBuilder.data = rows;
+      const result = await getAllJobs('co-1', { excludeClosed: false });
+      expect(result.total).toBe(rows.length);
+      expect(result.truncated).toBe(false);
     });
 
     it('applies production/fulfillment status filters server-side via .in()', async () => {
@@ -877,6 +938,102 @@ describe('jobsAccess', () => {
       // rows float to the top with the sort applied within each tier.
       expect(orderCalls[0]).toEqual(['is_hot', { ascending: false }]);
       expect(orderCalls[1]).toEqual(['created_at', { ascending: false }]);
+    });
+  });
+
+  // The search path had no coverage at all before #688 — which is how a cap that
+  // silently dropped rows, in job-id order, ahead of the filters survived.
+  describe('getAllJobs — search path', () => {
+    const rpc = () => mockSupabase.rpc as ReturnType<typeof vi.fn>;
+
+    /** RPC rows all carry the same total_matches, the way the SQL emits them. */
+    const rpcRows = (
+      matches: Array<{ job_id: string; match_source: string }>,
+      total = matches.length,
+    ) => ({
+      data: matches.map((m) => ({ ...m, total_matches: total })),
+      error: null,
+    });
+
+    it('resolves the RPC first, then restricts the main query to those ids', async () => {
+      rpc().mockResolvedValue(rpcRows([
+        { job_id: 'j1', match_source: 'job_number' },
+        { job_id: 'j2', match_source: 'customer' },
+      ]));
+      mockQueryBuilder.data = [
+        { id: 'j1', production_status: 'in_progress', fulfillment_status: 'unshipped' },
+        { id: 'j2', production_status: 'not_started', fulfillment_status: 'unshipped' },
+      ];
+      await getAllJobs('co-1', { search: 'apex' });
+      expect(mockQueryBuilder.in).toHaveBeenCalledWith('id', ['j1', 'j2']);
+    });
+
+    it('short-circuits to an empty page when nothing matches', async () => {
+      rpc().mockResolvedValue(rpcRows([]));
+      mockQueryBuilder.data = [{ id: 'should-not-be-read' }];
+      const result = await getAllJobs('co-1', { search: 'nothing-matches-this' });
+      expect(result).toEqual({ jobs: [], total: 0, truncated: false });
+      // No point asking PostgREST for `id IN ()`.
+      expect(mockQueryBuilder.in).not.toHaveBeenCalledWith('id', []);
+    });
+
+    it('mixes match_source onto the rows for the "matched packing slip" sub-line', async () => {
+      rpc().mockResolvedValue(rpcRows([{ job_id: 'j1', match_source: 'packing_slip' }]));
+      mockQueryBuilder.data = [
+        { id: 'j1', production_status: 'in_progress', fulfillment_status: 'unshipped' },
+      ];
+      const result = await getAllJobs('co-1', { search: 'PS-1001' });
+      expect(result.jobs[0].match_source).toBe('packing_slip');
+    });
+
+    it('no longer falls back to a job_number-only .or() — that branch was unreachable', async () => {
+      rpc().mockResolvedValue(rpcRows([{ job_id: 'j1', match_source: 'job_number' }]));
+      mockQueryBuilder.data = [
+        { id: 'j1', production_status: 'in_progress', fulfillment_status: 'unshipped' },
+      ];
+      await getAllJobs('co-1', { search: 'J-0001' });
+      expect(mockQueryBuilder.or).not.toHaveBeenCalled();
+    });
+
+    it('reports the cap honestly: total is what matched, truncated says it cut', async () => {
+      rpc().mockResolvedValue(rpcRows([{ job_id: 'j1', match_source: 'customer' }], 843));
+      mockQueryBuilder.data = [
+        { id: 'j1', production_status: 'in_progress', fulfillment_status: 'unshipped' },
+      ];
+      const result = await getAllJobs('co-1', { search: 'apex' });
+      expect(result.total).toBe(843);
+      expect(result.truncated).toBe(true);
+    });
+
+    it('is not truncated when the total equals what came back', async () => {
+      rpc().mockResolvedValue(rpcRows([{ job_id: 'j1', match_source: 'customer' }], 1));
+      mockQueryBuilder.data = [
+        { id: 'j1', production_status: 'in_progress', fulfillment_status: 'unshipped' },
+      ];
+      expect((await getAllJobs('co-1', { search: 'apex' })).truncated).toBe(false);
+    });
+
+    // This is the assertion that keeps the on-screen "showing N of M" honest. The
+    // stages went into the RPC, so the client-side closed-job filter has nothing
+    // left to remove — if that ever stops being true, the banner starts lying and
+    // this test is what catches it.
+    it('drops nothing client-side once the stages went into the RPC', async () => {
+      rpc().mockResolvedValue(rpcRows([
+        { job_id: 'open', match_source: 'customer' },
+        { job_id: 'done', match_source: 'customer' },
+      ]));
+      mockQueryBuilder.data = [
+        { id: 'open', production_status: 'in_progress', fulfillment_status: 'unshipped' },
+        { id: 'done', production_status: 'completed', fulfillment_status: 'fully_shipped' },
+      ];
+      const result = await getAllJobs('co-1', {
+        search: 'apex',
+        stages: ['in_progress', 'completed'],
+        // What the jobs page sends when a closed stage is ticked.
+        excludeClosed: false,
+      });
+      expect(result.jobs.map((j) => j.id)).toEqual(['open', 'done']);
+      expect(result.truncated).toBe(false);
     });
   });
 });

--- a/api/tests/integration/test_jobs_search_cap.py
+++ b/api/tests/integration/test_jobs_search_cap.py
@@ -1,0 +1,426 @@
+"""The jobs-list search cap applies AFTER every filter, in a meaningful order — 20260809001523.
+
+WHAT THIS GUARDS (#688). `search_jobs_by_identifier` has always capped its output, because the
+caller sends the matching ids back through a PostgREST `.in()` URL and that URL has a hard ceiling
+(see JOB_SEARCH_LIMIT in lib/queryLimits.ts). The cap is not the defect. Three things about it were:
+
+  1. `ORDER BY m.job_id` existed only to serve `DISTINCT ON`. It is not a ranking, so the rows that
+     survived LIMIT were whichever UUIDs happened to sort first — not the newest, not the most
+     relevant.
+  2. The status / customer / overdue filters were applied by the CALLER, on the main query, AFTER
+     the cap. So the filters cut into an already-arbitrary subset: search a customer with 300 jobs
+     and the open ones on screen were whichever open ones survived a random cut.
+  3. `deleted_at` was never filtered here, so archived jobs consumed cap slots and were then thrown
+     away by the caller — making (2) worse.
+
+WHY THIS IS A PYTHON INTEGRATION TEST. The behaviour only appears above the cap, and
+`supabase/seed.sql` has single-digit job counts — it can never trigger it, which is exactly why the
+bug survived preview branches and was only reasoned about, never observed. Seeding hundreds of jobs into
+`seed.sql` to fix that would slow every `db reset` and pollute the demo company for a property that
+is about scale, not fixtures. So these tests create their own rows and clean them up.
+
+The RLS test sets `request.jwt.claims` and `SET ROLE authenticated` to reproduce what PostgREST does
+per request, so it exercises the real EXECUTE grant and the real membership check rather than
+running as a superuser that would pass either way. That matters here because the DROP + CREATE in
+this migration rebuilt the function's ACL from scratch.
+
+Requires a local Postgres with all migrations applied. Skipped without it. From a git worktree the
+shared Supabase stack will NOT have this migration — point TEST_SUPABASE_DB_URL at a throwaway
+replay DB instead (docs/runbooks/local-dev-and-testing.md).
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import date, timedelta
+
+import psycopg2
+import pytest
+
+pytestmark = pytest.mark.integration
+
+DB_URL = os.getenv(
+    "TEST_SUPABASE_DB_URL", "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+)
+
+# Above the function's own 200 hard ceiling, so both the caller's cap and the clamp
+# are observable.
+JOB_COUNT = 250
+# The value the frontend actually sends (JOB_SEARCH_LIMIT in lib/queryLimits.ts).
+LIMIT = 120
+# Every job's number contains this, so one query matches the whole fixture.
+MARKER = "SEARCHCAP"
+
+
+def _connect():
+    try:
+        return psycopg2.connect(DB_URL)
+    except psycopg2.OperationalError as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"No local Postgres at {DB_URL}: {exc}")
+
+
+@pytest.fixture
+def db():
+    conn = _connect()
+    conn.autocommit = True
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def shop(db):
+    """A company with JOB_COUNT matching jobs, spread across statuses, plus archived decoys.
+
+    Job i is created i days ago, so "newest" is unambiguous and testable. `is_demo` so
+    `company_can_write()` is true without a billing row.
+    """
+    company = str(uuid.uuid4())
+    user = str(uuid.uuid4())
+    today = date.today()
+
+    with db.cursor() as cur:
+        cur.execute(
+            "INSERT INTO companies (id, name, is_demo) VALUES (%s, %s, true)",
+            (company, f"Search Cap {company[:8]}"),
+        )
+        cur.execute(
+            """
+            INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password,
+                                    email_confirmed_at, created_at, updated_at)
+            VALUES (%s, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
+                    %s, '', now(), now(), now())
+            """,
+            (user, f"searchcap-{company[:8]}@test.jigged.local"),
+        )
+        cur.execute(
+            "INSERT INTO user_company_access (user_id, company_id, role) VALUES (%s, %s, 'admin')",
+            (user, company),
+        )
+        cur.execute(
+            "INSERT INTO customers (company_id, name) VALUES (%s, %s) RETURNING id",
+            (company, f"Big Account {company[:8]}"),
+        )
+        big_customer = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO customers (company_id, name) VALUES (%s, %s) RETURNING id",
+            (company, f"Small Account {company[:8]}"),
+        )
+        small_customer = cur.fetchone()[0]
+
+        # Statuses cycle so every lifecycle stage is represented, and the overwhelming
+        # majority are closed — the shape of a real customer's history, and the reason
+        # a cap applied before the status filter was so damaging.
+        combos = [
+            ("completed", "fully_shipped"),   # closed
+            ("completed", "fully_shipped"),   # closed
+            ("cancelled", "unshipped"),       # closed
+            ("not_started", "unshipped"),     # open
+            ("in_progress", "unshipped"),     # open
+        ]
+        ids = []
+        for i in range(JOB_COUNT):
+            production, fulfillment = combos[i % len(combos)]
+            cur.execute(
+                """
+                INSERT INTO jobs (company_id, customer_id, job_number, production_status,
+                                  fulfillment_status, is_hot, due_date, created_at)
+                VALUES (%s, %s, %s, %s, %s, false, %s, now() - (%s || ' days')::interval)
+                RETURNING id
+                """,
+                (
+                    company,
+                    big_customer if i % 10 else small_customer,
+                    f"{MARKER}-{i:04d}",
+                    production,
+                    fulfillment,
+                    today - timedelta(days=1) if production == "not_started" else None,
+                    i,
+                ),
+            )
+            ids.append(cur.fetchone()[0])
+
+        # Archived decoys. They must not consume cap slots and must not be counted.
+        archived = []
+        for i in range(10):
+            cur.execute(
+                """
+                INSERT INTO jobs (company_id, customer_id, job_number, production_status,
+                                  fulfillment_status, deleted_at)
+                VALUES (%s, %s, %s, 'not_started', 'unshipped', now())
+                RETURNING id
+                """,
+                (company, big_customer, f"{MARKER}-ARCH-{i:02d}"),
+            )
+            archived.append(cur.fetchone()[0])
+
+    yield {
+        "company": company,
+        "user": user,
+        "big_customer": big_customer,
+        "small_customer": small_customer,
+        "ids": ids,
+        "archived": archived,
+    }
+
+    with db.cursor() as cur:
+        cur.execute("DELETE FROM shipment_line_items WHERE shipment_id IN "
+                    "(SELECT id FROM shipments WHERE company_id = %s)", (company,))
+        cur.execute("DELETE FROM shipments WHERE company_id = %s", (company,))
+        cur.execute("DELETE FROM job_parts WHERE company_id = %s", (company,))
+        cur.execute("DELETE FROM parts WHERE company_id = %s", (company,))
+        cur.execute("DELETE FROM jobs WHERE company_id = %s", (company,))
+        cur.execute("DELETE FROM customers WHERE company_id = %s", (company,))
+        cur.execute("DELETE FROM user_company_access WHERE company_id = %s", (company,))
+        cur.execute("DELETE FROM companies WHERE id = %s", (company,))
+        cur.execute("DELETE FROM auth.users WHERE id = %s", (user,))
+
+
+def search(db, company, query=MARKER, *, pairs=None, customer=None, overdue=False,
+           today=None, limit=LIMIT):
+    with db.cursor() as cur:
+        cur.execute(
+            "SELECT job_id, match_source, total_matches "
+            "FROM search_jobs_by_identifier(%s, %s, %s, %s, %s, %s, %s)",
+            (company, query, pairs, customer, overdue, today or date.today(), limit),
+        )
+        return cur.fetchall()
+
+
+def job_numbers(db, rows):
+    """Resolve returned ids to job numbers, preserving the RPC's row order."""
+    ids = [r[0] for r in rows]
+    if not ids:
+        return []
+    with db.cursor() as cur:
+        cur.execute("SELECT id, job_number FROM jobs WHERE id = ANY(%s::uuid[])", (ids,))
+        by_id = dict(cur.fetchall())
+    return [by_id[i] for i in ids]
+
+
+# --------------------------------------------------------------------------------------
+# The cap itself
+# --------------------------------------------------------------------------------------
+
+def test_caps_rows_but_reports_the_true_total(db, shop):
+    """The list is cut; the count is not. This is what lets the UI say "120 of 150"."""
+    rows = search(db, shop["company"])
+    assert len(rows) == LIMIT
+    # Constant across every row, and it is the pre-cap count.
+    assert {r[2] for r in rows} == {JOB_COUNT}
+
+
+def test_keeps_the_newest_rows_not_a_uuid_lottery(db, shop):
+    """Job i was created i days ago, so the newest LIMIT jobs are 0000..0119."""
+    rows = search(db, shop["company"])
+    numbers = job_numbers(db, rows)
+    assert numbers == [f"{MARKER}-{i:04d}" for i in range(LIMIT)]
+
+
+def test_hot_jobs_survive_the_cap_even_when_old(db, shop):
+    """A rush job is the one row a shop cannot afford to have silently cut."""
+    oldest = f"{MARKER}-{JOB_COUNT - 1:04d}"
+    with db.cursor() as cur:
+        cur.execute(
+            "UPDATE jobs SET is_hot = true WHERE company_id = %s AND job_number = %s",
+            (shop["company"], oldest),
+        )
+    numbers = job_numbers(db, search(db, shop["company"]))
+    assert numbers[0] == oldest
+
+
+def test_clamps_the_limit_to_the_url_ceiling(db, shop):
+    """No caller can talk the function past what a PostgREST .in() URL can carry."""
+    assert len(search(db, shop["company"], limit=100_000)) == 200
+    # And a nonsense low limit clamps up rather than erroring out a search box.
+    assert len(search(db, shop["company"], limit=0)) == 1
+    assert len(search(db, shop["company"], limit=None)) == 100
+
+
+# --------------------------------------------------------------------------------------
+# Filters apply BEFORE the cap — the ordering-of-operations fix
+# --------------------------------------------------------------------------------------
+
+def test_archived_jobs_are_neither_returned_nor_counted(db, shop):
+    """They used to consume cap slots and then be discarded by the caller."""
+    rows = search(db, shop["company"])
+    assert rows[0][2] == JOB_COUNT  # not JOB_COUNT + 10
+    assert not set(r[0] for r in rows) & set(shop["archived"])
+
+
+def test_stage_pairs_narrow_before_the_cap(db, shop):
+    """The defect in one assertion: 30 open jobs must all come back, and count as 30.
+
+    Before the fix the cap took 100 arbitrary jobs first — mostly closed, since a real
+    history is mostly closed — and the caller then filtered those down to whatever
+    handful of open ones happened to survive.
+    """
+    open_pairs = ["not_started:unshipped", "in_progress:unshipped"]
+    rows = search(db, shop["company"], pairs=open_pairs)
+    expected = sum(1 for i in range(JOB_COUNT) if i % 5 in (3, 4))
+    assert len(rows) == expected
+    assert rows[0][2] == expected
+    numbers = set(job_numbers(db, rows))
+    assert numbers == {f"{MARKER}-{i:04d}" for i in range(JOB_COUNT) if i % 5 in (3, 4)}
+
+
+def test_empty_stage_pairs_match_nothing(db, shop):
+    """"The user ticked no statuses" is a real answer, not "don't narrow"."""
+    assert search(db, shop["company"], pairs=[]) == []
+
+
+def test_null_stage_pairs_mean_no_narrowing(db, shop):
+    assert search(db, shop["company"], pairs=None)[0][2] == JOB_COUNT
+
+
+def test_customer_narrows_before_the_cap(db, shop):
+    rows = search(db, shop["company"], customer=shop["small_customer"])
+    expected = sum(1 for i in range(JOB_COUNT) if i % 10 == 0)
+    assert len(rows) == expected
+    assert rows[0][2] == expected
+
+
+def test_overdue_narrows_before_the_cap_on_the_callers_local_date(db, shop):
+    """p_today drives the boundary, so the SQL agrees with the client's local midnight."""
+    rows = search(db, shop["company"], overdue=True)
+    # Only the not_started jobs carry a due date, and it is yesterday.
+    expected = sum(1 for i in range(JOB_COUNT) if i % 5 == 3)
+    assert len(rows) == expected
+
+    # Rewind "today" past those due dates and they stop being overdue — proving the
+    # parameter is what's consulted, not current_date.
+    assert search(db, shop["company"], overdue=True, today=date.today() - timedelta(days=5)) == []
+
+    # An omitted date falls back to the server's today rather than silently
+    # reporting that nothing is overdue (`due_date < NULL` is NULL).
+    assert len(search(db, shop["company"], overdue=True, today=None)) == expected
+
+
+def test_filters_compose(db, shop):
+    rows = search(
+        db,
+        shop["company"],
+        pairs=["not_started:unshipped"],
+        customer=shop["small_customer"],
+    )
+    expected = sum(1 for i in range(JOB_COUNT) if i % 5 == 3 and i % 10 == 0)
+    assert len(rows) == expected
+    assert all(r[2] == expected for r in rows)
+
+
+# --------------------------------------------------------------------------------------
+# Behaviour that must NOT have changed
+# --------------------------------------------------------------------------------------
+
+def test_blank_query_returns_nothing(db, shop):
+    assert search(db, shop["company"], query="   ") == []
+    assert search(db, shop["company"], query=None) == []
+
+
+def test_wildcards_in_the_query_are_escaped_not_interpreted(db, shop):
+    """'%' must match a literal percent sign, not every job."""
+    assert search(db, shop["company"], query="%") == []
+
+
+def test_match_source_still_reports_which_field_matched(db, shop):
+    rows = search(db, shop["company"], query=f"{MARKER}-0001")
+    assert [r[1] for r in rows] == ["job_number"]
+
+    rows = search(db, shop["company"], query="Big Account")
+    assert rows and {r[1] for r in rows} == {"customer"}
+
+
+def test_voided_shipments_do_not_match_by_packing_slip(db, shop):
+    """Regression guard on pre-existing behaviour the rewrite had to preserve."""
+    company, job = shop["company"], shop["ids"][0]
+    slip = f"PS-{company[:8]}"
+    with db.cursor() as cur:
+        cur.execute(
+            "INSERT INTO parts (company_id, part_name, source, primary_unit) "
+            "VALUES (%s, %s, 'made', 'each') RETURNING id",
+            (company, f"SLIPPART-{company[:8]}"),
+        )
+        part = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO job_parts (company_id, job_id, part_id, sequence, quantity, "
+            "production_status, fulfillment_status) "
+            "VALUES (%s, %s, %s, 1, 1, 'not_started', 'unshipped') RETURNING id",
+            (company, job, part),
+        )
+        job_part = cur.fetchone()[0]
+        cur.execute(
+            """
+            INSERT INTO shipments (company_id, customer_id, job_id, packing_slip_number, voided_at)
+            SELECT %s, j.customer_id, j.id, %s, now() FROM jobs j WHERE j.id = %s
+            RETURNING id
+            """,
+            (company, slip, job),
+        )
+        shipment = cur.fetchone()[0]
+        cur.execute(
+            "INSERT INTO shipment_line_items (shipment_id, job_part_id, quantity) "
+            "VALUES (%s, %s, 1)",
+            (shipment, job_part),
+        )
+
+    assert search(db, company, query=slip) == []
+
+    with db.cursor() as cur:
+        cur.execute("UPDATE shipments SET voided_at = NULL WHERE id = %s", (shipment,))
+    rows = search(db, company, query=slip)
+    assert [r[1] for r in rows] == ["packing_slip"]
+
+
+# --------------------------------------------------------------------------------------
+# The DROP + CREATE rebuilt the ACL, so re-prove tenancy end to end
+# --------------------------------------------------------------------------------------
+
+def test_a_member_can_execute_it_as_the_browser_role(db, shop):
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT set_config('request.jwt.claims', %s, true)",
+                (json.dumps({"sub": shop["user"], "role": "authenticated"}),),
+            )
+            cur.execute("SET LOCAL ROLE authenticated")
+            cur.execute(
+                "SELECT count(*) FROM search_jobs_by_identifier(%s, %s, NULL, NULL, false, %s, %s)",
+                (shop["company"], MARKER, date.today(), LIMIT),
+            )
+            assert cur.fetchone()[0] == LIMIT
+        conn.rollback()
+    finally:
+        conn.close()
+
+
+def test_a_non_member_sees_nothing_because_it_is_security_invoker(db, shop):
+    """p_company_id is a narrowing filter, never the security boundary — RLS is."""
+    stranger = str(uuid.uuid4())
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT set_config('request.jwt.claims', %s, true)",
+                (json.dumps({"sub": stranger, "role": "authenticated"}),),
+            )
+            cur.execute("SET LOCAL ROLE authenticated")
+            cur.execute(
+                "SELECT count(*) FROM search_jobs_by_identifier(%s, %s, NULL, NULL, false, %s, %s)",
+                (shop["company"], MARKER, date.today(), LIMIT),
+            )
+            assert cur.fetchone()[0] == 0
+        conn.rollback()
+    finally:
+        conn.close()
+
+
+def test_anon_may_not_execute_it_at_all(db):
+    """The baseline granted anon EXECUTE; this migration deliberately does not."""
+    with db.cursor() as cur:
+        cur.execute(
+            "SELECT has_function_privilege('anon', "
+            "'public.search_jobs_by_identifier(uuid, text, text[], uuid, boolean, date, integer)', "
+            "'EXECUTE')"
+        )
+        assert cur.fetchone()[0] is False

--- a/app/dashboard/[companyId]/jobs/page.tsx
+++ b/app/dashboard/[companyId]/jobs/page.tsx
@@ -91,6 +91,9 @@ function matchSourceLabel(source: string): string {
   }
 }
 
+/** Thousands separators, so "1,842 matches" doesn't read as 1842 at a glance. */
+const formatCount = (n: number) => n.toLocaleString();
+
 // The default Status selection: every open (non-closed) stage. Completed and
 // cancelled jobs are hidden until the user explicitly picks them — this replaces
 // the old "Show completed & cancelled" checkbox.
@@ -163,14 +166,17 @@ export default function JobsPage() {
   // and bound to the visible Customer dropdown below.
   //
   // That dropdown was once removed as "redundant, search already matches
-  // customer name". True of the manual case, false of the two that matter:
-  // search_jobs_by_identifier is capped at LIMIT 100 and getAllJobs applies the
-  // status filters AFTER that cap, so a busy customer's search silently
-  // truncates in job-id order with nothing saying rows were dropped; and a
-  // substring cannot express "exactly this customer", which the count link
-  // requires. This filter is .eq('customer_id', …) on the main query, never the
-  // RPC, so it is exact by construction — and it doubles as the on-screen
-  // explanation for an arriving deep link, which previously had none.
+  // customer name". It isn't: a substring cannot express "exactly this
+  // customer", which is precisely what the count deep-link means. Searching
+  // "Apex" also matches "Apex Aerospace" and "Apex Medical"; this filter is an
+  // id equality, so it can't. It also doubles as the on-screen explanation for
+  // an arriving deep link, which previously had none.
+  //
+  // (It used to carry a second justification — that the search RPC capped at
+  // 100 rows before the status filters ran, so a busy customer's search was
+  // silently, arbitrarily wrong. That is fixed: the cap now applies after every
+  // filter, keeps the newest rows rather than a UUID-ordered slice, and the
+  // list says so on screen when it bites. See #688 and JOB_SEARCH_LIMIT.)
   const [customerId, setCustomerId] = useState<string>(
     () => searchParams.get('customer') ?? '',
   );
@@ -226,6 +232,7 @@ export default function JobsPage() {
   const {
     data: jobsData,
     loading,
+    error: jobsError,
     reload: fetchJobs,
   } = useLoad(
     () => {
@@ -239,6 +246,11 @@ export default function JobsPage() {
         // Hide closed jobs unless a closed stage is explicitly selected. (An
         // empty selection shows no rows anyway — see visibleJobs.)
         excludeClosed: !includesClosed,
+        // The exact stages, for the search path only. Off it this is ignored
+        // and visibleJobs does the narrowing client-side; on it the search RPC
+        // needs them, because its row cap has to apply to the set the user
+        // actually ends up looking at rather than to a superset of it.
+        stages: statusFilter,
       };
       return getAllJobs(companyId, filters, sortModel.field, sortModel.sort);
     },
@@ -260,7 +272,12 @@ export default function JobsPage() {
       },
     },
   );
-  const jobs = jobsData ?? EMPTY_JOBS;
+  const jobs = jobsData?.jobs ?? EMPTY_JOBS;
+  // How many jobs matched before the search cap, and whether it cut anything.
+  // Both are only ever meaningful on the search path — off it getAllJobs
+  // returns everything and reports truncated: false.
+  const matchTotal = jobsData?.total ?? 0;
+  const truncated = jobsData?.truncated ?? false;
 
   // Jobs whose only live work is out at a vendor read as stalled in the normal
   // list (the "current op" is a sent external op, which counts as incomplete but
@@ -762,10 +779,30 @@ export default function JobsPage() {
         </Button>
       </Box>
 
+      {/* A failed load used to fall through to the "No jobs found" card below,
+          which reads as a definitive answer when we don't actually have one.
+          Say we couldn't check instead. */}
+      {jobsError != null && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Couldn&apos;t load jobs. Check your connection and try again.
+        </Alert>
+      )}
+
+      {/* Search matched more jobs than one screenful can carry back, so say so
+          rather than showing an arbitrary slice as if it were everything (#688).
+          The count is exact and reflects every filter above, so "of {matchTotal}"
+          is the number of jobs the user would see if the cap were lifted. */}
+      {truncated && jobsError == null && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Showing the {jobs.length} newest matches out of {formatCount(matchTotal)}. Type
+          more of the job number, or pick a customer or a status, to narrow this down.
+        </Alert>
+      )}
+
       {/* Data Grid or Empty State. Jobs come from converting an accepted quote
           (utils/quotesAccess#convertQuoteToJob) or directly from a customer PO
           (New Job from PO -> utils/jobsAccess#createJobFromPurchaseOrder). */}
-      {!loading && visibleJobs.length === 0 ? (
+      {!loading && jobsError == null && visibleJobs.length === 0 ? (
         <Card elevation={2}>
           <CardContent sx={{ p: 6, textAlign: 'center' }}>
             <WorkIcon sx={{ fontSize: 64, color: 'text.secondary', mb: 2 }} />

--- a/components/inventory/JobTagPicker.tsx
+++ b/components/inventory/JobTagPicker.tsx
@@ -34,10 +34,15 @@ export const jobPartsLabel = (j: JobWithRelations): string =>
     .filter((n): n is string => Boolean(n))
     .join(', ');
 
-/** Active jobs for the picker. Never throws — the tag is optional. */
+/**
+ * Active jobs for the picker. Never throws — the tag is optional.
+ *
+ * Takes just the rows off the page envelope: this never searches, so nothing
+ * is capped and there is no truncation for the caller to report.
+ */
 export async function loadTaggableJobs(companyId: string): Promise<JobWithRelations[]> {
   try {
-    return await getAllJobs(companyId, { productionStatus: ACTIVE_STATUSES });
+    return (await getAllJobs(companyId, { productionStatus: ACTIVE_STATUSES })).jobs;
   } catch {
     return [];
   }

--- a/docs/modules/jobs.md
+++ b/docs/modules/jobs.md
@@ -238,6 +238,24 @@ Toolbar: search (job number, customer name, customer PO, part number, packing-sl
 overdue-only toggle, a customer filter, and **New Job from PO**. The Status selection is persisted
 **per company, device-locally**; the default selection is every open stage, which counts as
 "unfiltered" for the empty state. Empty selection legitimately shows no rows.
+
+**Search is capped, and the cap announces itself.** `search_jobs_by_identifier` returns at most
+[`JOB_SEARCH_LIMIT`](../../lib/queryLimits.ts) rows because `getAllJobs` sends the matching ids
+back through a PostgREST `.in()` URL, which has a measured ~8 KB ceiling — a bigger number would
+turn a truncated list into a hard 414. Three properties make that cap honest, and all three were
+added in #688:
+
+- **Every filter goes into the RPC** (stage pairs via `stagesToStatusPairs`, customer, overdue),
+  so the cap applies to the set the user actually ends up looking at. They used to be applied by
+  the caller *after* the cap, which meant they cut into an already-arbitrary subset.
+- **The retained rows are hot first, then newest** — not `ORDER BY job_id`, which existed only to
+  serve `DISTINCT ON` and made the survivors a UUID lottery.
+- **Archived jobs are excluded** rather than consuming cap slots and being discarded downstream,
+  and the RPC returns an exact `total_matches` counted *before* the cap. When it cuts, the list
+  says so: *"Showing the 120 newest matches out of 843."*
+
+If the cap ever genuinely constrains a shop, the escalation is a pager, not a bigger number — see
+the inventory count page for that pattern.
 *(This doc previously described a single-choice dropdown reading "All Jobs / Not Started / In
 Progress / Completed / Shipped / Cancelled", six colour-coded pills, and the empty-state string
 "No jobs yet. Create a job or convert a quote to get started." All three were replaced by the
@@ -453,8 +471,11 @@ unless stated.
 
 | Behaviour | Verification |
 |---|---|
-| Search over job number, customer, customer PO, part number, packing slip; blank is a no-op | `describe('searchJobsByIdentifier')` — 3 it |
-| Closed stages hidden by default; stage filters applied server-side via `.in()` | `describe('getAllJobs')` — 4 it; [`e2e/jobs-list-status.spec.ts`](../../e2e/jobs-list-status.spec.ts) `test.describe('Jobs list — combined status filter')` — 2 tests |
+| Search over job number, customer, customer PO, part number, packing slip; blank is a no-op; filters + `JOB_SEARCH_LIMIT` forwarded to the RPC | `describe('searchJobsByIdentifier')` — 7 it |
+| Search restricts the main query by id, mixes in `match_source`, reports `total`/`truncated`, and drops nothing client-side | `describe('getAllJobs — search path')` — 6 it |
+| The cap applies after every filter, keeps the newest (hot first), excludes archived jobs, clamps `p_limit`, and stays SECURITY INVOKER | [`api/tests/integration/test_jobs_search_cap.py`](../../api/tests/integration/test_jobs_search_cap.py) — 18 tests. Needs >`JOB_SEARCH_LIMIT` jobs, which `seed.sql` deliberately does not have |
+| Stage → status-pair mapping is exact, total and disjoint (the banner's count depends on it) | [`__tests__/types/job.test.ts`](../../__tests__/types/job.test.ts) `describe('stagesToStatusPairs')` — 9 it |
+| Closed stages hidden by default; stage filters applied server-side via `.in()` | `describe('getAllJobs')` — 5 it; [`e2e/jobs-list-status.spec.ts`](../../e2e/jobs-list-status.spec.ts) `test.describe('Jobs list — combined status filter')` — 2 tests |
 | Overdue uses one canonical clause set on the same builder | `describe('applyOverdueJobsFilter')` — 1 it |
 | Quote → job: one `job_part` per (part, qty) with cloned ops; fractional qty survives | [`e2e/quote-to-job.spec.ts`](../../e2e/quote-to-job.spec.ts) `test.describe('Quote to Job workflow')` — 1 test; [`e2e/fractional-quote-to-job.spec.ts`](../../e2e/fractional-quote-to-job.spec.ts) `test.describe('Fractional quote to job workflow')` — 1 test |
 | PO path validates everything before any write, and fails fast on a made part with no routing | `describe('createJobFromPurchaseOrder')` — 7 it |

--- a/e2e/jobs-list-status.spec.ts
+++ b/e2e/jobs-list-status.spec.ts
@@ -45,12 +45,13 @@ test.describe('Jobs list — combined status filter', () => {
 
     // Customer is back, and this assertion is INVERTED from what it used to be.
     // It was removed as "redundant — search already matches customer name",
-    // which is true of the manual case and false of the two that matter:
-    // search_jobs_by_identifier is capped at LIMIT 100 (and jobsAccess applies
-    // the status filters AFTER that cap), so a busy customer's list silently
-    // truncates in UUID order; and a substring can never express "exactly this
-    // customer", which the customer page's Quotes/Jobs count links require.
-    // The dropdown filters on customer_id, so it is exact by construction.
+    // which is true of the manual case and false of the one that matters: a
+    // substring can never express "exactly this customer", which the customer
+    // page's Quotes/Jobs count links require. The dropdown filters on
+    // customer_id, so it is exact by construction.
+    // (It had a second justification until #688 — the search RPC capped at 100
+    // rows in UUID order before the status filters ran. Fixed: the cap now
+    // applies after every filter, keeps the newest rows, and the list says so.)
     await expect(page.getByRole('combobox', { name: /^Customer$/i })).toBeVisible();
 
     // Isolate the seeded jobs by their shared job-number prefix.

--- a/lib/queryLimits.ts
+++ b/lib/queryLimits.ts
@@ -18,3 +18,27 @@
  * `location_id` term some callers add) rather than sitting just under the cliff.
  */
 export const ID_CHUNK = 120;
+
+/**
+ * How many jobs the jobs-list search may return.
+ *
+ * `search_jobs_by_identifier` resolves the matching ids, and `getAllJobs` then sends them
+ * back as one un-chunked `.in('id', …)` — so this is a URL budget, not a product decision.
+ *
+ * **Measured, not guessed** — against the local gateway on 2026-08-08, with the real
+ * `getAllJobs` select string (the `customers` / `quotes` / `job_parts` / `parts` embed block,
+ * ~250 chars before any ids) and real UUIDs: 200 ids → **200 OK** at 7,791 bytes of URL,
+ * 220 ids → **414 URI Too Long** at 8,531. The gateway's ceiling is 8 KB, and it does not
+ * care that this query is longer than the ones `ID_CHUNK` was measured against — the cliff
+ * lands in the same place.
+ *
+ * 120 (4,831 bytes) keeps the same headroom `ID_CHUNK` does, which the jobs query needs:
+ * status, customer and overdue filters all add terms to the same URL.
+ *
+ * **Raising this is not free.** Past the ceiling the failure mode changes from a truncated
+ * list — which the UI now admits to, see JobsPage.total — to a hard 414 that reads as
+ * "no jobs". If the cap ever genuinely constrains a shop, the answer is a pager, not a
+ * bigger number: `app/dashboard/[companyId]/inventory/count/page.tsx` documents that
+ * escalation and the debounce/page-reset guard it needs.
+ */
+export const JOB_SEARCH_LIMIT = ID_CHUNK;

--- a/supabase/migrations/20260809001523_jobs_search_filters_before_cap.sql
+++ b/supabase/migrations/20260809001523_jobs_search_filters_before_cap.sql
@@ -1,0 +1,159 @@
+-- #688 — the jobs-list search cap now applies to the FINAL set, in a meaningful order,
+-- and reports how much it cut.
+--
+-- Three defects, one function:
+--
+--   1. ORDER BY m.job_id existed only to serve DISTINCT ON. It is not a ranking, so the
+--      100 rows that survived LIMIT were a UUID lottery — not the newest, not the most
+--      relevant, just whichever ids sorted first.
+--   2. The status / customer / overdue filters were applied by the CALLER, on the main
+--      query, AFTER this cap. The default jobs view hides closed jobs and a busy
+--      customer's history is mostly closed, so the cap filled with closed jobs that were
+--      then discarded and the handful of open ones left was a fraction of what existed.
+--   3. deleted_at was never filtered here, so archived jobs consumed cap slots and were
+--      then thrown away by the caller's .is('deleted_at', null) — making (2) worse, and a
+--      live instance of the repo's most-violated rule.
+--
+-- The fix is not a bigger number. The caller round-trips these ids back through a
+-- PostgREST GET as .in('id', …), and lib/queryLimits.ts records the measured cliff
+-- (200 ids OK, 220 → 414 URI Too Long), so raising the cap past ~200 would trade a
+-- silent truncation for a silent request failure. Instead the ~120 rows become the
+-- RIGHT ~120 — every filter applied before the cap, ordered hot-then-newest — and
+-- total_matches lets the UI say "showing 120 of 843" out loud.
+--
+-- The return type gains total_matches, so CREATE OR REPLACE is unavailable: this is a
+-- DROP + CREATE. That destroys both the ACL and the COMMENT, which are re-issued at the
+-- bottom.
+--
+-- The new parameters carry DEFAULTs, which is safe precisely because the DROP leaves no
+-- second signature for a two-arg call to be ambiguous against (42725). It also earns
+-- something at the call site: Supabase's type generator marks defaulted parameters
+-- optional, so `filters.customerId` being undefined omits the key instead of forcing a
+-- null through an argument type that is generated as non-nullable.
+
+DROP FUNCTION IF EXISTS public.search_jobs_by_identifier(uuid, text);
+
+CREATE FUNCTION public.search_jobs_by_identifier(
+    p_company_id  uuid,
+    p_query       text,
+    -- Exact 'production:fulfillment' pairs for the selected lifecycle stages, built by
+    -- stagesToStatusPairs() in types/job.ts. That helper enumerates the 12 combinations
+    -- through getJobLifecycleStage itself rather than reading the hand-maintained
+    -- STAGE_TO_JOB_FILTERS inverse: the latter ANDs two IN lists, which is exact for a
+    -- single stage but a SUPERSET for a multi-select ({not_started, partially_shipped}
+    -- would also admit in_progress+unshipped). A superset would make total_matches
+    -- over-count and the on-screen "of N" lie, which is the whole thing we are fixing.
+    -- NULL = no stage narrowing. '{}' = the user ticked nothing, which matches nothing.
+    p_stage_pairs text[] DEFAULT NULL,
+    p_customer_id uuid    DEFAULT NULL,
+    p_overdue     boolean DEFAULT false,
+    -- The CALLER's local date. Mirrors applyOverdueJobsFilter / todayLocalISODate in
+    -- utils/jobsAccess.ts: the overdue day boundary is the shop's local midnight, not
+    -- UTC's. Taking it as a parameter keeps the two definitions agreeing; current_date
+    -- here would flip a job overdue in the search but not in the list for part of a day.
+    p_today       date    DEFAULT NULL,
+    p_limit       integer DEFAULT 100
+) RETURNS TABLE("job_id" uuid, "match_source" text, "total_matches" bigint)
+    LANGUAGE plpgsql STABLE SECURITY INVOKER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+    v_pattern text;
+    -- Hard ceiling, enforced here so no caller can talk the function past the URL cliff
+    -- described above. Clamped rather than rejected: a bad p_limit should not error out
+    -- a search box.
+    v_limit int := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 200);
+BEGIN
+    IF p_query IS NULL OR length(trim(p_query)) = 0 THEN
+        RETURN;
+    END IF;
+    v_pattern := '%' || replace(replace(replace(trim(p_query), '\', '\\'), '%', '\%'), '_', '\_') || '%';
+
+    RETURN QUERY
+    WITH deduped AS (
+        -- One row per job, carrying its highest-priority match_source. The ORDER BY here
+        -- is required by DISTINCT ON and is NOT the output order — see the final SELECT.
+        SELECT DISTINCT ON (m.job_id) m.job_id, m.match_source
+          FROM (
+              SELECT j.id AS job_id, 'packing_slip'::text AS match_source, 1::int AS priority
+                FROM public.jobs j
+                JOIN public.job_parts jp ON jp.job_id = j.id
+                JOIN public.shipment_line_items sli ON sli.job_part_id = jp.id
+                JOIN public.shipments s ON s.id = sli.shipment_id
+               WHERE j.company_id = p_company_id
+                 AND j.deleted_at IS NULL
+                 AND s.voided_at IS NULL
+                 AND s.packing_slip_number ILIKE v_pattern
+              UNION ALL
+              SELECT j.id, 'job_number'::text, 2
+                FROM public.jobs j
+               WHERE j.company_id = p_company_id
+                 AND j.deleted_at IS NULL
+                 AND j.job_number ILIKE v_pattern
+              UNION ALL
+              SELECT j.id, 'customer_po'::text, 3
+                FROM public.jobs j
+               WHERE j.company_id = p_company_id
+                 AND j.deleted_at IS NULL
+                 AND j.customer_po_number ILIKE v_pattern
+              UNION ALL
+              -- customers.deleted_at and parts.deleted_at are deliberately NOT filtered.
+              -- The jobs list renders an archived customer's and an archived part's name
+              -- (retained-FK by-id reads, which architecture.md §16 exempts from the
+              -- filter rule), so a name visible on screen has to stay searchable.
+              SELECT j.id, 'customer'::text, 4
+                FROM public.jobs j
+                JOIN public.customers c ON c.id = j.customer_id
+               WHERE j.company_id = p_company_id
+                 AND j.deleted_at IS NULL
+                 AND c.name ILIKE v_pattern
+              UNION ALL
+              SELECT j.id, 'part'::text, 5
+                FROM public.jobs j
+                JOIN public.job_parts jp ON jp.job_id = j.id
+                JOIN public.parts p ON p.id = jp.part_id
+               WHERE j.company_id = p_company_id
+                 AND j.deleted_at IS NULL
+                 AND p.part_name ILIKE v_pattern
+          ) AS m
+         ORDER BY m.job_id, m.priority
+    ),
+    filtered AS (
+        -- Every filter the caller used to apply AFTER the cap now applies BEFORE it, so
+        -- the rows that survive are rows the user would actually have seen.
+        SELECT d.job_id, d.match_source, j.is_hot, j.created_at
+          FROM deduped d
+          JOIN public.jobs j ON j.id = d.job_id
+         WHERE (p_stage_pairs IS NULL
+                OR (j.production_status || ':' || j.fulfillment_status) = ANY (p_stage_pairs))
+           AND (p_customer_id IS NULL OR j.customer_id = p_customer_id)
+           -- COALESCE on p_today, not a bare comparison: `due_date < NULL` is NULL,
+           -- so an omitted date would quietly report "nothing is overdue" rather
+           -- than falling back to the server's idea of today. The app always sends
+           -- it; this is about the default not being a trap.
+           AND (NOT COALESCE(p_overdue, false)
+                OR (j.due_date IS NOT NULL
+                    AND j.due_date < COALESCE(p_today, current_date)
+                    AND j.fulfillment_status <> 'fully_shipped'
+                    AND j.production_status IN ('not_started', 'in_progress')))
+    )
+    -- count(*) OVER () is evaluated across the whole `filtered` set before LIMIT, so the
+    -- total is exact no matter how much the cap cuts. Rush jobs first, then newest;
+    -- job_id is the tiebreak so the retained set is deterministic when created_at ties.
+    SELECT f.job_id, f.match_source, count(*) OVER ()::bigint
+      FROM filtered f
+     ORDER BY f.is_hot DESC, f.created_at DESC NULLS LAST, f.job_id
+     LIMIT v_limit;
+END $$;
+
+ALTER FUNCTION public.search_jobs_by_identifier(uuid, text, text[], uuid, boolean, date, integer) OWNER TO postgres;
+
+-- The DROP took the ACL with it. The baseline granted ALL to anon as well; that is not
+-- re-issued. Under SECURITY INVOKER anon holds no user_company_access row and so already
+-- saw zero rows — dropping the grant is hygiene, not a behaviour change.
+REVOKE EXECUTE ON FUNCTION public.search_jobs_by_identifier(uuid, text, text[], uuid, boolean, date, integer) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.search_jobs_by_identifier(uuid, text, text[], uuid, boolean, date, integer) TO authenticated, service_role;
+
+-- The DROP took the COMMENT too.
+COMMENT ON FUNCTION public.search_jobs_by_identifier(uuid, text, text[], uuid, boolean, date, integer) IS
+  'Extended jobs-list search across job_number, jobs.customer_po_number, customers.name, parts.part_name, shipments.packing_slip_number. Returns one row per matching non-archived job with its highest-priority match_source, plus total_matches — the exact count of matches AFTER every filter, so the UI can say "showing 120 of 843" instead of truncating silently (#688). Stage / customer / overdue filters are applied BEFORE the cap; they used to be applied by the caller after it, which cut into an arbitrary subset. Retained rows are hot first, then newest. p_limit is clamped to 200 because the caller round-trips these ids through a PostgREST .in() URL — see JOB_SEARCH_LIMIT in lib/queryLimits.ts; the escalation past that ceiling is a pager, not a bigger number. SECURITY INVOKER, so jobs/customers/parts RLS still enforces tenancy and p_company_id is only a narrowing filter.';

--- a/types/database.ts
+++ b/types/database.ts
@@ -3833,10 +3833,19 @@ export type Database = {
         Returns: undefined
       }
       search_jobs_by_identifier: {
-        Args: { p_company_id: string; p_query: string }
+        Args: {
+          p_company_id: string
+          p_customer_id?: string
+          p_limit?: number
+          p_overdue?: boolean
+          p_query: string
+          p_stage_pairs?: string[]
+          p_today?: string
+        }
         Returns: {
           job_id: string
           match_source: string
+          total_matches: number
         }[]
       }
       seed_demo_data: {

--- a/types/job.ts
+++ b/types/job.ts
@@ -363,8 +363,20 @@ export interface JobFilters {
    * search_jobs_by_identifier RPC (job_number, customer_po, customer
    * name, part number, packing slip number) and surfaces the match_source
    * on the returned rows.
+   *
+   * The RPC caps its result at JOB_SEARCH_LIMIT rows — the ids round-trip
+   * back through a PostgREST `.in()` URL, which has a hard ceiling. Every
+   * other filter here is forwarded to the RPC so the cap applies to the
+   * final set, and JobsPage.total reports how many matched before it.
    */
   search?: string;
+  /**
+   * Selected lifecycle stages. Forwarded to the search RPC as exact
+   * status pairs (see stagesToStatusPairs) so the search cap can't cut into
+   * a set the caller is about to narrow further. Ignored off the search
+   * path, where the jobs list does this narrowing client-side.
+   */
+  stages?: JobLifecycleStage[];
   overdue?: boolean;
   /** When true (default), hide "closed" jobs — the FR-18 done predicate OR
    *  cancelled (see isJobClosed). The jobs list turns this off when the user
@@ -444,6 +456,39 @@ export const STAGE_TO_JOB_FILTERS: Record<
   },
   cancelled: { productionStatus: ['cancelled'], showClosed: true },
 };
+
+/**
+ * The other inverse of getJobLifecycleStage: the EXACT
+ * `production_status:fulfillment_status` pairs covered by a set of stages,
+ * for `search_jobs_by_identifier`'s `p_stage_pairs`.
+ *
+ * Why this exists alongside STAGE_TO_JOB_FILTERS rather than reusing it: that
+ * one is two `.in()` lists ANDed together, which is exact for ONE stage and a
+ * superset for a multi-select. Ticking {not_started, partially_shipped} unions
+ * to production ∈ {not_started, …} AND fulfillment ∈ {unshipped,
+ * partially_shipped}, which also admits `in_progress + unshipped` — a stage the
+ * user did not tick. Harmless when it only widens a pre-filter, fatal here: the
+ * RPC counts what it matches, and an over-count makes the jobs list's
+ * "showing 120 of N" claim a lie (#688).
+ *
+ * Derived by enumerating all production × fulfillment combinations through
+ * getJobLifecycleStage itself, so it cannot drift from the forward mapping the
+ * way a hand-maintained table can.
+ */
+export function stagesToStatusPairs(stages: JobLifecycleStage[]): string[] {
+  const productions = Object.keys(PRODUCTION_STATUS_CONFIG) as ProductionStatus[];
+  const fulfillments = Object.keys(FULFILLMENT_STATUS_CONFIG) as FulfillmentStatus[];
+  const wanted = new Set(stages);
+  const pairs: string[] = [];
+  for (const production_status of productions) {
+    for (const fulfillment_status of fulfillments) {
+      if (wanted.has(getJobLifecycleStage({ production_status, fulfillment_status }))) {
+        pairs.push(`${production_status}:${fulfillment_status}`);
+      }
+    }
+  }
+  return pairs;
+}
 
 // ============== Operation Types ==============
 

--- a/utils/jobsAccess.ts
+++ b/utils/jobsAccess.ts
@@ -26,12 +26,12 @@ import type {
   OperationUpdateResult,
   CurrentOperationInfo,
 } from '@/types/job';
-import { isJobClosed } from '@/types/job';
+import { isJobClosed, stagesToStatusPairs } from '@/types/job';
+import { JOB_SEARCH_LIMIT } from '@/lib/queryLimits';
 import type { PricingBasisSnapshot } from '@/types/quote';
 import type { FreightTerms } from '@/types/shipment';
 import { resolveJobPartUnitPrice, type JobPartPricingBasis } from '@/utils/quotePricingResolver';
 import { getJobPartShipmentSummaries } from '@/utils/shipmentsAccess';
-import { orIlikeValue } from '@/utils/searchFilter';
 import { getJobPartInvoiceSummaries } from '@/utils/quickbooksAccess';
 import {
   createOperationCompletion,
@@ -105,16 +105,36 @@ export function applyOverdueJobsFilter<
 // ============== Read Queries ==============
 
 /**
+ * A page of jobs, plus the count the display cap hid.
+ *
+ * Mirrors LocationContentsPage in inventoryLocationsAccess: an explicit cap
+ * paired with an exact total lets the UI say "showing 120 of 843" instead of
+ * quietly lying. Off the search path there is no cap, so `total` is just
+ * `jobs.length` and `truncated` is false.
+ */
+export interface JobsPage {
+  jobs: JobWithRelations[];
+  /** Jobs matching every filter, ignoring the search cap. */
+  total: number;
+  /** Whether the cap actually cut anything — the UI's cue to say so. */
+  truncated: boolean;
+}
+
+/**
  * Get all jobs for a company (batch fetch for AG Grid). Pulls each job's
  * job_parts list with the linked part name + qty so the dashboard list can
  * show "ADP-001, ADP-002" style summaries without extra round-trips.
+ *
+ * On the search path the returned rows are capped at JOB_SEARCH_LIMIT, and
+ * `total` says how many matched — see the RPC call below for why the cap has
+ * to exist and why every filter is forwarded into it.
  */
 export async function getAllJobs(
   companyId: string,
   filters: JobFilters = {},
   sortField: string = 'created_at',
   sortDirection: 'asc' | 'desc' = 'desc',
-): Promise<JobWithRelations[]> {
+): Promise<JobsPage> {
   const supabase = getSupabase();
   const BATCH_SIZE = 1000;
   let allData: JobWithRelations[] = [];
@@ -125,10 +145,23 @@ export async function getAllJobs(
   // match_source up-front via the extended search RPC. The main query
   // restricts to those ids; the result rows get match_source mixed in
   // so the cell renderer can show "matched packing slip" sub-text.
+  //
+  // Every other filter goes INTO that call rather than being applied here
+  // afterwards. The RPC caps its output (the ids come back through a URL —
+  // see JOB_SEARCH_LIMIT), and a cap applied before the filters cuts into a
+  // set the caller is about to shrink further: search a customer with 300
+  // jobs and the open ones you saw were whichever open ones survived an
+  // arbitrary cut. That was #688.
   let matchSourceByJobId: Map<string, string> | null = null;
+  let searchTotal = 0;
   if (filters.search?.trim()) {
-    const matches = await searchJobsByIdentifier(companyId, filters.search.trim());
+    const { matches, total } = await searchJobsByIdentifier(companyId, filters.search.trim(), {
+      stages: filters.stages,
+      customerId: filters.customerId,
+      overdue: filters.overdue,
+    });
     matchSourceByJobId = new Map(matches.map((m) => [m.job_id, m.match_source]));
+    searchTotal = total;
   }
 
   while (hasMore) {
@@ -165,15 +198,14 @@ export async function getAllJobs(
     if (matchSourceByJobId !== null) {
       // search_jobs_by_identifier has already resolved the matching set
       // (see top of getAllJobs). Restrict the main query to those ids;
-      // an empty set short-circuits to no rows.
+      // an empty set short-circuits to no rows. The list is bounded by
+      // JOB_SEARCH_LIMIT, which is sized to fit in this URL.
       const ids = Array.from(matchSourceByJobId.keys());
       if (ids.length === 0) {
         hasMore = false;
         break;
       }
       query = query.in('id', ids);
-    } else if (filters.search?.trim()) {
-      query = query.or(`job_number.ilike.${orIlikeValue(filters.search.trim())}`);
     }
     if (filters.overdue) {
       // Single source of truth for the overdue predicate — see
@@ -210,29 +242,61 @@ export async function getAllJobs(
     }));
   }
 
-  return allData;
+  // Off the search path nothing is capped, so the rows ARE the total. On it,
+  // compare against what we actually returned rather than against the cap: a
+  // job archived between the RPC and the main query drops a row without
+  // changing the total, and the UI should still be able to say so.
+  const total = matchSourceByJobId === null ? allData.length : searchTotal;
+  return { jobs: allData, total, truncated: total > allData.length };
 }
 
 /**
  * Resolve the matching job-ids + per-row match_source for an extended
  * search query (job_number, customer_po, customer name, part number,
- * packing slip number). Capped server-side at 100 rows by the RPC.
+ * packing slip number), along with the exact number of matches.
+ *
+ * The RPC caps its rows at JOB_SEARCH_LIMIT because getAllJobs sends the ids
+ * back through a PostgREST `.in()` URL. `total` is counted *before* that cap
+ * and *after* every filter passed here, which is what lets the jobs list say
+ * "showing 120 of 843" and be telling the truth (#688).
  */
 export async function searchJobsByIdentifier(
   companyId: string,
   query: string,
-): Promise<Array<{ job_id: string; match_source: string }>> {
-  if (!query.trim()) return [];
+  filters: Pick<JobFilters, 'stages' | 'customerId' | 'overdue'> = {},
+): Promise<{ matches: Array<{ job_id: string; match_source: string }>; total: number }> {
+  if (!query.trim()) return { matches: [], total: 0 };
   const supabase = getSupabase();
   const { data, error } = await supabase.rpc('search_jobs_by_identifier', {
     p_company_id: companyId,
     p_query: query.trim(),
+    // Omitted (undefined) means "no stage narrowing" — the SQL default is NULL.
+    // An empty selection is a real answer (the user ticked nothing), so it must
+    // stay an empty array and match nothing.
+    p_stage_pairs: filters.stages && stagesToStatusPairs(filters.stages),
+    p_customer_id: filters.customerId,
+    p_overdue: filters.overdue ?? false,
+    // The overdue day boundary is the shop's local midnight — same source as
+    // applyOverdueJobsFilter, so the two can't disagree about what "today" is.
+    p_today: todayLocalISODate(),
+    p_limit: JOB_SEARCH_LIMIT,
   });
   if (error) {
+    // .rpc() is deliberately outside the Supabase Sentry integration's coverage,
+    // so this one reports itself by throwing to the caller's error state.
     console.error('search_jobs_by_identifier failed:', error);
     throw new Error(`Search failed: ${error.message}`);
   }
-  return (data ?? []) as Array<{ job_id: string; match_source: string }>;
+  const rows = (data ?? []) as Array<{
+    job_id: string;
+    match_source: string;
+    total_matches: number;
+  }>;
+  return {
+    matches: rows.map(({ job_id, match_source }) => ({ job_id, match_source })),
+    // Constant across rows; no rows means no matches.
+    total: rows[0]?.total_matches ?? 0,
+  };
 }
 
 /**


### PR DESCRIPTION
Closes #688.

## Confirmed still live

Queried production directly before touching anything: `search_jobs_by_identifier` still ends in `ORDER BY m.job_id, m.priority LIMIT 100`, and no migration since the baseline touches it.

Worth stating plainly for scoping: **the cap does not fire for anyone today.** The largest company in prod has 63 jobs total and the largest customer 15. This is latent — it fires once a shop accumulates >100 matching jobs, and it fails worst on the biggest accounts, which are the ones people search for.

The issue documents two consequences. There is a third it doesn't mention: **the RPC never filtered `deleted_at`**, so archived jobs consumed cap slots and were then discarded by the caller's `.is('deleted_at', null)`. That is a live instance of the repo's most-violated rule, and it makes consequence #2 worse.

## Why not just raise the cap

`getAllJobs` sends the matching ids back through a PostgREST `GET` as `.in('id', …)`. `lib/queryLimits.ts` already records a measured cliff for shorter queries; I re-measured against **this** query's real select string (the ~250-char embed block) on 2026-08-08:

| ids | URL bytes | result |
|---|---|---|
| 200 | 7,791 | 200 OK |
| 220 | 8,531 | **414 URI Too Long** |

An 8 KB ceiling. Raising the cap past ~200 trades a silent truncation for a silent request failure — strictly worse, because a 414 renders as "no jobs". So the cap stays at `ID_CHUNK` (120, 4,831 bytes, with headroom for the status/customer/overdue terms that share the URL) and **the fix is that those 120 become the right 120.**

Chunking the `.in()` to allow a larger cap was rejected: chunked results concatenate out of order, forcing a client-side re-implementation of `is_hot DESC, <sortField>` — a second sort definition free to drift from the SQL one.

## What changed

**Migration** — `DROP` + `CREATE` (the return type gains a column, so `CREATE OR REPLACE` is unavailable). The ACL and `COMMENT` are destroyed by the drop and re-issued.

- Every filter moves **into** the RPC — exact `production:fulfillment` pairs, customer id, overdue — so the cap applies to the final set instead of a superset the caller then shrinks.
- `ORDER BY is_hot DESC, created_at DESC NULLS LAST, job_id`. The old `ORDER BY m.job_id` existed only to serve `DISTINCT ON` and was never a ranking.
- `j.deleted_at IS NULL` on all five branches. `customers.deleted_at` / `parts.deleted_at` are deliberately **not** filtered — the list renders an archived customer's and part's name (retained-FK by-id reads, exempt per architecture.md §16), so a name on screen stays searchable.
- `count(*) OVER ()` returns an exact `total_matches` from before the cap; `p_limit` is clamped to 200 in SQL so no caller can talk it past the URL ceiling.

**`stagesToStatusPairs`** (`types/job.ts`) enumerates the 12 status combinations through `getJobLifecycleStage` itself. It deliberately does **not** reuse `STAGE_TO_JOB_FILTERS`: that inverse ANDs two `.in()` lists, which is exact for one stage but a **superset** for a multi-select — `{not_started, partially_shipped}` would also admit `in_progress + unshipped`. Harmless where it only widens a pre-filter, fatal here, because the RPC counts what it matches and an over-count makes the on-screen number a lie.

**`getAllJobs` returns a `JobsPage` envelope** (`{ jobs, total, truncated }`), mirroring `LocationContentsPage`. Also deletes the dead `else if` branch at the old `jobsAccess.ts:175-177` — unreachable, since the same `filters.search?.trim()` condition set the map non-null two branches earlier.

**UI** — an info Alert when the cap bites: *"Showing the 120 newest matches out of 843. Type more of the job number, or pick a customer or a status, to narrow this down."*

Because the stages go into the RPC, the two client-side narrowing steps (`excludeClosed`, `visibleJobs`) become **no-ops on the search path by construction**, so `visibleJobs.length === min(total, JOB_SEARCH_LIMIT)` and the banner is strictly true rather than true-ish. There is a test asserting they drop zero rows — that assertion is what keeps the banner honest if someone later changes one side.

## Two things reviewers should look at deliberately

**1. The `anon` EXECUTE grant is not re-issued.** The baseline granted `ALL` to `anon`. Under `SECURITY INVOKER`, `anon` holds no `user_company_access` row and so already saw zero rows — dropping it is hygiene, not a behaviour change. Called out so it isn't mistaken for an accident. `function_execute_leaks()` is unaffected; it scopes `SECURITY DEFINER` only.

**2. The deploy window.** For one Vercel build (~5 min) after merge, the old bundle calls the dropped 2-arg signature and gets `PGRST202`. Today that surfaces as "No jobs found" — the exact silent lie this issue is about, because the page throws its load error into `console.error`. Rather than ship a compatibility shim that leaves dead surface in the schema, this PR **surfaces the error**: "Couldn't load jobs. Check your connection and try again." That fixes the window and every future RPC failure.

## Tests

The search path had **zero** coverage before this — which is how a cap that dropped rows in job-id order ahead of the filters survived review.

- `__tests__/utils/jobsAccess.test.ts` — `describe('getAllJobs — search path')`, 6 new; `searchJobsByIdentifier` extended 3 → 7.
- `__tests__/types/job.test.ts` — `describe('stagesToStatusPairs')`, 9: exact per stage, total over all 12 combos, pairwise disjoint, and the specific multi-select case `STAGE_TO_JOB_FILTERS` gets wrong.
- `api/tests/integration/test_jobs_search_cap.py` — **18 new**, psycopg2 against a local stack. The behaviour only appears above the cap and `seed.sql` has single-digit job counts, so it can never trigger it — which is precisely why this shipped unobserved. Seeding hundreds of jobs into `seed.sql` would slow every `db reset` and pollute the demo company for a property that is about scale, not fixtures, so the tests build and tear down their own 250-job company.

  **These were mutation-checked.** Reverting the SQL to the old semantics (UUID ordering, no `deleted_at`, filters after the cap) fails 9 of the 18, including each of the three defects specifically.

## Verification done

Run from a git worktree, so per the runbook the shared local Supabase stack was never reset. The migration was replayed into a throwaway DB (one `psql` per file — the baseline blanks `search_path` for the session), and `types/database.ts` was regenerated against that rather than the shared stack, whose `public` schema holds another branch's WIP.

- 108 migrations replay clean; regenerated types diff is exactly this function, 14 lines.
- `tsc --noEmit` clean · `pnpm lint` 0 errors · standards checks (doc links, analytics registry, interaction) green.
- Full vitest: 2,257 passed. One unrelated file (`MachineLogPanel`) has 3 pointer-event flakes under parallel load; passes in isolation and shares no code with this change.
- Not yet verified in a browser — the shared local stack still has the old function, so that belongs on the preview.

## Telemetry

**No PostHog event, deliberately.** This adds no user-facing write. A "truncation shown" event would be a read-path render firing on every debounced keystroke — the passive shape this repo avoids — and its only interesting property, the match count, is the shop's own business data, which the registry convention forbids. If we later want to know whether the cap bites, the honest instrument is a jobs-per-company query.

## Not fixed here

- **The cap ignores the user's chosen column sort.** Sort by due date and it still keeps the newest 120, then sorts those. Following the sort needs dynamic SQL or a `CASE` ladder — over-engineering at 63 jobs. The banner stays true either way.
- **`jobs.customer_name`** (denormalized) isn't searched; the RPC joins `customers.name`. A job with a null customer FK but a set snapshot name is unsearchable by customer. Probably worth its own issue.
- **No jobs-list component test** exists and there's no AG Grid harness in `__tests__`; building one is its own project. The banner's logic is covered by the `truncated`/`total` unit tests — only the JSX is uncovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)