### PR TITLE
fix(observability): one issue per backend failure, and none from a laptop

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -46,12 +46,25 @@ def resolve_sentry_environment() -> str:
 # Initialize Sentry for error monitoring.
 SENTRY_ENVIRONMENT = resolve_sentry_environment()
 
+# Only DEPLOYED environments report, matching the frontend's
+# `enabled: process.env.NODE_ENV === "production"` guard in instrumentation-client.ts.
+#
+# The pytest guard alone was not enough. `load_dotenv` above reads SENTRY_DSN out of
+# .env.local, so a developer running `python api/index.py` reports to the real project —
+# tagged `development`, but sitting in the same queue as production, and indistinguishable
+# from it at a glance. Every deliberately-provoked local failure (a `stripe listen` secret
+# that no longer matches, a QuickBooks sandbox 500) lands there as a real issue, which is
+# one of the explanations for backend issues appearing after the code that filed them was
+# already fixed.
+_REPORTING_ENVIRONMENTS = {"production", "preview"}
+_SENTRY_ENABLED = not _UNDER_PYTEST and SENTRY_ENVIRONMENT in _REPORTING_ENVIRONMENTS
+
 # Disabling needs an EMPTY STRING, not None — there is no `enabled` kwarg, and a None
 # dsn makes the SDK fall back to reading SENTRY_DSN from the environment, which
 # `load_dotenv` above has already populated from .env.local. So `dsn=None` looks like
 # "off" and is actually "on"; only a falsy-but-not-None value truly disables it.
 sentry_sdk.init(
-    dsn="" if _UNDER_PYTEST else os.getenv("SENTRY_DSN"),
+    dsn=os.getenv("SENTRY_DSN") if _SENTRY_ENABLED else "",
     traces_sample_rate=0.1,
     environment=SENTRY_ENVIRONMENT,
     send_default_pii=True,

--- a/api/routes/quickbooks_routes.py
+++ b/api/routes/quickbooks_routes.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sentry_sdk
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
@@ -601,7 +602,12 @@ async def push_invoice(company_id: str, job_id: str, request: Request, body: Com
         raise
     except Exception as exc:  # noqa: BLE001
         db.table("quickbooks_invoice_links").update({"status": "error"}).eq("id", link_id).execute()
-        logger.exception("QuickBooks push failed for job %s", job_id)
+        # WARNING, not exception: `LoggingIntegration` files an ERROR-level record as its own
+        # Sentry event, and `_map_qb_error` raises an HTTPException the Starlette integration
+        # already captures for any 5xx (its default `failed_request_status_codes` is 500-599).
+        # Two captures for one failure, fingerprinted differently — the trap in telemetry.md.
+        # `exc_info` keeps the traceback in the log, where it costs nothing.
+        logger.warning("QuickBooks push failed for job %s", job_id, exc_info=True)
         raise _map_qb_error(exc)
 
     # Success: flip the link to created. This fires the invoicing_status recompute
@@ -640,8 +646,19 @@ async def push_invoice(company_id: str, job_id: str, request: Request, body: Com
         db.table("quickbooks_invoice_links").update(
             {"status": "error", "qb_invoice_id": result["id"], "qb_invoice_url": invoice_url}
         ).eq("id", link_id).execute()
-        logger.exception(
-            "Invoice %s created in QBO but recording its lines failed (link %s)", result["id"], link_id
+        # Same double-capture reasoning as the push failure above — but this is the path with
+        # real data consequences (money exists in QBO that Jigged has not recorded), so the ids
+        # go into Sentry's context rather than being lost with the duplicate event. The 500
+        # below is what files the issue; this is what makes it actionable.
+        sentry_sdk.set_context(
+            "quickbooks_invoice",
+            {"qb_invoice_id": result["id"], "link_id": link_id, "job_id": job_id},
+        )
+        logger.warning(
+            "Invoice %s created in QBO but recording its lines failed (link %s)",
+            result["id"],
+            link_id,
+            exc_info=True,
         )
         raise HTTPException(
             status_code=500,

--- a/api/tests/unit/test_sentry_config.py
+++ b/api/tests/unit/test_sentry_config.py
@@ -78,3 +78,31 @@ class TestEnvironmentResolution:
         monkeypatch.setenv("VERCEL_ENV", "")
         monkeypatch.setenv("ENVIRONMENT", "")
         assert index.resolve_sentry_environment() == "development"
+
+
+class TestOnlyDeployedEnvironmentsReport:
+    """A locally-run backend must not file into the same queue as production.
+
+    The pytest guard covers CI. It does not cover `python api/index.py`, which is how the
+    backend is run in development — and `load_dotenv` reads SENTRY_DSN out of `.env.local`,
+    so that process reports for real. The events land tagged `development`, in the same
+    project as production, and are indistinguishable at a glance from something a user hit.
+    That is one explanation for a backend issue appearing days after the code that filed it
+    was fixed.
+
+    The frontend has always had this guard (`enabled: NODE_ENV === "production"`); the
+    backend did not.
+    """
+
+    def test_development_does_not_report(self):
+        assert "development" not in index._REPORTING_ENVIRONMENTS
+
+    def test_deployed_environments_do_report(self):
+        # Preview is deliberately included: a preview deployment IS running our code for
+        # real, and #625 exists precisely so its failures are visible and separable.
+        assert index._REPORTING_ENVIRONMENTS == {"production", "preview"}
+
+    def test_pytest_still_wins_over_a_deployed_environment_name(self):
+        # Belt and braces: CI sets VERCEL_ENV on some runners, and a test run must stay
+        # silent regardless of what the environment claims to be.
+        assert index._SENTRY_ENABLED is False

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -250,7 +250,7 @@ Post-#625 the environment tags are trustworthy:
 | Frontend, local dev / CI E2E | **nothing — the SDK is disabled** |
 | Backend, production | `production` |
 | Backend, preview | `preview` |
-| Backend, local | `development` |
+| Backend, local / pytest | **nothing — the SDK is disabled** |
 
 Note the asymmetry: the frontend's tags come from Vercel's Sentry integration
 (`vercel-` prefixed), the backend's from `resolve_sentry_environment()` in


### PR DESCRIPTION
Two sources of backend noise, both found while triaging why a Stripe `SignatureVerificationError` appeared **days after** the commit that stopped reporting it (`c5aac298`, 2026-08-03).

## One failure, two issues

`api/index.py` passes no `before_send`, no `ignore_errors` and no integration overrides, so the Starlette integration's default `failed_request_status_codes = range(500, 600)` **already captures every 5xx `HTTPException`**. Both QuickBooks push paths called `logger.exception` immediately before raising one — and `LoggingIntegration` files an ERROR-level record as its own event — so each failure arrived as **two issues with different fingerprints**. That's the trap [`telemetry.md`](https://github.com/debola31/Jigged/blob/main/docs/telemetry.md) names: two captures for one failure is worse than either alone, because neither is a reliable count any more.

Dropped to `logger.warning(..., exc_info=True)` — breadcrumb rather than event, traceback still in the log where it costs nothing.

**Not `logger.error`**, which would have changed nothing: the level is the load-bearing part, exactly as in `stripe_routes.py`, where the signature-rejection path is a warning for this same reason.

The invoice-recording failure **keeps its ids**, via `sentry_sdk.set_context` rather than the duplicate event. It's the path with real consequences — money exists in QuickBooks that Jigged hasn't recorded — and the surviving 500's detail string carries no invoice or link id, so without this the remaining issue would be unactionable.

`quickbooks_routes.py:189` deliberately **keeps** its `logger.exception`: the OAuth callback returns a **302**, not an `HTTPException`, so nothing else reports it.

## Reporting from a laptop

The DSN was gated only on pytest. But `load_dotenv` reads `SENTRY_DSN` out of `.env.local`, so `python api/index.py` — how the backend is actually run in development — **reports for real**, tagged `development`, into the same project as production and indistinguishable from it at a glance. Any deliberately-provoked local failure (a `stripe listen` secret that no longer matches, a QuickBooks sandbox 500) lands there looking genuine.

The frontend has always had this guard (`enabled: NODE_ENV === "production"`); the backend did not. Now only `production` and `preview` arm the SDK — **preview included on purpose**, since a preview deployment is running our code for real and #625 exists precisely to keep its failures visible and separable.

**This is a live candidate explanation for the Stripe issue**, whose events postdate the fix that should have prevented them. The other is deploy lag: `vercel.json` sets `deploymentEnabled.main = false`, so production ships only via the gated `deploy-production.yml` hook and the commit date isn't the live date. Worth confirming per-event before archiving that issue — note an issue is a *group*, and an environment filter matches if **any** event matches:

```bash
sentry api "/api/0/organizations/jigged/issues/7650729981/tags/environment/" \
  | jq -r '.topValues[]?|"\(.count)x \(.value)"'
```

`telemetry.md`'s environment table said "Backend, local | `development`", which is no longer true.

## Tests

236 backend unit tests pass, including a new `TestOnlyDeployedEnvironmentsReport` class and the existing bad-signature test that the pytest guard exists to silence. The integration suite needs a local Supabase stack and was not run here; CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)