### PR TITLE
fix(invites): an expired invitation link explains itself and offers a live one

### DIFF
--- a/__tests__/app/auth/confirmRoute.test.ts
+++ b/__tests__/app/auth/confirmRoute.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The email-link confirmation route, and what it does when the token is dead.
+ *
+ * The bug these exist for (#722): `/auth/confirm` failed closed to a bare `/login`. An invitee
+ * whose link had aged out — an hour was all it took — got an unexplained sign-in form, typed
+ * credentials for an account that had never been given a password, and was told "Invalid login
+ * credentials". Three people at one shop stalled on that screen until the invites were re-sent
+ * live on a call.
+ *
+ * Failing closed is still right; failing closed *silently* was not. So the assertions here are
+ * about what travels with the redirect — a reason, and the invitation the person was trying to
+ * reach — without loosening the open-redirect guard that makes `next` safe to carry.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockVerifyOtp = vi.fn();
+
+vi.mock('@/utils/supabase/server', () => ({
+  createClient: async () => ({
+    auth: { verifyOtp: (...args: unknown[]) => mockVerifyOtp(...args) },
+  }),
+}));
+
+import { GET } from '@/app/auth/confirm/route';
+
+const ORIGIN = 'https://www.jigged.app';
+const INVITE_NEXT = '/accept-invite/59df141a-874e-41aa-b176-caa512c76b53';
+
+function confirmUrl(params: Record<string, string>): NextRequest {
+  const url = new URL('/auth/confirm', ORIGIN);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
+/** The `location` a route handler redirected to, as a parsed URL. */
+async function redirectOf(request: NextRequest): Promise<URL> {
+  const response = await GET(request);
+  return new URL(response.headers.get('location') as string);
+}
+
+beforeEach(() => {
+  mockVerifyOtp.mockReset();
+});
+
+describe('GET /auth/confirm', () => {
+  it('forwards to `next` once the token verifies', async () => {
+    mockVerifyOtp.mockResolvedValue({ error: null });
+
+    const location = await redirectOf(
+      confirmUrl({ token_hash: 'live-token', type: 'invite', next: INVITE_NEXT })
+    );
+
+    expect(location.pathname).toBe(INVITE_NEXT);
+    expect(location.searchParams.get('reason')).toBeNull();
+  });
+
+  it('explains an expired invite link instead of dumping the invitee on a login form', async () => {
+    mockVerifyOtp.mockResolvedValue({ error: { message: 'Token has expired or is invalid' } });
+
+    const location = await redirectOf(
+      confirmUrl({ token_hash: 'dead-token', type: 'invite', next: INVITE_NEXT })
+    );
+
+    expect(location.pathname).toBe('/login');
+    expect(location.searchParams.get('reason')).toBe('invite-link-expired');
+    // Carries the invitation, which is what lets /login offer a fresh link rather than
+    // sending them back to their administrator.
+    expect(location.searchParams.get('returnTo')).toBe(INVITE_NEXT);
+  });
+
+  it('names the recovery flow when a password-reset link is the dead one', async () => {
+    mockVerifyOtp.mockResolvedValue({ error: { message: 'Token has expired or is invalid' } });
+
+    const location = await redirectOf(
+      confirmUrl({ token_hash: 'dead-token', type: 'recovery', next: '/reset-password' })
+    );
+
+    expect(location.searchParams.get('reason')).toBe('reset-link-expired');
+  });
+
+  it('refuses an unknown otp type without calling verifyOtp', async () => {
+    const location = await redirectOf(
+      confirmUrl({ token_hash: 'whatever', type: 'not-a-type', next: INVITE_NEXT })
+    );
+
+    expect(mockVerifyOtp).not.toHaveBeenCalled();
+    expect(location.pathname).toBe('/login');
+  });
+
+  it.each([
+    ['protocol-relative', '//evil.example'],
+    ['backslash-normalised', '/\\evil.example'],
+  ])('drops a %s `next` rather than carrying it into the redirect', async (_label, hostile) => {
+    mockVerifyOtp.mockResolvedValue({ error: { message: 'nope' } });
+
+    const location = await redirectOf(
+      confirmUrl({ token_hash: 'dead-token', type: 'invite', next: hostile })
+    );
+
+    expect(location.origin).toBe(ORIGIN);
+    expect(location.pathname).toBe('/login');
+    // `/` is the sanitised fallback, and a returnTo of `/` is worth nothing — so it is omitted
+    // rather than shipped as an empty promise.
+    expect(location.searchParams.get('returnTo')).toBeNull();
+  });
+
+  it('keeps a hostile `next` out of the success redirect too', async () => {
+    mockVerifyOtp.mockResolvedValue({ error: null });
+
+    const location = await redirectOf(
+      confirmUrl({ token_hash: 'live-token', type: 'invite', next: '//evil.example' })
+    );
+
+    expect(location.origin).toBe(ORIGIN);
+    expect(location.pathname).toBe('/');
+  });
+});

--- a/__tests__/components/auth/LoginExpiredInvite.test.tsx
+++ b/__tests__/components/auth/LoginExpiredInvite.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * What /login says to someone holding a dead invitation link.
+ *
+ * This screen is the far end of #722. An invitee whose link had expired arrived at a sign-in form
+ * with no explanation, and the only thing it offered was a password field for an account that had
+ * never been given a password — so the app answered "Invalid login credentials", which named
+ * neither the real problem nor anything they could act on.
+ *
+ * The contract asserted here: say what happened, say why signing in won't help yet, and offer the
+ * one action that resolves it. The resend endpoint takes no destination from the caller, so the
+ * button can be offered to a visitor with no session at all — the assertions cover that the request
+ * is keyed only by the invitation id.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@/__tests__/test-utils';
+import userEvent from '@testing-library/user-event';
+
+import Login from '@/components/auth/Login';
+
+const mockCapture = vi.fn();
+
+vi.mock('posthog-js', () => ({
+  default: { identify: vi.fn(), capture: (...args: unknown[]) => mockCapture(...args) },
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => ({ auth: { signInWithPassword: vi.fn() } }),
+  getEdgeFunctionUrl: (name: string) => `https://edge.test/${name}`,
+}));
+
+vi.mock('@/utils/companyAccess', () => ({
+  getPostLoginRoute: vi.fn(async () => '/'),
+}));
+
+const INVITATION_ID = '59df141a-874e-41aa-b176-caa512c76b53';
+const INVITE_RETURN_TO = `/accept-invite/${INVITATION_ID}`;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockCapture.mockReset();
+  fetchMock = vi.fn(async () => new Response(JSON.stringify({ success: true }), { status: 200 }));
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('Login — expired invitation link', () => {
+  it('says nothing about invitations on an ordinary visit', () => {
+    render(<Login />);
+
+    expect(screen.queryByText(/invitation link has expired/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it('explains the expiry and warns that signing in may not work yet', () => {
+    render(<Login reason="invite-link-expired" returnTo={INVITE_RETURN_TO} />);
+
+    expect(screen.getByText(/that invitation link has expired/i)).toBeInTheDocument();
+    // Hedged, because an invitee joining a second company DOES already have a password —
+    // this screen cannot tell the two apart, so it must not assert either one.
+    expect(screen.getByText(/if this is your\s+first Jigged invitation/i)).toBeInTheDocument();
+  });
+
+  it('offers a new link, and asks for it by invitation id alone', async () => {
+    const user = userEvent.setup();
+    render(<Login reason="invite-link-expired" returnTo={INVITE_RETURN_TO} />);
+
+    await user.click(screen.getByRole('button', { name: /send me a new link/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`https://edge.test/team-invites/${INVITATION_ID}/request-resend`);
+    expect(init.method).toBe('POST');
+    // No email, no destination — the endpoint reads the address off the invitation row, which is
+    // what makes an unauthenticated resend safe to offer.
+    expect(init.body).toBeUndefined();
+
+    expect(await screen.findByText(/a new link is on its way/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /send me a new link/i })).not.toBeInTheDocument();
+  });
+
+  it('surfaces a refused resend instead of claiming one was sent', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'A new link was just sent. Check your inbox — and your spam folder.' }), {
+        status: 429,
+      })
+    );
+    const user = userEvent.setup();
+    render(<Login reason="invite-link-expired" returnTo={INVITE_RETURN_TO} />);
+
+    await user.click(screen.getByRole('button', { name: /send me a new link/i }));
+
+    expect(await screen.findByText(/a new link was just sent/i)).toBeInTheDocument();
+    expect(screen.queryByText(/on its way/i)).not.toBeInTheDocument();
+    // Still offered, because the refusal is temporary.
+    expect(screen.getByRole('button', { name: /send me a new link/i })).toBeInTheDocument();
+  });
+
+  it('falls back to naming the administrator when there is no invitation to resend', () => {
+    render(<Login reason="invite-link-expired" returnTo="/dashboard/abc" />);
+
+    expect(screen.getByText(/ask your administrator to resend/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /send me a new link/i })).not.toBeInTheDocument();
+  });
+
+  it('records the drop-off, with whether self-service was possible', () => {
+    render(<Login reason="invite-link-expired" returnTo={INVITE_RETURN_TO} />);
+
+    expect(mockCapture).toHaveBeenCalledWith('invitation link expired', { can_self_resend: true });
+  });
+
+  it('points an expired reset link at forgot-password, not at a resend', () => {
+    render(<Login reason="reset-link-expired" returnTo="/reset-password" />);
+
+    expect(screen.getByText(/password reset link has expired/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /request a new one/i })).toHaveAttribute(
+      'href',
+      '/forgot-password'
+    );
+  });
+});

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -6,13 +6,21 @@ import { createClient } from '@/utils/supabase/server';
  * First-party email-link confirmation.
  *
  * Invite (and, later, other) auth emails point here —
- * https://jigged.app/auth/confirm?token_hash=…&type=invite&next=/accept-invite/<id>
+ * https://www.jigged.app/auth/confirm?token_hash=…&type=invite&next=/accept-invite/<id>
  * — instead of the raw Supabase verify endpoint, so the visible link is
  * first-party. We exchange the one-time `token_hash` for a session server-side
  * (setting the auth cookies the browser client reads), then forward to `next`.
  *
  * On anything unexpected (missing/invalid params, unknown type, or a consumed/
- * expired token — `verifyOtp` tokens are single-use) we fail closed to /login.
+ * expired token — `verifyOtp` tokens are single-use) we still fail closed to
+ * /login, but we say why and carry `next` with us.
+ *
+ * Failing closed *silently* is what made #722 look like a broken product: an
+ * invitee whose link had aged out landed on an unexplained sign-in form and
+ * typed credentials for an account that had never been given a password, so the
+ * app answered "Invalid login credentials" — naming the wrong problem twice
+ * over. The reason and the invitation id are what let /login explain itself and
+ * offer a new link.
  */
 
 // Token-hash types `verifyOtp` accepts. Reject anything else rather than passing
@@ -40,5 +48,12 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  return NextResponse.redirect(`${origin}/login`);
+  // `next` rides along already sanitised — /login reads the invitation id out of
+  // it to offer a resend, and uses it as the post-sign-in destination.
+  const failed = new URL('/login', origin);
+  failed.searchParams.set('reason', type === 'recovery' ? 'reset-link-expired' : 'invite-link-expired');
+  if (next !== '/') {
+    failed.searchParams.set('returnTo', next);
+  }
+  return NextResponse.redirect(failed);
 }

--- a/app/dashboard/[companyId]/team/members/new/page.tsx
+++ b/app/dashboard/[companyId]/team/members/new/page.tsx
@@ -14,6 +14,7 @@ import InputLabel from '@mui/material/InputLabel';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import posthog from 'posthog-js';
 import { getSupabase, getEdgeFunctionUrl } from '@/lib/supabase';
 import type { InviteResponse } from '@/types/team';
 
@@ -95,6 +96,11 @@ export default function InviteTeamMemberPage() {
       if (!data.success) {
         throw new Error(data.message || 'Failed to send invitation');
       }
+
+      // Top of the funnel. Captured for both outcomes, with `email_sent` telling them apart —
+      // an invite that was created but never delivered is the drop-off we most need to see,
+      // and counting only the happy path would hide it.
+      posthog.capture('invitation sent', { role, email_sent: data.email_sent !== false });
 
       // The invitation row can be created even when the email fails to send.
       // Don't show a green "sent" confirmation in that case — surface a warning

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,7 +40,11 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://jigged.app'),
+  // www, not the apex: Vercel serves www and answers the apex with a 307. Publishing the apex as
+  // canonical means every URL we hand out points at a redirect — browsers follow it silently,
+  // machines often don't, and that asymmetry is what silently broke the live Stripe webhook for
+  // five days (#695). Name the host that actually answers 200.
+  metadataBase: new URL('https://www.jigged.app'),
   title: {
     template: '%s | Jigged',
     default: 'Jigged — Manufacturing Operations System',
@@ -81,7 +85,7 @@ export const metadata: Metadata = {
     title: 'Jigged — Manufacturing Operations System',
     description:
       'The operations system built for small manufacturing shops. Track jobs, manage inventory, and empower your operators.',
-    url: 'https://jigged.app',
+    url: 'https://www.jigged.app',
     siteName: 'Jigged',
     locale: 'en_US',
     type: 'website',

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -14,6 +14,7 @@ function LoginPageContent() {
 
   const expired = searchParams.get('expired') === 'true';
   const returnTo = searchParams.get('returnTo');
+  const reason = searchParams.get('reason');
 
   useEffect(() => {
     if (!loading && user) {
@@ -45,7 +46,7 @@ function LoginPageContent() {
 
   return (
     <AuthLayout>
-      <LoginComponent expired={expired} returnTo={returnTo} />
+      <LoginComponent expired={expired} returnTo={returnTo} reason={reason} />
     </AuthLayout>
   );
 }

--- a/components/auth/Login.tsx
+++ b/components/auth/Login.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Card from '@mui/material/Card';
@@ -17,13 +17,28 @@ import IconButton from '@mui/material/IconButton';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import posthog from 'posthog-js';
-import { getSupabase } from '@/lib/supabase';
+import { getSupabase, getEdgeFunctionUrl } from '@/lib/supabase';
 import { getPostLoginRoute } from '@/utils/companyAccess';
 import { isValidEmail } from '@/lib/validators';
 
 interface LoginProps {
   expired?: boolean;
   returnTo?: string | null;
+  /** Why /auth/confirm sent them here, when it did. See app/auth/confirm/route.ts. */
+  reason?: string | null;
+}
+
+/**
+ * Pull the invitation id out of a `/accept-invite/<uuid>` returnTo, so an invitee holding a dead
+ * link can be offered a live one. Returns null for every other destination — this must never widen
+ * into "any path shaped roughly like an invite".
+ */
+function invitationIdFromReturnTo(returnTo: string | null | undefined): string | null {
+  if (!returnTo) return null;
+  const match = /^\/accept-invite\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i.exec(
+    returnTo
+  );
+  return match ? match[1] : null;
 }
 
 /**
@@ -44,13 +59,61 @@ function isValidReturnTo(path: string): boolean {
   }
 }
 
-export default function Login({ expired, returnTo }: LoginProps) {
+export default function Login({ expired, returnTo, reason }: LoginProps) {
   const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showPassword, setShowPassword] = useState(false);
+  const [resendState, setResendState] = useState<'idle' | 'sending' | 'sent'>('idle');
+  const [resendError, setResendError] = useState<string | null>(null);
+
+  const inviteLinkExpired = reason === 'invite-link-expired';
+  const resetLinkExpired = reason === 'reset-link-expired';
+  const invitationId = invitationIdFromReturnTo(returnTo);
+
+  useEffect(() => {
+    if (inviteLinkExpired) {
+      posthog.capture('invitation link expired', { can_self_resend: invitationId !== null });
+    }
+  }, [inviteLinkExpired, invitationId]);
+
+  /**
+   * Ask for a fresh invitation link. Unauthenticated by necessity — the whole point is that this
+   * person has no account they can reach yet — so the anon key is the only credential we can send,
+   * and the endpoint mails only the address already on the invitation row.
+   */
+  const handleResendRequest = async () => {
+    if (!invitationId) return;
+    setResendState('sending');
+    setResendError(null);
+
+    try {
+      const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+      const response = await fetch(
+        `${getEdgeFunctionUrl('team-invites')}/${invitationId}/request-resend`,
+        {
+          method: 'POST',
+          headers: anonKey ? { apikey: anonKey, Authorization: `Bearer ${anonKey}` } : {},
+        }
+      );
+      const body = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        throw new Error(body?.error || 'Could not send a new link. Please try again in a moment.');
+      }
+
+      setResendState('sent');
+      posthog.capture('invitation link resend requested');
+    } catch (err) {
+      console.error('Invitation resend request failed:', err);
+      setResendState('idle');
+      setResendError(
+        err instanceof Error ? err.message : 'Could not send a new link. Please try again in a moment.'
+      );
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -117,6 +180,63 @@ export default function Login({ expired, returnTo }: LoginProps) {
         {expired && (
           <Alert severity="info" sx={{ mb: 2 }}>
             Your session expired. Please sign in again.
+          </Alert>
+        )}
+
+        {/*
+          An expired invite link used to land here with no explanation at all, so the invitee did
+          the only thing the page offered — typed a password for an account that had never been
+          given one — and got "Invalid login credentials" (#722). Say what happened, and hand them
+          the one action that actually resolves it.
+        */}
+        {inviteLinkExpired && (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            {/*
+              Hedged on purpose. An invitee joining a SECOND company already has a password and
+              could sign in below; a first-time invitee has none and cannot. This page can't tell
+              them apart — no session, and probing for one would leak which addresses have accounts
+              — so the sentence has to be true of both.
+            */}
+            <Typography variant="body2" sx={{ mb: invitationId ? 1.5 : 0 }}>
+              That invitation link has expired — they&apos;re good for 24 hours. If this is your
+              first Jigged invitation you don&apos;t have a password yet, so signing in below
+              won&apos;t work until you&apos;ve opened a live link.
+            </Typography>
+            {invitationId && resendState !== 'sent' && (
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={handleResendRequest}
+                disabled={resendState === 'sending'}
+              >
+                {resendState === 'sending' ? 'Sending…' : 'Send me a new link'}
+              </Button>
+            )}
+            {invitationId && resendState === 'sent' && (
+              <Typography variant="body2">
+                A new link is on its way. Check your inbox — and your spam folder.
+              </Typography>
+            )}
+            {!invitationId && (
+              <Typography variant="body2">
+                Ask your administrator to resend the invitation.
+              </Typography>
+            )}
+            {resendError && (
+              <Typography variant="body2" color="error" sx={{ mt: 1 }}>
+                {resendError}
+              </Typography>
+            )}
+          </Alert>
+        )}
+
+        {resetLinkExpired && (
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            That password reset link has expired.{' '}
+            <MuiLink component={Link} href="/forgot-password" underline="hover">
+              Request a new one
+            </MuiLink>
+            .
           </Alert>
         )}
 

--- a/docs/modules/invitation-system.md
+++ b/docs/modules/invitation-system.md
@@ -104,8 +104,24 @@ and `CREATE INDEX idx_invitations_token`; neither has ever existed in the schema
 | `invitations_status_check` | `pending` \| `accepted` \| `expired` \| `revoked` |
 | `idx_invitations_pending_email_company` | UNIQUE on `(email, company_id) WHERE status = 'pending'` — one pending invite per email per company |
 | `idx_invitations_company_id`, `idx_invitations_email` | plain btree |
-| Expiry | `expires_at = now + 7 days`, set on create and reset on resend |
+| Expiry | `expires_at = now + 24 hours`, set on create and reset on every (re)send — see §3.1 |
 | FKs | `company_id → companies ON DELETE CASCADE`; `invited_by`, `accepted_by → auth.users` |
+
+### 3.1 Why 24 hours, and why it is not ours to pick
+
+`expires_at` is **not** the thing that decides whether a link works. The link carries a GoTrue
+one-time token minted by `generateLink`, and that token's lifetime is the project's **Email OTP
+Expiration** — capped by Supabase at 24 hours (*"An expiry duration of more than 86400 seconds is
+disallowed"*). `expires_at` is our own bookkeeping on top, and it must not promise more than the
+token can deliver.
+
+It did, for a long time: the row said **7 days** while the setting said **1 hour**. So the team page
+showed a week-long invitation for a link that was dead before the end of the working day. That is
+the whole of [#722](https://github.com/debola31/Jigged/issues/722) — three invites to one shop went
+out at 7pm, were opened the next morning, and were refused; re-sent live on a call, two of the three
+were accepted inside two minutes. The number now lives in one place per side —
+`INVITE_TTL_HOURS` in `supabase/functions/team-invites/index.ts`, `otp_expiry` in
+`supabase/config.toml`, and the dashboard setting — and the three must move together.
 
 Two RLS policies, both in `supabase/migrations/20260527151536_baseline.sql`:
 `Admins can manage invitations` (ALL, `is_company_admin(company_id)`) and
@@ -154,6 +170,14 @@ The handler validates `type` against `['invite','magiclink','recovery','email','
 honours `next` only if it is relative and neither `//` nor `/\` (open-redirect guard), exchanges
 the single-use `token_hash` via `verifyOtp` (setting the cookies the browser client reads), and
 **fails closed to `/login`** on anything missing, invalid, or already consumed.
+
+It fails closed **with an explanation**: `?reason=invite-link-expired` (or `reset-link-expired` for
+`type=recovery`), plus `returnTo=<the sanitised next>`. `Login.tsx` reads both — it says the link
+aged out, warns that signing in will not work because no password exists yet, and offers **Send me
+a new link**, which pulls the invitation id out of `returnTo` and calls `request-resend` (§7).
+Before this, an expired link produced a bare sign-in form; the invitee typed credentials for a
+password-less account and was told "Invalid login credentials", which was true, useless, and named
+the wrong problem.
 
 **Page state machine** (`app/accept-invite/[invitationId]/page.tsx`):
 `loading → { no-session | confirm-join | name-prompt | accepting | error }`.
@@ -244,11 +268,12 @@ auth check, so every route's authorization is whatever the function does itself.
 
 | Method / path | Auth | Behaviour |
 |---|---|---|
-| `POST /team-invites` | `verifyAdmin` | Validate role + email shape (400s), reject demo companies (400, "…Invite users to the main company instead — they will automatically get demo access"), reject an email that **already has access** to the company (400), revoke any prior pending invite, insert with `expires_at = now + 7d`, mint a one-time link, send via Resend. Returns `email_sent`. |
+| `POST /team-invites` | `verifyAdmin` | Validate role + email shape (400s), reject demo companies (400, "…Invite users to the main company instead — they will automatically get demo access"), reject an email that **already has access** to the company (400), revoke any prior pending invite, insert with `expires_at = now + 24h`, mint a one-time link, send via Resend. Returns `email_sent`. |
 | `GET /team-invites?company_id=X` | `verifyAdmin` | Lazily flip `pending` rows past `expires_at` to `expired`, then list newest-first. |
 | `GET /team-invites/{id}` | **none** | Returns the invitation + `company_name`. No `verifyAdmin`, no `getUser`, and `verify_jwt=false` — so this route is **unauthenticated**; the unguessable invitation uuid is the only capability. *(This doc previously listed its auth as "Session (no admin check)".)* See the open question below. |
 | `DELETE /team-invites/{id}` | `verifyAdmin` | Only a `pending` invitation is revocable → `status='revoked'`; otherwise 400. |
-| `POST /team-invites/{id}/resend` | `verifyAdmin` | Only `pending`; resets `expires_at` to now + 7d and re-sends; otherwise 400. Email failure here returns **500**, not `email_sent:false`. |
+| `POST /team-invites/{id}/resend` | `verifyAdmin` | `pending` **or `expired`** (`RESENDABLE_STATUSES`); resets `expires_at` to now + 24h, sets `status='pending'`, re-sends. Email failure here returns **500**, not `email_sent:false`. |
+| `POST /team-invites/{id}/request-resend` | **none** | The invitee's own escape hatch from an expired link. Same effect as `resend`, minus `verifyAdmin` — deliberately, since the caller by definition has no account to authenticate with. Refuses `accepted` / `revoked`, and 429s if `expires_at` is still within 60 s of its ceiling (a send just happened). |
 
 No `validate` route, no `accept` route, no referral routes.
 
@@ -263,6 +288,14 @@ and after expiry too, since neither status short-circuits the read. `DELETE` and
 existence the same way, 404-ing before `verifyAdmin` runs. Either add a `getUser()` (any session,
 no role check — it costs nothing and the caller always has one) or write the capability-URL
 choice down in the function. Until then treat this as unruled, not as a design decision.
+
+**`request-resend` is the one place that choice IS written down.** It is unauthenticated on
+purpose, and the reasoning is narrower than "the uuid is a capability": the request carries no
+destination. The address comes off the row, so the whole power of a leaked invitation uuid is to
+send mail to the person who was already invited — bounded to once a minute by the `expires_at`
+guard. If the `GET` question above is ever settled by adding a session requirement, this route must
+be excluded from that change; requiring a session here would re-create the dead-end it exists to
+remove.
 
 `verifyAdmin(supabase, authHeader, companyId)` extracts the user from the JWT via the anon
 client, then checks `user_company_access.role IN ('admin')` for that company via the service
@@ -333,6 +366,8 @@ DMARC records, plus `RESEND_API_KEY` set as an Edge Function secret.
 | `invitations` is **exempt** from the billing write-gate | The identity/bootstrap exempt list in `tenant_tables_missing_write_gate()`, asserted by `api/tests/integration/test_billing_enforcement.py::test_no_tenant_table_left_ungated` | Gating it would block team onboarding for a shop whose subscription lapsed. Deliberate — do not "fix" it by adding the gate. |
 | One pending invite per (email, company) | `idx_invitations_pending_email_company` **and** the POST handler revoking the prior row first | A partial-unique index alone would make the second invite a 23505 error instead of a re-send. |
 | `/auth/confirm` fails closed | `app/auth/confirm/route.ts` — type allow-list, relative-`next` check, redirect to `/login` on any error | Open redirect; a consumed token rendering a half-authenticated page. |
+| …and fails closed *legibly* | `__tests__/app/auth/confirmRoute.test.ts` — asserts `reason` + `returnTo` travel with the failure, and that a hostile `next` is dropped from both the success and failure redirects | The silent login wall of #722: an unexplained sign-in form that answers a password-less account with "Invalid login credentials". |
+| `expires_at` never outlives the token in the link | `INVITE_TTL_HOURS` (edge function) = `otp_expiry` (config.toml) = Email OTP Expiration (dashboard), §3.1 | A team page that shows a live invitation whose link stopped working hours ago. **Nothing enforces this** — the three values are in three systems. |
 | Concurrent acceptance is safe | `SELECT … FOR UPDATE` in `accept_invitation()` + the `WHERE NOT EXISTS` guard on the access insert | Duplicate `user_company_access` rows from a double-clicked link. |
 
 **Standing gap — still largely uncovered, but no longer zero.** The accept page now has
@@ -351,8 +386,8 @@ in priority order:
 | Layer | Target |
 |---|---|
 | DB | `accept_invitation()` — new user, user already in company, expired row, concurrent acceptance |
-| Edge Function | `verifyAdmin` (admin allowed; user/operator/no-access → 401/403); POST valid + invalid-role + demo-company + already-has-access + prior-pending-revoked; GET list lazy-expire; DELETE and resend pending-only |
-| Frontend | Accept page: expired/revoked/accepted branches, email mismatch. `/auth/confirm`: valid redirect, open-redirect rejection, fail-closed. Team page: merge, search, demo-mode button hiding |
+| Edge Function | `verifyAdmin` (admin allowed; user/operator/no-access → 401/403); POST valid + invalid-role + demo-company + already-has-access + prior-pending-revoked; GET list lazy-expire; DELETE pending-only; resend accepting `expired`; `request-resend` refusing `accepted`/`revoked`, honouring the 60 s guard, and mailing only the row's own address |
+| Frontend | Accept page: expired/revoked/accepted branches, email mismatch. Team page: merge, search, demo-mode button hiding. **Done:** `/auth/confirm` (`__tests__/app/auth/confirmRoute.test.ts`) and the expired-invite login screen (`__tests__/components/auth/LoginExpiredInvite.test.tsx`) |
 | E2E | New-hire invite → email → `/auth/confirm` → accept → `user_company_access` created → home surface; revoke-then-open-link |
 
 ---

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -138,6 +138,9 @@ fails, and so does a listed property nothing passes.
 |---|---|---|---|
 | `user signed in` | The login form is submitted successfully | — | [Login.tsx](../components/auth/Login.tsx) |
 | `user signed out` | Supabase emits `SIGNED_OUT` | — | [AuthProvider.tsx](../components/providers/AuthProvider.tsx) |
+| `invitation sent` | An admin submits the invite form and the edge function answers | `role`, `email_sent` | [members/new/page.tsx](../app/dashboard/[companyId]/team/members/new/page.tsx) |
+| `invitation link expired` | An invitee lands on /login because their link no longer verified | `can_self_resend` | [Login.tsx](../components/auth/Login.tsx) |
+| `invitation link resend requested` | An invitee asks for a fresh link from that screen | — | [Login.tsx](../components/auth/Login.tsx) |
 | `invitation accepted` | An invitee completes acceptance | `role`, `existing_user` | [accept-invite/page.tsx](../app/accept-invite/[invitationId]/page.tsx) |
 | `quote created` | A new quote is saved | `line_item_count`, `custom_priced_line_count`, `customer_id` | [QuoteForm.tsx](../components/quotes/QuoteForm.tsx) |
 | `quote converted to job` | A quote is accepted and becomes a job | `quote_id`, `part_count`, `is_hot` | [ConvertToJobModal.tsx](../components/quotes/ConvertToJobModal.tsx) |

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -222,7 +222,11 @@ max_frequency = "1s"
 # Number of characters used in the email OTP.
 otp_length = 6
 # Number of seconds before the email OTP expires (defaults to 1 hour).
-otp_expiry = 3600
+# 24h — the maximum Supabase allows, and the number the invitation flow is built around: the link in
+# an invite email carries a token with exactly this lifetime, and `invitations.expires_at` is set to
+# match. At the old 1 hour, an invite sent at the end of the day was dead before it was read (#722).
+# Kept in step with the project's Email OTP Expiration setting in the dashboard.
+otp_expiry = 86400
 
 # Use a production-ready SMTP server
 # [auth.email.smtp]

--- a/supabase/functions/_shared/email.ts
+++ b/supabase/functions/_shared/email.ts
@@ -9,11 +9,16 @@
  * outbound emails. Deliberately NOT derived from the request origin
  * (getOriginUrl) — an admin sending mail from a Vercel preview must not mint an
  * email that points at an ephemeral preview URL that gets torn down. Set the
- * SITE_URL secret per environment (the staging URL on staging); defaults to the
- * production apex.
+ * SITE_URL secret per environment (the staging URL on staging).
+ *
+ * The default is `www`, the host Vercel actually serves; the apex answers with a
+ * 307. In an email that redirect is not free — Outlook commonly declines to
+ * follow one when loading a remote image, so the apex default rendered our logo
+ * as a broken box on exactly the message that most needs to look legitimate
+ * (#722), and the same mismatch cost five days of Stripe webhooks (#695).
  */
 export function getEmailBaseUrl(): string {
-  return Deno.env.get('SITE_URL') ?? 'https://jigged.app';
+  return Deno.env.get('SITE_URL') ?? 'https://www.jigged.app';
 }
 
 /**

--- a/supabase/functions/team-invites/index.ts
+++ b/supabase/functions/team-invites/index.ts
@@ -18,6 +18,34 @@ import { getEmailBaseUrl, getEmailFrom } from '../_shared/email.ts';
 const RESEND_API_URL = 'https://api.resend.com/emails';
 
 /**
+ * How long an invitation is good for.
+ *
+ * This number is not ours to choose freely. The link carries a GoTrue one-time token minted by
+ * `generateLink`, and that token's lifetime is the project's Email OTP Expiration — which Supabase
+ * caps at 24 hours. `invitations.expires_at` used to say 7 days, so the team page promised a week
+ * for a link that was already dead. That gap is what stranded L&L's first invites: sent 7pm,
+ * clicked the next morning, refused (#722). Keep the two in step — if the project setting ever
+ * changes, change this with it.
+ */
+const INVITE_TTL_HOURS = 24;
+const INVITE_TTL_MS = INVITE_TTL_HOURS * 60 * 60 * 1000;
+
+/** Expiry for a freshly sent or resent invitation, as an ISO timestamp. */
+function inviteExpiresAt(): string {
+  return new Date(Date.now() + INVITE_TTL_MS).toISOString();
+}
+
+/**
+ * Which invitations a resend may revive.
+ *
+ * `expired` belongs here and used to be refused. The list endpoint lazily flips a past-due
+ * invitation to `expired`, so simply opening the team page disarmed the Resend button for the very
+ * invitation whose holder was stuck — the admin-side half of the same dead-end. `accepted` and
+ * `revoked` stay refused: those are decisions, not timeouts.
+ */
+const RESENDABLE_STATUSES = ['pending', 'expired'];
+
+/**
  * Verify the caller is an admin of the specified company.
  * Uses an anon client with the user's JWT to extract user identity,
  * then uses the service role client for admin queries.
@@ -137,6 +165,10 @@ function buildInviteEmailHtml(companyName: string, actionLink: string): string {
             Accept Invitation
           </a>
         </td></tr>
+        <tr><td align="center" style="color:#B0B3B8; font-size:12px; padding-bottom:12px;">
+          This link works for ${INVITE_TTL_HOURS} hours. If it has expired, the page it opens will
+          offer to send you a new one.
+        </td></tr>
         <tr><td align="center" style="color:#B0B3B8; font-size:12px;">
           If you weren't expecting this invitation, you can safely ignore this email.
         </td></tr>
@@ -145,6 +177,37 @@ function buildInviteEmailHtml(companyName: string, actionLink: string): string {
   </table>
 </body>
 </html>`;
+}
+
+/**
+ * Mint a fresh one-time link for an invitation and email it to the invitee.
+ *
+ * Shared by all three send paths — first send, admin resend, invitee-requested resend — so the
+ * link shape, the metadata and the email body cannot drift apart between them.
+ *
+ * `redirectTo` is vestigial (Supabase no longer performs the redirect — our /auth/confirm route
+ * does), but it is still passed so `generateLink`'s allow-list validation and the auth-callback
+ * metadata fallback are unaffected.
+ */
+async function mintAndSendInvite(
+  supabase: ReturnType<typeof getServiceRoleClient>,
+  resendApiKey: string,
+  invitation: { id: string; email: string; role: string },
+  companyName: string,
+  siteUrl: string,
+): Promise<void> {
+  const redirectTo = `${siteUrl}/accept-invite/${invitation.id}`;
+
+  const { hashedToken, type } = await generateInviteLink(supabase, invitation.email, redirectTo, {
+    invitation_id: invitation.id,
+    company_name: companyName,
+    invited_role: invitation.role,
+  });
+
+  const next = `/accept-invite/${invitation.id}`;
+  const actionLink = `${getEmailBaseUrl()}/auth/confirm?token_hash=${encodeURIComponent(hashedToken)}&type=${type}&next=${encodeURIComponent(next)}`;
+
+  await sendInviteEmail(resendApiKey, invitation.email, companyName, actionLink);
 }
 
 /**
@@ -274,9 +337,6 @@ Deno.serve(async (req) => {
       const companyName = companyData?.name || '';
 
       // Create invitation record
-      const expiresAt = new Date();
-      expiresAt.setDate(expiresAt.getDate() + 7);
-
       const { data: invitation, error: insertError } = await supabase
         .from('invitations')
         .insert({
@@ -284,7 +344,7 @@ Deno.serve(async (req) => {
           email: email.toLowerCase(),
           role,
           invited_by: userId,
-          expires_at: expiresAt.toISOString(),
+          expires_at: inviteExpiresAt(),
         })
         .select()
         .single();
@@ -295,23 +355,14 @@ Deno.serve(async (req) => {
       }
 
       // Generate the one-time token and send a first-party email via Resend.
-      // redirectTo is now vestigial (Supabase no longer does the redirect — our
-      // /auth/confirm route does), but we keep it so generateLink's allow-list
-      // validation and the auth-callback metadata fallback are unaffected.
-      const siteUrl = getOriginUrl(req);
-      const redirectTo = `${siteUrl}/accept-invite/${invitation.id}`;
-
       try {
-        const { hashedToken, type } = await generateInviteLink(supabase, email.toLowerCase(), redirectTo, {
-          invitation_id: invitation.id,
-          company_name: companyName,
-          invited_role: role,
-        });
-
-        const next = `/accept-invite/${invitation.id}`;
-        const actionLink = `${getEmailBaseUrl()}/auth/confirm?token_hash=${encodeURIComponent(hashedToken)}&type=${type}&next=${encodeURIComponent(next)}`;
-
-        await sendInviteEmail(resendApiKey, email.toLowerCase(), companyName, actionLink);
+        await mintAndSendInvite(
+          supabase,
+          resendApiKey,
+          { id: invitation.id, email: email.toLowerCase(), role },
+          companyName,
+          getOriginUrl(req),
+        );
       } catch (emailErr) {
         console.error('Email sending error:', emailErr);
         // The invitation row exists, but the email never went out. Report this
@@ -443,8 +494,8 @@ Deno.serve(async (req) => {
 
       await verifyAdmin(supabase, authHeader, invitation.company_id);
 
-      if (invitation.status !== 'pending') {
-        return errorResponse('Only pending invitations can be resent', 400);
+      if (!RESENDABLE_STATUSES.includes(invitation.status ?? '')) {
+        return errorResponse(`An invitation that has been ${invitation.status} cannot be resent`, 400);
       }
 
       // Look up company name
@@ -456,30 +507,14 @@ Deno.serve(async (req) => {
 
       const companyName = companyData?.name || '';
 
-      // Reset expiry
-      const newExpiresAt = new Date();
-      newExpiresAt.setDate(newExpiresAt.getDate() + 7);
-
+      // Reset expiry, and revive an invitation the lazy sweep had marked expired.
       await supabase
         .from('invitations')
-        .update({ expires_at: newExpiresAt.toISOString() })
+        .update({ expires_at: inviteExpiresAt(), status: 'pending' })
         .eq('id', invitationId);
 
-      // Generate the one-time token and resend a first-party email via Resend.
-      const siteUrl = getOriginUrl(req);
-      const redirectTo = `${siteUrl}/accept-invite/${invitation.id}`;
-
       try {
-        const { hashedToken, type } = await generateInviteLink(supabase, invitation.email, redirectTo, {
-          invitation_id: invitation.id,
-          company_name: companyName,
-          invited_role: invitation.role,
-        });
-
-        const next = `/accept-invite/${invitation.id}`;
-        const actionLink = `${getEmailBaseUrl()}/auth/confirm?token_hash=${encodeURIComponent(hashedToken)}&type=${type}&next=${encodeURIComponent(next)}`;
-
-        await sendInviteEmail(resendApiKey, invitation.email, companyName, actionLink);
+        await mintAndSendInvite(supabase, resendApiKey, invitation, companyName, getOriginUrl(req));
       } catch (emailErr) {
         console.error('Resend error:', emailErr);
         return errorResponse('Failed to resend invitation email', 500);
@@ -488,6 +523,82 @@ Deno.serve(async (req) => {
       return jsonResponse({
         success: true,
         message: `Invitation resent to ${invitation.email}`,
+      });
+    }
+
+    // POST /team-invites/:id/request-resend — invitee asks for a fresh link.
+    //
+    // Deliberately unauthenticated: the person who needs this is holding a dead link and has no
+    // session — that is the whole failure being fixed (#722). Requiring auth would mean requiring
+    // exactly the account they cannot yet reach, and routing them back through their admin.
+    //
+    // Safe without a caller identity because the caller supplies nothing that steers the email:
+    // the destination is read from the invitation row, never from the request, so the only thing a
+    // stranger with a stolen invitation UUID can do is mail the person who was already invited.
+    // The 60-second guard below bounds how often.
+    if (req.method === 'POST' && pathParts.length === 3 && pathParts[2] === 'request-resend') {
+      const invitationId = pathParts[1];
+
+      const { data: invitation } = await supabase
+        .from('invitations')
+        .select('id, company_id, email, role, status, expires_at')
+        .eq('id', invitationId)
+        .single();
+
+      if (!invitation) {
+        return errorResponse('Invitation not found', 404);
+      }
+
+      if (invitation.status === 'accepted') {
+        return errorResponse('This invitation was already accepted — sign in instead.', 400);
+      }
+
+      if (!RESENDABLE_STATUSES.includes(invitation.status ?? '')) {
+        return errorResponse(
+          'This invitation is no longer valid. Ask your administrator to send a new one.',
+          400,
+        );
+      }
+
+      // Rate limit with the data we already have rather than a new column: every send pushes
+      // expires_at to now + TTL, so an expiry still within a minute of its ceiling means a link
+      // went out moments ago. Bounds this to one email a minute per invitation.
+      const sentJustNow =
+        new Date(invitation.expires_at).getTime() > Date.now() + INVITE_TTL_MS - 60_000;
+      if (sentJustNow) {
+        return errorResponse(
+          'A new link was just sent. Check your inbox — and your spam folder.',
+          429,
+        );
+      }
+
+      const { data: companyData } = await supabase
+        .from('companies')
+        .select('name')
+        .eq('id', invitation.company_id)
+        .single();
+
+      await supabase
+        .from('invitations')
+        .update({ expires_at: inviteExpiresAt(), status: 'pending' })
+        .eq('id', invitationId);
+
+      try {
+        await mintAndSendInvite(
+          supabase,
+          resendApiKey,
+          invitation,
+          companyData?.name || '',
+          getOriginUrl(req),
+        );
+      } catch (emailErr) {
+        console.error('Requested resend error:', emailErr);
+        return errorResponse('Could not send a new link. Please try again in a moment.', 500);
+      }
+
+      return jsonResponse({
+        success: true,
+        message: `A new link is on its way to ${invitation.email}.`,
       });
     }
 


### PR DESCRIPTION
Fixes the first defect in #722, and closes the code-vs-Vercel half of #695.

## Why the issue couldn't be reproduced

The invite link is a GoTrue one-time token. Its lifetime was **one hour**. `invitations.expires_at` said **seven days**, so the team page showed a live invitation for a link that had died before the end of the working day. A test invite is always clicked within a minute or two, so the bug is invisible to whoever sends it.

Production evidence for the L&L onboarding:

| Time (UTC) | Event |
|---|---|
| Aug 7 00:07–00:17 | brad@, cory@, bryce@ invited (7pm local) — links dead by ~01:17 |
| Aug 7 00:07:42 | an internal test invite, clicked immediately → accepted |
| Aug 7 15:02:38–56 | all three re-invited **live on the call** |
| Aug 7 15:03:09 | cory confirmed — **31 s** after the resend |
| Aug 7 15:04:55 | bryce confirmed — **2 min** after the resend |

No `email_confirmed_at` was set from the first batch, and `generateLink({type:'invite'})` succeeded again at 15:02 — which only works against an unconfirmed user. Those links were never redeemed by anyone; they simply aged out overnight.

Landing there was worse than the expiry itself. `/auth/confirm` failed closed to a bare `/login`, so the invitee met an unexplained sign-in form, typed credentials for an account that had never been given a password, and was told *"Invalid login credentials"* — true, useless, and naming the wrong problem. One of the three is still locked out today.

## What changed

- **`expires_at` is 24h**, matching the token in the link, and the email says so. 24h is the ceiling Supabase allows (`> 86400s is disallowed`), so seven days was never deliverable — documented in `invitation-system.md` §3.1 with the three places the number lives.
- **`/auth/confirm` still fails closed, but legibly** — `?reason=invite-link-expired&returnTo=/accept-invite/<id>`. The open-redirect guard is unchanged and now tested.
- **`/login` explains it** and offers **Send me a new link**, instead of a password form the invitee cannot satisfy. Copy is hedged because an invitee joining a *second* company does already have a password and this page can't tell them apart.
- **New `POST /team-invites/:id/request-resend`** — unauthenticated by necessity, since the person who needs it has no account to authenticate with. The request carries no destination: the address is read off the invitation row, so a leaked invitation uuid can only mail the person already invited, at most once a minute (guarded via `expires_at`, no new column).
- **Admin resend now accepts an `expired` invitation.** Opening the team page ran the lazy sweep and disarmed the Resend button for exactly the invitation whose holder was stuck — the same dead-end from the admin's side.
- **Email links and metadata point at `www`.** The apex 307s to it, and Outlook commonly won't follow a redirect for a remote image, so our logo rendered broken on the one email that most needs to look legitimate. L&L is on Microsoft 365 (`MX = *.mail.protection.outlook.com`), which is also the junk-folder half of #722 — and the junk folder is what delayed the click past the old 1-hour window.
- **Funnel instrumented:** `invitation sent` → `invitation link expired` → `invitation link resend requested` → `invitation accepted`, with registry rows.

## Already applied outside this PR

- Email OTP Expiration `3600 → 86400` in the Supabase dashboard. This makes the `auth_otp_long_expiry` advisor lint fire — accepted: it targets brute-forceable 6-digit codes, not high-entropy hashed link tokens.
- `supabase secrets set SITE_URL=https://www.jigged.app`.

## On #695

This closes the **mismatch** — code no longer advertises a host Vercel answers with a redirect. It does **not** settle apex-vs-www; #695 stays open, re-scoped to whether the shorter apex is worth migrating to, which is now a QR-payload-length question against `lib/qrVector.ts`.

## Known residual risk (not fixed here)

`/auth/confirm` is a GET that *consumes* the token, so a Microsoft Defender Safe Links prefetch can burn it before the human clicks — [Supabase names this the top cause of premature `otp_expired`](https://supabase.com/docs/guides/troubleshooting/otp-verification-failures-token-has-expired-or-otp_expired-errors-5ee4d0). It did **not** happen to L&L (no early confirmation exists in prod), but it is live for the next M365 shop. The fix is a link whose GET only reads, with the token consumed on submit — deliberately deferred.

## Verification

- `vitest run` — 2377 passed. New: `__tests__/app/auth/confirmRoute.test.ts` (7), `__tests__/components/auth/LoginExpiredInvite.test.tsx` (7).
- `tsc --noEmit` clean; `eslint` 16 warnings (ceiling 17, all pre-existing); doc-link and analytics-registry checks pass.
- Manual repro that was missing: set `otp_expiry = 60`, `supabase db reset`, send an invite, wait 61 s, click. Before: bare `/login`. After: the explanation plus a working resend.
- **After deploy:** send a real invite to an M365 address, click at **T+2h** (dead before this change), and check Resend for Inbox-vs-Junk and that the logo loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)