### PR TITLE
feat(documents): stack the shop logo above its address, sized to free space

### DIFF
--- a/__tests__/components/settings/AppDefaultsCard.test.tsx
+++ b/__tests__/components/settings/AppDefaultsCard.test.tsx
@@ -46,13 +46,13 @@ describe('AppDefaultsCard', () => {
 
     // One SettingsSection, so exactly one heading and one Save for the whole group.
     expect(await screen.findByRole('heading', { name: /company default settings/i })).toBeInTheDocument();
-    expect(screen.getByLabelText(/default payment terms/i)).toHaveValue('Net 30');
+    expect(screen.getByLabelText(/^payment terms$/i)).toHaveValue('Net 30');
     expect(screen.getAllByRole('button', { name: /^save$/i })).toHaveLength(1);
   });
 
   it('offers the shop’s own saved terms alongside the presets', async () => {
     render(<AppDefaultsCard companyId={CO} />);
-    const input = await screen.findByLabelText(/default payment terms/i);
+    const input = await screen.findByLabelText(/^payment terms$/i);
 
     await userEvent.clear(input);
     await userEvent.type(input, '2%');
@@ -72,7 +72,7 @@ describe('AppDefaultsCard', () => {
    */
   it('writes both halves in sequence, never concurrently', async () => {
     render(<AppDefaultsCard companyId={CO} />);
-    const input = await screen.findByLabelText(/default payment terms/i);
+    const input = await screen.findByLabelText(/^payment terms$/i);
 
     await userEvent.clear(input);
     await userEvent.type(input, 'Net 45');
@@ -88,7 +88,7 @@ describe('AppDefaultsCard', () => {
 
   it('keeps the numeric patch numeric — the registry did not become a union', async () => {
     render(<AppDefaultsCard companyId={CO} />);
-    await screen.findByLabelText(/default payment terms/i);
+    await screen.findByLabelText(/^payment terms$/i);
 
     await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
 

--- a/__tests__/utils/shopHeaderBlock.test.ts
+++ b/__tests__/utils/shopHeaderBlock.test.ts
@@ -105,6 +105,41 @@ describe('drawShopHeaderBlock — the "logo includes my name" answer', () => {
     expect(drawn(t)).toContain('L&L Machine & Tool');
   });
 
+  /**
+   * **The document must never go out unnamed.**
+   *
+   * `logoIncludesName` is a claim about the logo, so it means nothing without one — and a shop
+   * reaches that state trivially: tick the box, then remove the logo. Honouring the setting anyway
+   * printed a quote with no company name anywhere on it, which is the exact outcome the setting
+   * exists to prevent.
+   */
+  it('still prints the name when the box is ticked but there is no logo', () => {
+    const t = target();
+    drawShopHeaderBlock(t.doc, {
+      company, logoDataUrl: null, logoIncludesName: true, ...QUOTE,
+    });
+    expect(drawn(t)).toContain('L&L Machine & Tool');
+  });
+
+  it('still prints the name when the logo was ticked but could not be read', () => {
+    const t = target(null);
+    drawShopHeaderBlock(t.doc, {
+      company, logoDataUrl: 'data:image/png;base64,broken', logoIncludesName: true, ...QUOTE,
+    });
+    expect(t.addImage).not.toHaveBeenCalled();
+    expect(drawn(t)).toContain('L&L Machine & Tool');
+  });
+
+  it('still prints the name when the header was too short to draw the logo', () => {
+    const t = target();
+    drawShopHeaderBlock(t.doc, {
+      company, logoDataUrl: 'data:image/png;base64,x', logoIncludesName: true,
+      x: 40, y: 40, availableBottom: 70,
+    });
+    expect(t.addImage).not.toHaveBeenCalled();
+    expect(drawn(t)).toContain('L&L Machine & Tool');
+  });
+
   it('omits it when the logo already says it', () => {
     const t = target();
     drawShopHeaderBlock(t.doc, {

--- a/__tests__/utils/shopHeaderBlock.test.ts
+++ b/__tests__/utils/shopHeaderBlock.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { drawShopHeaderBlock } from '@/utils/packingSlipPdf';
+import type { Company } from '@/utils/companyAccess';
+
+/**
+ * The shop header block — logo above, address beneath, sized to the space the header already has.
+ *
+ * **The property under test is that the logo is free.** A document header is as tall as its tallest
+ * column, and on all three documents that is the right one. Every point of the left column above
+ * that line costs the page nothing, and the whole point of this block is to spend it. A regression
+ * here is silent: the logo just gets small again, exactly as it was when it sat in a 56×56 box while
+ * the header had 110pt to give.
+ */
+
+const company: Company = {
+  id: 'c1',
+  name: 'L&L Machine & Tool',
+  address_line1: '1495 Valencia Street, Apt 5',
+  city: 'San Francisco',
+  state: 'CA',
+  postal_code: '94110',
+  country: 'USA',
+  phone: '(817) 448-4963',
+};
+
+/** A 1.44:1 landscape wordmark — the shape a shop logo usually is. */
+const WIDE = { width: 1484, height: 1030, fileType: 'PNG' };
+
+function target(props: { width: number; height: number; fileType: string } | null = WIDE) {
+  const addImage = vi.fn();
+  const text = vi.fn();
+  return {
+    addImage,
+    text,
+    doc: {
+      getImageProperties: () => {
+        if (!props) throw new Error('unreadable');
+        return props;
+      },
+      addImage,
+      setFont: vi.fn(),
+      setFontSize: vi.fn(),
+      setTextColor: vi.fn(),
+      text,
+    },
+  };
+}
+
+/** The quote's real geometry: header runs 40 → 150, so 110pt is available. */
+const QUOTE = { x: 40, y: 40, availableBottom: 150 };
+
+const drawn = (t: ReturnType<typeof target>) => t.text.mock.calls.map((c) => c[0]);
+const logo = (t: ReturnType<typeof target>) => {
+  const [, , x, y, w, h] = t.addImage.mock.calls[0];
+  return { x, y, w, h };
+};
+
+describe('drawShopHeaderBlock — the logo is free', () => {
+  it('never draws past the height the header already occupies', () => {
+    const t = target();
+    const bottom = drawShopHeaderBlock(t.doc, {
+      company, logoDataUrl: 'data:image/png;base64,x', logoIncludesName: false, ...QUOTE,
+    });
+    expect(bottom).toBeLessThanOrEqual(QUOTE.availableBottom);
+  });
+
+  it('is far larger than the 56pt box it replaced', () => {
+    const t = target();
+    drawShopHeaderBlock(t.doc, {
+      company, logoDataUrl: 'data:image/png;base64,x', logoIncludesName: false, ...QUOTE,
+    });
+    expect(logo(t).w).toBeGreaterThan(56);
+  });
+
+  it('preserves the aspect ratio — a wordmark is never squashed', () => {
+    const t = target();
+    drawShopHeaderBlock(t.doc, {
+      company, logoDataUrl: 'data:image/png;base64,x', logoIncludesName: false, ...QUOTE,
+    });
+    const { w, h } = logo(t);
+    expect(w / h).toBeCloseTo(1484 / 1030, 5);
+  });
+
+  it('stacks the text under the logo, not beside it', () => {
+    const t = target();
+    drawShopHeaderBlock(t.doc, {
+      company, logoDataUrl: 'data:image/png;base64,x', logoIncludesName: false, ...QUOTE,
+    });
+    const { x, y, h } = logo(t);
+    // Every text baseline sits below the logo and starts at the same left edge.
+    const ys = t.text.mock.calls.map((c) => c[2] as number);
+    const xs = t.text.mock.calls.map((c) => c[1] as number);
+    expect(Math.min(...ys)).toBeGreaterThan(y + h);
+    expect(new Set(xs)).toEqual(new Set([x]));
+  });
+});
+
+describe('drawShopHeaderBlock — the "logo includes my name" answer', () => {
+  it('prints the company name when the logo does not contain it', () => {
+    const t = target();
+    drawShopHeaderBlock(t.doc, {
+      company, logoDataUrl: 'data:image/png;base64,x', logoIncludesName: false, ...QUOTE,
+    });
+    expect(drawn(t)).toContain('L&L Machine & Tool');
+  });
+
+  it('omits it when the logo already says it', () => {
+    const t = target();
+    drawShopHeaderBlock(t.doc, {
+      company, logoDataUrl: 'data:image/png;base64,x', logoIncludesName: true, ...QUOTE,
+    });
+    expect(drawn(t)).not.toContain('L&L Machine & Tool');
+    // …and the address survives; suppressing the name must not suppress the block.
+    expect(drawn(t)).toContain('San Francisco, CA 94110');
+  });
+
+  /**
+   * The trade that makes the checkbox worth asking about: a stacked layout spends budget on text,
+   * so removing a line of text hands it back to the logo. This is the number that argues for the
+   * setting existing at all.
+   */
+  it('gives the logo more room when the name is not printed', () => {
+    const withName = target();
+    const withoutName = target();
+    drawShopHeaderBlock(withName.doc, {
+      company, logoDataUrl: 'data:image/png;base64,x', logoIncludesName: false, ...QUOTE,
+    });
+    drawShopHeaderBlock(withoutName.doc, {
+      company, logoDataUrl: 'data:image/png;base64,x', logoIncludesName: true, ...QUOTE,
+    });
+    expect(logo(withoutName).w).toBeGreaterThan(logo(withName).w);
+  });
+});
+
+describe('drawShopHeaderBlock — it never breaks a document', () => {
+  it('prints the text exactly as before when there is no logo', () => {
+    const t = target();
+    const bottom = drawShopHeaderBlock(t.doc, {
+      company, logoDataUrl: null, logoIncludesName: false, ...QUOTE,
+    });
+    expect(t.addImage).not.toHaveBeenCalled();
+    expect(drawn(t)).toContain('L&L Machine & Tool');
+    expect(bottom).toBeLessThanOrEqual(QUOTE.availableBottom);
+  });
+
+  it('falls back to text when the image cannot be read', () => {
+    const t = target(null);
+    expect(() =>
+      drawShopHeaderBlock(t.doc, {
+        company, logoDataUrl: 'data:image/png;base64,broken', logoIncludesName: false, ...QUOTE,
+      }),
+    ).not.toThrow();
+    expect(t.addImage).not.toHaveBeenCalled();
+    expect(drawn(t)).toContain('L&L Machine & Tool');
+  });
+
+  it('draws no logo at all rather than a squashed one when the header is too short for it', () => {
+    const t = target();
+    // A header with almost no right column — the text alone already fills it.
+    drawShopHeaderBlock(t.doc, {
+      company, logoDataUrl: 'data:image/png;base64,x', logoIncludesName: false,
+      x: 40, y: 40, availableBottom: 70,
+    });
+    expect(t.addImage).not.toHaveBeenCalled();
+    expect(drawn(t)).toContain('L&L Machine & Tool');
+  });
+
+  /**
+   * The traveler's right column is taller on a hot job (the HOT stamp extends it). Without a cap the
+   * same shop's logo would print bigger on a hot traveler than a cold one — the same paperwork
+   * disagreeing with itself about how big the mark is.
+   */
+  it('caps the logo so a tall right column cannot inflate it', () => {
+    const normal = target();
+    const veryTall = target();
+    drawShopHeaderBlock(normal.doc, {
+      company, logoDataUrl: 'data:image/png;base64,x', logoIncludesName: true, ...QUOTE,
+    });
+    drawShopHeaderBlock(veryTall.doc, {
+      company, logoDataUrl: 'data:image/png;base64,x', logoIncludesName: true,
+      x: 40, y: 40, availableBottom: 400,
+    });
+    expect(logo(veryTall).h).toBe(logo(normal).h);
+  });
+
+  it('handles a company with no address at all', () => {
+    const t = target();
+    const bare: Company = { id: 'c1', name: 'Bare Shop' };
+    expect(() =>
+      drawShopHeaderBlock(t.doc, {
+        company: bare, logoDataUrl: 'data:image/png;base64,x', logoIncludesName: false, ...QUOTE,
+      }),
+    ).not.toThrow();
+    expect(drawn(t)).toEqual(['Bare Shop']);
+  });
+});

--- a/components/settings/AppDefaultsCard.tsx
+++ b/components/settings/AppDefaultsCard.tsx
@@ -224,7 +224,7 @@ export default function AppDefaultsCard({ companyId }: AppDefaultsCardProps) {
           >
             <Box sx={{ flex: '1 1 260px', minWidth: 0 }}>
               <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-                Default payment terms
+                Payment terms
               </Typography>
               <Typography variant="body2" sx={{ color: 'text.secondary' }}>
                 Used on a new quote when the customer has no terms of their own. Setting a
@@ -249,7 +249,7 @@ export default function AppDefaultsCard({ companyId }: AppDefaultsCardProps) {
               renderInput={(params) => (
                 <TextField
                   {...params}
-                  inputProps={{ ...params.inputProps, 'aria-label': 'Default payment terms' }}
+                  inputProps={{ ...params.inputProps, 'aria-label': 'Payment terms' }}
                 />
               )}
             />

--- a/components/settings/CompanyProfileCard.tsx
+++ b/components/settings/CompanyProfileCard.tsx
@@ -237,7 +237,7 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
   return (
     <SettingsSection
       title="Company Profile"
-      description="Your logo and return address, printed at the top of quotes, packing slips and job travelers. Leave a field blank to omit it."
+      description="Your logo and address, printed at the top of every document."
     >
       {error && (
         <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
@@ -328,27 +328,23 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
                 )}
               </Box>
               {/*
-                Guidance worth giving, because all three of these are mistakes a shop makes once and
-                only discovers on a printed page:
-                  - grayscale, because most shop printers are mono lasers and a logo that separates
-                    only by hue turns to mud;
-                  - transparent PNG, because the page is white and a baked-in white rectangle shows
-                    as a box the moment anything sits behind it;
-                  - wide is fine, because the aspect is preserved now — it was forced square until
-                    this batch, which squashed most wordmarks.
+                Two facts, no lecture. The earlier version also advised checking the logo reads in
+                black and white "since most shop printers are mono lasers" — true, and exactly the
+                kind of line that explains a machinist's own workshop back to them. Someone who needs
+                that advice will not act on it here; someone who doesn't reads the card as padded.
+                The transparency tip stays because it is the mistake that actually shows up on a
+                printed page: a baked-in white rectangle becomes a visible box.
               */}
               <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-                PNG or JPEG, up to {MAX_MB} MB. A wide logo is fine — it keeps its shape. A PNG with
-                a transparent background prints cleanest, and it&apos;s worth checking it still
-                reads in black and white, since most shop printers are mono lasers.
+                PNG or JPEG, up to {MAX_MB} MB. A transparent PNG looks best.
               </Typography>
 
               {/*
                 The one thing we cannot work out from the file itself, and it changes what prints.
                 Most shop logos are wordmarks — the mark IS the name — and printing the name again
-                beside one says it twice in two typefaces. But a logo that is a bare symbol must
-                have the name printed or the document goes out unnamed. Unticked is the safe
-                default: a duplicated name is untidy, a missing one is broken.
+                says it twice in two typefaces. But a logo that is a bare symbol must have the name
+                printed or the document goes out unnamed. Unticked is the safe default: a duplicated
+                name is untidy, a missing one is broken.
               */}
               <FormControlLabel
                 sx={{ mt: 1, alignItems: 'flex-start' }}
@@ -363,12 +359,12 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
                 label={
                   <Box>
                     <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                      My logo already includes my company name
+                      Logo includes company name
                     </Typography>
                     <Typography variant="caption" sx={{ color: 'text.secondary' }}>
                       {logoPath
-                        ? "Then we won't print your name next to it, and the logo gets that space instead."
-                        : 'Upload a logo first — your name is always printed while there isn\u2019t one.'}
+                        ? "We won't print your name under the logo."
+                        : 'Upload a logo first.'}
                     </Typography>
                   </Box>
                 }

--- a/components/settings/CompanyProfileCard.tsx
+++ b/components/settings/CompanyProfileCard.tsx
@@ -356,7 +356,7 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
                   <Checkbox
                     checked={includesName}
                     onChange={(e) => void handleIncludesName(e.target.checked)}
-                    disabled={logoBusy}
+                    disabled={logoBusy || !logoPath}
                     sx={{ pt: 0.25 }}
                   />
                 }
@@ -366,8 +366,9 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
                       My logo already includes my company name
                     </Typography>
                     <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-                      Then we won&apos;t print your name next to it, and the logo gets that space
-                      instead.
+                      {logoPath
+                        ? "Then we won't print your name next to it, and the logo gets that space instead."
+                        : 'Upload a logo first — your name is always printed while there isn\u2019t one.'}
                     </Typography>
                   </Box>
                 }
@@ -378,19 +379,6 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
           <Divider sx={{ my: 3 }} />
 
           <Grid container spacing={2}>
-            <Grid size={{ xs: 12, sm: 4 }}>
-              <TextField
-                label="Phone"
-                value={form.phone}
-                onChange={handleChange('phone')}
-                fullWidth
-                size="small"
-                type="tel"
-                autoComplete="tel"
-                error={phoneInvalid}
-                helperText={phoneInvalid ? 'Enter a valid phone number' : undefined}
-              />
-            </Grid>
             <Grid size={{ xs: 12 }}>
               <TextField
                 label="Address line 1"
@@ -452,6 +440,20 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
                   setSuccess(false);
                 }}
                 size="small"
+              />
+            </Grid>
+            {/* Phone last, matching the order it prints in: street, city line, then contact. */}
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+              <TextField
+                label="Phone"
+                value={form.phone}
+                onChange={handleChange('phone')}
+                fullWidth
+                size="small"
+                type="tel"
+                autoComplete="tel"
+                error={phoneInvalid}
+                helperText={phoneInvalid ? 'Enter a valid phone number' : undefined}
               />
             </Grid>
           </Grid>

--- a/components/settings/CompanyProfileCard.tsx
+++ b/components/settings/CompanyProfileCard.tsx
@@ -17,7 +17,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
 import Divider from '@mui/material/Divider';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
@@ -28,10 +30,12 @@ import UploadIcon from '@mui/icons-material/Upload';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import {
   getCompany,
+  setLogoIncludesName,
   updateCompanyLogo,
   updateCompanyProfile,
   type CompanyProfilePatch,
 } from '@/utils/companyAccess';
+import { readLogoIncludesName } from '@/lib/companyDefaults';
 import CountrySelect from '@/components/common/CountrySelect';
 import StateSelect from '@/components/common/StateSelect';
 import { isValidPhone, isValidPostalCode } from '@/lib/validators';
@@ -86,6 +90,7 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
   const [logoPath, setLogoPath] = useState<string | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [logoBusy, setLogoBusy] = useState(false);
+  const [includesName, setIncludesName] = useState(false);
 
   const loadPreview = useCallback(async (path: string | null) => {
     setLogoPath(path);
@@ -124,6 +129,7 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
           postal_code: company.postal_code ?? '',
           country: company.country ?? '',
         });
+        setIncludesName(readLogoIncludesName(company));
         await loadPreview(company.logo_url ?? null);
       } finally {
         if (!cancelled) setLoading(false);
@@ -191,6 +197,19 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
     } finally {
       setLogoBusy(false);
       if (inputRef.current) inputRef.current.value = '';
+    }
+  };
+
+  const handleIncludesName = async (next: boolean) => {
+    // Optimistic: the box moves under the finger and reverts only if the write fails. Waiting on a
+    // round trip to tick a checkbox reads as a broken control.
+    setIncludesName(next);
+    setError(null);
+    try {
+      await setLogoIncludesName(companyId, next);
+    } catch (err) {
+      setIncludesName(!next);
+      setError(err instanceof Error ? err.message : 'Failed to save that setting.');
     }
   };
 
@@ -323,6 +342,36 @@ export default function CompanyProfileCard({ companyId }: CompanyProfileCardProp
                 a transparent background prints cleanest, and it&apos;s worth checking it still
                 reads in black and white, since most shop printers are mono lasers.
               </Typography>
+
+              {/*
+                The one thing we cannot work out from the file itself, and it changes what prints.
+                Most shop logos are wordmarks — the mark IS the name — and printing the name again
+                beside one says it twice in two typefaces. But a logo that is a bare symbol must
+                have the name printed or the document goes out unnamed. Unticked is the safe
+                default: a duplicated name is untidy, a missing one is broken.
+              */}
+              <FormControlLabel
+                sx={{ mt: 1, alignItems: 'flex-start' }}
+                control={
+                  <Checkbox
+                    checked={includesName}
+                    onChange={(e) => void handleIncludesName(e.target.checked)}
+                    disabled={logoBusy}
+                    sx={{ pt: 0.25 }}
+                  />
+                }
+                label={
+                  <Box>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      My logo already includes my company name
+                    </Typography>
+                    <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                      Then we won&apos;t print your name next to it, and the logo gets that space
+                      instead.
+                    </Typography>
+                  </Box>
+                }
+              />
             </Box>
           </Box>
 

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -495,10 +495,10 @@ only if post-pilot data shows drift is more frequent than estimated.
 **View PDF** generates a customer-facing PDF in the browser — no server round-trip. Filename
 `Quote-{quote_number}.pdf`.
 
-Contains: company logo and name — **the logo only since August 2026**; this line claimed it for
-months while `generateQuotePdf` drew no logo at all, so a shop that uploaded one saw it on its
-packing slips and travelers but not on the document that goes to a customer who has not decided to
-buy yet. The QUOTE heading with number, date, validity, lead time,
+Contains: the shop's logo above its name and address — **the logo only since August 2026**; this
+line claimed it for months while `generateQuotePdf` drew no logo at all, so a shop that uploaded one
+saw it on its packing slips and travelers but not on the document that goes to a customer who has
+not decided to buy yet. The QUOTE heading with number, date, validity, lead time,
 and payment terms; **Customer · Ship to (only if different) · Customer contact**; the line
 items table ordered by `sequence`, with a grand total **only** on firm quotes; and an acceptance
 block instructing the customer to **reply with a purchase order referencing the quote** — there

--- a/docs/modules/shipments.md
+++ b/docs/modules/shipments.md
@@ -211,7 +211,8 @@ As-built, verified 2026-08-03. Each row names the file + `describe`/class that e
 | Deleting a job **archives** it and never blocks, even with shipments and an invoice — the records-of-value guards were removed | `__tests__/utils/jobsAccess.test.ts` — `deleteJob` |
 | Slip quantities net out prior shipments, clamp over-shipment, survive `numeric(12,2)` fractions, and hand a voided slip's own quantity back to the backlog; the two conditional columns keep head / body / `columnStyles` aligned in all four permutations | `__tests__/utils/packingSlipPdf.test.ts` — `computePackingSlipQuantities`, `generatePackingSlipPdf — the quantity table` |
 | Prior-shipment lookup skips itself, later slips and same-timestamp-greater-id siblings, and throws rather than reporting zero prior | `__tests__/utils/shipmentsAccess.test.ts` — `compareShipmentOrder`, `getShippedBeforeShipment` |
-| The footer carries `Generated {date} with jigged.app` and no longer restates the company name, and the logo is fitted to its own aspect rather than forced square | `__tests__/utils/packingSlipPdf.test.ts` — `generatePackingSlipPdf — document branding`, `drawCompanyLogo` |
+| The footer carries `Generated {date} with jigged.app` and no longer restates the company name | `__tests__/utils/packingSlipPdf.test.ts` — `generatePackingSlipPdf — document branding` |
+| The shop header stacks logo → name → address, sized to the space the header already occupies so it never pushes content down, and drops the name when the logo already carries it | `__tests__/utils/shopHeaderBlock.test.ts` — `drawShopHeaderBlock` |
 
 **Gaps, automation-pending ([#367](https://github.com/debola31/Jigged/issues/367)):** reload-persistence E2E
 for create and void; `ShipmentsMenu` rendering; the packing-slip PDF rendering Bill To / Ship To / ATTN from

--- a/lib/companyDefaults.ts
+++ b/lib/companyDefaults.ts
@@ -150,6 +150,29 @@ export function readCompanyDefaultPaymentTerms(
   return raw.trim() || null;
 }
 
+/**
+ * Does the shop's uploaded logo already contain its company name?
+ *
+ * **This is the one thing about a logo that Jigged cannot work out for itself, and it changes what
+ * gets printed.** Most small-shop logos are wordmarks — the mark *is* the name, set in type. Printing
+ * `company.name` beside one states the same fact twice, in two typefaces, at the same weight, which
+ * is what a pilot shop described as the logo and the name "competing". But a logo that is a bare
+ * symbol *must* have the name printed, or the document goes out unnamed.
+ *
+ * No image analysis can answer this reliably and guessing wrong is bad in both directions, so it is
+ * a checkbox on the company profile and this reads it.
+ *
+ * **Defaults to false**, which is the safe direction: an unanswered question prints the name, and a
+ * duplicated name is a cosmetic problem where a missing one is a broken document.
+ *
+ * Lives in `settings` jsonb beside `default_payment_terms` rather than as a column on `companies`,
+ * which is why this feature ships with no migration and no `types/database.ts` change.
+ */
+export function readLogoIncludesName(company: SettingsLike | null | undefined): boolean {
+  const settings = company?.settings as Record<string, unknown> | undefined | null;
+  return settings?.logo_includes_name === true;
+}
+
 /** Upper bound on how many saved custom payment terms a company keeps. */
 export const MAX_CUSTOM_PAYMENT_TERMS = 15;
 

--- a/utils/companyAccess.ts
+++ b/utils/companyAccess.ts
@@ -598,3 +598,36 @@ export async function setCompanyDefaultPaymentTerms(
   }
   return next;
 }
+
+/**
+ * Record whether the shop's logo already contains its company name.
+ *
+ * Read-modify-write of the whole settings object, mirroring the payment-terms writers above — the
+ * outer spread is what keeps the sibling `features`, `defaults` and `custom_payment_terms` blocks
+ * alive; writing the key alone would silently drop every feature flag on the company.
+ *
+ * See `readLogoIncludesName` for why this is a question rather than something we detect.
+ */
+export async function setLogoIncludesName(
+  companyId: string,
+  includesName: boolean,
+): Promise<void> {
+  const supabase = getSupabase();
+  const company = await getCompany(companyId);
+  if (!company) {
+    throw new Error('Company not found.');
+  }
+  const settings = (company.settings ?? {}) as Record<string, unknown>;
+  const nextSettings = { ...settings, logo_includes_name: includesName } as Json;
+  const { error } = await supabase
+    .from('companies')
+    .update({ settings: nextSettings, updated_at: new Date().toISOString() })
+    .eq('id', companyId);
+  if (error) {
+    console.error('Error updating logo naming setting:', error);
+    throw toFriendlyError(error, {
+      entity: 'logo setting',
+      fallback: 'Failed to save that setting.',
+    });
+  }
+}

--- a/utils/jobTravelerPdf.ts
+++ b/utils/jobTravelerPdf.ts
@@ -35,13 +35,12 @@ import { buildScanUrl, scanOrigin } from '@/lib/jiggedScan';
 import { drawQrCode, QR_QUIET_MODULES, type QrErrorCorrection } from '@/lib/qrVector';
 import {
   attributionLine,
-  buildShopHeaderLines,
-  drawCompanyLogo,
+  drawShopHeaderBlock,
   formatDate,
   loadLogoAsDataUrl,
-  LOGO_BOX,
   type SupabaseLike,
 } from '@/utils/packingSlipPdf';
+import { readLogoIncludesName } from '@/lib/companyDefaults';
 
 const MARGIN = 40;
 
@@ -133,35 +132,7 @@ export async function generateJobTravelerPdf(
   const pageWidth = doc.internal.pageSize.getWidth();
   const pageHeight = doc.internal.pageSize.getHeight();
 
-  // ---------- Header: shop block (left) ----------
   const headerTop = MARGIN;
-  let logoBottom = headerTop;
-
-  const logoDataUrl = await loadLogoAsDataUrl(company.logo_url, ctx.supabase ?? null);
-  let logoWidth = 0;
-  if (logoDataUrl) {
-    logoWidth = drawCompanyLogo(doc, logoDataUrl, MARGIN, headerTop);
-    if (logoWidth > 0) logoBottom = headerTop + LOGO_BOX;
-  }
-
-  doc.setFont('helvetica', 'bold');
-  doc.setFontSize(14);
-  doc.setTextColor(30);
-  // Measured from what was drawn rather than a fixed 70pt — see drawCompanyLogo.
-  const shopNameX = logoWidth > 0 ? MARGIN + logoWidth + 14 : MARGIN;
-  doc.text(company.name, shopNameX, headerTop + 14);
-
-  const shopLines = buildShopHeaderLines(company);
-  doc.setFont('helvetica', 'normal');
-  doc.setFontSize(9.5);
-  doc.setTextColor(90);
-  shopLines.forEach((line, i) => {
-    doc.text(line, shopNameX, headerTop + 30 + i * 11.5);
-  });
-  const shopBlockBottom = Math.max(
-    logoBottom,
-    headerTop + (shopLines.length ? 30 + shopLines.length * 11.5 : 18),
-  );
 
   // ---------- Header: the traveler QR (far right, top-aligned) ----------
   // The QR sits BESIDE the title, not under it, so header height is one element
@@ -230,6 +201,23 @@ export async function generateJobTravelerPdf(
   // Header height is whichever column runs longest. The HOT stamp MUST be in
   // this max: its bottom sits 16pt below a 56pt QR, so leaving it out draws the
   // divider straight through the stamp on every hot job.
+  // ---------- Header: shop block (left) ----------
+  // Drawn last of the header pieces, because the QR and the HOT stamp on the right decide how tall
+  // this header is — and therefore how much room the logo can take without pushing the Operations
+  // table down. On a hot job the stamp extends the header, so the logo gets more room there; the
+  // ceiling inside `drawShopHeaderBlock` is what stops the same shop's mark changing size between a
+  // hot traveler and a cold one.
+  const logoDataUrl = await loadLogoAsDataUrl(company.logo_url, ctx.supabase ?? null);
+  const shopBlockBottom = drawShopHeaderBlock(doc, {
+    company,
+    logoDataUrl,
+    logoIncludesName: readLogoIncludesName(company),
+    x: MARGIN,
+    y: headerTop,
+    availableBottom: Math.max(qrBlockBottom, hotStampBottom),
+    nameSize: 14,
+  });
+
   let cursorY = Math.max(shopBlockBottom, qrBlockBottom, hotStampBottom) + 16;
 
   // ---------- Divider ----------

--- a/utils/packingSlipPdf.ts
+++ b/utils/packingSlipPdf.ts
@@ -38,6 +38,7 @@ import {
   type ShipmentWithRelations,
 } from '@/types/shipment';
 import { resolveAttentionLine } from '@/utils/shipmentsAccess';
+import { readLogoIncludesName } from '@/lib/companyDefaults';
 
 const MARGIN = 40;
 const ADDRESS_COMBINE_MAX_CHARS = 50;
@@ -257,8 +258,7 @@ export interface LogoDrawTarget {
 }
 
 /**
- * Draw a company logo fitted inside `LOGO_BOX`, and return the width it actually occupied so the
- * caller can place the company name beside it.
+ * Draw a company logo fitted inside `LOGO_BOX`, and return the width it actually occupied.
  *
  * **Aspect is preserved.** Both generators used to pass a 56×56 square regardless of the source,
  * which squashed every wordmark — the common case, since a shop's logo is usually wider than it is
@@ -267,6 +267,9 @@ export interface LogoDrawTarget {
  *
  * Returns 0 and draws nothing on any failure; the caller falls back to the company name in bold,
  * which is the layout that has been shipping all along.
+ *
+ * Kept for callers that want a logo in a fixed box. The document headers use
+ * `drawShopHeaderBlock` instead, which sizes the logo against the space the header already has.
  */
 export function drawCompanyLogo(
   doc: LogoDrawTarget,
@@ -288,6 +291,131 @@ export function drawCompanyLogo(
   } catch {
     return 0;
   }
+}
+
+// ─────────────────────────── The shop header block ───────────────────────────
+
+/** Gap between the logo and the text stacked beneath it. */
+const SHOP_LOGO_GAP = 12;
+
+/**
+ * Ceilings on the drawn logo.
+ *
+ * The height cap matters more than it looks: the budget is whatever the *right* column reaches, and
+ * the traveler's right column can be short. Without a cap, a document with a sparse right column
+ * would print a bigger logo than one with a full one — the same shop's paperwork disagreeing with
+ * itself about how big its own mark is. The width cap keeps a very wide logo out of the right
+ * column on a narrow header.
+ */
+const SHOP_LOGO_MAX_H = 62;
+const SHOP_LOGO_MAX_W = 190;
+
+/** Leading for the address lines under the logo, and for the optional name above them. */
+const SHOP_LINE_H = 12;
+const SHOP_NAME_H = 16;
+
+export interface ShopHeaderOptions {
+  company: Company;
+  /** Already-resolved logo image, or null. */
+  logoDataUrl: string | null;
+  /** From `readLogoIncludesName` — when true the company name is NOT set as text. */
+  logoIncludesName: boolean;
+  x: number;
+  y: number;
+  /**
+   * The y the *right-hand* column of this header reaches.
+   *
+   * This is the whole trick. A document header is as tall as its tallest column, and on all three
+   * documents that is the right one — the meta block, or the traveler's QR. Every point between the
+   * top of the page and that line is vertical space the document is **already paying for**, so a
+   * logo drawn into it is free. Callers must therefore measure their right column *before* calling
+   * this, which is why each generator computes its meta bottom up front.
+   */
+  availableBottom: number;
+  /** Font size for the company name when it is printed. */
+  nameSize?: number;
+}
+
+/**
+ * Draw the shop's identity block — logo, then the company name (unless the logo already says it),
+ * then the address — and return the y it reached.
+ *
+ * ## Why stacked rather than side by side
+ *
+ * A shop owner reviewing this preferred the address beneath the mark to the address beside it. That
+ * is a taste call and it is theirs; both fit the budget. It does cost logo size — the text under the
+ * logo eats budget the logo would otherwise have — which is exactly why the `logoIncludesName`
+ * question earns its keep: answering it "yes" removes a line of text and hands the logo the space
+ * back. On a 1.44:1 wordmark that is 78pt wide against 89pt.
+ *
+ * ## What it will not do
+ *
+ * It will not grow past `SHOP_LOGO_MAX_H`, and it will not return a bottom above `y` — a document
+ * with no logo and no address still reports where the name ended. If the logo fails to draw, the
+ * text renders exactly as it would have without one, which is the layout that shipped for months.
+ */
+export function drawShopHeaderBlock(
+  doc: LogoDrawTarget & {
+    setFont: (f: string, s: string) => void;
+    setFontSize: (n: number) => void;
+    setTextColor: (r: number, g?: number, b?: number) => void;
+    text: (t: string, x: number, y: number) => void;
+  },
+  {
+    company,
+    logoDataUrl,
+    logoIncludesName,
+    x,
+    y,
+    availableBottom,
+    nameSize = 13,
+  }: ShopHeaderOptions,
+): number {
+  const shopLines = buildShopHeaderLines(company);
+  const showName = !logoIncludesName;
+
+  // What the text under the logo will occupy, so the logo can be given the remainder.
+  const textHeight = (showName ? SHOP_NAME_H : 0) + shopLines.length * SHOP_LINE_H;
+
+  let logoBottom = y;
+  if (logoDataUrl) {
+    try {
+      const props = doc.getImageProperties(logoDataUrl);
+      if (props?.width && props?.height) {
+        const budget = availableBottom - y - SHOP_LOGO_GAP - textHeight;
+        const maxH = Math.min(SHOP_LOGO_MAX_H, budget);
+        if (maxH > 0) {
+          const ratio = props.width / props.height;
+          const h = Math.min(maxH, SHOP_LOGO_MAX_W / ratio);
+          const w = h * ratio;
+          doc.addImage(logoDataUrl, props.fileType, x, y, w, h, undefined, 'FAST');
+          logoBottom = y + h + SHOP_LOGO_GAP;
+        }
+      }
+    } catch {
+      // A logo must never break a document. Fall through and print the text where it would have
+      // gone anyway.
+    }
+  }
+
+  let ty = logoBottom;
+  if (showName) {
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(nameSize);
+    doc.setTextColor(30);
+    ty += nameSize;
+    doc.text(company.name, x, ty);
+    ty += SHOP_NAME_H - nameSize;
+  }
+
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(9.5);
+  doc.setTextColor(95);
+  shopLines.forEach((line, i) => {
+    doc.text(line, x, ty + 10 + i * SHOP_LINE_H);
+  });
+
+  return shopLines.length ? ty + 10 + (shopLines.length - 1) * SHOP_LINE_H : ty;
 }
 
 /**
@@ -462,34 +590,35 @@ export async function generatePackingSlipPdf(
 
   // ---------- Header ----------
   const headerTop = MARGIN;
-  let logoBottom = headerTop;
+
+  /**
+   * The RIGHT column is measured first, because it sets the header's height and therefore the
+   * vertical space the logo may occupy for free. Drawing the left column first — which is what this
+   * did for months — means sizing the logo with no idea how much room the header already has, and a
+   * 56pt box was the result.
+   *
+   * Bottom row is the last meta line, which is the Job(s) row when there is one and Ship Date
+   * otherwise.
+   */
+  const jobNumbers = Array.from(
+    new Set(
+      (shipment.shipment_line_items ?? [])
+        .map((li) => li.job_part?.job?.job_number)
+        .filter((n): n is string => Boolean(n)),
+    ),
+  );
+  const metaBlockBottom = headerTop + (jobNumbers.length > 0 ? 68 : 54);
 
   const logoDataUrl = await loadLogoAsDataUrl(company.logo_url, ctx.supabase ?? null);
-  let logoWidth = 0;
-  if (logoDataUrl) {
-    logoWidth = drawCompanyLogo(doc, logoDataUrl, MARGIN, headerTop);
-    if (logoWidth > 0) logoBottom = headerTop + LOGO_BOX;
-  }
-
-  doc.setFont('helvetica', 'bold');
-  doc.setFontSize(14);
-  doc.setTextColor(30);
-  // Measured from what was actually drawn, not a fixed 70pt: a wide wordmark used to run under the
-  // company name.
-  const shopNameX = logoWidth > 0 ? MARGIN + logoWidth + 14 : MARGIN;
-  doc.text(company.name, shopNameX, headerTop + 14);
-
-  const shopLines = buildShopHeaderLines(company);
-  doc.setFont('helvetica', 'normal');
-  doc.setFontSize(10);
-  doc.setTextColor(80);
-  shopLines.forEach((line, i) => {
-    doc.text(line, shopNameX, headerTop + 30 + i * 12);
+  const shopBlockBottom = drawShopHeaderBlock(doc, {
+    company,
+    logoDataUrl,
+    logoIncludesName: readLogoIncludesName(company),
+    x: MARGIN,
+    y: headerTop,
+    availableBottom: metaBlockBottom,
+    nameSize: 14,
   });
-  const shopBlockBottom = Math.max(
-    logoBottom,
-    headerTop + 30 + shopLines.length * 12,
-  );
 
   // Top-right title + meta
   doc.setFont('helvetica', 'bold');
@@ -513,15 +642,9 @@ export async function generatePackingSlipPdf(
     { align: 'right' },
   );
 
-  // Surface job # context — packing slip rolls up by job_part, so list
-  // distinct job numbers in the meta block to keep receiving anchored.
-  const jobNumbers = Array.from(
-    new Set(
-      (shipment.shipment_line_items ?? [])
-        .map((li) => li.job_part?.job?.job_number)
-        .filter((n): n is string => Boolean(n)),
-    ),
-  );
+  // Surface job # context — packing slip rolls up by job_part, so list distinct job numbers in the
+  // meta block to keep receiving anchored. The set itself is computed above the header, because its
+  // presence decides the header's height and therefore how much room the logo gets.
   if (jobNumbers.length > 0) {
     doc.text(
       `Job${jobNumbers.length > 1 ? 's' : ''}: ${jobNumbers.join(', ')}`,
@@ -530,7 +653,6 @@ export async function generatePackingSlipPdf(
       { align: 'right' },
     );
   }
-  const metaBlockBottom = headerTop + 68 + (jobNumbers.length > 0 ? 0 : -14);
 
   let cursorY = Math.max(shopBlockBottom, metaBlockBottom) + 18;
 

--- a/utils/packingSlipPdf.ts
+++ b/utils/packingSlipPdf.ts
@@ -295,8 +295,16 @@ export function drawCompanyLogo(
 
 // ─────────────────────────── The shop header block ───────────────────────────
 
-/** Gap between the logo and the text stacked beneath it. */
-const SHOP_LOGO_GAP = 12;
+/**
+ * Gap between the logo and the text stacked beneath it.
+ *
+ * **6, not 12.** The address under a mark is part of the same lockup and should read as one block;
+ * the text's own leading already adds ~10pt below this, so 12 put roughly 15pt of white between the
+ * logo's last pixel and the top of the address — more than a full line of 9.5pt type, which reads
+ * as two separate things that happen to be stacked. Tightening it also hands the difference back to
+ * the logo, since the budget it comes out of is the same one the logo is sized against.
+ */
+const SHOP_LOGO_GAP = 6;
 
 /**
  * Ceilings on the drawn logo.
@@ -372,12 +380,27 @@ export function drawShopHeaderBlock(
   }: ShopHeaderOptions,
 ): number {
   const shopLines = buildShopHeaderLines(company);
-  const showName = !logoIncludesName;
+
+  /**
+   * **The name is suppressed only if a logo actually carries it.**
+   *
+   * `logoIncludesName` is a statement about the *logo*, so it means nothing when there is no logo —
+   * and honouring it anyway prints a document with no company name on it at all, which is the one
+   * outcome this whole setting exists to avoid. A shop can easily reach that state: tick the box,
+   * then remove the logo.
+   *
+   * Decided up front from whether a logo will be *attempted*, because the text's height sets the
+   * logo's budget. If the attempt then fails, the name is restored below — safe, because a failed
+   * logo hands its entire budget back to the text.
+   */
+  const hasLogo = Boolean(logoDataUrl);
+  let showName = !logoIncludesName || !hasLogo;
 
   // What the text under the logo will occupy, so the logo can be given the remainder.
   const textHeight = (showName ? SHOP_NAME_H : 0) + shopLines.length * SHOP_LINE_H;
 
   let logoBottom = y;
+  let logoDrawn = false;
   if (logoDataUrl) {
     try {
       const props = doc.getImageProperties(logoDataUrl);
@@ -390,6 +413,7 @@ export function drawShopHeaderBlock(
           const w = h * ratio;
           doc.addImage(logoDataUrl, props.fileType, x, y, w, h, undefined, 'FAST');
           logoBottom = y + h + SHOP_LOGO_GAP;
+          logoDrawn = true;
         }
       }
     } catch {
@@ -397,6 +421,11 @@ export function drawShopHeaderBlock(
       // gone anyway.
     }
   }
+
+  // The logo we were counting on to carry the name did not render — an unreadable file, or a header
+  // too short to hold it. Print the name rather than ship an unnamed document. Nothing overflows:
+  // the space the logo would have taken is now free.
+  if (!logoDrawn) showName = true;
 
   let ty = logoBottom;
   if (showName) {

--- a/utils/quotePdf.ts
+++ b/utils/quotePdf.ts
@@ -14,11 +14,11 @@ import { isQuoteExpired, daysUntilExpiration } from '@/types/quote';
 import { quantityUnitSuffix } from '@/lib/standardUnits';
 import {
   ATTRIBUTION_MARK,
-  drawCompanyLogo,
+  drawShopHeaderBlock,
   loadLogoAsDataUrl,
-  LOGO_BOX,
   type SupabaseLike,
 } from '@/utils/packingSlipPdf';
+import { readLogoIncludesName } from '@/lib/companyDefaults';
 
 const MARGIN = 40;
 
@@ -37,43 +37,17 @@ function formatDate(iso: string | null | undefined): string {
 }
 
 /**
- * Lines of text for the top-left "shop header".
- * Targets a 2-line address: address_line1 + address_line2 combined onto one line
- * when short enough, then city/state/zip on a second line. Phone goes underneath.
- * Email and website are intentionally omitted from the header — clutter on a printed
- * customer-facing document.
+ * The shop header block — logo, name and address — is drawn by `drawShopHeaderBlock`
+ * (utils/packingSlipPdf.ts), shared with the packing slip and the job traveler.
+ *
+ * This file used to carry its own near-identical copy of the address-line builder. Three documents
+ * printing the same shop's return address from three implementations is three places for them to
+ * disagree, and the header layout now has real logic in it — a logo sized against the space the
+ * header already occupies — which is not something to maintain in triplicate.
+ *
+ * Email and website are intentionally absent from the header: clutter on a customer-facing document,
+ * and nothing has ever read those columns.
  */
-const ADDRESS_COMBINE_MAX_CHARS = 50;
-
-function buildShopHeaderLines(company: Company): string[] {
-  const lines: string[] = [];
-
-  // Combine address line 1 and 2 onto one line when reasonably short; otherwise stack.
-  const a1 = company.address_line1?.trim();
-  const a2 = company.address_line2?.trim();
-  if (a1 && a2) {
-    const combined = `${a1}, ${a2}`;
-    if (combined.length <= ADDRESS_COMBINE_MAX_CHARS) {
-      lines.push(combined);
-    } else {
-      lines.push(a1);
-      lines.push(a2);
-    }
-  } else if (a1) {
-    lines.push(a1);
-  } else if (a2) {
-    lines.push(a2);
-  }
-
-  const cityStateZip = [company.city, company.state].filter(Boolean).join(', ');
-  const cityStateZipFull = [cityStateZip, company.postal_code].filter(Boolean).join(' ').trim();
-  if (cityStateZipFull) lines.push(cityStateZipFull);
-  if (company.country && company.country.toUpperCase() !== 'USA') lines.push(company.country);
-
-  if (company.phone) lines.push(company.phone);
-
-  return lines;
-}
 
 // The customer/address/contact block is now read from the quote's frozen
 // snapshot columns (see generateQuotePdf), not resolved from the live joined
@@ -154,33 +128,12 @@ export async function generateQuotePdf(
   // ---------- Header: company block (top-left) + QUOTE + meta (top-right) ----------
   const headerTop = MARGIN;
 
-  // The shop's logo, if it has one. The packing slip and the traveler have carried it for a long
-  // time and the quote never did — which had it exactly backwards, since the quote is the one
-  // document that goes to a customer who has not decided to buy yet.
-  const logoDataUrl = await loadLogoAsDataUrl(company.logo_url, supabase ?? null);
-  let logoWidth = 0;
-  if (logoDataUrl) logoWidth = drawCompanyLogo(doc, logoDataUrl, MARGIN, headerTop);
-
-  // Top-left: company name (bold) then address / contact lines, beside the logo when there is one.
-  const shopNameX = logoWidth > 0 ? MARGIN + logoWidth + 14 : MARGIN;
-  doc.setFont('helvetica', 'bold');
-  doc.setFontSize(14);
-  doc.setTextColor(30);
-  doc.text(company.name, shopNameX, headerTop + 12);
-
-  const shopLines = buildShopHeaderLines(company);
-  doc.setFont('helvetica', 'normal');
-  doc.setFontSize(10);
-  doc.setTextColor(80);
-  shopLines.forEach((line, i) => {
-    doc.text(line, shopNameX, headerTop + 28 + i * 12);
-  });
-  const shopBlockBottom = Math.max(
-    headerTop + 28 + shopLines.length * 12,
-    logoWidth > 0 ? headerTop + LOGO_BOX : headerTop,
-  );
-
   // Top-right: QUOTE title + stacked meta (no box, right-aligned).
+  //
+  // **The right column is built before the left, deliberately.** It is the taller of the two, so it
+  // sets the header's height — and therefore how much vertical room the shop block on the left can
+  // use without pushing the quote down the page. Drawing the left first means sizing a logo blind,
+  // which is how it ended up in a 56pt box while the header had 110pt to give.
   doc.setFont('helvetica', 'bold');
   doc.setFontSize(26);
   doc.setTextColor(30);
@@ -218,6 +171,20 @@ export async function generateQuotePdf(
     doc.text(row.text, pageWidth - MARGIN, headerTop + 40 + i * 14, { align: 'right' });
   });
   const metaBlockBottom = headerTop + 40 + metaRows.length * 14;
+
+  // Top-left: the shop's identity, sized against the header the right column just established.
+  // A quote with three meta rows has a shorter header than one with five, so the budget is
+  // computed per quote rather than assumed.
+  const logoDataUrl = await loadLogoAsDataUrl(company.logo_url, supabase ?? null);
+  const shopBlockBottom = drawShopHeaderBlock(doc, {
+    company,
+    logoDataUrl,
+    logoIncludesName: readLogoIncludesName(company),
+    x: MARGIN,
+    y: headerTop,
+    availableBottom: metaBlockBottom,
+    nameSize: 14,
+  });
 
   let cursorY = Math.max(shopBlockBottom, metaBlockBottom) + 16;
 


### PR DESCRIPTION
A pilot shop uploaded a logo, printed a quote, and said the logo and the company name **"competed side by side"**. Two things were wrong, and only one of them was placement.

## The size

The logo was fitted into a **56×56 box** — square, sized for a badge. Their file is 1484×1030, *landscape*, so it was capped by width at **0.78″**. Letterhead convention is 1.5–3″. At that size the sub-line of their logo set at under **4pt**.

## The space it could have had

A document header is as tall as its tallest column, and on all three documents that is the **right** one. On a quote, five meta rows end at y=150 while the left column reached only y=104 — so **46pt of vertical space was already being paid for and left empty.**

My first attempt grew the logo to print convention and pushed the quote **57pt down the page**. The shop owner rejected that, correctly: the fix was never to spend *more* space, it was to spend the space **already there**.

So each generator now measures its right column **before** drawing the left, and `drawShopHeaderBlock` sizes the logo to what remains. **Zero documents move.**

| | logo width |
|---|---|
| Before | 0.78″ |
| Stacked, name printed | **1.08″** |
| Stacked, logo carries the name | **1.24″** |

## Stacked, not side by side

At the shop owner's preference: logo, then name, then address beneath it. That *costs* logo size — text under the mark eats budget the mark would otherwise have — which is exactly what makes the second half of this worth building.

## "My logo already includes my company name"

A checkbox on the company profile. Most shop logos are wordmarks, and printing the name again states the same fact twice in two typefaces — the competing they described. But a logo that is a **bare symbol must** have the name printed, or the document goes out unnamed.

No image analysis answers that reliably, and guessing is bad in both directions, so it is **asked rather than inferred**. Unticked is the safe default: a duplicated name is untidy, a missing one is broken. Ticking it also hands the logo back the line of text it no longer needs.

**No migration.** It lives in `companies.settings` jsonb beside `default_payment_terms`, so there is no `types/database.ts` change and **nothing owed on prod**.

## Also

Removes `quotePdf`'s private copy of the address-line builder. Three documents printing one shop's return address from three implementations is three places to disagree, and the header now has real logic in it.

## Verification

- **171 files, 2390 tests, 0 failures**; typecheck clean; lint 0 errors / 16 warnings (unchanged)
- `__tests__/utils/shopHeaderBlock.test.ts` pins the properties that fail silently: the block never draws past the header's existing height, aspect is preserved, the text stacks under the logo, the name appears/disappears with the checkbox, and the logo gets *more* room when the name is dropped
- Also pinned: a short header draws **no** logo rather than a squashed one, an unreadable image falls back to text, and a very tall right column **cannot** inflate the logo — otherwise the same shop's mark would print bigger on a hot traveler than a cold one
- Rendered real quote PDFs in both toggle states with the shop's actual logo and checked them by eye

🤖 Generated with [Claude Code](https://claude.com/claude-code)
