### PR TITLE
fix(test): wait for the pre-selected value, not just the field

### DIFF
--- a/__tests__/components/inventory/locations/place/PlaceStockActionForm.test.tsx
+++ b/__tests__/components/inventory/locations/place/PlaceStockActionForm.test.tsx
@@ -237,8 +237,15 @@ describe('PlaceStockActionForm', () => {
     });
     setup('deplete');
 
-    const field = await screen.findByRole('combobox', { name: /part/i });
-    expect(field).toHaveValue('RAW-STEEL-BLANK — 12 ea');
+    /*
+     * Wait for the VALUE, not for the field.
+     *
+     * `findByRole` resolves the moment the combobox exists, which is the first render — before
+     * `useLoad` has resolved the bin's contents, and therefore before there is one part to
+     * pre-select. The assertion then raced the fetch: it usually won locally and lost on a loaded
+     * CI runner, which is how a green PR turned main red and blocked the production deploy.
+     */
+    expect(await screen.findByDisplayValue('RAW-STEEL-BLANK — 12 ea')).toBeInTheDocument();
   });
 
   /**


### PR DESCRIPTION
## Why this is urgent

**main is red and the production deploy is gated behind it.** `Deploy Production` did not run for the #749 merge.

## The bug

`PlaceStockActionForm > pre-selects the only part in the bin` raced the fetch it was asserting about:

```ts
const field = await screen.findByRole('combobox', { name: /part/i });
expect(field).toHaveValue('RAW-STEEL-BLANK — 12 ea');
```

`findByRole` resolves the moment the combobox exists — the **first render**, before `useLoad` has resolved the bin's contents and therefore before there is one part to pre-select. The `toHaveValue` that follows is synchronous, so it asserts against an empty box and only passes because the mocked promise usually settles first.

It usually won locally and lost on a loaded CI runner: green on the PR, red on main.

## The fix

One line — wait for the thing the test is actually about:

```ts
expect(await screen.findByDisplayValue('RAW-STEEL-BLANK — 12 ea')).toBeInTheDocument();
```

Ran the file five times in a row locally: 12/12 each time. Full suite 2445 passing.

## Note on #751

[#751](https://github.com/debola31/Jigged/pull/751) removes this test entirely — the batch rework lists every row rather than pre-selecting one — so merging that also makes main green. This PR exists so unblocking the production deploy does not have to wait on a feature. If you merge this first, #751 will need a trivial conflict resolution on this one file (it rewrites it wholesale); I'll handle that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)