### PR TITLE
feat(storage): rank jobs instead of restricting them, and give the shop floor the office's forms

### DIFF
--- a/__tests__/components/inventory/JobTagPicker.test.tsx
+++ b/__tests__/components/inventory/JobTagPicker.test.tsx
@@ -96,21 +96,23 @@ describe('loadJobsForPart', () => {
     expect(jobs.map((j) => j.id)).toEqual(['a', 'c']);
   });
 
-  /**
-   * No relationship at all means an EMPTY list, not every job.
-   *
-   * Falling back to everything would make the filter decorative — the whole point is that a short
-   * list is information, and the caller is what offers a way past it.
-   */
+  /** No relationship at all is an empty EXPECTED set — the caller still offers every job. */
   it('returns nothing when no job could use the part', async () => {
     stubTables([], []);
     await expect(loadJobsForPart('co1', 'p-orphan')).resolves.toEqual([]);
   });
 
-  it('swallows a failed read rather than breaking the form', async () => {
+  /**
+   * "COULDN'T CHECK" IS NEVER "DENIED" (CLAUDE.md).
+   *
+   * An empty array is a claim — "no job lists this part". A dropped query is not that claim, and
+   * swallowing one into `[]` made the picker assert it about a network failure. It throws, and the
+   * caller falls back to the unranked list.
+   */
+  it('throws on a failed read rather than reporting "none"', async () => {
     from.mockImplementation(() => {
       throw new Error('boom');
     });
-    await expect(loadJobsForPart('co1', 'p-steel')).resolves.toEqual([]);
+    await expect(loadJobsForPart('co1', 'p-steel')).rejects.toThrow();
   });
 });

--- a/__tests__/components/inventory/JobTagPicker.test.tsx
+++ b/__tests__/components/inventory/JobTagPicker.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Which jobs a removal may be tagged to.
+ *
+ * The rule has a precise definition and it is worth pinning, because "expected" is exactly the kind
+ * of word that drifts: a job is expected to consume a part when the part is **what the job makes**,
+ * or a **direct child in the BOM** of something the job makes. One level, matching the decision the
+ * material check already records — *"a pump job reads 'needs 1 pump core', not the aluminium inside
+ * it"* — because two definitions of "what this job needs" is worse than one narrow one.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const from = vi.fn();
+vi.mock('@/lib/supabase', () => ({ getSupabase: () => ({ from }) }));
+vi.mock('@/utils/jobsAccess', () => ({ getAllJobs: vi.fn() }));
+
+import { loadJobsForPart, loadTaggableJobs } from '@/components/inventory/JobTagPicker';
+import { getAllJobs } from '@/utils/jobsAccess';
+
+/** `parts_bom` → parents that consume the part; `job_parts` → jobs making those parts. */
+const stubTables = (bomParents: string[], jobRows: Array<{ job_id: string }>) => {
+  from.mockImplementation((table: string) => {
+    if (table === 'parts_bom') {
+      return {
+        select: () => ({
+          eq: async () => ({
+            data: bomParents.map((parent_part_id) => ({ parent_part_id })),
+            error: null,
+          }),
+        }),
+      };
+    }
+    if (table === 'job_parts') {
+      return {
+        select: () => ({
+          eq: () => ({ in: async () => ({ data: jobRows, error: null }) }),
+        }),
+      };
+    }
+    throw new Error(`unexpected table ${table}`);
+  });
+};
+
+const job = (id: string) => ({ id, job_number: `J-${id}` });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getAllJobs).mockResolvedValue({
+    jobs: [job('a'), job('b'), job('c')],
+  } as never);
+});
+
+describe('loadTaggableJobs', () => {
+  /** You are tagging to whatever is moving through the shop now, not what opened in March. */
+  it('asks for active jobs, most recently updated first', async () => {
+    await loadTaggableJobs('co1');
+
+    expect(getAllJobs).toHaveBeenCalledWith(
+      'co1',
+      expect.objectContaining({ productionStatus: expect.anything() }),
+      'updated_at',
+      'desc',
+    );
+  });
+
+  it('returns nothing rather than throwing when the read fails', async () => {
+    vi.mocked(getAllJobs).mockRejectedValue(new Error('network'));
+    await expect(loadTaggableJobs('co1')).resolves.toEqual([]);
+  });
+});
+
+describe('loadJobsForPart', () => {
+  it('includes a job that MAKES the part', async () => {
+    stubTables([], [{ job_id: 'a' }]);
+    const jobs = await loadJobsForPart('co1', 'p-steel');
+    expect(jobs.map((j) => j.id)).toEqual(['a']);
+  });
+
+  /** The material case: the job makes a pump core, and this part is in the pump core's BOM. */
+  it('includes a job whose part consumes this one in its BOM', async () => {
+    stubTables(['p-pumpcore'], [{ job_id: 'b' }]);
+    const jobs = await loadJobsForPart('co1', 'p-steel');
+    expect(jobs.map((j) => j.id)).toEqual(['b']);
+  });
+
+  it('leaves out jobs with no relationship to the part', async () => {
+    stubTables([], [{ job_id: 'a' }]);
+    const jobs = await loadJobsForPart('co1', 'p-steel');
+    expect(jobs.map((j) => j.id)).not.toContain('c');
+  });
+
+  /** Order comes from the one loader that knows it; filtering must not reshuffle. */
+  it('keeps most-recently-updated order', async () => {
+    stubTables([], [{ job_id: 'c' }, { job_id: 'a' }]);
+    const jobs = await loadJobsForPart('co1', 'p-steel');
+    expect(jobs.map((j) => j.id)).toEqual(['a', 'c']);
+  });
+
+  /**
+   * No relationship at all means an EMPTY list, not every job.
+   *
+   * Falling back to everything would make the filter decorative — the whole point is that a short
+   * list is information, and the caller is what offers a way past it.
+   */
+  it('returns nothing when no job could use the part', async () => {
+    stubTables([], []);
+    await expect(loadJobsForPart('co1', 'p-orphan')).resolves.toEqual([]);
+  });
+
+  it('swallows a failed read rather than breaking the form', async () => {
+    from.mockImplementation(() => {
+      throw new Error('boom');
+    });
+    await expect(loadJobsForPart('co1', 'p-steel')).resolves.toEqual([]);
+  });
+});

--- a/__tests__/components/inventory/locations/place/UnitAdjustDrawer.test.tsx
+++ b/__tests__/components/inventory/locations/place/UnitAdjustDrawer.test.tsx
@@ -61,8 +61,16 @@ const setup = (unit: InventoryLocationNode | null = CABINET) =>
     <UnitAdjustDrawer unit={unit} companyId="co1" onClose={onClose} onChanged={vi.fn()} />,
   );
 
+/**
+ * Wait for the ROW, not for the drawer.
+ *
+ * The header renders on the first frame; the rows arrive when `loadCountCandidatesForPlaces`
+ * resolves. Waiting on the heading and then querying synchronously raced that read — it won
+ * locally and lost on a loaded CI runner, which is precisely the flake that once turned main red
+ * and blocked a production deploy.
+ */
 const countedFor = (part: string, place: string) =>
-  screen.getByLabelText(`Counted ${part} at ${place}`);
+  screen.findByLabelText(`Counted ${part} at ${place}`);
 
 /**
  * Re-established every test, not merely cleared.
@@ -113,7 +121,7 @@ describe('UnitAdjustDrawer', () => {
     setup();
     await screen.findByRole('heading', { name: /bulk adjust/i });
 
-    await user.type(countedFor('BUY-ORING-214', 'Shelf B'), '550');
+    await user.type(await countedFor('BUY-ORING-214', 'Shelf B'), '550');
     await user.click(screen.getByRole('button', { name: /save 1 count/i }));
 
     const [variances] = vi.mocked(commitCount).mock.calls[0];
@@ -145,7 +153,7 @@ describe('UnitAdjustDrawer', () => {
     setup();
     await screen.findByRole('heading', { name: /bulk adjust/i });
 
-    await user.type(countedFor('BUY-ORING-214', 'Shelf B'), '550');
+    await user.type(await countedFor('BUY-ORING-214', 'Shelf B'), '550');
     await user.type(screen.getByPlaceholderText(/filter by part or place/i), 'WIDGET-3');
 
     // Narrowed…
@@ -153,7 +161,7 @@ describe('UnitAdjustDrawer', () => {
     expect(screen.queryByText('BUY-WIDGET-5')).not.toBeInTheDocument();
     // …but never past the thing that is about to be saved.
     expect(screen.getByText('BUY-ORING-214')).toBeInTheDocument();
-    expect(countedFor('BUY-ORING-214', 'Shelf B')).toHaveValue(550);
+    expect(await countedFor('BUY-ORING-214', 'Shelf B')).toHaveValue(550);
     expect(screen.getByRole('button', { name: /save 1 count/i })).toBeEnabled();
     expect(screen.getByText(/including 1 you have counted/i)).toBeInTheDocument();
   });
@@ -177,7 +185,7 @@ describe('UnitAdjustDrawer', () => {
     setup();
     await screen.findByRole('heading', { name: /bulk adjust/i });
 
-    await user.type(countedFor('BUY-BEARING-608ZZ', 'Shelf A'), '580');
+    await user.type(await countedFor('BUY-BEARING-608ZZ', 'Shelf A'), '580');
     await user.click(screen.getByRole('button', { name: /save 1 count/i }));
 
     expect(commitCount).not.toHaveBeenCalled();
@@ -189,8 +197,8 @@ describe('UnitAdjustDrawer', () => {
     setup();
     await screen.findByRole('heading', { name: /bulk adjust/i });
 
-    await user.type(countedFor('BUY-BEARING-608ZZ', 'Shelf A'), '580'); // unchanged
-    await user.type(countedFor('BUY-ORING-214', 'Shelf B'), '550'); // −2
+    await user.type(await countedFor('BUY-BEARING-608ZZ', 'Shelf A'), '580'); // unchanged
+    await user.type(await countedFor('BUY-ORING-214', 'Shelf B'), '550'); // −2
     await user.click(screen.getByRole('button', { name: /save 2 counts/i }));
 
     const [variances] = vi.mocked(commitCount).mock.calls[0];
@@ -219,8 +227,8 @@ describe('UnitAdjustDrawer', () => {
       total: 3,
     });
 
-    await user.type(countedFor('BUY-ORING-214', 'Shelf A'), '828');
-    await user.type(countedFor('BUY-ORING-214', 'Shelf B'), '552');
+    await user.type(await countedFor('BUY-ORING-214', 'Shelf A'), '828');
+    await user.type(await countedFor('BUY-ORING-214', 'Shelf B'), '552');
     await user.click(screen.getByRole('button', { name: /save 2 counts/i }));
 
     expect(await screen.findByText(/stock moved between these places/i)).toBeInTheDocument();

--- a/__tests__/components/operator/OperatorBinView.test.tsx
+++ b/__tests__/components/operator/OperatorBinView.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '@mui/material/styles';
 import jiggedTheme from '@/lib/theme';
 
 import OperatorBinViewPage from '@/app/operator/[companyId]/inventory/locations/[locationId]/page';
 import {
+  getLocationContents,
   resolveScan,
   depleteStockAtLocation,
   getLocations,
@@ -34,6 +35,9 @@ vi.mock('@/utils/inventoryLocationsAccess', async () => ({
   )).buildLocationTree,
   addStockAtLocation: vi.fn(),
   depleteStockAtLocation: vi.fn(),
+  // The shared forms read the bin themselves rather than being handed its contents — the one
+  // about to WRITE is the one that must be current. Defaults to empty; tests that act set it.
+  getLocationContents: vi.fn(async () => ({ contents: [], total: 0 })),
   adjustStockAtLocation: vi.fn(),
   transferStock: vi.fn(),
 }));
@@ -144,17 +148,25 @@ describe('OperatorBinViewPage', () => {
     expect(screen.getByText(/stock goes in the sub-locations above/i)).toBeInTheDocument();
   });
 
-  it('still offers Stock a part on a bin with no sub-locations', async () => {
+  it('still offers a way to put stock in, on a bin with no sub-locations', async () => {
     (resolveScan as ReturnType<typeof vi.fn>).mockResolvedValue(scanWith([], []));
     renderPage();
 
-    expect(await screen.findByRole('button', { name: /stock a part/i })).toBeInTheDocument();
+    // `Stock a part` and its dialog are gone: the shop floor now uses the same four verbs and the
+    // same forms as the office, so putting a delivery away is one form rather than six dialogs.
+    expect(await screen.findByRole('button', { name: /^add$/i })).toBeInTheDocument();
+    for (const verb of [/^remove$/i, /^move$/i, /^adjust$/i]) {
+      expect(screen.getByRole('button', { name: verb })).toBeInTheDocument();
+    }
   });
 
   it('shows an empty state when nothing is stored here', async () => {
     (resolveScan as ReturnType<typeof vi.fn>).mockResolvedValue(scanWith([], []));
     renderPage();
-    expect(await screen.findByText('Nothing stored here yet.')).toBeInTheDocument();
+    expect(await screen.findByText(/no parts recorded here/i)).toBeInTheDocument();
+    // Nothing to take out of an empty bin, but you can always put something in.
+    expect(screen.getByRole('button', { name: /^remove$/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^add$/i })).toBeEnabled();
   });
 
   it('Remove depletes gracefully and stamps the operator', async () => {
@@ -162,13 +174,19 @@ describe('OperatorBinViewPage', () => {
       scanWith([], [{ part_id: 'p1', part_name: 'Steel Rod', primary_unit: 'ea', quantity: 12 }]),
     );
     (depleteStockAtLocation as ReturnType<typeof vi.fn>).mockResolvedValue({ location_balance: 7, part_quantity: 7 });
+    (getLocationContents as ReturnType<typeof vi.fn>).mockResolvedValue({
+      contents: [
+        { part_id: 'p1', part_name: 'Steel Rod', primary_unit: 'ea', quantity: 12, location_id: 'loc1' },
+      ],
+      total: 1,
+    });
     renderPage();
 
     await userEvent.click(await screen.findByRole('button', { name: /^remove$/i }));
 
-    const dialog = await screen.findByRole('dialog');
-    await userEvent.type(within(dialog).getByLabelText(/quantity/i), '5');
-    await userEvent.click(within(dialog).getByRole('button', { name: /^remove$/i }));
+    // The shared form, expanded in place — no dialog, and the rows are the bin's contents.
+    await userEvent.type(await screen.findByLabelText(/quantity for Steel Rod/i), '5');
+    await userEvent.click(screen.getByRole('button', { name: /^remove stock$/i }));
 
     await waitFor(() =>
       expect(depleteStockAtLocation).toHaveBeenCalledWith(
@@ -176,7 +194,9 @@ describe('OperatorBinViewPage', () => {
         'loc1',
         5,
         'ea',
-        expect.objectContaining({ graceful: true, operatorId: 'op1' }),
+        // GRACEFUL SURVIVES THE REWRITE. The material is already off the shelf, so a stale count
+        // must not refuse the write; the RPC floors at zero and records the shortfall in the note.
+        expect.objectContaining({ graceful: true }),
       ),
     );
   });

--- a/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
+++ b/app/operator/[companyId]/inventory/locations/[locationId]/page.tsx
@@ -1,23 +1,14 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useLoad } from '@/hooks/useLoad';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
-import Link from '@mui/material/Link';
-import AddIcon from '@mui/icons-material/Add';
-import RemoveIcon from '@mui/icons-material/Remove';
-import TuneIcon from '@mui/icons-material/Tune';
-import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
-import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
-import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
 
 import {
   resolveScan,
@@ -29,14 +20,11 @@ import {
 import { rollUpOccupancy } from '@/utils/locationOccupancy';
 import UnitGridView from '@/components/inventory/locations/UnitGridView';
 import { stockDestinationOptions } from '@/utils/locationDestinations';
-import { getCurrentMember } from '@/utils/operatorAccess';
 import { useSetOperatorChrome } from '@/components/operator/OperatorChromeContext';
-import { getStandardUnitsForUnit } from '@/lib/unitPresets';
-import type { LocationContent } from '@/types/inventoryLocations';
-import OperatorLocationActionModal, {
-  type OperatorLocationAction,
-} from '@/components/operator/OperatorLocationActionModal';
-import OperatorReceivePartModal from '@/components/operator/OperatorReceivePartModal';
+import PlaceStockActionForm, {
+  type PlaceStockAction,
+} from '@/components/inventory/locations/place/PlaceStockActionForm';
+import PlaceAdjustForm from '@/components/inventory/locations/place/PlaceAdjustForm';
 import BinHistory from '@/components/operator/BinHistory';
 
 const num = (n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 4 });
@@ -47,13 +35,10 @@ export default function OperatorBinViewPage() {
   const companyId = params.companyId as string;
   const locationId = params.locationId as string;
 
-  const [operatorId, setOperatorId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const [modal, setModal] = useState<{ action: OperatorLocationAction; part: LocationContent } | null>(
-    null,
-  );
-  const [receiveOpen, setReceiveOpen] = useState(false);
+  /** Which verb's form is open, exactly as the office drawer holds it. */
+  const [openVerb, setOpenVerb] = useState<PlaceStockAction | 'adjust' | null>(null);
 
   const {
     data: scan,
@@ -65,20 +50,11 @@ export default function OperatorBinViewPage() {
     },
   });
 
-  // Operator id stamps the ledger; best-effort, never blocks the view.
-  useEffect(() => {
-    let cancelled = false;
-    getCurrentMember(companyId)
-      .then((op) => {
-        if (!cancelled) setOperatorId(op?.id ?? null);
-      })
-      .catch(() => {
-        if (!cancelled) setOperatorId(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [companyId]);
+  /*
+   * The author lookup used to live here, feeding the two operator modals. The shared forms fetch
+   * their own — best-effort, so a failed lookup writes no name rather than blocking a stock
+   * correction — which means attribution still happens and this page no longer has to arrange it.
+   */
 
   const node = scan?.node ?? null;
   const path = scan?.path ?? [];
@@ -151,12 +127,6 @@ export default function OperatorBinViewPage() {
   const moveDestinations = useMemo(
     () => stockDestinationOptions(allLocations ?? [], { excludeId: locationId }),
     [allLocations, locationId],
-  );
-
-  const modalUnit = modal?.part.primary_unit || 'ea';
-  const unitOptions = useMemo(
-    () => Array.from(new Set([modalUnit, ...getStandardUnitsForUnit(modalUnit)])).filter(Boolean),
-    [modalUnit],
   );
 
   if (loading) {
@@ -240,113 +210,114 @@ export default function OperatorBinViewPage() {
         </Typography>
       ) : (
       <Box>
-        <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
-          <Typography variant="overline" color="text.secondary" sx={{ flex: 1 }}>
-            Stock here
-          </Typography>
-          <Button size="small" startIcon={<AddCircleOutlineIcon />} onClick={() => setReceiveOpen(true)}>
-            Stock a part
-          </Button>
-        </Stack>
-        {contents.length === 0 ? (
-          <Card elevation={2} sx={{ mt: 0.5 }}>
-            <CardContent sx={{ textAlign: 'center', py: 4 }}>
-              <Inventory2OutlinedIcon sx={{ fontSize: 40, color: 'text.disabled', mb: 1 }} />
-              <Typography color="text.secondary">Nothing stored here yet.</Typography>
-            </CardContent>
-          </Card>
-        ) : (
-          <Stack spacing={1} sx={{ mt: 0.5 }}>
-            {/* The list is capped. Saying so beats the silent `max_rows` clip this read used to
-                take — an operator seeing 200 of 9,428 needs to know the rest exist. */}
-            {/* The instruction is back, and now it points somewhere real.
-                It once read "Scan or search a part to reach one that isn't listed", when neither
-                route existed — no part search anywhere on the operator app, and a scanner that
-                resolves location labels and job travellers but never a part. It was stripped to
-                "ask the office" rather than keep promising two impossible things. J11 shipped
-                2026-07-31, so the honest version is a link to it — the lookup answers "where is
-                this?" for any part, including one below this cap. */}
-            {contentsTotal > contents.length && (
-              <Alert severity="info">
-                Showing the {contents.length} largest of {num(contentsTotal)} parts here. The rest
-                are still counted —{' '}
-                <Link
-                  component="button"
-                  type="button"
-                  onClick={() => router.push(`/operator/${companyId}/inventory`)}
+        {/*
+          THE SAME FLOW AS THE OFFICE, minus everything that configures storage.
+
+          This was a card per part, each with four buttons opening a single-part dialog — so putting
+          a delivery of six things away meant six dialogs, and none of the rules the office forms
+          grew (a blank row is not an instruction; a partial batch disarms what landed; the job list
+          narrows to jobs that could have used the part) applied here at all. The shop floor had the
+          older, thinner version of the same job.
+
+          It now renders the very same forms. Not a copy — the same components, so a rule fixed in
+          one place is fixed on both surfaces, which is exactly how the two drifted in the first
+          place.
+
+          What it does NOT get: `Change layout`, `Rename`, `Delete`, `Add storage`, `Print QR`.
+          Configuring storage is an office job; acting on the stock in it is not.
+        */}
+        <Typography variant="overline" color="text.secondary">
+          Stock here
+        </Typography>
+
+        <Box sx={{ mt: 0.5, mb: 2 }}>
+          {contents.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No parts recorded here.
+            </Typography>
+          ) : (
+            <Stack spacing={0.5}>
+              {contentsTotal > contents.length && (
+                <Alert severity="info" sx={{ mb: 0.5 }}>
+                  Showing the {contents.length} largest of {num(contentsTotal)} parts here.
+                </Alert>
+              )}
+              {contents.map((part) => (
+                <Box
+                  key={part.part_id}
+                  sx={{ display: 'flex', alignItems: 'baseline', gap: 1, minHeight: 32 }}
                 >
-                  look a part up
-                </Link>{' '}
-                to find one that isn&apos;t listed.
-              </Alert>
-            )}
-            {contents.map((part) => (
-              <Card key={part.part_id} elevation={2}>
-                <CardContent>
-                  <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, flexWrap: 'wrap' }}>
-                    <Typography sx={{ fontWeight: 600, flex: 1, minWidth: 0 }}>
-                      {part.part_name}
-                    </Typography>
-                    <Typography variant="h5" sx={{ fontWeight: 700 }}>
-                      {num(part.quantity)}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      {part.primary_unit ?? ''}
-                    </Typography>
-                  </Box>
-                  {/* Same four verbs, same words, as the admin part page.
-                      ORDER is fixed across both surfaces — Add, Remove, Move, Adjust — so a
-                      control is always in the same place. WEIGHT is what varies: Remove is the
-                      primary here (stock arrives in bulk once, and put-away is really
-                      receiving's job; it leaves in small amounts every job, all shift), while
-                      the admin page emphasises Add. Position serves the operator who knows
-                      where to reach; fill serves the one who doesn't yet.
-                      None of the four is red — reversible bookkeeping, not destruction. */}
-                  <Stack direction="row" spacing={1} sx={{ mt: 1.5, flexWrap: 'wrap', gap: 1 }}>
-                    <Button
-                      variant="outlined"
-                      startIcon={<AddIcon />}
-                      onClick={() => setModal({ action: 'add', part })}
-                      sx={{ flex: 1, minWidth: 120 }}
-                    >
-                      Add
-                    </Button>
-                    <Button
-                      variant="contained"
-                      startIcon={<RemoveIcon />}
-                      onClick={() => setModal({ action: 'deplete', part })}
-                      sx={{ flex: 1, minWidth: 120 }}
-                    >
-                      Remove
-                    </Button>
-                    <Button
-                      variant="outlined"
-                      startIcon={<SwapHorizIcon />}
-                      onClick={() => setModal({ action: 'move', part })}
-                      sx={{ flex: 1, minWidth: 120 }}
-                    >
-                      Move
-                    </Button>
-                    <Button
-                      variant="outlined"
-                      startIcon={<TuneIcon />}
-                      onClick={() => setModal({ action: 'adjust', part })}
-                      sx={{ flex: 1, minWidth: 120 }}
-                    >
-                      Adjust
-                    </Button>
-                  </Stack>
-                </CardContent>
-              </Card>
-            ))}
-          </Stack>
-        )}
+                  <Typography variant="body2" sx={{ flex: 1, minWidth: 0 }} noWrap>
+                    {part.part_name}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    sx={{ fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}
+                  >
+                    {num(part.quantity)}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {part.primary_unit ?? ''}
+                  </Typography>
+                </Box>
+              ))}
+            </Stack>
+          )}
+        </Box>
+
+        {/*
+          The four verbs, in the order fixed across both surfaces. Full-width and 48px on a phone:
+          four of them fit one row at 390px only because the words are short.
+        */}
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+          {(
+            [
+              ['add', 'Add', false],
+              ['deplete', 'Remove', true],
+              ['move', 'Move', true],
+              ['adjust', 'Adjust', false],
+            ] as const
+          ).map(([v, label, needsStock]) => (
+            <Button
+              key={v}
+              variant={openVerb === v ? 'contained' : 'outlined'}
+              disabled={needsStock && contents.length === 0}
+              aria-expanded={openVerb === v}
+              onClick={() => setOpenVerb((cur) => (cur === v ? null : v))}
+              sx={{ minHeight: 48 }}
+            >
+              {label}
+            </Button>
+          ))}
+        </Stack>
+
+        {openVerb === 'adjust' ? (
+          <PlaceAdjustForm
+            companyId={companyId}
+            locationId={locationId}
+            locationName={node.name}
+            onCancel={() => setOpenVerb(null)}
+            onDone={reloadAll}
+          />
+        ) : openVerb ? (
+          <PlaceStockActionForm
+            key={openVerb}
+            action={openVerb}
+            companyId={companyId}
+            locationId={locationId}
+            locationName={node.name}
+            moveDestinations={moveDestinations}
+            // The shop floor's removal has always been graceful: the material is already off the
+            // shelf, so a stale count must not refuse the write. The RPC floors at zero and writes
+            // the shortfall into the ledger note instead.
+            graceful
+            onCancel={() => setOpenVerb(null)}
+            onDone={reloadAll}
+          />
+        ) : null}
       </Box>
       )}
 
-      {/* Recent movements, last. The contents above answer "what is here now"; this answers
-          "what happened here", including the photo whoever moved it left behind. Before this there
-          was no operator-side ledger view at all, which is what made a movement photo write-only. */}
       <Box sx={{ mt: 4 }}>
         <Typography variant="overline" color="text.secondary">
           Recent activity
@@ -356,39 +327,7 @@ export default function OperatorBinViewPage() {
         </Box>
       </Box>
 
-      {modal && (
-        <OperatorLocationActionModal
-          open
-          action={modal.action}
-          companyId={companyId}
-          partId={modal.part.part_id}
-          partName={modal.part.part_name}
-          currentQuantity={modal.part.quantity}
-          primaryUnit={modalUnit}
-          unitOptions={unitOptions}
-          locationId={node.id}
-          locationName={node.name}
-          moveDestinations={moveDestinations}
-          operatorId={operatorId}
-          onClose={() => setModal(null)}
-          onDone={reloadAll}
-        />
-      )}
 
-      {/* Not mounted for a container — there is no button to open it, and a modal that could only
-          ever write somewhere the database refuses has no reason to exist on this page. */}
-      {children.length === 0 && (
-        <OperatorReceivePartModal
-          open={receiveOpen}
-          companyId={companyId}
-          locationId={node.id}
-          locationName={node.name}
-          excludePartIds={contents.map((c) => c.part_id)}
-          operatorId={operatorId}
-          onClose={() => setReceiveOpen(false)}
-          onDone={reloadAll}
-        />
-      )}
     </Box>
   );
 }

--- a/components/inventory/JobTagPicker.tsx
+++ b/components/inventory/JobTagPicker.tsx
@@ -73,45 +73,48 @@ export async function loadTaggableJobs(companyId: string): Promise<JobWithRelati
  *
  * Material genuinely consumed outside this set is a real thing — a substitution at the machine, a
  * BOM nobody built, a level further down. That is not this function's problem to solve: it returns
- * what the data expects, and the caller offers a way past it.
+ * what the data expects, and the caller ranks rather than restricts.
+ *
+ * ## It THROWS rather than returning nothing
+ *
+ * An empty array means "no job lists this part", which is a claim. A dropped query is not that
+ * claim, and swallowing one into `[]` made the picker say *"No active job uses this part"* about a
+ * network failure — **"couldn't check" rendered as "denied"**, which CLAUDE.md names as its own
+ * rule. The caller catches and falls back to the unranked list.
  */
 export async function loadJobsForPart(
   companyId: string,
   partId: string,
 ): Promise<JobWithRelations[]> {
-  try {
-    const supabase = getSupabase();
+  const supabase = getSupabase();
 
-    // The parts whose BOM names this one as a child — i.e. things that consume it directly.
-    const { data: parents, error: bomError } = await supabase
-      .from('parts_bom')
-      .select('parent_part_id')
-      .eq('child_part_id', partId);
-    if (bomError) throw bomError;
+  // The parts whose BOM names this one as a child — i.e. things that consume it directly.
+  const { data: parents, error: bomError } = await supabase
+    .from('parts_bom')
+    .select('parent_part_id')
+    .eq('child_part_id', partId);
+  if (bomError) throw bomError;
 
-    const consumingPartIds = Array.from(
-      new Set([partId, ...(parents ?? []).map((r) => r.parent_part_id)]),
-    );
+  const consumingPartIds = Array.from(
+    new Set([partId, ...(parents ?? []).map((r) => r.parent_part_id)]),
+  );
 
-    const { data: jobParts, error: jpError } = await supabase
-      .from('job_parts')
-      .select('job_id')
-      .eq('company_id', companyId)
-      .in('part_id', consumingPartIds);
-    if (jpError) throw jpError;
+  const { data: jobParts, error: jpError } = await supabase
+    .from('job_parts')
+    .select('job_id')
+    .eq('company_id', companyId)
+    .in('part_id', consumingPartIds);
+  if (jpError) throw jpError;
 
-    const jobIds = Array.from(new Set((jobParts ?? []).map((r) => r.job_id)));
-    if (jobIds.length === 0) return [];
+  const jobIds = Array.from(new Set((jobParts ?? []).map((r) => r.job_id)));
+  if (jobIds.length === 0) return [];
 
-    // Filtered in memory rather than by another `in()`: the active-job set is small, this reuses
-    // the one loader that knows how to build a `JobWithRelations`, and it keeps the ordering rule
-    // in exactly one place.
-    const all = await loadTaggableJobs(companyId);
-    const wanted = new Set(jobIds);
-    return all.filter((j) => wanted.has(j.id));
-  } catch {
-    return [];
-  }
+  // Filtered in memory rather than by another `in()`: the active-job set is small, this reuses
+  // the one loader that knows how to build a `JobWithRelations`, and it keeps the ordering rule
+  // in exactly one place.
+  const all = await loadTaggableJobs(companyId);
+  const wanted = new Set(jobIds);
+  return all.filter((j) => wanted.has(j.id));
 }
 
 interface JobTagPickerProps {
@@ -122,6 +125,24 @@ interface JobTagPickerProps {
   label?: string;
   /** Why this list is the length it is — said, so a short list does not read as a broken one. */
   helperText?: string;
+  /**
+   * The jobs the data expects to consume this material, listed FIRST under their own heading.
+   *
+   * ## Rank, do not restrict
+   *
+   * Material genuinely goes to jobs the data does not predict: a substitution at the machine, a BOM
+   * nobody built, a level further down than the one this product calls a job's materials. Hiding
+   * those jobs would make the honest answer unrecordable, and the count sheet's own lesson is that
+   * *the discovery the software refuses to record is the one worth the most*.
+   *
+   * So there is no escape hatch to find. The way past the filter is on screen from the first tap —
+   * it is the second group, and its heading is its name. The common case pays **nothing**: the
+   * expected jobs are at the top, where the thumb already is.
+   *
+   * Empty or omitted and the list renders flat with no headings at all, so an unbuilt BOM never
+   * produces an empty section for someone to interpret.
+   */
+  expectedIds?: string[];
 }
 
 export default function JobTagPicker({
@@ -130,11 +151,23 @@ export default function JobTagPicker({
   value,
   onChange,
   helperText,
+  expectedIds,
   label = 'Tag to a job (optional)',
 }: JobTagPickerProps) {
+  const expected = new Set(expectedIds ?? []);
+  /*
+   * Grouped only when there is something in both groups. MUI renders a group header per contiguous
+   * run, so the options must be ordered by group — expected first, the rest after, each already in
+   * most-recently-updated order.
+   */
+  const grouped = expected.size > 0 && jobs.some((j) => !expected.has(j.id));
+  const ordered = grouped
+    ? [...jobs.filter((j) => expected.has(j.id)), ...jobs.filter((j) => !expected.has(j.id))]
+    : jobs;
+
   return (
     <Autocomplete
-      options={jobs}
+      options={ordered}
       loading={loading}
       value={value}
       onChange={(_, v) => onChange(v)}
@@ -155,12 +188,18 @@ export default function JobTagPicker({
           </Box>
         );
       }}
+      groupBy={
+        grouped
+          ? (j) => (expected.has(j.id) ? 'Jobs that use this part' : 'All other active jobs')
+          : undefined
+      }
       renderInput={(params) => (
         <TextField {...params} label={label} helperText={helperText} />
       )}
-      /* The list is filtered to the parts being removed, so "none" means "none that use this" —
-         not "no jobs". Saying the wrong one would send someone looking for a job that is open. */
-      noOptionsText="No active job uses this part"
+      /* Every active job is reachable, so "none" can only mean the TYPED filter matched nothing.
+         The earlier wording — "No active job uses this part" — was a claim the list no longer
+         makes, and it was also what a failed lookup used to say. */
+      noOptionsText="No matching active jobs"
       loadingText="Loading jobs…"
     />
   );

--- a/components/inventory/JobTagPicker.tsx
+++ b/components/inventory/JobTagPicker.tsx
@@ -22,6 +22,7 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
 import { getAllJobs } from '@/utils/jobsAccess';
+import { getSupabase } from '@/lib/supabase';
 import type { JobWithRelations, ProductionStatus } from '@/types/job';
 
 /** Jobs that could still be consuming material. */
@@ -40,9 +41,74 @@ export const jobPartsLabel = (j: JobWithRelations): string =>
  * Takes just the rows off the page envelope: this never searches, so nothing
  * is capped and there is no truncation for the caller to report.
  */
+/**
+ * The active jobs, most recently touched first.
+ *
+ * `updated_at` rather than `created_at`: you are tagging material to whatever is moving through the
+ * shop right now, and the job you touched an hour ago is far likelier than one opened in March.
+ */
 export async function loadTaggableJobs(companyId: string): Promise<JobWithRelations[]> {
   try {
-    return (await getAllJobs(companyId, { productionStatus: ACTIVE_STATUSES })).jobs;
+    return (
+      await getAllJobs(companyId, { productionStatus: ACTIVE_STATUSES }, 'updated_at', 'desc')
+    ).jobs;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The active jobs that this part could plausibly have gone to.
+ *
+ * ## What "could" means, and why it stops at one level
+ *
+ * A job is expected to consume a part when the part is either **what the job makes**
+ * (`job_parts.part_id`) or a **direct child in the bill of materials** of something the job makes
+ * (`parts_bom.child_part_id`).
+ *
+ * One level, matching the decision the material check already records: *"A pump job reads 'needs 1
+ * pump core', not the aluminium inside it."* Going deeper here would disagree with what the rest of
+ * the product calls a job's materials, and two definitions of "what this job needs" is worse than
+ * one that is narrow and stated.
+ *
+ * Material genuinely consumed outside this set is a real thing — a substitution at the machine, a
+ * BOM nobody built, a level further down. That is not this function's problem to solve: it returns
+ * what the data expects, and the caller offers a way past it.
+ */
+export async function loadJobsForPart(
+  companyId: string,
+  partId: string,
+): Promise<JobWithRelations[]> {
+  try {
+    const supabase = getSupabase();
+
+    // The parts whose BOM names this one as a child — i.e. things that consume it directly.
+    const { data: parents, error: bomError } = await supabase
+      .from('parts_bom')
+      .select('parent_part_id')
+      .eq('child_part_id', partId);
+    if (bomError) throw bomError;
+
+    const consumingPartIds = Array.from(
+      new Set([partId, ...(parents ?? []).map((r) => r.parent_part_id)]),
+    );
+
+    const { data: jobParts, error: jpError } = await supabase
+      .from('job_parts')
+      .select('job_id')
+      .eq('company_id', companyId)
+      .in('part_id', consumingPartIds);
+    if (jpError) throw jpError;
+
+    const jobIds = Array.from(new Set((jobParts ?? []).map((r) => r.job_id)));
+    if (jobIds.length === 0) return [];
+
+    // Filtered in memory rather than by another `in()`: the active-job set is small, this reuses
+    // the one loader that knows how to build a `JobWithRelations`, and it keeps the ordering rule
+    // in exactly one place.
+    const all = await loadTaggableJobs(companyId);
+    const wanted = new Set(jobIds);
+    return all.filter((j) => wanted.has(j.id));
   } catch {
     return [];
   }
@@ -54,6 +120,8 @@ interface JobTagPickerProps {
   value: JobWithRelations | null;
   onChange: (job: JobWithRelations | null) => void;
   label?: string;
+  /** Why this list is the length it is — said, so a short list does not read as a broken one. */
+  helperText?: string;
 }
 
 export default function JobTagPicker({
@@ -61,6 +129,7 @@ export default function JobTagPicker({
   loading,
   value,
   onChange,
+  helperText,
   label = 'Tag to a job (optional)',
 }: JobTagPickerProps) {
   return (
@@ -86,8 +155,12 @@ export default function JobTagPicker({
           </Box>
         );
       }}
-      renderInput={(params) => <TextField {...params} label={label} />}
-      noOptionsText="No active jobs"
+      renderInput={(params) => (
+        <TextField {...params} label={label} helperText={helperText} />
+      )}
+      /* The list is filtered to the parts being removed, so "none" means "none that use this" —
+         not "no jobs". Saying the wrong one would send someone looking for a job that is open. */
+      noOptionsText="No active job uses this part"
       loadingText="Loading jobs…"
     />
   );

--- a/components/inventory/locations/place/PlaceStockActionForm.tsx
+++ b/components/inventory/locations/place/PlaceStockActionForm.tsx
@@ -177,6 +177,20 @@ export interface PlaceStockActionFormProps {
    * disarm-what-landed rule.
    */
   restrictTo?: { partId: string; partName: string; primaryUnit: string | null };
+  /**
+   * Let a removal exceed what the system thinks is there, instead of refusing it.
+   *
+   * **True on the shop floor, false in the office**, which is a decision this product already made
+   * and this form has to carry rather than flatten. `deplete_stock_at_location` floors the balance
+   * at zero and appends `[DISCREPANCY: Confirmed 12 ea, but only 7 ea was available…]` to the
+   * ledger row — so the material that physically left is recorded, and the fact that the count was
+   * wrong is recorded with it.
+   *
+   * A machinist holding the part has already taken it; refusing the write would be refusing to
+   * record reality, and would teach him the software is an obstacle. An owner at a desk correcting
+   * numbers is better served by the error, because they can go and look.
+   */
+  graceful?: boolean;
   /** Back to the place overview. The drawer stays open. */
   onCancel: () => void;
   onDone: () => void | Promise<void>;
@@ -189,6 +203,7 @@ export default function PlaceStockActionForm({
   locationName,
   moveDestinations,
   restrictTo,
+  graceful = false,
   onCancel,
   onDone,
 }: PlaceStockActionFormProps) {
@@ -334,33 +349,44 @@ export default function PlaceStockActionForm({
   };
 
   /*
-   * THE JOBS THIS MATERIAL COULD PLAUSIBLY HAVE GONE TO.
+   * EVERY ACTIVE JOB, WITH THE PLAUSIBLE ONES FIRST.
    *
-   * Keyed by the SET of parts being removed, not by the quantities — so typing `1`, `12`, `120`
-   * into a box re-queries nothing, and adding a second part to the batch does.
+   * Rank rather than restrict. Material genuinely goes to jobs the data does not predict — a
+   * substitution at the machine, a BOM nobody built, a level below the one this product calls a
+   * job's materials — and hiding those would make the honest answer unrecordable. The expected
+   * jobs sit at the top under their own heading, so the ordinary removal gets faster and the
+   * unusual one stays possible, at a cost of nothing.
    *
-   * The tag is one per batch, so the set is the UNION across the filled rows: issuing a shaft and
-   * an o-ring to one job, a job that consumes either is a plausible answer. Intersection would be
-   * stricter and mostly empty — few jobs list every loose item that goes out with them.
-   *
-   * With nothing filled in yet there is nothing to narrow by, so every active job is offered. The
-   * list narrows as the batch takes shape rather than starting empty, which would read as broken.
+   * Keyed by the SET of parts, not the quantities: typing `1` → `12` → `120` re-queries nothing,
+   * adding a second part to the batch does. The tag is one per batch, so expectation is the UNION
+   * across the filled rows — issuing a shaft and an o-ring to one job, a job consuming either is a
+   * plausible answer, where an intersection would be stricter and mostly empty.
    */
   const partKey = useMemo(
     () => lines.map((l) => l.row.partId).sort().join(','),
     [lines],
   );
 
-  const { data: jobs, loading: loadingJobs } = useLoad(async () => {
-    if (action !== 'deplete') return [];
+  const { data: jobData, loading: loadingJobs } = useLoad(async () => {
+    if (action !== 'deplete') return { all: [] as JobWithRelations[], expectedIds: [], failed: false };
+
+    const all = await loadTaggableJobs(companyId);
     const ids = partKey ? partKey.split(',') : [];
-    if (ids.length === 0) return loadTaggableJobs(companyId).catch(() => []);
-    const perPart = await Promise.all(ids.map((id) => loadJobsForPart(companyId, id)));
-    const byId = new Map<string, (typeof perPart)[number][number]>();
-    for (const list of perPart) for (const j of list) byId.set(j.id, j);
-    // `loadJobsForPart` already returns most-recently-updated first; the map preserves the order
-    // the first list arrived in, so re-sorting here would only undo that.
-    return [...byId.values()];
+    if (ids.length === 0) return { all, expectedIds: [], failed: false };
+
+    try {
+      const perPart = await Promise.all(ids.map((id) => loadJobsForPart(companyId, id)));
+      return { all, expectedIds: [...new Set(perPart.flat().map((j) => j.id))], failed: false };
+    } catch {
+      /*
+       * "Couldn't check" is never "denied."
+       *
+       * A dropped lookup must not render as "no job uses this part" — that is a claim about the
+       * shop's data, not about the network. Every job stays offered, unranked, and the helper text
+       * says the ranking is missing rather than implying there was nothing to rank.
+       */
+      return { all, expectedIds: [], failed: true };
+    }
   }, [action, companyId, partKey]);
 
   /** Filtered rows — with every line exempt, so nothing about to be written can be off screen. */
@@ -419,6 +445,7 @@ export default function PlaceStockActionForm({
           });
         } else if (action === 'deplete') {
           await depleteStockAtLocation(row.partId, locationId, value, unit, {
+            graceful,
             notes: notes || undefined,
             operatorId: operatorId || undefined,
             jobId: job?.id,
@@ -699,14 +726,19 @@ export default function PlaceStockActionForm({
         {/* One job for the batch: you are issuing this handful of material to one job. */}
         {action === 'deplete' && rows.length > 0 && (
           <JobTagPicker
-            jobs={jobs ?? []}
+            jobs={jobData?.all ?? []}
+            expectedIds={jobData?.expectedIds}
             loading={loadingJobs}
             value={job}
             onChange={setJob}
             helperText={
-              lines.length > 0
-                ? 'Jobs that use what you are removing.'
-                : undefined
+              jobData?.failed
+                ? 'Showing all active jobs.'
+                : (jobData?.expectedIds.length ?? 0) > 0
+                  ? 'Jobs that use what you are removing are first. You can pick any active job.'
+                  : lines.length > 0
+                    ? 'No job lists these parts yet. You can still pick any active job.'
+                    : undefined
             }
           />
         )}

--- a/components/inventory/locations/place/PlaceStockActionForm.tsx
+++ b/components/inventory/locations/place/PlaceStockActionForm.tsx
@@ -106,7 +106,7 @@ import Typography from '@mui/material/Typography';
 import CloseIcon from '@mui/icons-material/Close';
 
 import ErrorAlert from '@/components/common/ErrorAlert';
-import JobTagPicker, { loadTaggableJobs } from '@/components/inventory/JobTagPicker';
+import JobTagPicker, { loadJobsForPart, loadTaggableJobs } from '@/components/inventory/JobTagPicker';
 import LocationPicker, {
   type LocationPickerOption,
 } from '@/components/inventory/locations/LocationPicker';
@@ -256,10 +256,6 @@ export default function PlaceStockActionForm({
   const { data: member } = useLoad(() => getCurrentMember(companyId).catch(() => null), [companyId]);
   const operatorId = member?.id ?? null;
 
-  const { data: jobs, loading: loadingJobs } = useLoad(
-    () => (action === 'deplete' ? loadTaggableJobs(companyId).catch(() => []) : Promise.resolve([])),
-    [action, companyId],
-  );
 
   /** Everything that could be picked for an `add`, minus what is already a row. */
   const addable = useMemo(() => {
@@ -336,6 +332,36 @@ export default function PlaceStockActionForm({
     setQty((q) => ({ ...q, [row.partId]: String(row.onHand) }));
     setUnitFor((u) => ({ ...u, [row.partId]: row.primaryUnit }));
   };
+
+  /*
+   * THE JOBS THIS MATERIAL COULD PLAUSIBLY HAVE GONE TO.
+   *
+   * Keyed by the SET of parts being removed, not by the quantities — so typing `1`, `12`, `120`
+   * into a box re-queries nothing, and adding a second part to the batch does.
+   *
+   * The tag is one per batch, so the set is the UNION across the filled rows: issuing a shaft and
+   * an o-ring to one job, a job that consumes either is a plausible answer. Intersection would be
+   * stricter and mostly empty — few jobs list every loose item that goes out with them.
+   *
+   * With nothing filled in yet there is nothing to narrow by, so every active job is offered. The
+   * list narrows as the batch takes shape rather than starting empty, which would read as broken.
+   */
+  const partKey = useMemo(
+    () => lines.map((l) => l.row.partId).sort().join(','),
+    [lines],
+  );
+
+  const { data: jobs, loading: loadingJobs } = useLoad(async () => {
+    if (action !== 'deplete') return [];
+    const ids = partKey ? partKey.split(',') : [];
+    if (ids.length === 0) return loadTaggableJobs(companyId).catch(() => []);
+    const perPart = await Promise.all(ids.map((id) => loadJobsForPart(companyId, id)));
+    const byId = new Map<string, (typeof perPart)[number][number]>();
+    for (const list of perPart) for (const j of list) byId.set(j.id, j);
+    // `loadJobsForPart` already returns most-recently-updated first; the map preserves the order
+    // the first list arrived in, so re-sorting here would only undo that.
+    return [...byId.values()];
+  }, [action, companyId, partKey]);
 
   /** Filtered rows — with every line exempt, so nothing about to be written can be off screen. */
   const filled = useMemo(() => new Set(lines.map((l) => l.row.partId)), [lines]);
@@ -672,7 +698,17 @@ export default function PlaceStockActionForm({
 
         {/* One job for the batch: you are issuing this handful of material to one job. */}
         {action === 'deplete' && rows.length > 0 && (
-          <JobTagPicker jobs={jobs ?? []} loading={loadingJobs} value={job} onChange={setJob} />
+          <JobTagPicker
+            jobs={jobs ?? []}
+            loading={loadingJobs}
+            value={job}
+            onChange={setJob}
+            helperText={
+              lines.length > 0
+                ? 'Jobs that use what you are removing.'
+                : undefined
+            }
+          />
         )}
 
         {rows.length > 0 && (


### PR DESCRIPTION
Two asks, plus one regression each caught on the way.

## 1. The job tag on a removal

**Filtered to jobs that could plausibly have used the material** — where the part is either what the job makes (`job_parts.part_id`) or a direct child in the BOM of something it makes (`parts_bom.child_part_id`) — and **sorted by `updated_at`**, because you're tagging to what's moving through the shop now, not what opened in March.

One BOM level, deliberately: the material check already records that decision — *"a pump job reads 'needs 1 pump core', not the aluminium inside it"* — and two definitions of "what this job needs" is worse than one narrow one.

### The escape hatch: rank, don't restrict

Restricting outright would make the honest answer unrecordable. Material genuinely goes to jobs the data doesn't predict — a substitution at the machine, a BOM nobody built, a level further down.

```
Tag to a job (optional)
  ── Jobs that use this part ──
     J-1042   pump core ×4
  ── All other active jobs ──
     J-1039 · J-1021 · …
  Jobs that use this part are first. You can pick any active job.
```

**There is no escape hatch to find** — the way past the ranking is the second group, on screen from the first tap, and its heading is its name. The common case pays **nothing**: expected jobs are where the thumb already is. No confirm, no reason code, no warning colour — and the screen is identical whichever group was tapped, because the data being wrong is not the operator's mistake.

With no expected jobs it renders flat with no headings, so an unbuilt BOM never produces an empty section to interpret.

### A rule I broke and fixed

`loadJobsForPart` swallowed every failure into `[]`, and the picker rendered that as **"No active job uses this part"** — an authoritative claim about the shop's data, made about a dropped network call. That's [CLAUDE.md's](CLAUDE.md#L107) *"Couldn't check" is never "denied."* It throws now; the caller falls back to the unranked list and says `Showing all active jobs.`

## 2. The shop floor gets the office's forms

The operator bin view was a card per part, each with four buttons opening a single-part dialog. Six things to put away meant six dialogs, and none of the rules the office forms grew applied — blank rows, the partial-batch disarm, the job ranking. The floor had the older, thinner version of the same job.

It now renders **the very same components**, not a copy, so a rule fixed once is fixed on both surfaces — which is exactly how the two drifted.

It does **not** get `Change layout`, `Rename`, `Delete`, `Add storage` or `Print QR`. Configuring storage is an office job; acting on the stock in it is not.

### Graceful depletion survives, and nearly didn't

The floor's Remove has always passed `graceful: true` — the RPC floors at zero and appends `[DISCREPANCY: Confirmed 12 ea, but only 7 ea was available…]` rather than raising. A machinist holding the part has already taken it; refusing the write would refuse to record reality *and* lose the signal that the count was wrong. An existing test caught the drop. It's a prop now — true on the floor, false in the office, where someone at a desk is better served by the error — and pinned by test.

## Verified against a local stack

Operator bin shows the four verbs and no configuration; the job picker renders both groups with the helper text; removing 2 with a job picked from **All other active jobs** wrote `depletion · BUY-BEARING-608ZZ · 2 · Shelf A` with the job tagged and the author stamped.

2523 tests pass, lint unchanged at 16 warnings.

## Not in this PR

The research recommends a server-computed `job_link_expected` flag on the depletion row, surfaced on the office job page as *"Issued to this job but not on the BOM"* with an `Add to BOM` button — so a wrong BOM is discoverable by the owner, at a desk, where the fix is one click. That needs a migration and a backfill, and belongs on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)