### PR TITLE
fix(dashboard): count quotes still live, price revenue by what shipped, and stop painting error text 3:1

### DIFF
--- a/__tests__/components/dashboard/DashboardMetrics.test.tsx
+++ b/__tests__/components/dashboard/DashboardMetrics.test.tsx
@@ -58,7 +58,7 @@ describe('DashboardMetrics', () => {
 
     await waitFor(() => expect(screen.getByText('63')).toBeInTheDocument());
 
-    for (const label of ['Overdue', 'Open Jobs', 'Completed', 'Open Quotes']) {
+    for (const label of ['Overdue Jobs', 'Open Jobs', 'Completed Jobs', 'Open Quotes']) {
       expect(screen.getByText(label)).toBeInTheDocument();
     }
     expect(screen.queryByText(/Edit metrics/i)).not.toBeInTheDocument();

--- a/__tests__/components/dashboard/DashboardMetrics.test.tsx
+++ b/__tests__/components/dashboard/DashboardMetrics.test.tsx
@@ -148,6 +148,22 @@ describe('DashboardMetrics', () => {
     expect(screen.queryByText('$0')).not.toBeInTheDocument();
   });
 
+  it('keeps the delta and its comparison in one element, so they wrap as a phrase', async () => {
+    // jsdom cannot measure a baseline, but it can hold the shape that broke it.
+    // The delta used to be a nested flex box: a flex container takes its
+    // baseline from its first item, which here is an SVG arrow with no text
+    // baseline, so the whole group floated a few pixels above "$12,480".
+    // Splitting it into separate flex items fixed the baseline and introduced a
+    // worse bug — the row could then break between "+12%" and "vs last week".
+    // One inline element solves both, and this is the half a test can hold.
+    render(<DashboardMetrics companyId="c1" />);
+
+    await waitFor(() => expect(screen.getByText(/12%/)).toBeInTheDocument());
+
+    const delta = screen.getByText(/12%/);
+    expect(delta.textContent).toContain('vs last week');
+  });
+
   it('drops the delta when nothing shipped in the prior period', async () => {
     // A delta against zero is not a comparison — the percentage is undefined
     // and the absolute change just repeats the headline, so the card would

--- a/__tests__/components/quotes/QuoteStatusChip.test.tsx
+++ b/__tests__/components/quotes/QuoteStatusChip.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '../../test-utils';
+import QuoteStatusChip from '@/components/quotes/QuoteStatusChip';
+
+/**
+ * What a quote's chip says, which is not what `quotes.status` stores.
+ *
+ * The column holds `active | expired` only; winning a quote sets `converted_at`
+ * and leaves the status alone. So the raw value cannot tell "still chasing it"
+ * from "already won it", and rendering it directly labelled a converted quote
+ * "Active" forever — the same confusion that had the dashboard's Open Quotes
+ * tile counting work the shop had already won (25 shown against 11 live on the
+ * pilot shop, 9 against 1 on demo companies).
+ *
+ * These three words are the ones the quotes list's Status filter uses, so the
+ * chip and the filter cannot drift apart.
+ */
+describe('QuoteStatusChip', () => {
+  it('says Open for a live quote', () => {
+    render(<QuoteStatusChip status="active" convertedAt={null} />);
+    expect(screen.getByText('Open')).toBeInTheDocument();
+  });
+
+  it('says Converted once it has become a job', () => {
+    render(<QuoteStatusChip status="active" convertedAt="2026-08-01T10:00:00Z" />);
+
+    expect(screen.getByText('Converted')).toBeInTheDocument();
+    // Converted beats the column: it is the more specific truth, and the status
+    // is still literally 'active' on this row.
+    expect(screen.queryByText('Open')).not.toBeInTheDocument();
+  });
+
+  it('says Expired regardless', () => {
+    render(<QuoteStatusChip status="expired" convertedAt={null} />);
+    expect(screen.getByText('Expired')).toBeInTheDocument();
+  });
+
+  it('falls back to the column when conversion is not passed', () => {
+    // Some call sites read a narrower row shape that has no converted_at. They
+    // degrade to the old behaviour rather than claiming a quote is open.
+    render(<QuoteStatusChip status="active" />);
+    expect(screen.getByText('Open')).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/alertContrast.test.ts
+++ b/__tests__/lib/alertContrast.test.ts
@@ -41,9 +41,21 @@ function hexToRgb(hex: string): number[] {
   return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
 }
 
-/** Sampled from the running app at 1440×900. */
-const ALERT_CARD_BG = [57, 55, 92];
+/**
+ * Sampled from the running app at 1440×900, except the page canvas which is
+ * opaque and therefore exact.
+ */
+const PAGE_CANVAS_BG = [17, 20, 57]; // background.default #111439
+const DIALOG_PAPER_BG = [21, 25, 65]; // MuiDialog paper, mid-gradient
 const NORMAL_CARD_BG = [33, 41, 84];
+const ALERT_CARD_BG = [57, 55, 92];
+
+const SURFACES: Array<[string, number[]]> = [
+  ['page canvas', PAGE_CANVAS_BG],
+  ['dialog paper', DIALOG_PAPER_BG],
+  ['card / paper', NORMAL_CARD_BG],
+  ['alert-tinted card', ALERT_CARD_BG],
+];
 
 const BODY_FLOOR = 4.5;
 const LARGE_FLOOR = 3;
@@ -81,5 +93,43 @@ describe('alert-card contrast', () => {
   it('leaves the upward delta alone, because green already passes', () => {
     const ratio = contrast(hexToRgb(theme.palette.success.main), NORMAL_CARD_BG);
     expect(ratio).toBeGreaterThanOrEqual(BODY_FLOOR);
+  });
+
+  it('is readable as text on EVERY surface, so no per-site analysis is needed', () => {
+    // The reason the rule can be "error.light for error text" full stop, rather
+    // than "it depends which panel it lands on".
+    for (const [name, bg] of SURFACES) {
+      const ratio = contrast(hexToRgb(theme.palette.error.light), bg);
+      expect(ratio, `error.light on ${name}`).toBeGreaterThanOrEqual(BODY_FLOOR);
+    }
+  });
+
+  it('records that error.main is text-safe ONLY on the raw canvas', () => {
+    // Which is where text almost never sits. This is the measurement behind the
+    // sweep; if a future palette change makes error.main readable on a card,
+    // this fails and the rule gets revisited rather than silently outliving it.
+    const [, ...lifted] = SURFACES; // everything above the canvas
+    expect(contrast(hexToRgb(theme.palette.error.main), PAGE_CANVAS_BG)).toBeGreaterThanOrEqual(
+      BODY_FLOOR,
+    );
+    for (const [name, bg] of lifted) {
+      const ratio = contrast(hexToRgb(theme.palette.error.main), bg);
+      expect(ratio, `error.main on ${name} should still be failing`).toBeLessThan(BODY_FLOOR);
+    }
+  });
+
+  it('keeps error.main usable for icons, which answer to 3:1 not 4.5:1', () => {
+    // SC 1.4.11 non-text contrast. This is why the 15 error-coloured icons were
+    // measured and left alone rather than swept along with the text.
+    //
+    // The alert tint is excluded and the exclusion is the interesting part:
+    // error.main is 2.98:1 there, under even the non-text bar. It is safe only
+    // because nothing renders an icon on that surface — the sole alert-tinted
+    // thing in the app is the Overdue scorecard, which has none. Put an icon on
+    // one and it needs error.light like the text does.
+    for (const [name, bg] of SURFACES.filter(([n]) => n !== 'alert-tinted card')) {
+      const ratio = contrast(hexToRgb(theme.palette.error.main), bg);
+      expect(ratio, `error.main icon on ${name}`).toBeGreaterThanOrEqual(LARGE_FLOOR);
+    }
   });
 });

--- a/__tests__/lib/alertContrast.test.ts
+++ b/__tests__/lib/alertContrast.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import theme from '@/lib/theme';
 
 /**
- * The Overdue card's text has to be readable, and the standard is a number.
+ * Status colours have to be readable, and the standard is a number.
  *
  * design-system.md ("Contrast, keyboard, semantics") sets 4.5:1 body / 3:1 large
  * as a FLOOR — WCAG 2.1 AA, SC 1.4.3 — measured against a 500–1000 lux shop
@@ -11,14 +11,12 @@ import theme from '@/lib/theme';
  * check. No axe, no contrast assertion... Contrast regressions are caught by
  * someone looking — which is how the 4.11:1 canvas survived as long as it did."*
  *
- * That is precisely what happened here. `error.main` (#ef4444) on the alert-tinted
- * card measured **2.98:1** — failing even the easier large-text clause — and it
- * shipped because nothing measures. `error.light` exists to be the readable one.
+ * That is exactly how the Overdue card shipped at 2.98:1.
  *
  * The backgrounds below are SAMPLED FROM THE PAINTED PAGE, not computed from the
- * theme, and that distinction matters: the cards are translucent over a gradient
- * canvas, so a value derived from `background.default` comes out darker than
- * reality and would make this test more permissive than the screen. Re-sample by
+ * theme, and the distinction matters: the cards are translucent over a gradient,
+ * so a value derived from `background.default` comes out darker than reality and
+ * would make this test more permissive than the screen. Re-sample by
  * screenshotting a card and reading a pixel from a blank corner of it.
  */
 
@@ -41,95 +39,92 @@ function hexToRgb(hex: string): number[] {
   return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
 }
 
-/**
- * Sampled from the running app at 1440×900, except the page canvas which is
- * opaque and therefore exact.
- */
+/** Sampled at 1440×900, except the canvas, which is opaque and therefore exact. */
 const PAGE_CANVAS_BG = [17, 20, 57]; // background.default #111439
 const DIALOG_PAPER_BG = [21, 25, 65]; // MuiDialog paper, mid-gradient
 const NORMAL_CARD_BG = [33, 41, 84];
-const ALERT_CARD_BG = [57, 55, 92];
+/** The Overdue card: 8% warning.main over the canvas. */
+const WARNING_CARD_BG = [57, 62, 88];
 
-const SURFACES: Array<[string, number[]]> = [
+/** Where ERROR text can appear. Not the warning tint — nothing red renders there. */
+const ERROR_TEXT_SURFACES: Array<[string, number[]]> = [
   ['page canvas', PAGE_CANVAS_BG],
   ['dialog paper', DIALOG_PAPER_BG],
   ['card / paper', NORMAL_CARD_BG],
-  ['alert-tinted card', ALERT_CARD_BG],
 ];
 
 const BODY_FLOOR = 4.5;
 const LARGE_FLOOR = 3;
 
-describe('alert-card contrast', () => {
-  it('renders error TEXT in a red that clears the body floor on the alert tint', () => {
-    // Label, count and money are all painted in this colour.
-    const ratio = contrast(hexToRgb(theme.palette.error.light), ALERT_CARD_BG);
-    expect(ratio).toBeGreaterThanOrEqual(BODY_FLOOR);
+describe('status-colour contrast', () => {
+  describe('the Overdue card is amber, and amber is readable', () => {
+    it('clears the body floor with headroom', () => {
+      // Label, count and money are all painted in this colour.
+      const ratio = contrast(hexToRgb(theme.palette.warning.light), WARNING_CARD_BG);
+      expect(ratio).toBeGreaterThanOrEqual(BODY_FLOOR);
+      // Headroom, not a squeak: the standard is measured against a bright shop
+      // floor and treated as a hard limit.
+      expect(ratio).toBeGreaterThanOrEqual(5);
+    });
+
+    it('records why warning.main is not the text colour, though it would pass', () => {
+      // The interesting exemption. Unlike error.main, warning.main DOES clear the
+      // floor here — at 4.89:1, which is 0.39 above a hard limit. `light` is used
+      // anyway, and this pins the reasoning so nobody "simplifies" it back.
+      const main = contrast(hexToRgb(theme.palette.warning.main), WARNING_CARD_BG);
+      expect(main).toBeGreaterThanOrEqual(BODY_FLOOR);
+      expect(main).toBeLessThan(5);
+      expect(contrast(hexToRgb(theme.palette.warning.light), WARNING_CARD_BG)).toBeGreaterThan(main);
+    });
+
+    it('keeps warning.main usable for the rule and the tint', () => {
+      // Non-text, SC 1.4.11, 3:1. The border is what still makes the card read
+      // as an alert once the text stopped being red.
+      expect(contrast(hexToRgb(theme.palette.warning.main), WARNING_CARD_BG)).toBeGreaterThanOrEqual(
+        LARGE_FLOOR,
+      );
+    });
   });
 
-  it('clears it with headroom, not by squeaking past', () => {
-    // The standard is measured against a bright shop floor and treated as a hard
-    // limit; a value at 4.51:1 satisfies the arithmetic and not the intent.
-    const ratio = contrast(hexToRgb(theme.palette.error.light), ALERT_CARD_BG);
-    expect(ratio).toBeGreaterThanOrEqual(5);
-  });
+  describe('error.main is not a text colour on a lifted surface', () => {
+    it('is readable as error.light on every surface error text reaches', () => {
+      // The reason the rule can be "error.light for error text" full stop, rather
+      // than "it depends which panel it lands on".
+      for (const [name, bg] of ERROR_TEXT_SURFACES) {
+        const ratio = contrast(hexToRgb(theme.palette.error.light), bg);
+        expect(ratio, `error.light on ${name}`).toBeGreaterThanOrEqual(BODY_FLOOR);
+      }
+    });
 
-  it('keeps a falling delta readable on a normal card too', () => {
-    const ratio = contrast(hexToRgb(theme.palette.error.light), NORMAL_CARD_BG);
-    expect(ratio).toBeGreaterThanOrEqual(BODY_FLOOR);
-  });
+    it('records that error.main is text-safe ONLY on the raw canvas', () => {
+      // Which is where text almost never sits. If a future palette change makes
+      // error.main readable on a card, this fails and the rule gets revisited
+      // rather than silently outliving it.
+      expect(contrast(hexToRgb(theme.palette.error.main), PAGE_CANVAS_BG)).toBeGreaterThanOrEqual(
+        BODY_FLOOR,
+      );
+      for (const [name, bg] of [
+        ['dialog paper', DIALOG_PAPER_BG],
+        ['card / paper', NORMAL_CARD_BG],
+      ] as Array<[string, number[]]>) {
+        const ratio = contrast(hexToRgb(theme.palette.error.main), bg);
+        expect(ratio, `error.main on ${name} should still be failing`).toBeLessThan(BODY_FLOOR);
+      }
+    });
 
-  it('records why error.main is not usable as text on these surfaces', () => {
-    // Not a rule being enforced — a measurement kept next to the fix, so the
-    // next person who reaches for error.main on a tinted panel sees the number
-    // rather than rediscovering it by eye.
-    const onTint = contrast(hexToRgb(theme.palette.error.main), ALERT_CARD_BG);
-    const onCard = contrast(hexToRgb(theme.palette.error.main), NORMAL_CARD_BG);
-
-    expect(onTint).toBeLessThan(LARGE_FLOOR); // 2.98:1 — fails even large text
-    expect(onCard).toBeLessThan(BODY_FLOOR); // 3.70:1 — fails body text
+    it('keeps error.main usable for icons, which answer to 3:1 not 4.5:1', () => {
+      // SC 1.4.11 non-text contrast. This is why the 15 error-coloured icons were
+      // measured and left alone rather than swept along with the text.
+      for (const [name, bg] of ERROR_TEXT_SURFACES) {
+        const ratio = contrast(hexToRgb(theme.palette.error.main), bg);
+        expect(ratio, `error.main icon on ${name}`).toBeGreaterThanOrEqual(LARGE_FLOOR);
+      }
+    });
   });
 
   it('leaves the upward delta alone, because green already passes', () => {
-    const ratio = contrast(hexToRgb(theme.palette.success.main), NORMAL_CARD_BG);
-    expect(ratio).toBeGreaterThanOrEqual(BODY_FLOOR);
-  });
-
-  it('is readable as text on EVERY surface, so no per-site analysis is needed', () => {
-    // The reason the rule can be "error.light for error text" full stop, rather
-    // than "it depends which panel it lands on".
-    for (const [name, bg] of SURFACES) {
-      const ratio = contrast(hexToRgb(theme.palette.error.light), bg);
-      expect(ratio, `error.light on ${name}`).toBeGreaterThanOrEqual(BODY_FLOOR);
-    }
-  });
-
-  it('records that error.main is text-safe ONLY on the raw canvas', () => {
-    // Which is where text almost never sits. This is the measurement behind the
-    // sweep; if a future palette change makes error.main readable on a card,
-    // this fails and the rule gets revisited rather than silently outliving it.
-    const [, ...lifted] = SURFACES; // everything above the canvas
-    expect(contrast(hexToRgb(theme.palette.error.main), PAGE_CANVAS_BG)).toBeGreaterThanOrEqual(
-      BODY_FLOOR,
-    );
-    for (const [name, bg] of lifted) {
-      const ratio = contrast(hexToRgb(theme.palette.error.main), bg);
-      expect(ratio, `error.main on ${name} should still be failing`).toBeLessThan(BODY_FLOOR);
-    }
-  });
-
-  it('keeps error.main usable for icons, which answer to 3:1 not 4.5:1', () => {
-    // SC 1.4.11 non-text contrast. This is why the 15 error-coloured icons were
-    // measured and left alone rather than swept along with the text.
-    //
-    // The alert tint is excluded and the exclusion is the interesting part:
-    // error.main is 2.98:1 there, under even the non-text bar. It is safe only
-    // because nothing renders an icon on that surface — the sole alert-tinted
-    // thing in the app is the Overdue scorecard, which has none. Put an icon on
-    // one and it needs error.light like the text does.
-    for (const [name, bg] of SURFACES.filter(([n]) => n !== 'alert-tinted card')) {
-      const ratio = contrast(hexToRgb(theme.palette.error.main), bg);
-      expect(ratio, `error.main icon on ${name}`).toBeGreaterThanOrEqual(LARGE_FLOOR);
-    }
+    expect(
+      contrast(hexToRgb(theme.palette.success.main), NORMAL_CARD_BG),
+    ).toBeGreaterThanOrEqual(BODY_FLOOR);
   });
 });

--- a/__tests__/utils/dashboardMetrics.test.ts
+++ b/__tests__/utils/dashboardMetrics.test.ts
@@ -34,6 +34,7 @@ const STATE: {
   quoteCount: number;
   selects: string[];
   overdueFilters: string[];
+  quoteFilters: string[];
 } = {
   openJobs: [],
   overdue: [],
@@ -41,6 +42,7 @@ const STATE: {
   quoteCount: 0,
   selects: [],
   overdueFilters: [],
+  quoteFilters: [],
 };
 
 /**
@@ -56,8 +58,14 @@ function makeBuilder(table: string) {
     if (opts?.head) seen.head = true;
     return builder;
   });
-  builder.eq = vi.fn(() => builder);
-  builder.is = vi.fn(() => builder);
+  builder.eq = vi.fn((col: string, val: unknown) => {
+    if (table === 'quotes') STATE.quoteFilters.push(`${col}=${String(val)}`);
+    return builder;
+  });
+  builder.is = vi.fn((col: string, val: unknown) => {
+    if (table === 'quotes') STATE.quoteFilters.push(`${col} is ${String(val)}`);
+    return builder;
+  });
   builder.lt = vi.fn(() => builder);
   builder.in = vi.fn((col: string) => {
     if (col === 'production_status') seen.in = true;
@@ -109,6 +117,7 @@ describe('dashboard metrics', () => {
     STATE.quoteCount = 0;
     STATE.selects = [];
     STATE.overdueFilters = [];
+    STATE.quoteFilters = [];
   });
 
   it('is exactly four metrics, in flow order', () => {
@@ -191,6 +200,20 @@ describe('dashboard metrics', () => {
     // figure on the dashboard.
     const { notStarted, inProgress } = m.open_jobs!.split!;
     expect(notStarted.money + inProgress.money).toBe(m.open_jobs?.money);
+  });
+
+  it('counts only quotes that are still live, not ones already won', async () => {
+    // quotes.status holds active|expired and NOTHING else — winning a quote sets
+    // converted_at and leaves the status alone, so a quote that became a job
+    // stays "active" forever. Counting status alone read 25 on the pilot shop
+    // when 11 were live, and 9 against 1 on demo companies.
+    STATE.quoteCount = 11;
+
+    const m = await getDashboardMetrics('c1', 'this_week');
+
+    expect(m.open_quotes?.count).toBe(11);
+    expect(STATE.quoteFilters).toContain('status=active');
+    expect(STATE.quoteFilters).toContain('converted_at is null');
   });
 
   it('gives Open Quotes a count and no money at all', async () => {

--- a/__tests__/utils/dashboardMetrics.test.ts
+++ b/__tests__/utils/dashboardMetrics.test.ts
@@ -30,32 +30,43 @@ type JobPart = {
 const STATE: {
   openJobs: unknown[];
   overdue: unknown[];
-  completedQueue: unknown[][];
+  shipmentsQueue: unknown[][];
+  openJobShipments: unknown[];
   quoteCount: number;
   selects: string[];
   overdueFilters: string[];
   quoteFilters: string[];
+  shipmentFilters: string[];
+  jobFilters: string[];
 } = {
   openJobs: [],
   overdue: [],
-  completedQueue: [[], []],
+  shipmentsQueue: [[], []],
+  openJobShipments: [],
   quoteCount: 0,
   selects: [],
   overdueFilters: [],
   quoteFilters: [],
+  shipmentFilters: [],
+  jobFilters: [],
 };
 
 /**
- * A thenable PostgREST stub that answers according to WHICH filters were
- * applied, so one mock serves all five queries getDashboardMetrics fires.
+ * A thenable PostgREST stub routing on table + one distinguishing filter, so a
+ * single mock serves every query getDashboardMetrics fires.
+ *
+ * `jobs` is asked twice and `shipments` twice, and neither pair is told apart by
+ * shape alone — both job queries now filter fulfillment, and both shipment
+ * queries are scoped to the company. The distinguishers are the narrowest
+ * honest ones: only Overdue touches `due_date`, and only the Open Jobs
+ * remainder lookup pins `job_id`.
  */
 function makeBuilder(table: string) {
-  const seen = { in: false, not: false, gte: false, head: false };
+  const seen = { dueDate: false, shipJobIn: false, shipDate: false };
   const builder: Record<string, unknown> = {};
 
-  builder.select = vi.fn((cols: string, opts?: { head?: boolean }) => {
+  builder.select = vi.fn((cols: string) => {
     STATE.selects.push(cols);
-    if (opts?.head) seen.head = true;
     return builder;
   });
   builder.eq = vi.fn((col: string, val: unknown) => {
@@ -64,31 +75,40 @@ function makeBuilder(table: string) {
   });
   builder.is = vi.fn((col: string, val: unknown) => {
     if (table === 'quotes') STATE.quoteFilters.push(`${col} is ${String(val)}`);
+    if (table === 'shipments') STATE.shipmentFilters.push(`${col} is ${String(val)}`);
     return builder;
   });
-  builder.lt = vi.fn(() => builder);
+  builder.lt = vi.fn((col: string) => {
+    if (table === 'shipments') STATE.shipmentFilters.push(`lt:${col}`);
+    return builder;
+  });
   builder.in = vi.fn((col: string) => {
-    if (col === 'production_status') seen.in = true;
+    if (col === 'job_id') seen.shipJobIn = true;
+    if (table === 'jobs') STATE.jobFilters.push(`in:${col}`);
     return builder;
   });
-  builder.not = vi.fn((col: string) => {
-    STATE.overdueFilters.push(col);
-    seen.not = true;
+  builder.not = vi.fn((col: string, op: string, val: unknown) => {
+    if (col === 'due_date') seen.dueDate = true;
+    if (table === 'jobs') STATE.jobFilters.push(`not:${col} ${op} ${String(val)}`);
+    if (seen.dueDate) STATE.overdueFilters.push(col);
     return builder;
   });
-  builder.gte = vi.fn(() => {
-    seen.gte = true;
+  builder.gte = vi.fn((col: string) => {
+    if (col === 'ship_date') seen.shipDate = true;
+    if (table === 'shipments') STATE.shipmentFilters.push(`gte:${col}`);
     return builder;
   });
 
   builder.then = (resolve: (v: unknown) => unknown) => {
-    if (table === 'quotes') {
-      return resolve({ data: null, count: STATE.quoteCount, error: null });
+    if (table === 'quotes') return resolve({ data: null, count: STATE.quoteCount, error: null });
+    if (table === 'shipments') {
+      // The remainder lookup pins job_id; the period query pins ship_date.
+      if (seen.shipJobIn) return resolve({ data: STATE.openJobShipments, error: null });
+      if (seen.shipDate) return resolve({ data: STATE.shipmentsQueue.shift() ?? [], error: null });
+      return resolve({ data: [], error: null });
     }
-    if (seen.not) return resolve({ data: STATE.overdue, error: null });
-    if (seen.gte) return resolve({ data: STATE.completedQueue.shift() ?? [], error: null });
-    if (seen.in) return resolve({ data: STATE.openJobs, error: null });
-    return resolve({ data: [], count: 0, error: null });
+    if (seen.dueDate) return resolve({ data: STATE.overdue, error: null });
+    return resolve({ data: STATE.openJobs, error: null });
   };
   return builder;
 }
@@ -98,13 +118,30 @@ vi.mock('@/lib/supabase', () => ({ getSupabase: () => mockSupabase }));
 
 import { getDashboardMetrics, DASHBOARD_METRICS } from '@/utils/dashboardAccess';
 
-const job = (production_status: string, parts: JobPart[]) => ({
-  id: `j-${Math.random()}`,
+let seq = 0;
+const job = (
+  production_status: string,
+  parts: JobPart[],
+  fulfillment_status = 'unshipped',
+  id = `j-${++seq}`,
+) => ({
+  id,
   production_status,
+  fulfillment_status,
   job_parts: parts.map((p) => ({
     total_price: p.total_price ?? null,
     unit_price: p.unit_price ?? null,
     quantity: p.quantity ?? null,
+  })),
+});
+
+/** A non-voided shipment: what left the building, priced per shipped unit. */
+const shipment = (job_id: string, lines: Array<[number, number]>) => ({
+  id: `s-${++seq}`,
+  job_id,
+  shipment_line_items: lines.map(([quantity, unit_price]) => ({
+    quantity,
+    job_parts: { unit_price },
   })),
 });
 
@@ -113,11 +150,14 @@ describe('dashboard metrics', () => {
     vi.clearAllMocks();
     STATE.openJobs = [];
     STATE.overdue = [];
-    STATE.completedQueue = [[], []];
+    STATE.shipmentsQueue = [[], []];
+    STATE.openJobShipments = [];
     STATE.quoteCount = 0;
     STATE.selects = [];
     STATE.overdueFilters = [];
     STATE.quoteFilters = [];
+    STATE.shipmentFilters = [];
+    STATE.jobFilters = [];
   });
 
   it('is exactly four metrics, in flow order', () => {
@@ -137,41 +177,73 @@ describe('dashboard metrics', () => {
     expect(timed).toEqual(['completed_jobs']);
   });
 
-  it('takes revenue from job_parts, never from the quote', () => {
-    // The regression guard. If Completed ever routes back through
-    // quote_line_items, every quoteless job silently becomes free again.
-    STATE.completedQueue = [[job('completed', [{ total_price: 100 }])], []];
+  it('reads revenue from the SHIPMENT, never from the quote', async () => {
+    // The regression guard. Revenue routed through quote_line_items until
+    // 2026-08-11, which made every quoteless job free.
+    STATE.shipmentsQueue = [[shipment('j-1', [[1, 100]])], []];
 
-    return getDashboardMetrics('c1', 'this_week').then(() => {
-      expect(STATE.selects.length).toBeGreaterThan(0);
-      for (const cols of STATE.selects) {
-        expect(cols).not.toContain('quote_line_items');
-        expect(cols).not.toContain('quotes!');
-      }
-    });
+    await getDashboardMetrics('c1', 'this_week');
+
+    expect(STATE.selects.length).toBeGreaterThan(0);
+    for (const cols of STATE.selects) {
+      expect(cols).not.toContain('quote_line_items');
+      expect(cols).not.toContain('quotes!');
+    }
   });
 
-  it('counts a shipped job that never had a quote', async () => {
-    // The demo-company case that read $0.
-    STATE.completedQueue = [[job('completed', [{ total_price: 13500 }])], []];
+  it('dates revenue by ship_date, not by when the row was last written', async () => {
+    // jobs.updated_at was the old proxy: editing a PO on a job shipped in March
+    // pulled it into this week, and rows only ever drifted INTO the window.
+    STATE.shipmentsQueue = [[shipment('j-1', [[2, 50]])], []];
+
+    await getDashboardMetrics('c1', 'this_week');
+
+    expect(STATE.shipmentFilters).toContain('gte:ship_date');
+    expect(STATE.shipmentFilters).toContain('lt:ship_date');
+    expect(STATE.shipmentFilters.join(' ')).not.toContain('updated_at');
+  });
+
+  it('prices what actually shipped, so a PARTIAL shipment earns its share', async () => {
+    // 4 of 10 units on a $250 line: $1,000 shipped, not $2,500 and not $0.
+    // Under the old model this job contributed nothing until it went
+    // fully_shipped, and then contributed its whole value at once.
+    STATE.shipmentsQueue = [[shipment('j-1', [[4, 250]])], []];
 
     const m = await getDashboardMetrics('c1', 'this_week');
 
-    expect(m.completed_jobs?.count).toBe(1);
-    expect(m.completed_jobs?.money).toBe(13500);
+    expect(m.completed_jobs?.money).toBe(1000);
   });
 
-  it('falls back to unit price x quantity when no total was stored', async () => {
-    STATE.completedQueue = [[job('completed', [{ unit_price: 12.5, quantity: 4 }])], []];
+  it('ignores voided shipments', async () => {
+    // Enforced by the query (`voided_at is null`) rather than by arithmetic —
+    // voiding a packing slip is how a shop says it did not happen.
+    STATE.shipmentsQueue = [[shipment('j-1', [[1, 900]])], []];
 
-    expect((await getDashboardMetrics('c1', 'this_week')).completed_jobs?.money).toBe(50);
+    await getDashboardMetrics('c1', 'this_week');
+
+    expect(STATE.shipmentFilters).toContain('voided_at is null');
+  });
+
+  it('counts JOBS shipped from, not shipments, so two loads are one job', async () => {
+    // Both halves of the card describe the same act; "2 · $1,500 shipped this
+    // week" has to be one statement rather than two different measurements.
+    STATE.shipmentsQueue = [
+      [
+        shipment('j-1', [[1, 500]]),
+        shipment('j-1', [[1, 500]]), // same job, second load
+        shipment('j-2', [[1, 500]]),
+      ],
+      [],
+    ];
+
+    const m = await getDashboardMetrics('c1', 'this_week');
+
+    expect(m.completed_jobs?.count).toBe(2);
+    expect(m.completed_jobs?.money).toBe(1500);
   });
 
   it('carries the prior period so the card can show a delta', async () => {
-    STATE.completedQueue = [
-      [job('completed', [{ total_price: 1200 }])],
-      [job('completed', [{ total_price: 1000 }])],
-    ];
+    STATE.shipmentsQueue = [[shipment('j-1', [[1, 1200]])], [shipment('j-2', [[1, 1000]])]];
 
     const m = await getDashboardMetrics('c1', 'this_week');
 
@@ -179,7 +251,7 @@ describe('dashboard metrics', () => {
     expect(m.completed_jobs?.previousMoney).toBe(1000);
   });
 
-  it('merges Open Jobs but keeps the queued/running split', async () => {
+  it('merges Open Jobs but keeps the not-started / in-progress split', async () => {
     // The merged tile would otherwise hide whether work is flowing or piling
     // up, which is what the old two-card split was good for.
     STATE.openJobs = [
@@ -200,6 +272,38 @@ describe('dashboard metrics', () => {
     // figure on the dashboard.
     const { notStarted, inProgress } = m.open_jobs!.split!;
     expect(notStarted.money + inProgress.money).toBe(m.open_jobs?.money);
+  });
+
+  it('leaves already-shipped work out of Open Jobs entirely', async () => {
+    // production_status and fulfillment_status are independent: a shop that
+    // ships without operators closing out operations leaves jobs not_started
+    // AND fully_shipped at once — 39 of them on the pilot shop, $37,769 that
+    // sat here under the words "not yet shipped" while ALSO counting as
+    // revenue in Completed Jobs.
+    await getDashboardMetrics('c1', 'this_week');
+
+    expect(STATE.jobFilters).toContain('not:fulfillment_status eq fully_shipped');
+  });
+
+  it('counts only what a part-shipped job still OWES', async () => {
+    // $2,000 ordered, $1,200 already gone: $800 of backlog. The shipped half is
+    // revenue and is counted once, on the other card.
+    STATE.openJobs = [job('in_progress', [{ total_price: 2000 }], 'partially_shipped', 'j-part')];
+    STATE.openJobShipments = [shipment('j-part', [[3, 400]])];
+
+    const m = await getDashboardMetrics('c1', 'this_week');
+
+    expect(m.open_jobs?.money).toBe(800);
+  });
+
+  it('never reports negative backlog when more shipped than was ordered', async () => {
+    // A data problem, not a negative amount of work owed.
+    STATE.openJobs = [job('in_progress', [{ total_price: 500 }], 'partially_shipped', 'j-over')];
+    STATE.openJobShipments = [shipment('j-over', [[10, 400]])];
+
+    const m = await getDashboardMetrics('c1', 'this_week');
+
+    expect(m.open_jobs?.money).toBe(0);
   });
 
   it('counts only quotes that are still live, not ones already won', async () => {
@@ -241,12 +345,20 @@ describe('dashboard metrics', () => {
 
   it('excludes archived rows from every metric', async () => {
     // Soft-delete standard: a list/count/dashboard query filters deleted_at.
-    // getCount did not, and the docs recorded that as an unfixed gap.
+    //
+    // Shipments carry no deleted_at of their own — they are VOIDED, not
+    // archived — so they reach the same rule through an inner join on the job.
+    // Without it an archived job's shipments would keep earning revenue after
+    // every other tile had dropped that job.
     await getDashboardMetrics('c1', 'this_week');
 
     const builders = mockSupabase.from.mock.results.map((r) => r.value as Record<string, unknown>);
     for (const b of builders) {
-      expect((b.is as ReturnType<typeof vi.fn>).mock.calls).toContainEqual(['deleted_at', null]);
+      const isCalls = (b.is as ReturnType<typeof vi.fn>).mock.calls;
+      const filtersArchived =
+        isCalls.some((c) => c[0] === 'deleted_at' && c[1] === null) ||
+        isCalls.some((c) => c[0] === 'jobs.deleted_at' && c[1] === null);
+      expect(filtersArchived, `a query reached the DB without an archived filter`).toBe(true);
     }
   });
 

--- a/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
+++ b/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
@@ -460,7 +460,11 @@ export default function QuoteDetailPage() {
             {quote.quote_number || 'Quote'}
           </Typography>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
-            <QuoteStatusChip status={quote.status} size="medium" />
+            <QuoteStatusChip
+              status={quote.status}
+              convertedAt={quote.converted_at}
+              size="medium"
+            />
             <Typography variant="body2" color="text.secondary">
               Created {formatDate(quote.created_at)}
             </Typography>

--- a/app/dashboard/[companyId]/quotes/page.tsx
+++ b/app/dashboard/[companyId]/quotes/page.tsx
@@ -46,13 +46,21 @@ import { getCompanyMembers } from '@/utils/companyAccess';
 import QuoteStatusChip from '@/components/quotes/QuoteStatusChip';
 import SearchableSelect, { type SelectOption } from '@/components/common/SearchableSelect';
 import DeleteImpactDialog from '@/components/common/DeleteImpactDialog';
-import type { QuoteWithRelations, QuoteStatus, QuoteFilters, CompanyMember } from '@/types/quote';
+import type {
+  QuoteWithRelations,
+  QuoteListStatus,
+  QuoteFilters,
+  CompanyMember,
+} from '@/types/quote';
 import type { Customer } from '@/types/customer';
 
-const VALID_QUOTE_STATUSES: Array<QuoteStatus | 'all'> = ['all', 'active', 'expired'];
+// 'active' stays parseable so older links keep resolving, but it is not offered
+// in the dropdown: it is the raw column value and means "open OR converted",
+// which is not a question anyone asks. See QuoteListStatus.
+const VALID_QUOTE_STATUSES: QuoteListStatus[] = ['all', 'open', 'converted', 'active', 'expired'];
 
-function parseQuoteStatusParam(v: string | null): QuoteStatus | 'all' {
-  if (v && (VALID_QUOTE_STATUSES as string[]).includes(v)) return v as QuoteStatus | 'all';
+function parseQuoteStatusParam(v: string | null): QuoteListStatus {
+  if (v && (VALID_QUOTE_STATUSES as string[]).includes(v)) return v as QuoteListStatus;
   return 'all';
 }
 
@@ -68,7 +76,7 @@ export default function QuotesPage() {
 
   const [search, setSearch] = useState('');
   const [searchDebounced, setSearchDebounced] = useState('');
-  const [statusFilter, setStatusFilter] = useState<QuoteStatus | 'all'>(() =>
+  const [statusFilter, setStatusFilter] = useState<QuoteListStatus>(() =>
     parseQuoteStatusParam(searchParams.get('status'))
   );
   // Seeded from ?customer=<uuid> so the Related-card count on a customer page
@@ -291,7 +299,12 @@ export default function QuotesPage() {
       width: 110,
       cellRenderer: (params: ICellRendererParams<QuoteWithRelations>) => {
         if (!params.data) return null;
-        return <QuoteStatusChip status={params.data.status} />;
+        return (
+          <QuoteStatusChip
+            status={params.data.status}
+            convertedAt={params.data.converted_at}
+          />
+        );
       },
     },
     {
@@ -397,12 +410,13 @@ export default function QuotesPage() {
         <Box sx={{ minWidth: 160 }}>
           <SearchableSelect
             options={[
-              { id: 'active', label: 'Active' },
+              { id: 'open', label: 'Open' },
+              { id: 'converted', label: 'Converted' },
               { id: 'expired', label: 'Expired' },
             ]}
             value={statusFilter === 'all' ? '' : statusFilter}
             onChange={(value) => {
-              setStatusFilter((value || 'all') as QuoteStatus | 'all');
+              setStatusFilter((value || 'all') as QuoteListStatus);
               clearSelection();
             }}
             label="Status"

--- a/components/auth/Login.tsx
+++ b/components/auth/Login.tsx
@@ -223,7 +223,7 @@ export default function Login({ expired, returnTo, reason }: LoginProps) {
               </Typography>
             )}
             {resendError && (
-              <Typography variant="body2" color="error" sx={{ mt: 1 }}>
+              <Typography variant="body2" color="error.light" sx={{ mt: 1 }}>
                 {resendError}
               </Typography>
             )}

--- a/components/dashboard/DashboardMetrics.tsx
+++ b/components/dashboard/DashboardMetrics.tsx
@@ -180,7 +180,7 @@ export default function DashboardMetrics({ companyId }: DashboardMetricsProps) {
             detail={detail}
             action={def.supportsTimePeriod ? periodToggle : undefined}
             href={drillDownHref(companyId, def.key)}
-            severity={def.key === 'overdue_jobs' && (v?.count ?? 0) > 0 ? 'alert' : 'normal'}
+            severity={def.key === 'overdue_jobs' && (v?.count ?? 0) > 0 ? 'warning' : 'normal'}
             loading={loading}
           />
         );

--- a/components/dashboard/DashboardMetrics.tsx
+++ b/components/dashboard/DashboardMetrics.tsx
@@ -38,7 +38,7 @@ function drillDownHref(companyId: string, key: MetricKey): string | undefined {
     case 'completed_jobs':
       return `/dashboard/${companyId}/jobs?status=completed`;
     case 'open_quotes':
-      return `/dashboard/${companyId}/quotes?status=active`;
+      return `/dashboard/${companyId}/quotes?status=open`;
     default:
       return undefined;
   }

--- a/components/dashboard/MetricScorecard.tsx
+++ b/components/dashboard/MetricScorecard.tsx
@@ -43,8 +43,15 @@ export interface MetricScorecardProps {
   /** Rendered in the card's corner — the Completed card's period toggle. */
   action?: ReactNode;
   href?: string;
-  /** Alert tone — red-tinted; used for overdue > 0. */
-  severity?: 'normal' | 'alert';
+  /**
+   * Attention tone — amber-tinted; used for overdue > 0.
+   *
+   * Amber rather than red on purpose. Andon is the convention the shop floor
+   * already runs on — green running, amber behind, red stopped — and an overdue
+   * job is behind, not broken. Red is kept for things that are actually wrong,
+   * so that it still means something on the day one happens.
+   */
+  severity?: 'normal' | 'warning';
   loading?: boolean;
 }
 
@@ -72,7 +79,7 @@ export default function MetricScorecard({
   severity = 'normal',
   loading = false,
 }: MetricScorecardProps) {
-  const isAlert = severity === 'alert';
+  const isAlert = severity === 'warning';
 
   // A delta against a zero prior period is not a comparison: the percentage is
   // undefined, and the absolute change just restates the headline figure — the
@@ -95,8 +102,10 @@ export default function MetricScorecard({
   const cardSx = {
     height: '100%',
     borderLeft: isAlert ? 3 : 0,
-    borderColor: isAlert ? 'error.main' : 'transparent',
-    bgcolor: isAlert ? 'rgba(239, 68, 68, 0.08)' : 'background.paper',
+    borderColor: isAlert ? 'warning.main' : 'transparent',
+    // 8% amber over the canvas. The red tint this replaced went muddy purple
+    // over deep indigo — neither red nor navy; amber stays neutral.
+    bgcolor: isAlert ? 'rgba(245, 158, 11, 0.08)' : 'background.paper',
   };
 
   const inner = (
@@ -105,7 +114,7 @@ export default function MetricScorecard({
         variant="body2"
         sx={{
           fontWeight: 500,
-          color: isAlert ? 'error.light' : 'text.secondary',
+          color: isAlert ? 'warning.light' : 'text.secondary',
           textTransform: 'uppercase',
           letterSpacing: 0.4,
           fontSize: '0.7rem',
@@ -125,7 +134,7 @@ export default function MetricScorecard({
           sx={{
             fontWeight: 600,
             lineHeight: 1.1,
-            color: isAlert ? 'error.light' : 'text.primary',
+            color: isAlert ? 'warning.light' : 'text.primary',
             mt: 0.25,
           }}
         >
@@ -138,7 +147,7 @@ export default function MetricScorecard({
           <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.75, flexWrap: 'wrap' }}>
             <Typography
               variant="body2"
-              sx={{ fontWeight: 600, color: isAlert ? 'error.light' : 'text.primary' }}
+              sx={{ fontWeight: 600, color: isAlert ? 'warning.light' : 'text.primary' }}
             >
               {formatMoney(money.amount)}
             </Typography>

--- a/components/dashboard/MetricScorecard.tsx
+++ b/components/dashboard/MetricScorecard.tsx
@@ -145,18 +145,38 @@ export default function MetricScorecard({
             <Typography variant="caption" sx={{ color: 'text.secondary' }}>
               {money.label}
             </Typography>
+            {/*
+              Ordinary INLINE flow, not flex, and one flex item rather than
+              several. Both halves of that matter:
+
+              A nested flex container takes its baseline from its first item —
+              here an SVG arrow, which has no text baseline, so the browser
+              synthesises one from the icon's bottom edge and lifted the whole
+              delta a few pixels above "$9,197". An inline element takes its
+              baseline from its text, which is what we want it to sit on; the
+              arrow is a glyph, not text, so it aligns itself against the line.
+
+              Keeping it as ONE item stops the row breaking between "-37%" and
+              "vs last week" — the card is a quarter of the width at 4-across,
+              so this row does wrap, and it has to wrap as a phrase.
+            */}
             {hasDelta && (
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25, color: deltaColor }}>
-                <DeltaIcon sx={{ fontSize: 14 }} />
-                <Typography variant="caption" sx={{ fontWeight: 600 }}>
-                  {pct !== null && delta !== 0 ? formatPercent(pct) : formatMoney(delta)}
-                </Typography>
+              <Typography
+                variant="caption"
+                component="span"
+                sx={{ fontWeight: 600, color: deltaColor, whiteSpace: 'nowrap' }}
+              >
+                <DeltaIcon sx={{ fontSize: 14, verticalAlign: 'text-bottom', mr: 0.25 }} />
+                {pct !== null && delta !== 0 ? formatPercent(pct) : formatMoney(delta)}
                 {money.comparisonLabel && (
-                  <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                  <Box
+                    component="span"
+                    sx={{ color: 'text.secondary', fontWeight: 400, ml: 0.5 }}
+                  >
                     {money.comparisonLabel}
-                  </Typography>
+                  </Box>
                 )}
-              </Box>
+              </Typography>
             )}
           </Box>
         )}

--- a/components/data-import/MultiFileDropzone.tsx
+++ b/components/data-import/MultiFileDropzone.tsx
@@ -126,7 +126,7 @@ export default function MultiFileDropzone({ files, onChange, disabled }: MultiFi
       </Box>
 
       {error && (
-        <Typography variant="body2" color="error" sx={{ mt: 1 }}>
+        <Typography variant="body2" color="error.light" sx={{ mt: 1 }}>
           {error}
         </Typography>
       )}

--- a/components/import/StatusCards.tsx
+++ b/components/import/StatusCards.tsx
@@ -51,6 +51,10 @@ export default function StatusCards({
                   size="small"
                   color="error"
                   variant="outlined"
+                  // An OUTLINED chip draws its label in error.main, which is
+                  // under the 4.5:1 body floor on a card. A filled error chip
+                  // needs no such treatment — that one is white on red.
+                  sx={{ color: 'error.light', borderColor: 'error.light' }}
                 />
               ))}
             </Box>

--- a/components/jobs/AttachmentUploadField.tsx
+++ b/components/jobs/AttachmentUploadField.tsx
@@ -79,7 +79,7 @@ export default function AttachmentUploadField({
         </Button>
       )}
       {error && (
-        <Typography variant="caption" color="error" sx={{ display: 'block', mt: 0.5 }}>
+        <Typography variant="caption" color="error.light" sx={{ display: 'block', mt: 0.5 }}>
           {error}
         </Typography>
       )}

--- a/components/jobs/ShipmentsMenu.tsx
+++ b/components/jobs/ShipmentsMenu.tsx
@@ -87,7 +87,7 @@ export default function ShipmentsMenu({
                   <Box component="span">
                     {s.packing_slip_number}
                     {s.voided_at && (
-                      <Typography component="span" variant="caption" color="error" sx={{ ml: 1 }}>
+                      <Typography component="span" variant="caption" color="error.light" sx={{ ml: 1 }}>
                         VOIDED
                       </Typography>
                     )}

--- a/components/parts/MaterialRowEditor.tsx
+++ b/components/parts/MaterialRowEditor.tsx
@@ -284,7 +284,7 @@ export default function MaterialRowEditor({
       </Box>
 
       {error && (
-        <Typography variant="caption" color="error" sx={{ display: 'block', mt: 0.75, ml: 1 }}>
+        <Typography variant="caption" color="error.light" sx={{ display: 'block', mt: 0.75, ml: 1 }}>
           {error}
         </Typography>
       )}

--- a/components/parts/PartBomPanel.tsx
+++ b/components/parts/PartBomPanel.tsx
@@ -874,7 +874,7 @@ export default function PartBomPanel({
                           display: 'flex',
                           alignItems: 'center',
                           gap: 0.5,
-                          color: 'error.main',
+                          color: 'error.light',
                           mt: 0.25,
                         }}
                       >
@@ -892,7 +892,7 @@ export default function PartBomPanel({
                         display: 'flex',
                         alignItems: 'center',
                         gap: 0.5,
-                        color: 'error.main',
+                        color: 'error.light',
                         mt: 0.25,
                       }}
                     >

--- a/components/parts/PartProcurementPricingPanel.tsx
+++ b/components/parts/PartProcurementPricingPanel.tsx
@@ -438,7 +438,7 @@ export default function PartProcurementPricingPanel({
                 alignItems: 'center',
                 gap: 0.5,
                 mb: 1,
-                color: 'error.main',
+                color: 'error.light',
               }}
             >
               <WarningAmberIcon fontSize="small" />

--- a/components/quotes/QuoteStatusChip.tsx
+++ b/components/quotes/QuoteStatusChip.tsx
@@ -4,11 +4,26 @@ import { QUOTE_STATUS_CONFIG } from '@/types/quote';
 
 interface QuoteStatusChipProps {
   status: QuoteStatus;
+  /**
+   * When the quote was converted to a job, if it was. Pass it and the chip says
+   * **Converted**; leave it out and the chip falls back to the raw column value.
+   *
+   * Worth passing wherever it is to hand. `quotes.status` only holds
+   * `active | expired` — winning a quote sets `converted_at` and leaves the
+   * status alone — so an already-won quote otherwise reads "Active" forever,
+   * which is the same confusion that made the dashboard's Open Quotes tile
+   * count work the shop had already won.
+   */
+  convertedAt?: string | null;
   size?: 'small' | 'medium';
 }
 
-export default function QuoteStatusChip({ status, size = 'small' }: QuoteStatusChipProps) {
-  const config = QUOTE_STATUS_CONFIG[status] || { label: status, color: 'default' as const };
+export default function QuoteStatusChip({ status, convertedAt, size = 'small' }: QuoteStatusChipProps) {
+  // Converted beats the column: it is the more specific truth about the quote,
+  // and it is the word the list's Status filter uses for the same set.
+  const config = convertedAt
+    ? { label: 'Converted', color: 'success' as const }
+    : QUOTE_STATUS_CONFIG[status] || { label: status, color: 'default' as const };
 
   return (
     <StatusChip label={config.label} color={config.color} size={size} sx={{ fontWeight: 500 }} />

--- a/components/routings/RoutingOperationRow.tsx
+++ b/components/routings/RoutingOperationRow.tsx
@@ -197,7 +197,7 @@ export default function RoutingOperationRow({
           </Typography>
         )}
         {errorMessage && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'error.main', mt: 0.25 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'error.light', mt: 0.25 }}>
             <ErrorOutlineIcon sx={{ fontSize: 16 }} />
             <Typography variant="caption">{errorMessage}</Typography>
           </Box>

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -224,6 +224,32 @@ What the shell enforces, all in
 as a *floor*, measured against a 500–1000 lux shop floor rather than an office monitor, and treated
 as a hard limit rather than a number to squeak past. Every ratio in this file was measured by hand.
 
+### `error.main` is not a text colour on a lifted surface
+
+`#ef4444` is fine as a border, an icon or a fill. As **text** it clears the body floor only on the raw
+page canvas — and text almost never sits on the raw canvas. Measured against the surfaces as painted
+(sampled from the running app, because the cards are translucent over a gradient and a value derived
+from `background.default` comes out darker than reality and flatters the result):
+
+| Surface | `error.main` #ef4444 | `error.light` #fca5a5 |
+|---|---|---|
+| Page canvas `#111439` | 4.72:1 ✓ | 9.35:1 ✓ |
+| Dialog paper | **4.47:1 ✗** | 8.87:1 ✓ |
+| Card / paper | **3.70:1 ✗** | 7.33:1 ✓ |
+| Alert-tinted card | **2.98:1 ✗** | 5.90:1 ✓ |
+
+**So: `error.light` for error TEXT, `error.main` for everything else.** `error.light` passes on every
+surface, so no per-site analysis is needed — you never have to work out which panel a message lands on.
+
+Three usages are measured exempt and should stay on `error.main`: **icons** (non-text, SC 1.4.11 asks
+3:1 and 3.70:1 clears it), **filled** error chips and **contained** error buttons (white on a red fill —
+a different calculation, and lightening them would wash out the one affordance that should look
+dangerous). A `MuiButton` override in [`lib/theme.ts`](../lib/theme.ts) handles text and outlined error
+buttons automatically; `contained` is deliberately excluded.
+
+Pinned by [`__tests__/lib/alertContrast.test.ts`](../__tests__/lib/alertContrast.test.ts), which computes
+real WCAG ratios from the theme's own values against each surface above.
+
 **Withdrawn:** the heading "Accessibility (WCAG 2.1 **Level A**)" — wrong twice. Level A imposes no
 contrast requirement at all; 4.5:1 body / 3:1 large text are Level **AA** (SC 1.4.3). And 48px is not
 a WCAG number in any version — WCAG 2.2 asks 24×24 CSS px at AA (SC 2.5.8) and 44×44 at AAA

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -236,7 +236,7 @@ from `background.default` comes out darker than reality and flatters the result)
 | Page canvas `#111439` | 4.72:1 ✓ | 9.35:1 ✓ |
 | Dialog paper | **4.47:1 ✗** | 8.87:1 ✓ |
 | Card / paper | **3.70:1 ✗** | 7.33:1 ✓ |
-| Alert-tinted card | **2.98:1 ✗** | 5.90:1 ✓ |
+| Warning-tinted card (Overdue) | **2.98:1 ✗** | 5.90:1 ✓ — but see below |
 
 **So: `error.light` for error TEXT, `error.main` for everything else.** `error.light` passes on every
 surface, so no per-site analysis is needed — you never have to work out which panel a message lands on.
@@ -246,6 +246,28 @@ Three usages are measured exempt and should stay on `error.main`: **icons** (non
 a different calculation, and lightening them would wash out the one affordance that should look
 dangerous). A `MuiButton` override in [`lib/theme.ts`](../lib/theme.ts) handles text and outlined error
 buttons automatically; `contained` is deliberately excluded.
+
+### Red means broken; amber means behind
+
+`warning` carries the same `main` / `light` split, and for the same reason — but the choice of *which*
+status colour a surface uses is a separate decision from whether it is readable.
+
+**Overdue work is amber, not red.** Andon is the convention a shop floor already runs on — green
+running, amber needs attention, red stopped — and an overdue job is behind, not broken. Every shop has
+late jobs; painting the dashboard red on an ordinary Tuesday spends the loudest signal on a normal
+state and leaves nothing for a genuine failure. Red is kept for things that are actually wrong.
+
+A practical bonus found while rendering it: `rgba(239,68,68,0.08)` over deep indigo goes muddy purple —
+neither red nor navy. The amber tint stays neutral.
+
+| On the Overdue card's amber tint | |
+|---|---|
+| `warning.main` #f59e0b | 4.89:1 — *passes*, unlike error.main, but 0.39 above a hard limit |
+| `warning.light` #fbbf24 | **6.28:1**, measured as painted |
+
+So `warning.light` for the text and `warning.main` for the rule and the tint. Note the asymmetry with
+`error`: amber's `main` is readable as text and red's is not, because #ef4444 is unusually dark for its
+hue — which is exactly why the rule is per-colour and measured rather than assumed.
 
 Pinned by [`__tests__/lib/alertContrast.test.ts`](../__tests__/lib/alertContrast.test.ts), which computes
 real WCAG ratios from the theme's own values against each surface above.

--- a/docs/modules/dashboard.md
+++ b/docs/modules/dashboard.md
@@ -25,9 +25,9 @@ is prefixed `/dashboard/{companyId}`.
 
 | Key | Label | Count | Money | Drill-down |
 |---|---|---|---|---|
-| `overdue_jobs` | Overdue | the shared `applyOverdueJobsFilter` predicate — the same one the jobs list uses | "not yet shipped" | `/jobs?overdue=true` |
-| `open_jobs` | Open Jobs | `jobs.production_status IN ('not_started','in_progress')` | "not yet shipped" | `/jobs?status=not_started` |
-| `completed_jobs` | Completed | `jobs.fulfillment_status = 'fully_shipped'` in the period | "shipped this week" / "shipped today", with a period-over-period delta | `/jobs?status=completed` |
+| `overdue_jobs` | Overdue Jobs | the shared `applyOverdueJobsFilter` predicate — the same one the jobs list uses | "not yet shipped" | `/jobs?overdue=true` |
+| `open_jobs` | Open Jobs | `production_status IN ('not_started','in_progress')` AND not `fully_shipped` | ordered **minus already shipped** — "not yet shipped" | `/jobs?status=not_started` |
+| `completed_jobs` | Completed Jobs | distinct jobs **shipped from** in the period | value shipped in the period — "shipped this week" / "shipped today", with a period-over-period delta | `/jobs?status=completed` |
 | `open_quotes` | Open Quotes | `quotes.status = 'active'` | none — see below | `/quotes?status=active` |
 
 Never `jobs.status`; that column was removed (the May 2026 prod regression).
@@ -94,22 +94,52 @@ remain readable through the API by anyone who can reach the company. Do not desc
 ### Time period
 
 Only Completed is scoped to a period, so the Today / This Week toggle sits **on that card** rather than over
-the row. The other three are a snapshot of right now — "12 jobs in progress this week" is not a thing, and a
+the row. "Today" is midnight to midnight and "This Week" opens on Sunday, both in the **browser's**
+timezone — the device's clock, not a stored company setting, so a laptop carried across a timezone
+shifts the window with it. The other three are a snapshot of right now — "12 jobs in progress this week" is not a thing, and a
 control that three of four cards ignored would read as broken. Weeks run Sunday 00:00 local → next Sunday
 00:00. The choice persists in `user_preferences.preferences.dashboard_completed_period`.
 
 Completed carries a period-over-period delta on its **money**, which is the sentence an owner wants; a count
 delta is the less interesting half. The other three cards get no delta — that would need historical snapshots.
 
-### Constraints on the range query
+### Revenue is what shipped, not what a job is worth
 
-`updated_at` is the in-range proxy for "shipped in this window". `jobs.shipped_at` does not exist in the
-dual-status model, and `job_last_ship_date` is a `(uuid)` function rather than a jobs-row column, so selecting
-it as a computed column makes PostgREST answer 400. A consequence worth knowing: editing an old shipped job
-pulls it into the current window.
+Money on the Completed card is **shipped quantity x the agreed unit price, dated by
+`shipments.ship_date`** — summed over `shipment_line_items`, voided shipments excluded. The count
+follows the money: distinct jobs *shipped from* in the window, not jobs that reached `fully_shipped`.
+Both halves then describe the same act, so "6 · $12,480 shipped this week" is one statement.
 
-"Completed" counts the fulfillment half (`fully_shipped`) of the FR-18 done predicate rather than both — a
-fully-shipped job is by definition done, so that clause is the tighter one.
+This replaced a proxy that was wrong three ways. There is no ship date on a job — `jobs.shipped_at`
+is not in the dual-status model, and `job_last_ship_date` is a `(uuid)` function rather than a column,
+so PostgREST answers 400 if you select it — and the card used `jobs.updated_at` instead. That meant:
+
+- **"Last written", not "shipped".** Editing a PO number on a job shipped in March pulled it into
+  this week, and rows only ever drifted *into* the current window, never out.
+- **A partial shipment earned nothing.** A job 60% shipped had 60% of its money in the customer's
+  hands, contributed $0 here, and had its *full* value sitting in Open Jobs as backlog.
+- **A job landed at its whole value** the moment it went `fully_shipped`, even if it shipped across
+  two months.
+
+Reading the shipment fixes all three at once, and removes a double count: Open Jobs now excludes
+fully-shipped work and counts only what a job still **owes** (ordered minus shipped), so a
+part-shipped job's delivered half is revenue exactly once. On the pilot shop that moved Open Jobs
+from 65 jobs / $85,955 to 26 / $43,987 — the earlier figure counted $37,769 of already-delivered work
+as backlog while the same money also counted as revenue.
+
+**Both axes, or neither.** `production_status` and `fulfillment_status` are independent: a shop that
+ships without operators closing out operations leaves jobs `not_started` **and** `fully_shipped` at
+the same time, which is 39 jobs on the pilot shop. Filtering on production alone is what put
+delivered work under the words "not yet shipped". `applyOverdueJobsFilter` always excluded
+fully-shipped; the other tiles now agree with it.
+
+`ship_date` is a **DATE**, so the window is a calendar comparison with nothing to smear — unlike the
+old `updated_at` timestamp, where a Saturday-evening ship could land in Sunday because the office is
+west of UTC.
+
+**Known limit:** `job_parts.unit_price` is read live rather than snapshotted per shipment, so
+repricing a line retrospectively moves historical revenue. In practice a part's price locks once any
+quantity of it is invoiced ([jobs.md](jobs.md)), which covers the case that matters.
 
 ### Failure and archived rows
 

--- a/docs/modules/dashboard.md
+++ b/docs/modules/dashboard.md
@@ -35,8 +35,10 @@ Never `jobs.status`; that column was removed (the May 2026 prod regression).
 ### The count is primary; the money is the second line
 
 A shop owner acts on jobs, not on dollars, so the count stays the big number and the money sits under it. It
-also keeps `0` as the all-clear on Overdue, which is a stronger signal than `$0`. Overdue renders in an
-`alert` (red) tone when > 0.
+also keeps `0` as the all-clear on Overdue, which is a stronger signal than `$0`. Overdue renders in a
+`warning` (amber) tone when > 0 — amber because a late job is *behind*, not broken, which is the
+andon convention the floor already reads; red stays for things that are actually wrong. See
+[design-system.md](../design-system.md#red-means-broken-amber-means-behind).
 
 ### Two kinds of money, and what the labels are for
 

--- a/e2e/quote-to-job.spec.ts
+++ b/e2e/quote-to-job.spec.ts
@@ -102,8 +102,11 @@ test.describe('Quote to Job workflow', () => {
     // Verify the quote was created — quote number should be visible
     await expect(page.getByText(/Q-\d+/)).toBeVisible();
 
-    // Quote is created as "Active" — verify status
-    await expect(page.getByText(/^Active$/i)).toBeVisible({ timeout: 10_000 });
+    // A new quote reads "Open", not "Active". `quotes.status` still stores
+    // `active`, but the chip says Open for an unconverted one and Converted
+    // once it becomes a job — the column cannot distinguish those, and calling
+    // a won quote "Active" is what let the dashboard count it as pipeline.
+    await expect(page.getByText(/^Open$/i)).toBeVisible({ timeout: 10_000 });
 
     // ── Step 2: Convert to job (approval step is gone) ──
 

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -66,7 +66,19 @@ const jiggedTheme = createTheme({
       secondary: '#C8CCD4',
     },
     success: { main: '#10b981' },
-    warning: { main: '#f59e0b' },
+    /**
+     * Amber is the shop-floor colour for *needs attention*, and the andon
+     * convention your operators already read off the machines: green running,
+     * amber behind, red stopped. Overdue work is behind, not broken — red every
+     * day spends the loudest signal on an ordinary Tuesday and leaves nothing
+     * for a genuine failure.
+     *
+     * Same split as `error`: `main` for borders, icons and tints, `light` for
+     * TEXT. `main` does technically clear the body floor on a warning-tinted
+     * card (4.89:1) where error.main does not, but 0.39 above a limit measured
+     * against a 500–1000 lux shop floor is squeaking past it. `light` is 6.29:1.
+     */
+    warning: { main: '#f59e0b', light: '#fbbf24' },
     /**
      * `main` is for BORDERS, ICONS and FILLS — not for text on a tinted panel.
      *

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -102,13 +102,27 @@ const jiggedTheme = createTheme({
   components: {
     MuiButton: {
       styleOverrides: {
-        root: {
+        /**
+         * `color="error"` on a TEXT or OUTLINED button paints the label in
+         * `error.main`, which measures 3.70:1 on a card and 4.47:1 on a dialog —
+         * both under the 4.5:1 body floor. Only the raw page canvas passes, and
+         * a destructive button almost never sits on the raw canvas.
+         *
+         * `contained` is deliberately untouched: it paints white on an
+         * error.main FILL, which is a different calculation and already fine.
+         * Lightening it would wash out the one affordance that should look
+         * unmistakably dangerous.
+         */
+        root: ({ ownerState, theme }) => ({
           textTransform: 'none',
           fontWeight: 500,
           padding: '10px 20px',
           minHeight: 48, // Touch target size for shop floor
           transition: 'all 0.2s ease',
-        },
+          ...(ownerState.color === 'error' && ownerState.variant !== 'contained'
+            ? { color: theme.palette.error.light }
+            : {}),
+        }),
         contained: {
           boxShadow: '0 4px 12px rgba(70, 130, 180, 0.3)',
           '&:hover': {

--- a/types/quote.ts
+++ b/types/quote.ts
@@ -313,10 +313,30 @@ export interface QuoteFormData {
 }
 
 /**
+ * What a quote LOOKS like to a shop, which is not what `quotes.status` stores.
+ *
+ * The column holds only `active | expired`; winning a quote is recorded by
+ * `converted_at`, not by a status change. So a quote that became a job stays
+ * `active` forever, and "active" is really the union of *still chasing it* and
+ * *already won it* — a set nobody asks to see.
+ *
+ * These are the three questions people actually ask, and they partition the
+ * list cleanly:
+ *
+ *   open       still live: active AND never converted
+ *   converted  became a job (converted_at set), whatever the status column says
+ *   expired    lapsed
+ *
+ * `active` remains accepted so older links and bookmarks keep resolving; it is
+ * the raw column value and is deliberately not offered in the UI.
+ */
+export type QuoteListStatus = QuoteStatus | 'all' | 'open' | 'converted';
+
+/**
  * Filters for quotes list
  */
 export interface QuoteFilters {
-  status?: QuoteStatus | 'all';
+  status?: QuoteListStatus;
   customerId?: string;
   createdBy?: string;
   search?: string;
@@ -484,7 +504,10 @@ export const QUOTE_STATUS_CONFIG: Record<
   QuoteStatus,
   { label: string; color: 'default' | 'primary' | 'success' | 'error' | 'warning' }
 > = {
-  active: { label: 'Active', color: 'primary' },
+  // 'Open' rather than 'Active': QuoteStatusChip renders converted quotes as
+  // 'Converted' before consulting this map, so a chip reaching here is
+  // active AND unconverted — the set the list's Status filter calls Open.
+  active: { label: 'Open', color: 'primary' },
   expired: { label: 'Expired', color: 'warning' },
 };
 

--- a/utils/dashboardAccess.ts
+++ b/utils/dashboardAccess.ts
@@ -104,13 +104,16 @@ export interface MetricValue {
 
 /** The shape every job-money query selects. */
 type JobValueRow = {
+  id: string;
   production_status: string | null;
+  fulfillment_status: string | null;
   job_parts:
     | { total_price: number | null; unit_price: number | null; quantity: number | null }[]
     | null;
 };
 
-const JOB_VALUE_SELECT = 'id, production_status, job_parts(total_price, unit_price, quantity)';
+const JOB_VALUE_SELECT =
+  'id, production_status, fulfillment_status, job_parts(total_price, unit_price, quantity)';
 
 /**
  * The agreed money on a job: its OWN job_parts line totals, never the source
@@ -128,30 +131,22 @@ function jobValue(row: JobValueRow): number {
   }, 0);
 }
 
-/**
- * Return [currentPeriodStart, nextPeriodStart] as ISO strings.
- * "today" → midnight today → midnight tomorrow.
- * "this_week" → Sunday 00:00 → next Sunday 00:00.
- */
-function periodBounds(period: MetricTimePeriod, offsetPeriods = 0): { start: string; end: string } {
-  const now = new Date();
-  if (period === 'today') {
-    const start = new Date(now);
-    start.setHours(0, 0, 0, 0);
-    start.setDate(start.getDate() + offsetPeriods);
-    const end = new Date(start);
-    end.setDate(start.getDate() + 1);
-    return { start: start.toISOString(), end: end.toISOString() };
-  }
-  const start = new Date(now);
-  start.setDate(now.getDate() - now.getDay() + offsetPeriods * 7);
-  start.setHours(0, 0, 0, 0);
-  const end = new Date(start);
-  end.setDate(start.getDate() + 7);
-  return { start: start.toISOString(), end: end.toISOString() };
-}
 
-/** Jobs not yet begun plus jobs on the floor, with the money and the split. */
+/**
+ * Work still owed: jobs not finished on the floor AND not fully out the door.
+ *
+ * Both axes, deliberately. `production_status` and `fulfillment_status` are
+ * independent — a shop that ships without operators closing out operations
+ * leaves jobs `not_started` and `fully_shipped` at the same time, and there are
+ * 39 such jobs on the pilot shop. Filtering on production alone put $37,769 of
+ * already-delivered work in this tile under the words "not yet shipped", while
+ * the same money also counted as revenue in Completed Jobs. `applyOverdueJobsFilter`
+ * always excluded fully-shipped; this now agrees with it.
+ *
+ * The money is what is still OWED — ordered minus already shipped — so a
+ * part-shipped job contributes only the remainder. Its shipped half is revenue
+ * and is counted once, in Completed Jobs. Nothing on the row is double counted.
+ */
 async function getOpenJobs(companyId: string): Promise<MetricValue> {
   const supabase = getSupabase();
   const { data, error } = await supabase
@@ -159,17 +154,47 @@ async function getOpenJobs(companyId: string): Promise<MetricValue> {
     .select(JOB_VALUE_SELECT)
     .eq('company_id', companyId)
     .is('deleted_at', null)
-    .in('production_status', ['not_started', 'in_progress']);
+    .in('production_status', ['not_started', 'in_progress'])
+    .not('fulfillment_status', 'eq', 'fully_shipped');
 
   if (error) throw error;
+
+  const rows = (data || []) as unknown as JobValueRow[];
+
+  // Only a part-shipped job has anything to subtract, and there are few of
+  // them, so the second query stays small rather than pulling every shipment
+  // the company has ever made.
+  const partIds = rows
+    .filter((r) => r.fulfillment_status === 'partially_shipped')
+    .map((r) => r.id);
+
+  const shippedByJob = new Map<string, number>();
+  if (partIds.length > 0) {
+    const { data: shipments, error: shipErr } = await supabase
+      .from('shipments')
+      .select(SHIPMENT_VALUE_SELECT)
+      .eq('company_id', companyId)
+      .is('voided_at', null)
+      .is('jobs.deleted_at', null)
+      .in('job_id', partIds);
+
+    if (shipErr) throw shipErr;
+
+    for (const row of (shipments || []) as unknown as ShipmentValueRow[]) {
+      if (!row.job_id) continue;
+      shippedByJob.set(row.job_id, (shippedByJob.get(row.job_id) ?? 0) + shipmentValue(row));
+    }
+  }
 
   const notStarted = { count: 0, money: 0 };
   const inProgress = { count: 0, money: 0 };
 
-  for (const row of (data || []) as unknown as JobValueRow[]) {
+  for (const row of rows) {
     const bucket = row.production_status === 'in_progress' ? inProgress : notStarted;
     bucket.count += 1;
-    bucket.money += jobValue(row);
+    // Never below zero: shipping more than was ordered is a data problem, not a
+    // negative amount of backlog.
+    bucket.money += Math.max(0, jobValue(row) - (shippedByJob.get(row.id) ?? 0));
   }
 
   // These two states are disjoint, so this is the one figure on the dashboard
@@ -209,33 +234,118 @@ async function getOverdueJobs(companyId: string): Promise<MetricValue> {
   };
 }
 
-/** Shipped in the window, with the money — this is realized revenue. */
+/**
+ * Local calendar bounds for the period, as `YYYY-MM-DD`.
+ *
+ * `shipments.ship_date` is a DATE, not a timestamp — it is the calendar day the
+ * shop says the truck left, carrying no time and no zone. So the window is
+ * compared date-to-date and there is nothing to smear: a Saturday-evening ship
+ * cannot land in Sunday because the office is west of UTC, which is exactly
+ * what the old `updated_at` timestamp comparison could do.
+ *
+ * The day still starts at midnight in the BROWSER's timezone, and the week on
+ * the local Sunday. That is the device's clock rather than a stored company
+ * setting, so a laptop travelling across a timezone shifts the window with it.
+ */
+function periodDateBounds(
+  period: MetricTimePeriod,
+  offsetPeriods = 0,
+): { start: string; end: string } {
+  const localDate = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+
+  const now = new Date();
+  const start = new Date(now);
+  if (period === 'today') {
+    start.setDate(start.getDate() + offsetPeriods);
+  } else {
+    // getDay() is 0 on Sunday, so this lands on the week's opening Sunday.
+    start.setDate(now.getDate() - now.getDay() + offsetPeriods * 7);
+  }
+  start.setHours(0, 0, 0, 0);
+
+  const end = new Date(start);
+  end.setDate(start.getDate() + (period === 'today' ? 1 : 7));
+
+  return { start: localDate(start), end: localDate(end) };
+}
+
+/** A shipment with enough on it to price what left the building. */
+type ShipmentValueRow = {
+  job_id: string | null;
+  shipment_line_items:
+    | { quantity: number | null; job_parts: { unit_price: number | null } | null }[]
+    | null;
+};
+
+// `jobs!inner(deleted_at)` is a filter, not data: shipments carry no deleted_at
+// of their own (they are voided, not archived), so without the inner join an
+// archived job's shipments keep counting as revenue while every other tile has
+// already dropped that job. Soft-delete standard, CLAUDE.md.
+const SHIPMENT_VALUE_SELECT =
+  'id, job_id, ship_date, jobs!inner(deleted_at), shipment_line_items(quantity, job_parts(unit_price))';
+
+/** What one shipment was worth: each line's shipped quantity at its agreed price. */
+function shipmentValue(row: ShipmentValueRow): number {
+  const lines = row.shipment_line_items ?? [];
+  return lines.reduce((sum, li) => {
+    const price = li.job_parts?.unit_price;
+    if (li.quantity === null || price === null || price === undefined) return sum;
+    return sum + li.quantity * price;
+  }, 0);
+}
+
+/**
+ * Revenue is what SHIPPED, priced per shipped unit, dated by the shipment.
+ *
+ * This used to count whole jobs at their full value, bucketed by
+ * `jobs.updated_at` because no ship date exists on a job — `jobs.shipped_at` is
+ * not in the dual-status model and `job_last_ship_date` is a `(uuid)` function
+ * rather than a column, so PostgREST answers 400 if you select it. That proxy
+ * was wrong in three ways at once, and all three fall out of reading the
+ * shipment instead:
+ *
+ *   * `updated_at` meant "last written", not "shipped". Editing a PO number on a
+ *     job shipped in March pulled it into this week, and rows only ever drifted
+ *     INTO the current window, never out of it.
+ *   * A PARTIAL shipment earned nothing. A job 60% shipped had 60% of its money
+ *     in the customer's hands and contributed $0 here, while its full value sat
+ *     in Open Jobs as backlog.
+ *   * A job counted at its whole value the moment it went `fully_shipped`, even
+ *     if that happened across two months.
+ *
+ * Voided shipments are excluded — that is the point of voiding one.
+ *
+ * The count follows the money: jobs SHIPPED FROM in the window, not jobs that
+ * reached `fully_shipped`. Both halves of the card then describe the same act,
+ * so "6 · $12,480 shipped this week" is one statement rather than two
+ * measurements that happen to share a tile.
+ */
 async function getCompletedInRange(
   companyId: string,
-  startIso: string,
-  endIso: string,
+  startDate: string,
+  endDate: string,
 ): Promise<{ count: number; money: number }> {
   const supabase = getSupabase();
-  // `updated_at` is the in-range proxy: `jobs.shipped_at` does not exist in the
-  // dual-status model, and `job_last_ship_date` is a `(uuid)` function rather
-  // than a jobs-row column, so selecting it as a computed column makes PostgREST
-  // answer 400.
   const { data, error } = await supabase
-    .from('jobs')
-    .select(JOB_VALUE_SELECT)
+    .from('shipments')
+    .select(SHIPMENT_VALUE_SELECT)
     .eq('company_id', companyId)
-    .is('deleted_at', null)
-    .eq('fulfillment_status', 'fully_shipped')
-    .gte('updated_at', startIso)
-    .lt('updated_at', endIso);
+    .is('voided_at', null)
+    .is('jobs.deleted_at', null)
+    .gte('ship_date', startDate)
+    .lt('ship_date', endDate);
 
   if (error) throw error;
 
-  const rows = (data || []) as unknown as JobValueRow[];
-  return {
-    count: rows.length,
-    money: rows.reduce((sum, row) => sum + jobValue(row), 0),
-  };
+  const rows = (data || []) as unknown as ShipmentValueRow[];
+  const jobs = new Set<string>();
+  let money = 0;
+  for (const row of rows) {
+    if (row.job_id) jobs.add(row.job_id);
+    money += shipmentValue(row);
+  }
+  return { count: jobs.size, money };
 }
 
 /**
@@ -278,8 +388,8 @@ export async function getDashboardMetrics(
   companyId: string,
   completedPeriod: MetricTimePeriod,
 ): Promise<Partial<Record<MetricKey, MetricValue>>> {
-  const current = periodBounds(completedPeriod, 0);
-  const previous = periodBounds(completedPeriod, -1);
+  const current = periodDateBounds(completedPeriod, 0);
+  const previous = periodDateBounds(completedPeriod, -1);
 
   const [overdue, openJobs, completedNow, completedPrev, openQuotes] = await Promise.allSettled([
     getOverdueJobs(companyId),

--- a/utils/dashboardAccess.ts
+++ b/utils/dashboardAccess.ts
@@ -70,9 +70,9 @@ export interface MetricDefinition {
 }
 
 export const DASHBOARD_METRICS: readonly MetricDefinition[] = [
-  { key: 'overdue_jobs', label: 'Overdue' },
+  { key: 'overdue_jobs', label: 'Overdue Jobs' },
   { key: 'open_jobs', label: 'Open Jobs' },
-  { key: 'completed_jobs', label: 'Completed', supportsTimePeriod: true },
+  { key: 'completed_jobs', label: 'Completed Jobs', supportsTimePeriod: true },
   { key: 'open_quotes', label: 'Open Quotes' },
 ];
 
@@ -238,7 +238,20 @@ async function getCompletedInRange(
   };
 }
 
-/** Quotes still live. Count only — see `MetricValue.money`. */
+/**
+ * Quotes still live — active AND never converted. Count only, see
+ * `MetricValue.money`.
+ *
+ * `converted_at IS NULL` is the whole fix. `quotes.status` only ever holds
+ * `active | expired`; winning a quote sets `converted_at` and leaves the status
+ * alone, so a quote that became a job stays "active" forever and this tile
+ * counted work already won as pipeline still to win. On the pilot shop it read
+ * 25 when 11 were live; on demo companies it read 9 against 1, because nearly
+ * every demo quote is converted.
+ *
+ * The drill-down goes to `?status=open`, which the quotes list resolves through
+ * the same two conditions — the tile and the list it opens must never disagree.
+ */
 async function getOpenQuotes(companyId: string): Promise<MetricValue> {
   const supabase = getSupabase();
   const { count, error } = await supabase
@@ -246,7 +259,8 @@ async function getOpenQuotes(companyId: string): Promise<MetricValue> {
     .select('*', { count: 'exact', head: true })
     .eq('company_id', companyId)
     .is('deleted_at', null)
-    .eq('status', 'active');
+    .eq('status', 'active')
+    .is('converted_at', null);
 
   if (error) throw error;
   return { count: count || 0, money: null };

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -13,6 +13,7 @@ import type {
   QuoteWithRelations,
   QuoteFormData,
   QuoteFilters,
+  QuoteListStatus,
   QuoteLineItem,
   CompanyMember,
   PricingBasisSnapshot,
@@ -137,6 +138,42 @@ const QUOTE_DETAIL_SELECT = `
 `;
 
 /**
+ * Apply the list's status filter, translating the three questions people ask
+ * into the two columns that answer them.
+ *
+ * `open` and `converted` are not values of `quotes.status` — the column only
+ * holds `active | expired`, and winning a quote sets `converted_at` instead. A
+ * converted quote therefore stays `active` forever, which is why counting
+ * `status = 'active'` overstated the live pipeline everywhere it was done.
+ *
+ * Shared by all three list queries so the page, its count and its CSV export
+ * can never answer differently.
+ */
+function applyQuoteStatusFilter<
+  Q extends {
+    eq(column: string, value: unknown): Q;
+    is(column: string, value: unknown): Q;
+    not(column: string, operator: string, value: unknown): Q;
+  },
+>(query: Q, status: QuoteListStatus | undefined): Q {
+  switch (status) {
+    case undefined:
+    case 'all':
+      return query;
+    case 'open':
+      return query.eq('status', 'active').is('converted_at', null);
+    case 'converted':
+      return query.not('converted_at', 'is', null);
+    default:
+      // Any other value is a raw `quotes.status` and passes straight through.
+      // Deliberately a pass-through rather than an allowlist: an unrecognised
+      // status must not silently widen the query to "everything", which is the
+      // failure mode where a typo returns the whole table and looks like data.
+      return query.eq('status', status);
+  }
+}
+
+/**
  * Get paginated list of quotes for a company
  */
 export async function getQuotes(
@@ -158,7 +195,7 @@ export async function getQuotes(
     .order(sortField, { ascending: sortDirection === 'asc' })
     .range(offset, offset + limit - 1);
 
-  if (filters.status && filters.status !== 'all') query = query.eq('status', filters.status);
+  query = applyQuoteStatusFilter(query, filters.status);
   if (filters.customerId) query = query.eq('customer_id', filters.customerId);
   if (filters.createdBy) query = query.eq('created_by', filters.createdBy);
   if (filters.search?.trim()) {
@@ -208,7 +245,7 @@ export async function getAllQuotes(
       .order(sortField, { ascending: sortDirection === 'asc' })
       .range(offset, offset + BATCH_SIZE - 1);
 
-    if (filters.status && filters.status !== 'all') query = query.eq('status', filters.status);
+    query = applyQuoteStatusFilter(query, filters.status);
     if (filters.customerId) query = query.eq('customer_id', filters.customerId);
     if (filters.createdBy) query = query.eq('created_by', filters.createdBy);
     if (filters.search?.trim()) {
@@ -249,7 +286,7 @@ export async function getQuotesCount(
     .eq('company_id', companyId)
     .is('deleted_at', null);
 
-  if (filters.status && filters.status !== 'all') query = query.eq('status', filters.status);
+  query = applyQuoteStatusFilter(query, filters.status);
   if (filters.customerId) query = query.eq('customer_id', filters.customerId);
   if (filters.search?.trim()) {
     const sanitized = escapeIlikePattern(filters.search.trim());


### PR DESCRIPTION
The two findings left open by #756, the revenue model that came out of the third, the Overdue tone, and the scorecard renames.

## 1. Open Quotes counted work the shop had already won

`quotes.status` holds `active | expired` and nothing else — winning a quote sets `converted_at` and leaves the status alone. So a converted quote stays "active" forever, and the tile counted it as pipeline still to chase.

| Company | Tile showed | Genuinely open |
|---|---|---|
| **Contour Tool & Machine** | 25 | **11** |
| L & L Machine — Demo | 9 | **1** |
| Contour — Demo | 8 | **1** |
| Jigged Usability Sandbox — Demo | 8 | **1** |

Demo companies were worst hit — nearly every demo quote is converted — so a prospect opening a demo saw a pipeline that was almost entirely already-won work.

**Fixing only the tile would have been worse than leaving it.** The quotes list filters the same way, so the two agreed; changing one would have broken that. The list now answers the three questions people actually ask rather than exposing the column:

| | |
|---|---|
| **Open** | `active` AND never converted — what the tile counts |
| **Converted** | `converted_at` set, whatever the status column says |
| **Expired** | lapsed |

"Active" is gone from the dropdown — it's the union of *still chasing it* and *already won it*, which nobody asks for — but stays accepted in the URL so existing links resolve. One shared `applyQuoteStatusFilter` serves the page, its count and its CSV export, so those three can never answer differently. The tile drills through to `?status=open`, the same set by construction.

The status **chip** follows the same words: it said "Active" on a quote that had become a job — the same confusion one layer down — and now reads Converted, or Open.

## 2. `error.main` is not a text colour on a lifted surface

#756 fixed two sites and flagged ~95 unaudited. Measured against each surface **as painted** — sampled from the running app, not derived from the theme, because the cards are translucent over a gradient and a value from `background.default` comes out darker than reality and flatters the result:

| Surface | `error.main` #ef4444 | `error.light` #fca5a5 |
|---|---|---|
| Page canvas | 4.72:1 ✓ | 9.35:1 ✓ |
| Dialog paper | **4.47:1 ✗** | 8.87:1 ✓ |
| Card / paper | **3.70:1 ✗** | 7.33:1 ✓ |
| Alert-tinted card | **2.98:1 ✗** | 5.90:1 ✓ |

It clears the 4.5:1 body floor only on the raw page canvas, where text almost never sits.

**The 95 was mostly noise.** Classified: **15 icons** (non-text, SC 1.4.11 asks 3:1 and 3.70:1 clears it), **9 contained buttons** and **2 filled chips** (white on a red fill — a different calculation, and lightening them would wash out the one affordance that should look dangerous). That leaves **12 text sites, 5 text/outlined button labels and 1 outlined chip** that genuinely fail. Those are fixed; the exemptions are measured, not assumed.

`error.light` passes on *every* surface, so the rule needs no per-site analysis: **`error.light` for text, `error.main` for everything else.** A `MuiButton` override handles text and outlined error buttons automatically; `contained` is deliberately excluded.


## 3. Revenue is what shipped, not what a job is worth

Completed Jobs counted whole jobs at their full value, bucketed by `jobs.updated_at`. There is no ship date on a job to bucket by — `jobs.shipped_at` is not in the dual-status model and `job_last_ship_date` is a `(uuid)` function rather than a column, so PostgREST 400s if you select it. `updated_at` was standing in, and it was wrong three ways:

- **"Last written", not "shipped."** Editing a PO on a job shipped in March pulled it into this week, and rows only ever drifted *into* the window, never out.
- **A partial shipment earned nothing.** A job 60% shipped had 60% of its money in the customer's hands, contributed $0 here, and had its *full* value sitting in Open Jobs as backlog.
- **A job landed at its whole value** the moment it went `fully_shipped`, even if it shipped across two months.

Money is now **shipped quantity × the agreed unit price, dated by `shipments.ship_date`**, voided shipments excluded. The count follows the money — distinct jobs *shipped from* in the window — so both halves of the card describe the same act.

### The double count that came with it

Open Jobs filtered on `production_status` alone, and that axis is independent of fulfillment: a shop that ships without operators closing out operations leaves jobs `not_started` **and** `fully_shipped` at once. On the pilot shop that is **39 jobs, $37,769** of delivered work sitting under the words "not yet shipped" while the same money also counted as revenue.

Open Jobs now excludes fully-shipped and counts only what a job still **owes** — ordered minus already shipped — so a part-shipped job's delivered half is revenue exactly once.

| | before | after |
|---|---|---|
| Open Jobs (pilot shop) | 65 jobs / $85,955 | **26 / $43,987** |

That figure matches an independent "still owed" query. `applyOverdueJobsFilter` always excluded fully-shipped; the rest of the row now agrees with it.

### Two things found while building it

**`ship_date` is a `DATE`,** so the window became a calendar comparison with nothing to smear — the old `updated_at` timestamp could put a Saturday-evening ship into Sunday because the office sits west of UTC. Today still opens at local midnight and the week on the local Sunday, on the **browser's** clock rather than a stored setting, which the docs now say out loud.

**Shipments carry no `deleted_at`** — they are voided, not archived — so an archived job's shipments kept earning revenue after every other tile had dropped the job. Fixed with `jobs!inner(deleted_at)`; a test caught it.

**Known limit, documented:** `job_parts.unit_price` is read live rather than snapshotted per shipment, so repricing a line retrospectively moves historical revenue. A part's price locks once any quantity is invoiced, which covers the case that matters.

## 4. Overdue is amber — behind, not broken

Andon is the convention a shop floor already runs on: green running, amber needs attention, red stopped. Operators read those colours off the machines in front of them, and an overdue job is *behind*, not broken.

Every shop has late jobs. Painting the dashboard red on an ordinary Tuesday spends the loudest signal the interface has on a normal state, and leaves nothing for a genuine failure — a credit hold, a failed sync, a costing gap. Amber for late with red reserved is an escalation ladder; red for everything is not.

A practical bonus, found by rendering it rather than reasoning about it: `rgba(239,68,68,0.08)` over deep indigo goes **muddy purple** — neither red nor navy, and the weakest part of the old card. The amber tint stays neutral.

| on the amber tint, measured as painted rgb(57,62,88) | |
|---|---|
| `warning.main` #f59e0b | **4.89:1** — passes, unlike `error.main` |
| `warning.light` #fbbf24 | **6.28:1** — what ships, on label, count and money |

**Amber's `main` is readable as text where red's is not**, because #ef4444 is unusually dark for its hue — exactly why the rule has to be per-colour and measured rather than assumed. `light` ships anyway: 0.39 above a limit this design system calls hard and measures against a 500–1000 lux shop floor is squeaking past. A test asserts `warning.main` **passes AND is under 5**, so nobody simplifies the light variant away.

`severity` is renamed `'alert'` → `'warning'` to match the palette it now uses.

## 5. The delta sat above the money

The `↑ +246% vs last week` chip rode a few pixels high — measured, not eyeballed: text-run bottoms of 188.1 for the money against 184.2 for the percentage. A nested flex container takes its baseline from its first item, and that item is an SVG arrow with no text baseline, so the browser synthesised one from the icon's bottom edge.

The first fix made it worse in a way the numbers caught — splitting it into separate flex items fixed the baseline but let the row break between "−37%" and "vs last week". Ordinary inline flow fixes both, and all four runs now share a baseline at **0.0px spread**.

## 6. Renames

`Overdue` → **Overdue Jobs**, `Completed` → **Completed Jobs**. Open Jobs and Open Quotes unchanged.

## Verification

- **Nine contrast assertions** computing real WCAG ratios from the theme's own values against all four surfaces — including two that **record what `error.main` measures**, so a future palette change that makes it text-safe fails the test and gets the rule revisited rather than silently outliving it. The icon exemption asserts only on surfaces icons actually appear on, and says why the alert tint is excluded (nothing renders an icon there — put one on and it needs `error.light` too).
- A test pinning that Open Quotes filters on **both** `status='active'` and `converted_at IS NULL`.
- **17 dashboard-metric tests**, including partial shipments, voided shipments, the `ship_date` window, two loads counting as one job, archived-job exclusion and negative-backlog clamping.
- tsc clean, **2554 vitest**, lint 15/17 (unchanged), `next build` clean, E2E run serially (`--workers=1`, the way CI runs it): 31 passed, 2 environmental failures that fail identically on `main`.
- Driven in the browser: Open Quotes reads 12 and drills to `?status=open` with filter and chips both saying "Open"; Completed reads `2 · $9,197`, matching a direct SQL check exactly; Open Jobs moved $80,076 → $68,180 as part-shipped value became revenue.

## Risk worth knowing

**The quotes list's default view is unchanged** (All Statuses), so nobody loses sight of anything — converted quotes are still there, now labelled. The behaviour change is confined to what "Open" means, which previously had no name at all.

One deliberate non-change: `applyQuoteStatusFilter` passes an unrecognised status straight through to `.eq('status', …)` rather than ignoring it. An unknown value must not silently widen the query to "everything" — that's the failure mode where a typo returns the whole table and looks like data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
