### PR TITLE
Preview alias: one stable URL for the newest preview

### DIFF
--- a/.github/workflows/preview-alias.yml
+++ b/.github/workflows/preview-alias.yml
@@ -1,0 +1,94 @@
+# One stable URL for the newest preview, whatever branch produced it.
+#
+# WHY: Intuit matches an OAuth redirect URI EXACTLY, and Vercel's preview URLs
+# carry a per-deployment hash. Every stable URL Vercel offers is branch-scoped —
+# the generated `<project>-git-<branch>-<scope>.vercel.app`, or a domain pinned to
+# one branch in project settings. Both would mean re-registering a URI per branch,
+# or keeping one long-lived branch alive purely to hold a URI — and a long-lived
+# branch holds a Supabase preview branch open for nothing.
+#
+# So: register https://preview.jigged.app/api/quickbooks/callback with Intuit
+# once, and repoint that domain at each new preview as it goes live.
+#
+# `vercel alias` moves a domain onto a deployment Vercel has ALREADY built. This
+# is NOT the CLI-build approach withdrawn in
+# docs/runbooks/database-migrations.md — that failed on build limits, none of
+# which apply to a metadata call.
+#
+# QuickBooks DESKTOP needs none of this: it has no OAuth callback at all. This
+# exists for QuickBooks Online, whose connect flow redirects back to us.
+
+name: Preview Alias
+
+# deployment_status is the only event whose payload carries the real preview URL
+# (environment_url). The commit STATUS Vercel also posts points at the vercel.com
+# dashboard, not at the site, so it cannot drive this.
+#
+# GitHub's docs say deployment_status workflows are read from the default branch
+# only. That is NOT what happened here — this ran on its own PR branch, before it
+# had ever been on main. Trust the Actions tab over either claim.
+on: deployment_status
+
+env:
+  ALIAS_DOMAIN: preview.jigged.app
+
+# Last one in wins, on purpose. When two previews finish together the domain
+# should end up on the NEWER one, so an in-flight alias is cancelled by the
+# deployment that superseded it rather than racing it to the finish.
+#
+# The consequence to know: this domain is shared mutable state. If someone else's
+# preview lands mid-test, an OAuth callback arrives at their build, not yours.
+concurrency:
+  group: preview-alias
+  cancel-in-progress: true
+
+# Touches neither the repo nor the GITHUB_TOKEN — it only calls Vercel.
+permissions: {}
+
+jobs:
+  alias:
+    # Production owns www.jigged.app; pointing the preview domain at a production
+    # deployment would be both wrong and confusing. `state` also filters out the
+    # pending/failure/error statuses that fire for the same deployment.
+    if: >-
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment_status.environment == 'Preview'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Point the preview domain at this deployment
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          # The team ID, never its slug. The slug already changed once — on the
+          # Pro upgrade, adebola-akeredolus-projects became psyco-ghost — which
+          # silently invalidates every URL built from it. The ID does not move.
+          VERCEL_SCOPE: ${{ secrets.VERCEL_ORG_ID }}
+          TARGET_URL: ${{ github.event.deployment_status.environment_url }}
+        # NEVER fails the run, deliberately. This is a convenience alias for
+        # QuickBooks Online OAuth testing, not a correctness gate — and this job
+        # attaches to the commit, so a hard failure paints a red X on every
+        # unrelated PR. A check that is red for a reason nobody needs to act on
+        # is how people learn to ignore red checks. The outcome is reported in
+        # the step summary and as a warning annotation instead.
+        run: |
+          set -uo pipefail
+          if [ -z "${TARGET_URL}" ]; then
+            echo "::warning::deployment_status carried no environment_url; nothing to alias."
+            exit 0
+          fi
+          # Pinned to a major, so an upstream break is one we chose to take.
+          if npx --yes vercel@59 alias set "${TARGET_URL}" "${ALIAS_DOMAIN}" \
+               --token "${VERCEL_TOKEN}" --scope "${VERCEL_SCOPE}"; then
+            echo "${ALIAS_DOMAIN} → ${TARGET_URL}" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            # The expected first failure is certificate issuance, which means DNS
+            # is not answering for the subdomain yet: jigged.app runs on
+            # third-party nameservers, so Vercel cannot create the record itself.
+            #
+            # Deliberately does NOT name a CNAME target. The generic
+            # cname.vercel-dns.com from Vercel's docs is NOT what this project
+            # uses -- it is issued a per-project host, and pasting the generic one
+            # leaves the domain unverifiable while looking correct. Ask Vercel.
+            echo "::warning::Could not point ${ALIAS_DOMAIN} at ${TARGET_URL}. If the log ends at 'Issuing a certificate', DNS is not answering for it yet. Run 'vercel domains verify ${ALIAS_DOMAIN}' for the exact record to create -- the CNAME target is project-specific, not the generic one in Vercel's docs."
+            echo "Alias FAILED — ${ALIAS_DOMAIN} unchanged. See the job log." >> "${GITHUB_STEP_SUMMARY}"
+          fi


### PR DESCRIPTION
Gives `preview.jigged.app` a permanent meaning: **the most recent successful preview deployment, whatever branch produced it.**

Replaces #761, which was cut from a stale local `main` ref and was therefore 68 commits and 7 migrations behind. That — not anything in this file — is what failed its Supabase check (`Remote migration versions not found in local migrations directory`: the preview branch is built from production's schema, and the branch's files were missing migrations production already had). Rebased onto the real `main` and squashed to one commit.

## Why

Intuit matches an OAuth redirect URI **exactly**, and Vercel preview URLs carry a per-deployment hash. Every stable URL Vercel offers is branch-scoped — the generated `<project>-git-<branch>-<scope>` host, or a domain pinned to one branch. Both mean re-registering a URI per branch, or keeping a long-lived branch alive purely to hold one, which would also hold a Supabase preview branch open indefinitely.

With this, `https://preview.jigged.app/api/quickbooks/callback` is registered once and never touched again.

## It reports, it does not gate

The job attaches to the commit, so failing hard would paint a red X on every unrelated PR whenever the alias couldn't be set. This is developer convenience, not correctness. Outcome goes to the step summary and a warning annotation.

**The trade to know: green means the job ran, not that the alias took.**

## Verified end to end before this PR

Certificate issued, alias created, `https://preview.jigged.app` serving **HTTP 200**, and the `alias` job green on a real run against live DNS.

Two things that only running it revealed, both now recorded in the file:

- `--scope` takes the **team ID**, not the slug — verified against the live CLI. The slug already changed once (`adebola-akeredolus-projects` → `psyco-ghost` on the Pro upgrade), silently invalidating every URL built from it.
- The failure warning deliberately **does not name a CNAME target**. Vercel's generic `cname.vercel-dns.com` is not what this project uses — it's issued a per-project host, and pasting the generic one leaves the domain unverifiable while looking correct on the DNS provider's screen.

## Shared mutable state

`cancel-in-progress: true` means the newest deployment wins, which is right. But if a colleague's preview lands mid-test, an OAuth callback arrives at their build. Invisible solo, a real trap with a team.

## Still to do outside this PR

`QUICKBOOKS_REDIRECT_URI` is set in Preview scope and `APP_BASE_URL` has been added, but the redirect URI still needs registering with Intuit before QBO OAuth completes on a preview.

Independent of #760 by design — QuickBooks Desktop has no OAuth callback and needs none of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)