### PR TITLE
Fix: QuickBooks Desktop panel now says what it is waiting for

### DIFF
--- a/__tests__/components/settings/quickbooks/QuickBooksDesktopPanel.test.tsx
+++ b/__tests__/components/settings/quickbooks/QuickBooksDesktopPanel.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '../../../test-utils';
+import userEvent from '@testing-library/user-event';
+import QuickBooksDesktopPanel from '@/components/settings/quickbooks/QuickBooksDesktopPanel';
+
+/**
+ * Every button here is a Web Connector round trip to the shop's own PC —
+ * ~0.5s warm, 3-10s cold, and far longer if QuickBooks was closed. A button that
+ * merely greys out for that long reads as broken, which is exactly how a shop
+ * reported it. These tests pin the feedback, not the fetching.
+ */
+
+const getStatus = vi.hoisted(() => vi.fn());
+const listAccounts = vi.hoisted(() => vi.fn());
+const setIncomeAccount = vi.hoisted(() => vi.fn());
+const testConnection = vi.hoisted(() => vi.fn());
+
+vi.mock('@/utils/quickbooksDesktop', () => ({
+  getQuickBooksDesktopStatus: (...a: unknown[]) => getStatus(...a),
+  listQuickBooksDesktopAccounts: (...a: unknown[]) => listAccounts(...a),
+  setQuickBooksDesktopIncomeAccount: (...a: unknown[]) => setIncomeAccount(...a),
+  testQuickBooksDesktop: (...a: unknown[]) => testConnection(...a),
+  disconnectQuickBooksDesktop: vi.fn(),
+}));
+vi.mock('posthog-js', () => ({ default: { capture: vi.fn() } }));
+
+const STATUS = {
+  connected: true,
+  linked: true,
+  qb_company_name: 'Rock Castle Construction',
+  last_successful_request_at: '2026-08-16T00:00:00Z',
+  needs_income_account: true,
+};
+
+/** A promise we control, so the in-flight state can actually be observed. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getStatus.mockResolvedValue(STATUS);
+  setIncomeAccount.mockResolvedValue(undefined);
+});
+
+describe('QuickBooksDesktopPanel — waiting on the shop PC', () => {
+  it('says it is reading accounts, and where from, while the round trip is in flight', async () => {
+    const d = deferred<{ accounts: { id: string; full_name: string }[] }>();
+    listAccounts.mockReturnValue(d.promise);
+
+    render(<QuickBooksDesktopPanel companyId="c1" onDisconnected={vi.fn()} />);
+    await userEvent.click(await screen.findByRole('button', { name: /choose account/i }));
+
+    expect(await screen.findByRole('button', { name: /reading accounts/i })).toBeInTheDocument();
+    // Naming the shop computer is the part that stops the pause reading as a fault.
+    expect(screen.getByText(/on the shop computer/i)).toBeInTheDocument();
+
+    d.resolve({ accounts: [{ id: '1', full_name: 'Sales' }, { id: '2', full_name: 'Services' }] });
+    await waitFor(() => expect(screen.queryByText(/on the shop computer/i)).not.toBeInTheDocument());
+  });
+
+  it('says it is asking QuickBooks while Test connection is in flight', async () => {
+    const d = deferred<{ ok: boolean; code: string | null; message: string | null }>();
+    testConnection.mockReturnValue(d.promise);
+
+    render(<QuickBooksDesktopPanel companyId="c1" onDisconnected={vi.fn()} />);
+    await userEvent.click(await screen.findByRole('button', { name: /test connection/i }));
+
+    expect(await screen.findByRole('button', { name: /asking quickbooks/i })).toBeInTheDocument();
+
+    d.resolve({ ok: true, code: null, message: null });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /test connection/i })).toBeInTheDocument(),
+    );
+  });
+
+  it('only the pressed button reports progress, not every disabled one', async () => {
+    const d = deferred<{ accounts: never[] }>();
+    listAccounts.mockReturnValue(d.promise);
+
+    render(<QuickBooksDesktopPanel companyId="c1" onDisconnected={vi.fn()} />);
+    await userEvent.click(await screen.findByRole('button', { name: /choose account/i }));
+
+    // Test connection is disabled meanwhile, but must not claim to be working.
+    const test = screen.getByRole('button', { name: /test connection/i });
+    expect(test).toBeDisabled();
+    expect(test).not.toHaveTextContent(/asking quickbooks/i);
+
+    d.resolve({ accounts: [] });
+  });
+});

--- a/components/settings/quickbooks/QuickBooksDesktopPanel.tsx
+++ b/components/settings/quickbooks/QuickBooksDesktopPanel.tsx
@@ -57,9 +57,19 @@ export default function QuickBooksDesktopPanel({
   const [unreachableCode, setUnreachableCode] = useState<string | null>(null);
   const [note, setNote] = useState<string | null>(null);
   const [accounts, setAccounts] = useState<DesktopIncomeAccount[] | null>(null);
+  /**
+   * WHICH action is in flight, not merely THAT one is. Every button on this
+   * panel is a Web Connector round trip to the shop's PC: ~0.5s warm, 3-10s
+   * cold, and up to ~30s more when QuickBooks was closed. `busy` alone only
+   * greys every button out, so the one you pressed sits there looking dead for
+   * seconds -- which a shop reported as "something is wrong". Naming the action
+   * lets the pressed button, and only that button, say what it is waiting for.
+   */
+  const [pending, setPending] = useState<null | 'test' | 'accounts'>(null);
 
   const handleTest = async () => {
     setBusy(true);
+    setPending('test');
     setUnreachable(null);
     setNote(null);
     const started = Date.now();
@@ -81,11 +91,13 @@ export default function QuickBooksDesktopPanel({
       setUnreachable(err instanceof Error ? err.message : null);
     } finally {
       setBusy(false);
+      setPending(null);
     }
   };
 
   const handleLoadAccounts = async () => {
     setBusy(true);
+    setPending('accounts');
     setUnreachable(null);
     try {
       const { accounts: rows } = await listQuickBooksDesktopAccounts(companyId);
@@ -98,6 +110,7 @@ export default function QuickBooksDesktopPanel({
       setUnreachable(err instanceof Error ? err.message : null);
     } finally {
       setBusy(false);
+      setPending(null);
     }
   };
 
@@ -180,8 +193,15 @@ export default function QuickBooksDesktopPanel({
               ).toLocaleString()}.`
             : 'Not yet used.'}
         </Typography>
-        <Button size="small" onClick={handleTest} disabled={busy}>
-          Test connection
+        <Button
+          size="small"
+          onClick={handleTest}
+          disabled={busy}
+          startIcon={
+            pending === 'test' ? <CircularProgress size={14} color="inherit" /> : undefined
+          }
+        >
+          {pending === 'test' ? 'Asking QuickBooks…' : 'Test connection'}
         </Button>
       </Stack>
 
@@ -216,14 +236,42 @@ export default function QuickBooksDesktopPanel({
               : 'Done. Change it any time.'}
           </Typography>
           {accounts === null ? (
-            <Button
-              variant={status.needs_income_account ? 'contained' : 'outlined'}
-              size="small"
-              onClick={handleLoadAccounts}
-              disabled={busy}
-            >
-              {status.needs_income_account ? 'Choose account' : 'Change account'}
-            </Button>
+            <>
+              <Button
+                variant={status.needs_income_account ? 'contained' : 'outlined'}
+                size="small"
+                onClick={handleLoadAccounts}
+                disabled={busy}
+                startIcon={
+                  pending === 'accounts' ? (
+                    <CircularProgress size={14} color="inherit" />
+                  ) : undefined
+                }
+              >
+                {pending === 'accounts'
+                  ? 'Reading accounts…'
+                  : status.needs_income_account
+                    ? 'Choose account'
+                    : 'Change account'}
+              </Button>
+              {/* Says WHERE the wait is, not just that there is one. The round
+                  trip is to the shop's PC, so "a few seconds" is normal and a
+                  closed QuickBooks makes it much longer -- naming that is what
+                  stops the pause reading as a fault. aria-live because the text
+                  appears after the press, not with it. */}
+              {pending === 'accounts' && (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  display="block"
+                  sx={{ mt: 1 }}
+                  aria-live="polite"
+                >
+                  Reading your accounts from QuickBooks on the shop computer. This takes a few
+                  seconds, and longer if QuickBooks was closed.
+                </Typography>
+              )}
+            </>
           ) : (
             <TextField
               select


### PR DESCRIPTION
Reported from production: after connecting, **"Choose account" sits static for several seconds** and reads as broken.

## Cause

The button was only `disabled={busy}` — no spinner, no label change — across a Web Connector round trip to the shop's own PC. Measured latency for that path: **~0.5s warm, 3–10s cold, and far longer if QuickBooks was closed.** Several seconds of a greyed-out button with no explanation is indistinguishable from a hang.

**Test connection had the identical flaw** two lines above it, so both are fixed rather than only the one that got noticed.

## Fix

`busy` records *that* something is in flight — enough to disable every button, not enough to explain any of them. A new `pending` records *which* action, so the pressed button (and only the pressed button) shows a spinner and says what it's waiting for.

That distinction matters: a neighbouring button that greys out *and* claims to be working would be a worse lie than saying nothing.

The caption names the shop computer rather than saying "loading":

> Reading your accounts from QuickBooks on the shop computer. This takes a few seconds, and longer if QuickBooks was closed.

The wait is normal, its cause is a machine somewhere else, and naming that is what stops the pause reading as a fault. `aria-live` because it appears after the press, not with it.

## Tests

First tests for this panel. They drive **deferred promises** so the in-flight state is genuinely observable rather than inferred, and one asserts the *unpressed* button stays quiet while disabled.

13 tests across the two QuickBooks Desktop components · tsc clean · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)