### PR TITLE
Fix: connect buttons now say what they are waiting for

### DIFF
--- a/__tests__/components/settings/QuickBooksIntegrationCard.test.tsx
+++ b/__tests__/components/settings/QuickBooksIntegrationCard.test.tsx
@@ -7,10 +7,11 @@ import type { QuickBooksStatus, QuickBooksPoField } from '@/utils/quickbooksAcce
 
 const mockGetStatus = vi.fn();
 const mockRefreshPoField = vi.fn();
+const mockStartConnect = vi.hoisted(() => vi.fn());
 
 vi.mock('@/utils/quickbooksAccess', () => ({
   getQuickBooksStatus: (...args: unknown[]) => mockGetStatus(...args),
-  startQuickBooksConnect: vi.fn(),
+  startQuickBooksConnect: (...args: unknown[]) => mockStartConnect(...args),
   disconnectQuickBooks: vi.fn(),
   refreshQuickBooksPoField: (...args: unknown[]) => mockRefreshPoField(...args),
 }));
@@ -21,9 +22,10 @@ vi.mock('@/hooks/useCompanyFeatures', () => ({
 }));
 
 const mockGetDesktopStatus = vi.fn();
+const mockStartDesktopConnect = vi.hoisted(() => vi.fn());
 vi.mock('@/utils/quickbooksDesktop', () => ({
   getQuickBooksDesktopStatus: (...args: unknown[]) => mockGetDesktopStatus(...args),
-  startQuickBooksDesktopConnect: vi.fn(),
+  startQuickBooksDesktopConnect: (...args: unknown[]) => mockStartDesktopConnect(...args),
   testQuickBooksDesktop: vi.fn(),
   disconnectQuickBooksDesktop: vi.fn(),
   listQuickBooksDesktopAccounts: vi.fn(),
@@ -176,5 +178,77 @@ describe('QuickBooksIntegrationCard — customer PO field', () => {
     ).not.toBeInTheDocument();
     // And it must not assert a status it never learned.
     expect(screen.queryByText(/Not connected/i)).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Both connects are multi-second — QuickBooks Online round-trips our API for an
+ * Intuit authorize URL before navigating away, and Desktop makes two Conductor
+ * calls. A button that only greys out for that long reads as a dropped click,
+ * which is what a shop reported about the panel's buttons.
+ */
+describe('QuickBooksIntegrationCard — connecting', () => {
+  const user = userEvent.setup();
+
+  /** A promise we control, so the in-flight state can actually be observed. */
+  function deferred<T>() {
+    let resolve!: (v: T) => void;
+    const promise = new Promise<T>((r) => (resolve = r));
+    return { promise, resolve };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetRouterMocks();
+    // Not connected to either, so the provider choice renders.
+    mockGetStatus.mockResolvedValue({
+      connected: false,
+      environment: 'sandbox',
+      qb_company_name: null,
+      reconnect_required: false,
+      connected_at: null,
+    });
+    mockGetDesktopStatus.mockResolvedValue({ connected: false, linked: false });
+    mockFeatures.mockReturnValue({ quickbooks_desktop: true });
+  });
+
+  it('says it is creating the setup link while Desktop connect is in flight', async () => {
+    const d = deferred<{ auth_flow_url: string; expires_at: string }>();
+    mockStartDesktopConnect.mockReturnValue(d.promise);
+
+    render(<QuickBooksIntegrationCard companyId="c1" />);
+    await user.click(await screen.findByRole('button', { name: /connect quickbooks desktop/i }));
+
+    expect(await screen.findByRole('button', { name: /creating setup link/i })).toBeInTheDocument();
+    // The other card is disabled meanwhile, but must not claim to be working.
+    const online = screen.getByRole('button', { name: /connect quickbooks online/i });
+    expect(online).toBeDisabled();
+    expect(online).not.toHaveTextContent(/opening quickbooks/i);
+
+    d.resolve({ auth_flow_url: 'https://connect.conductor.is/qbd/x', expires_at: null as never });
+  });
+
+  it('says it is opening QuickBooks while the Online connect is in flight', async () => {
+    const d = deferred<string>();
+    mockStartConnect.mockReturnValue(d.promise);
+
+    render(<QuickBooksIntegrationCard companyId="c1" />);
+    await user.click(await screen.findByRole('button', { name: /connect quickbooks online/i }));
+
+    expect(await screen.findByRole('button', { name: /opening quickbooks/i })).toBeInTheDocument();
+    d.resolve('https://appcenter.intuit.com/connect/oauth2?x=1');
+  });
+
+  it('restores the button when starting the connection fails', async () => {
+    mockStartDesktopConnect.mockRejectedValue(new Error('Conductor is unavailable'));
+
+    render(<QuickBooksIntegrationCard companyId="c1" />);
+    await user.click(await screen.findByRole('button', { name: /connect quickbooks desktop/i }));
+
+    // A spinner left running after a failure is how a retry becomes impossible.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /connect quickbooks desktop/i })).toBeEnabled(),
+    );
+    expect(await screen.findByText(/Conductor is unavailable/i)).toBeInTheDocument();
   });
 });

--- a/components/settings/QuickBooksIntegrationCard.tsx
+++ b/components/settings/QuickBooksIntegrationCard.tsx
@@ -69,6 +69,13 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
   const [statusFailed, setStatusFailed] = useState(false);
   const [desktop, setDesktop] = useState<DesktopStatus | null>(null);
   const [pendingLink, setPendingLink] = useState<DesktopLink | null>(null);
+  /** WHICH provider is being connected, not merely that something is. Both
+   *  connects are multi-second: QuickBooks Online round-trips our API for an
+   *  Intuit authorize URL and then navigates away, and Desktop makes two
+   *  Conductor calls (create the end user, mint an auth session). `busy` only
+   *  greys both cards out, which reads as a dead button rather than work in
+   *  progress -- the same complaint raised about the panel's buttons. */
+  const [connecting, setConnecting] = useState<null | 'qbo' | 'qbd'>(null);
 
   const handleCheckPoField = async () => {
     setError(null);
@@ -152,13 +159,18 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
   const handleConnect = async () => {
     setError(null);
     setBusy(true);
+    setConnecting('qbo');
     posthog.capture('accounting connect started', { provider: 'qbo' });
     try {
       const url = await startQuickBooksConnect(companyId);
+      // Deliberately does NOT clear the spinner: the browser is leaving for
+      // Intuit, and a button that goes idle during that hand-off looks like the
+      // click was dropped.
       window.location.href = url;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not start the QuickBooks connection.');
       setBusy(false);
+      setConnecting(null);
     }
   };
 
@@ -199,6 +211,7 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
   const handleConnectDesktop = async () => {
     setError(null);
     setBusy(true);
+    setConnecting('qbd');
     posthog.capture('accounting connect started', { provider: 'qbd' });
     try {
       setPendingLink(await startQuickBooksDesktopConnect(companyId));
@@ -208,6 +221,7 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
       );
     } finally {
       setBusy(false);
+      setConnecting(null);
     }
   };
 
@@ -300,16 +314,20 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
                 title="QuickBooks Online"
                 detail="You open QuickBooks in a web browser and sign in at qbo.intuit.com."
                 actionLabel="Connect QuickBooks Online"
+                pendingLabel="Opening QuickBooks…"
                 onConnect={handleConnect}
                 busy={busy}
+                pending={connecting === 'qbo'}
               />
               {desktopEnabled && (
               <ProviderOption
                 title="QuickBooks Desktop"
                 detail="QuickBooks is installed on a computer in the shop — Pro, Premier or Enterprise."
                 actionLabel="Connect QuickBooks Desktop"
+                pendingLabel="Creating setup link…"
                 onConnect={handleConnectDesktop}
                 busy={busy}
+                pending={connecting === 'qbd'}
               />
               )}
             </Stack>
@@ -422,14 +440,24 @@ function ProviderOption({
   title,
   detail,
   actionLabel,
+  pendingLabel,
   onConnect,
   busy,
+  pending,
 }: {
   title: string;
   detail: string;
   actionLabel: string;
+  /** What this button is actually waiting for. The two providers wait on
+   *  different things, so a shared "Connecting…" would be vague for one of them
+   *  and wrong for the other — Desktop is not connecting to anything yet, it is
+   *  minting a setup link. */
+  pendingLabel: string;
   onConnect: () => void;
   busy?: boolean;
+  /** THIS button is the one working. `busy` disables both, so without this the
+   *  unpressed card would also claim to be doing something. */
+  pending?: boolean;
 }) {
   return (
     <Card variant="outlined" sx={{ flex: 1, p: 2 }}>
@@ -439,8 +467,13 @@ function ProviderOption({
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
         {detail}
       </Typography>
-      <Button variant="contained" onClick={onConnect} disabled={busy}>
-        {actionLabel}
+      <Button
+        variant="contained"
+        onClick={onConnect}
+        disabled={busy}
+        startIcon={pending ? <CircularProgress size={16} color="inherit" /> : undefined}
+      >
+        {pending ? pendingLabel : actionLabel}
       </Button>
     </Card>
   );


### PR DESCRIPTION
Same complaint as #765, one screen earlier: **"Connect QuickBooks Online"** and **"Connect QuickBooks Desktop"** sit static for several seconds.

## Cause

Both were `disabled={busy}` with a static label, across waits that aren't short:

- **Online** round-trips our API for an Intuit authorize URL, then navigates away
- **Desktop** makes *two* Conductor calls — create the end user, mint an auth session

## Fix

`busy` records *that* something is in flight — it disables both cards and explains neither. A `connecting` discriminator records *which*, so the pressed button alone shows a spinner. The unpressed card greying out **and** claiming to work would be a worse lie than silence, and a test pins that.

The two labels differ because the two waits differ:

| Button | While working |
|---|---|
| Connect QuickBooks Online | *Opening QuickBooks…* |
| Connect QuickBooks Desktop | *Creating setup link…* |

Desktop isn't connecting to anything yet — it's minting a setup link — so a shared "Connecting…" would be vague for one and wrong for the other.

## One asymmetry worth knowing

The Online path **deliberately does not clear the spinner on success**: the browser is leaving for Intuit, and a button that goes idle during that hand-off looks like the click was dropped. It *does* clear on failure, where the opposite holds — a spinner left running after an error is how a retry becomes impossible. The third test covers exactly that.

## Tests

Three new cases driving deferred promises so the in-flight state is genuinely observed. 12 tests in this file, 38 across settings · tsc clean · lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)