### PR TITLE
Codify waiting: interaction-standards §5, BusyButton, and a scoped check

### DIFF
--- a/__tests__/components/common/BusyButton.test.tsx
+++ b/__tests__/components/common/BusyButton.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import BusyButton from '@/components/common/BusyButton';
+
+/**
+ * The shared control behind docs/interaction-standards.md §5. Its job is to make
+ * the rule unforgettable rather than merely documented: `pendingLabel` is a
+ * required prop, so a busy button cannot be shipped silent.
+ */
+describe('BusyButton', () => {
+  it('shows its own label at rest', () => {
+    render(<BusyButton pendingLabel="Asking QuickBooks…">Test connection</BusyButton>);
+    expect(screen.getByRole('button', { name: 'Test connection' })).toBeInTheDocument();
+  });
+
+  it('names what it is waiting for while pending', () => {
+    render(
+      <BusyButton pending pendingLabel="Asking QuickBooks…">
+        Test connection
+      </BusyButton>,
+    );
+    // "Loading…" would hide the one fact that makes a long pause legible.
+    expect(screen.getByRole('button', { name: /asking quickbooks/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Test connection' })).not.toBeInTheDocument();
+  });
+
+  it('marks itself busy for assistive tech', () => {
+    render(
+      <BusyButton pending pendingLabel="Working…">
+        Go
+      </BusyButton>,
+    );
+    expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('does not claim to be busy at rest', () => {
+    render(<BusyButton pendingLabel="Working…">Go</BusyButton>);
+    expect(screen.getByRole('button')).not.toHaveAttribute('aria-busy');
+  });
+
+  /**
+   * WCAG 2.2 SC 4.1.3 (AA): a status message must be programmatically
+   * determinable WITHOUT receiving focus. The detail appears after the press, so
+   * it has to be announced rather than read on a focus the user does not have.
+   */
+  it('announces the detail in a live region, and only while pending', () => {
+    const { rerender } = render(
+      <BusyButton pendingLabel="Reading accounts…" pendingDetail="Reading from the shop computer.">
+        Choose account
+      </BusyButton>,
+    );
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    rerender(
+      <BusyButton
+        pending
+        pendingLabel="Reading accounts…"
+        pendingDetail="Reading from the shop computer."
+      >
+        Choose account
+      </BusyButton>,
+    );
+    expect(screen.getByRole('status')).toHaveTextContent(/reading from the shop computer/i);
+  });
+
+  it('still fires onClick, and respects disabled', async () => {
+    const onClick = vi.fn();
+    const { rerender } = render(
+      <BusyButton pendingLabel="Working…" onClick={onClick}>
+        Go
+      </BusyButton>,
+    );
+    await userEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <BusyButton pendingLabel="Working…" onClick={onClick} disabled>
+        Go
+      </BusyButton>,
+    );
+    // MUI sets pointer-events:none when disabled, which userEvent refuses to
+    // click outright — so assert the state rather than staging a click that the
+    // test library would reject before the component ever saw it.
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/standards/interactionStandards.test.ts
+++ b/__tests__/standards/interactionStandards.test.ts
@@ -6,6 +6,7 @@ import {
   findGreyDeleteViolations,
   findButtonColorViolations,
   scanProject,
+  findSilentBusyButtonViolations,
 } from '../../scripts/interactionStandardsCheck';
 
 const REPO_ROOT = path.resolve(__dirname, '../..');
@@ -110,5 +111,39 @@ describe('interactionStandardsCheck — repo is clean', () => {
     const violations = scanProject(REPO_ROOT);
     const formatted = violations.map((v) => `${v.file}:${v.line} [${v.rule}] ${v.message}`).join('\n');
     expect(formatted, formatted).toBe('');
+  });
+});
+
+describe('silent busy buttons (§5)', () => {
+  const QB = 'components/settings/quickbooks/Thing.tsx';
+
+  it('flags a busy-disabled Button on a QuickBooks surface', () => {
+    const src = `<Button onClick={handleTest} disabled={busy}>Test connection</Button>`;
+    const v = findSilentBusyButtonViolations(src, QB);
+    expect(v).toHaveLength(1);
+    expect(v[0].rule).toBe('silent-busy-button');
+  });
+
+  it('accepts BusyButton, which is the fix', () => {
+    const src = `<BusyButton onClick={handleTest} disabled={busy} pendingLabel="Asking…">Test</BusyButton>`;
+    expect(findSilentBusyButtonViolations(src, QB)).toEqual([]);
+  });
+
+  // The rule must not creep into the ~260 sub-second sites it deliberately skips.
+  it('ignores the same pattern away from an integration surface', () => {
+    const src = `<Button onClick={handleSave} disabled={saving}>Save</Button>`;
+    expect(findSilentBusyButtonViolations(src, 'components/parts/PartForm.tsx')).toEqual([]);
+  });
+
+  // §4's business, not §5's: an action that is genuinely unavailable stays
+  // disabled-and-explained, and must never grow a spinner.
+  it('ignores a disable that is not a busy flag', () => {
+    const src = `<Button onClick={handleSend} disabled={!canSend}>Send</Button>`;
+    expect(findSilentBusyButtonViolations(src, QB)).toEqual([]);
+  });
+
+  it('ignores a button that only opens a dialog', () => {
+    const src = `<Button onClick={() => setDisconnectOpen(true)} disabled={busy}>Disconnect</Button>`;
+    expect(findSilentBusyButtonViolations(src, QB)).toEqual([]);
   });
 });

--- a/components/common/BusyButton.tsx
+++ b/components/common/BusyButton.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Button, { type ButtonProps } from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
+
+/**
+ * A button that says what it is waiting for.
+ *
+ * WHY THIS EXISTS. Three separate bug reports from a live shop, all the same
+ * shape: a button that only greys out during a multi-second round trip reads as
+ * a dropped click. `disabled` alone is not feedback — docs/interaction-standards
+ * §4 already said a disabled control needs a visible reason, and a busy button is
+ * exactly a disabled control with no reason given.
+ *
+ * WHEN TO USE IT. Only above ~1 second. Below that a spinner is noise, not help:
+ * Nielsen's limits put 0.1s at "instantaneous" and 1s at "flow of thought
+ * uninterrupted", with no feedback warranted under either. In this codebase that
+ * means Supabase CRUD stays a plain <Button>, and anything crossing to a third
+ * party — Conductor's Web Connector, Intuit, Stripe, Anthropic, FedEx — uses this.
+ * The full rule, including the >10s case, is docs/interaction-standards.md §5.
+ *
+ * WHAT IT GUARANTEES, each learned from one of those bugs:
+ *
+ *   ONLY THE PRESSED CONTROL SPEAKS. `pending` is per-button, never a shared
+ *   `busy`. A neighbour that greys out AND claims to be working is a worse lie
+ *   than silence, so callers pass `disabled={busy} pending={which === 'mine'}`.
+ *
+ *   THE LABEL NAMES THE WAIT. `pendingLabel` is required, not optional, because
+ *   "Loading…" hides the only fact that makes a long pause make sense — what is
+ *   being waited on. "Creating setup link…" and "Reading accounts…" are the
+ *   shipped examples.
+ *
+ *   ASSISTIVE TECH IS TOLD. `aria-busy` marks the control, and `pendingDetail`
+ *   renders in a role="status" live region. WCAG 2.2 SC 4.1.3 (Level AA) covers
+ *   exactly this — status messages "on the waiting state of an application, on
+ *   the progress of a process" must be programmatically determinable without
+ *   taking focus. A silent spinner is an AA gap, not a style choice.
+ *
+ * Not handled here, because it is a caller's judgment: whether to clear `pending`
+ * on success. A hand-off that navigates away should KEEP spinning (an idle button
+ * mid-redirect looks like the click was lost); everything else clears. Both must
+ * clear on failure, or retrying becomes impossible.
+ */
+export default function BusyButton({
+  pending,
+  pendingLabel,
+  pendingDetail,
+  children,
+  disabled,
+  startIcon,
+  ...rest
+}: Omit<ButtonProps, 'startIcon'> & {
+  /** True only for the control the user actually pressed. */
+  pending?: boolean;
+  /** What this button is waiting for — shown in place of the label. */
+  pendingLabel: string;
+  /** Optional line under the button for waits that can exceed ~10s: say WHERE
+   *  the wait is and that it may run long. Announced politely. */
+  pendingDetail?: string;
+  startIcon?: ButtonProps['startIcon'];
+}) {
+  const button = (
+    <Button
+      {...rest}
+      disabled={disabled}
+      aria-busy={pending || undefined}
+      startIcon={pending ? <CircularProgress size={16} color="inherit" /> : startIcon}
+    >
+      {pending ? pendingLabel : children}
+    </Button>
+  );
+
+  if (!pendingDetail) return button;
+
+  return (
+    <Box>
+      {button}
+      {/* Rendered only while pending, inside a live region, so it is announced
+          when it appears rather than read on focus the user does not have. */}
+      {pending && (
+        <Typography
+          role="status"
+          variant="caption"
+          color="text.secondary"
+          display="block"
+          sx={{ mt: 1 }}
+        >
+          {pendingDetail}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/components/quickbooks/QuickBooksUnreachableAlert.tsx
+++ b/components/quickbooks/QuickBooksUnreachableAlert.tsx
@@ -2,7 +2,7 @@
 
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
-import Button from '@mui/material/Button';
+import BusyButton from '@/components/common/BusyButton';
 
 /**
  * QuickBooks Desktop is not answering right now.
@@ -20,6 +20,7 @@ export default function QuickBooksUnreachableAlert({
   code,
   onRetry,
   busy,
+  retrying,
   sx,
 }: {
   /** Conductor's own userFacingMessage when we have one — it names the shop PC
@@ -31,6 +32,10 @@ export default function QuickBooksUnreachableAlert({
   code?: string | null;
   onRetry?: () => void;
   busy?: boolean;
+  /** True only while THIS retry is the work in flight. Distinct from `busy`,
+   *  which is true for any of the surface's actions — a retry button that spins
+   *  because something else is running would be reporting someone else's work. */
+  retrying?: boolean;
   sx?: object;
 }) {
   const notSetUp = code === 'qbd_not_connected';
@@ -40,9 +45,16 @@ export default function QuickBooksUnreachableAlert({
       sx={{ mb: 2, ...sx }}
       action={
         onRetry ? (
-          <Button color="inherit" size="small" onClick={onRetry} disabled={busy}>
+          <BusyButton
+            color="inherit"
+            size="small"
+            onClick={onRetry}
+            disabled={busy}
+            pending={retrying}
+            pendingLabel="Asking QuickBooks…"
+          >
             Try again
-          </Button>
+          </BusyButton>
         ) : undefined
       }
     >

--- a/components/settings/QuickBooksIntegrationCard.tsx
+++ b/components/settings/QuickBooksIntegrationCard.tsx
@@ -29,6 +29,7 @@ import SettingsSection from '@/components/settings/SettingsSection';
 import { useCompanyFeatures } from '@/hooks/useCompanyFeatures';
 import DesktopAuthHandoff from '@/components/settings/quickbooks/DesktopAuthHandoff';
 import QuickBooksDesktopPanel from '@/components/settings/quickbooks/QuickBooksDesktopPanel';
+import BusyButton from '@/components/common/BusyButton';
 import LoadFailedState from '@/components/common/LoadFailedState';
 import posthog from 'posthog-js';
 import {
@@ -75,11 +76,12 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
    *  Conductor calls (create the end user, mint an auth session). `busy` only
    *  greys both cards out, which reads as a dead button rather than work in
    *  progress -- the same complaint raised about the panel's buttons. */
-  const [connecting, setConnecting] = useState<null | 'qbo' | 'qbd'>(null);
+  const [pending, setPending] = useState<null | 'qbo' | 'qbd' | 'po-field'>(null);
 
   const handleCheckPoField = async () => {
     setError(null);
     setBusy(true);
+    setPending('po-field');
     try {
       const found = await refreshQuickBooksPoField(companyId);
       setPoField(found);
@@ -92,6 +94,7 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
       setError(err instanceof Error ? err.message : 'Could not read QuickBooks settings.');
     } finally {
       setBusy(false);
+      setPending(null);
     }
   };
 
@@ -159,7 +162,7 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
   const handleConnect = async () => {
     setError(null);
     setBusy(true);
-    setConnecting('qbo');
+    setPending('qbo');
     posthog.capture('accounting connect started', { provider: 'qbo' });
     try {
       const url = await startQuickBooksConnect(companyId);
@@ -170,7 +173,7 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not start the QuickBooks connection.');
       setBusy(false);
-      setConnecting(null);
+      setPending(null);
     }
   };
 
@@ -211,7 +214,7 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
   const handleConnectDesktop = async () => {
     setError(null);
     setBusy(true);
-    setConnecting('qbd');
+    setPending('qbd');
     posthog.capture('accounting connect started', { provider: 'qbd' });
     try {
       setPendingLink(await startQuickBooksDesktopConnect(companyId));
@@ -221,7 +224,7 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
       );
     } finally {
       setBusy(false);
-      setConnecting(null);
+      setPending(null);
     }
   };
 
@@ -317,7 +320,7 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
                 pendingLabel="Opening QuickBooks…"
                 onConnect={handleConnect}
                 busy={busy}
-                pending={connecting === 'qbo'}
+                pending={pending === 'qbo'}
               />
               {desktopEnabled && (
               <ProviderOption
@@ -327,7 +330,7 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
                 pendingLabel="Creating setup link…"
                 onConnect={handleConnectDesktop}
                 busy={busy}
-                pending={connecting === 'qbd'}
+                pending={pending === 'qbd'}
               />
               )}
             </Stack>
@@ -339,9 +342,16 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
                 severity="warning"
                 sx={{ mb: 2 }}
                 action={
-                  <Button color="inherit" size="small" onClick={handleConnect} disabled={busy}>
+                  <BusyButton
+                    color="inherit"
+                    size="small"
+                    onClick={handleConnect}
+                    disabled={busy}
+                    pending={pending === 'qbo'}
+                    pendingLabel="Opening QuickBooks…"
+                  >
                     Reconnect
-                  </Button>
+                  </BusyButton>
                 }
               >
                 The QuickBooks connection expired. Reconnect to keep pushing invoices.
@@ -398,14 +408,16 @@ export default function QuickBooksIntegrationCard({ companyId }: QuickBooksInteg
               </>
             )}
 
-            <Button
+            <BusyButton
               size="small"
               onClick={handleCheckPoField}
               disabled={busy}
+              pending={pending === 'po-field'}
+              pendingLabel="Reading QuickBooks settings…"
               sx={{ mb: 3, display: 'block' }}
             >
               {poField ? 'Check again' : 'Check QuickBooks settings'}
-            </Button>
+            </BusyButton>
 
             <Button variant="outlined" color="error" onClick={() => setDisconnectOpen(true)} disabled={busy}>
               Disconnect
@@ -467,14 +479,15 @@ function ProviderOption({
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
         {detail}
       </Typography>
-      <Button
+      <BusyButton
         variant="contained"
         onClick={onConnect}
         disabled={busy}
-        startIcon={pending ? <CircularProgress size={16} color="inherit" /> : undefined}
+        pending={pending}
+        pendingLabel={pendingLabel}
       >
-        {pending ? pendingLabel : actionLabel}
-      </Button>
+        {actionLabel}
+      </BusyButton>
     </Card>
   );
 }

--- a/components/settings/quickbooks/QuickBooksDesktopPanel.tsx
+++ b/components/settings/quickbooks/QuickBooksDesktopPanel.tsx
@@ -13,6 +13,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import BusyButton from '@/components/common/BusyButton';
 import QuickBooksUnreachableAlert from '@/components/quickbooks/QuickBooksUnreachableAlert';
 import { useLoad } from '@/hooks/useLoad';
 import {
@@ -65,7 +66,7 @@ export default function QuickBooksDesktopPanel({
    * seconds -- which a shop reported as "something is wrong". Naming the action
    * lets the pressed button, and only that button, say what it is waiting for.
    */
-  const [pending, setPending] = useState<null | 'test' | 'accounts'>(null);
+  const [pending, setPending] = useState<null | 'test' | 'accounts' | 'disconnect'>(null);
 
   const handleTest = async () => {
     setBusy(true);
@@ -127,12 +128,14 @@ export default function QuickBooksDesktopPanel({
 
   const handleDisconnect = async () => {
     setBusy(true);
+    setPending('disconnect');
     try {
       await disconnectQuickBooksDesktop(companyId);
       posthog.capture('accounting disconnected', { provider: 'qbd' });
       onDisconnected();
     } finally {
       setBusy(false);
+      setPending(null);
     }
   };
 
@@ -167,6 +170,7 @@ export default function QuickBooksDesktopPanel({
           code={unreachableCode}
           onRetry={handleTest}
           busy={busy}
+          retrying={pending === 'test'}
         />
       )}
       {note && (
@@ -193,16 +197,15 @@ export default function QuickBooksDesktopPanel({
               ).toLocaleString()}.`
             : 'Not yet used.'}
         </Typography>
-        <Button
+        <BusyButton
           size="small"
           onClick={handleTest}
           disabled={busy}
-          startIcon={
-            pending === 'test' ? <CircularProgress size={14} color="inherit" /> : undefined
-          }
+          pending={pending === 'test'}
+          pendingLabel="Asking QuickBooks…"
         >
-          {pending === 'test' ? 'Asking QuickBooks…' : 'Test connection'}
-        </Button>
+          Test connection
+        </BusyButton>
       </Stack>
 
       <Divider sx={{ my: 2 }} />
@@ -236,42 +239,20 @@ export default function QuickBooksDesktopPanel({
               : 'Done. Change it any time.'}
           </Typography>
           {accounts === null ? (
-            <>
-              <Button
-                variant={status.needs_income_account ? 'contained' : 'outlined'}
-                size="small"
-                onClick={handleLoadAccounts}
-                disabled={busy}
-                startIcon={
-                  pending === 'accounts' ? (
-                    <CircularProgress size={14} color="inherit" />
-                  ) : undefined
-                }
-              >
-                {pending === 'accounts'
-                  ? 'Reading accounts…'
-                  : status.needs_income_account
-                    ? 'Choose account'
-                    : 'Change account'}
-              </Button>
-              {/* Says WHERE the wait is, not just that there is one. The round
-                  trip is to the shop's PC, so "a few seconds" is normal and a
-                  closed QuickBooks makes it much longer -- naming that is what
-                  stops the pause reading as a fault. aria-live because the text
-                  appears after the press, not with it. */}
-              {pending === 'accounts' && (
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  display="block"
-                  sx={{ mt: 1 }}
-                  aria-live="polite"
-                >
-                  Reading your accounts from QuickBooks on the shop computer. This takes a few
-                  seconds, and longer if QuickBooks was closed.
-                </Typography>
-              )}
-            </>
+            <BusyButton
+              variant={status.needs_income_account ? 'contained' : 'outlined'}
+              size="small"
+              onClick={handleLoadAccounts}
+              disabled={busy}
+              pending={pending === 'accounts'}
+              pendingLabel="Reading accounts…"
+              // Says WHERE the wait is, not just that there is one: the round trip
+              // is to the shop's PC, so seconds are normal and a closed QuickBooks
+              // makes it much longer. Naming that stops the pause reading as a fault.
+              pendingDetail="Reading your accounts from QuickBooks on the shop computer. This takes a few seconds, and longer if QuickBooks was closed."
+            >
+              {status.needs_income_account ? 'Choose account' : 'Change account'}
+            </BusyButton>
           ) : (
             <TextField
               select
@@ -294,9 +275,16 @@ export default function QuickBooksDesktopPanel({
 
       <Divider sx={{ my: 3 }} />
 
-      <Button variant="outlined" color="error" onClick={handleDisconnect} disabled={busy}>
+      <BusyButton
+        variant="outlined"
+        color="error"
+        onClick={handleDisconnect}
+        disabled={busy}
+        pending={pending === 'disconnect'}
+        pendingLabel="Disconnecting…"
+      >
         Disconnect QuickBooks Desktop
-      </Button>
+      </BusyButton>
     </Box>
   );
 }

--- a/docs/interaction-standards.md
+++ b/docs/interaction-standards.md
@@ -455,3 +455,78 @@ Two details generalise beyond billing:
   it loads. Otherwise every healthy shop sees a subscription warning flash on every
   page load, which is the "couldn't check is never denied" rule from
   [CLAUDE.md](../CLAUDE.md) in UI form.
+
+---
+
+## 5. Waiting (added 2026-08-16)
+
+**Added after three separate bug reports from one shop, all the same shape:** a
+button that only greys out during a multi-second round trip reads as a dropped
+click. §4 already forbade a disabled control with no visible reason — a busy
+button is exactly that — but §4 is framed around *unavailable* actions, so
+nothing named the *in-progress* case. Before this rule the entire app contained
+**zero** buttons that showed progress; the convention did not exist to be
+followed.
+
+### The threshold decides, and the threshold is the call
+
+Feedback is keyed to how long the wait actually is, per
+[NN/g — Response Time Limits](https://www.nngroup.com/articles/response-times-3-important-limits/):
+
+| Wait | What the control does | Why |
+|---|---|---|
+| **< 1s** — local state, Supabase CRUD | Disable to stop a double-submit. **No spinner.** | Under 1s the user's flow of thought is unbroken; NN/g: *"no special feedback is necessary."* A spinner here is noise that makes a fast app feel busy. |
+| **1–10s** — any third-party hop: Conductor's Web Connector, Intuit, Stripe, Anthropic, FedEx | The **pressed** control shows a spinner and its label names what it is waiting for | Past 1s the user notices; past ~3s with no signal they assume the click was lost |
+| **> 10s** — Web Connector cold, or QuickBooks closed | Also say **where** the wait is and that it may run long | 10s is the limit of attention. "Reading your accounts from QuickBooks on the shop computer" makes a 30s pause legible; "Loading…" does not |
+
+Measured, not guessed: a Conductor round trip is ~0.5s warm, **3–10s cold**, and
+~30s longer when QuickBooks is shut ([quickbooks-desktop.md](modules/quickbooks-desktop.md)).
+
+### Four invariants, each learned from a real defect
+
+1. **Only the pressed control speaks.** `pending` is per-button, never a shared
+   `busy`. A neighbour that greys out *and* claims to be working is a worse lie
+   than silence. Callers pass `disabled={busy} pending={which === 'mine'}`.
+2. **The label names the wait**, because "Loading…" hides the one fact that makes
+   a long pause make sense. Shipped: *"Creating setup link…"*, *"Reading
+   accounts…"*, *"Opening QuickBooks…"*.
+3. **A hand-off keeps spinning.** When success navigates away — the QBO OAuth
+   redirect — do **not** clear the indicator; an idle button mid-redirect looks
+   like the click was lost. Everything else clears on success.
+4. **Always clear on failure.** A spinner left running after an error makes retry
+   impossible. Asserted in
+   [`QuickBooksIntegrationCard.test.tsx`](../__tests__/components/settings/QuickBooksIntegrationCard.test.tsx)
+   → *"restores the button when starting the connection fails"*.
+
+### Accessibility is a conformance requirement here, not polish
+
+[WCAG 2.2 SC 4.1.3 Status Messages](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html)
+is **Level AA** and covers exactly this — status messages *"on the waiting state
+of an application, on the progress of a process"* must be programmatically
+determinable **without receiving focus**. A silent spinner is an AA gap.
+`BusyButton` sets `aria-busy` and renders `pendingDetail` in a `role="status"`
+region, so following the rule satisfies the criterion by construction.
+
+### Use the shared component
+
+[`components/common/BusyButton`](../components/common/BusyButton.tsx) makes
+`pendingLabel` **required**, so the label cannot be forgotten — the same trick as
+`DeleteIconButton` making the destructive colour unsettable.
+
+**Enforced**, by rule 4 of
+[`interactionStandardsCheck.ts`](../scripts/interactionStandardsCheck.ts): inside
+a QuickBooks surface, a `<Button disabled={…busy…}>` fails the build.
+
+The check is **deliberately narrow**, and the scoping is the interesting part.
+`disabled={busy}` appears ~260 times across ~77 files, nearly all sub-second
+Supabase writes where a spinner would be wrong — flagging those yields a check
+nobody trusts and an allowlist that swallows the rule. The first draft scoped by
+*import* and flagged nine buttons on the job page, which imports `quickbooksAccess`
+merely to list invoice links. Scoping by **path** to the integration surfaces is
+the closest honest proxy for "this control calls out". Buttons that only flip
+local state (`onClick={() => setDialogOpen(true)}`) are skipped: opening a dialog
+waits for nothing.
+
+**So the rule is prose beyond those surfaces.** Widen `THIRD_PARTY_SURFACES` when
+another integration grows a UI; until then, this is a rule you apply rather than
+one you will be caught violating.

--- a/scripts/interactionStandardsCheck.ts
+++ b/scripts/interactionStandardsCheck.ts
@@ -15,6 +15,10 @@
  *      chip colors; on a button fill they mislead (a green button reads as
  *      "already done"). See docs/design-system.md "Buttons". This is exactly
  *      how the green "Complete"/"Mark Received" one-offs crept in.
+ *   4. Silent busy buttons — a control that only greys out during a third-party
+ *      round trip reads as a dropped click. Three live bug reports from one shop
+ *      before the rule existed. See docs/interaction-standards.md §5; use the
+ *      shared components/common/BusyButton, which makes the label mandatory.
  *
  * Mirrors scripts/schemaEmbedCheck.ts: a pure scan function the test drives,
  * plus a main() for `pnpm exec tsx`.
@@ -25,9 +29,28 @@ import path from 'path';
 export interface StandardsViolation {
   file: string; // relative to repo root
   line: number;
-  rule: 'placeholder' | 'grey-delete' | 'button-color';
+  rule: 'placeholder' | 'grey-delete' | 'button-color' | 'silent-busy-button';
   message: string;
 }
+
+/**
+ * Surfaces whose buttons cross to a THIRD PARTY, so their round trips are
+ * reliably over Nielsen's 1-second "no feedback needed" limit — Conductor's Web
+ * Connector hop to a PC in the shop is 3-10s cold, longer when QuickBooks is shut.
+ *
+ * Scoped by PATH, not by import. Importing a slow client says nothing about any
+ * individual button: the job page imports quickbooksAccess to list invoice links,
+ * and nine of its ten buttons are sub-second Supabase writes. Matching the
+ * integration surfaces themselves is the closest honest proxy for "this control
+ * calls out", and it is why the first draft of this rule was wrong.
+ *
+ * Deliberately narrow. `disabled={busy}` appears ~260 times across ~77 files and
+ * the overwhelming majority are fast local writes where a spinner is noise, not
+ * help. A check that flags those is a check nobody trusts and an allowlist that
+ * swallows the rule. Widen this only for a surface whose latency is known to
+ * exceed a second.
+ */
+const THIRD_PARTY_SURFACES = /quickbooks/i;
 
 // Escape hatch for genuine exceptions, keyed by `relativePath:line` is too
 // brittle (line numbers shift); key by `relativePath::snippet` instead.
@@ -165,11 +188,58 @@ export function findButtonColorViolations(source: string, relPath: string): Stan
   return out;
 }
 
+/**
+ * Find buttons that go silent during a third-party round trip.
+ *
+ * Scoped to the THIRD_PARTY_SURFACES paths, where a wait over a second is the
+ * norm rather than the exception. Inside those files a `<Button>` carrying a
+ * busy-ish `disabled` is flagged: `disabled` greys the control and says nothing,
+ * which is the same defect docs/interaction-standards.md §4 already bans for
+ * unavailable actions. Use components/common/BusyButton so the pending label
+ * cannot be forgotten — it makes `pendingLabel` required.
+ *
+ * Only the busy-ish names are matched (`disabled={saving}`, `{busy}`, …), not
+ * every `disabled`: a genuinely unavailable action — no rows selected, lapsed
+ * subscription — is §4's business and must NOT grow a spinner.
+ */
+export function findSilentBusyButtonViolations(
+  source: string,
+  relPath: string,
+): StandardsViolation[] {
+  if (!THIRD_PARTY_SURFACES.test(relPath)) return [];
+
+  const out: StandardsViolation[] = [];
+  const re = /<Button\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(source)) !== null) {
+    const tag = sliceOpeningTag(source, m.index);
+    if (!tag) continue;
+    // `busy`, `saving`, `isLoading`, `actionLoading`, `submitting`, `pending`…
+    if (!/\bdisabled=\{[^}]*\b\w*(?:busy|Busy|loading|Loading|saving|Saving|submitting|Submitting|pending|Pending)\w*\b[^}]*\}/.test(tag))
+      continue;
+    // A button that only flips local state — `onClick={() => setDisconnectOpen(true)}`
+    // — opens a dialog; it does not call out, so it waits for nothing and must
+    // not grow a spinner. It is still disabled during other work, which is right.
+    if (/onClick=\{\(\)\s*=>\s*set[A-Z]\w*\(/.test(tag)) continue;
+    if (ALLOWLIST.has(`${relPath}::silent-busy-button`)) continue;
+    const line = source.slice(0, m.index).split('\n').length;
+    out.push({
+      file: relPath,
+      line,
+      rule: 'silent-busy-button',
+      message:
+        '<Button disabled={…busy…}> in a file that calls a third-party client. A control that only greys out for a multi-second round trip reads as a dropped click. Use components/common/BusyButton (pendingLabel is required) — see docs/interaction-standards.md §5.',
+    });
+  }
+  return out;
+}
+
 export function scanSource(source: string, relPath: string): StandardsViolation[] {
   return [
     ...findPlaceholderViolations(source, relPath),
     ...findGreyDeleteViolations(source, relPath),
     ...findButtonColorViolations(source, relPath),
+    ...findSilentBusyButtonViolations(source, relPath),
   ];
 }
 
@@ -201,8 +271,9 @@ export function scanProject(
   const violations: StandardsViolation[] = [];
   for (const file of files) {
     const rel = path.relative(repoRoot, file);
-    // Don't flag the shared component's own internals.
+    // Don't flag the shared components' own internals — they ARE the fix.
     if (rel.endsWith(path.join('common', 'DeleteIconButton.tsx'))) continue;
+    if (rel.endsWith(path.join('common', 'BusyButton.tsx'))) continue;
     violations.push(...scanSource(readFileSync(file, 'utf8'), rel));
   }
   return violations;


### PR DESCRIPTION
Three bug reports from one shop in two days, all the same shape: **a button that only greys out during a multi-second round trip reads as a dropped click.**

§4 already banned a disabled control with no visible reason — a busy button *is* that — but §4 is written about **unavailable** actions, so nothing named the **in-progress** case. Measured before starting: the app contained **zero** buttons that showed progress. The convention didn't exist to be followed.

## 1. `docs/interaction-standards.md` §5 — keyed to the wait, not the widget

| Wait | Control | Why |
|---|---|---|
| **< 1s** — Supabase CRUD | Disable, **no spinner** | [NN/g](https://www.nngroup.com/articles/response-times-3-important-limits/): 1s is "flow of thought uninterrupted", *"no special feedback is necessary"*. A spinner here makes a fast app feel busy. |
| **1–10s** — Conductor, Intuit, Stripe, Anthropic, FedEx | Pressed control names what it waits for | Past ~3s with no signal, users assume the click was lost |
| **> 10s** — Web Connector cold | Also say **where** the wait is | "Loading…" hides the only fact that makes a 30s pause legible |

Four invariants, each from a real defect — including two that are opposites: a hand-off that navigates away must **keep** spinning, and every failure must **clear**.

## 2. `BusyButton` — makes the rule unforgettable

`pendingLabel` is a **required prop**, the same trick as `DeleteIconButton` making the destructive colour unsettable.

It also sets `aria-busy` and renders the detail in `role="status"`, so following the rule satisfies [WCAG 2.2 SC 4.1.3](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html) by construction. That criterion is **Level AA** and explicitly covers *"the waiting state of an application"* — which makes a silent spinner a conformance gap, not a matter of taste.

## 3. The check — and its scoping is the interesting part

Rule 4 in `interactionStandardsCheck.ts`. **My first draft was wrong and the failure is instructive:** scoping by *import* immediately flagged nine buttons on the job page, which imports `quickbooksAccess` merely to list invoice links while nine of its ten buttons are sub-second Supabase writes.

Scoping by **path** to the integration surfaces is the closest honest proxy for "this control calls out". The pattern appears **~260 times across ~77 files** and nearly all of them should *not* change — a wider check is one nobody trusts and an allowlist that swallows the rule. Buttons that only flip local state (`onClick={() => setDialogOpen(true)}`) are skipped: opening a dialog waits for nothing.

The doc says plainly that beyond those surfaces this is prose, not enforcement.

## Caught three sites I'd missed by hand

Reconnect, the PO-field check, and both disconnects — all genuine third-party round trips I hadn't noticed while fixing the ones that were reported. That's the check earning its place on day one.

## Verification

tsc clean · lint 0 errors · 24 tests across BusyButton and the checker (including one asserting the rule *ignores* the ~260 fast sites) · docLinkCheck 25/25 · full suite 2663 passed.

One pre-existing failure unrelated to this PR: `schemaEmbedCheck` reports 0 tables locally on Windows. It fails identically with these changes stashed, and CI is green on `main` — same Windows/CRLF class as the `docLinkCheck` bug fixed earlier. Worth its own fix; flagged, not bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)