### PR TITLE
feat(marketing): a pricing page, and the price the docs forgot

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -77,9 +77,10 @@ CONDUCTOR_PUBLISHABLE_KEY=your-conductor-publishable-key
 # key (rk_...) — least-privilege, and it matches the var the Stripe Dashboard /
 # Vercel label. Use separate keys per environment (test vs live).
 STRIPE_RESTRICTED_KEY=rk_test_your-restricted-key
-# The DEFAULT monthly Price id ($300) — chosen server-side for every self-serve
-# signup. The frontend never names a price.
-STRIPE_PRICE_ID=price_your-default-300-price-id
+# The DEFAULT monthly Price id ($399) — chosen server-side for every self-serve
+# signup. The frontend never names a price. The superseded $300 price is still
+# active in Stripe; don't point this back at it (docs/modules/billing.md §6).
+STRIPE_PRICE_ID=price_your-default-399-price-id
 # The reserved founder-customer Price id ($250). NOT read by the app directly —
 # it's the value you put in a company's company_billing.override_price_id
 # (service-role) to give that one customer the founder rate.

--- a/__tests__/lib/pricingCopy.test.ts
+++ b/__tests__/lib/pricingCopy.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { PRICING } from '@/lib/constants/marketing';
+
+/**
+ * The pricing page is cited in the Terms of Service, so its headline facts are
+ * commercial terms rather than ordinary marketing copy. These assertions exist to make
+ * an accidental edit fail loudly — the price in particular, which is a hardcoded string
+ * with nothing structurally linking it to Stripe's `STRIPE_PRICE_ID`
+ * (docs/modules/billing.md §6). Changing any of these on purpose means changing the
+ * ToS, and the price also means a new Stripe Price object.
+ */
+describe('PRICING copy', () => {
+  it('states the price that live Stripe charges', () => {
+    expect(PRICING.amount).toBe('$399');
+    expect(PRICING.period).toBe('/month');
+    expect(PRICING.unit).toBe('per shop');
+  });
+
+  it('points its CTA at the request-access flow', () => {
+    // Must match the token in app/(marketing)/invite/tokens.ts, or the CTA 404s.
+    expect(PRICING.cta.href).toBe('/invite/early-access');
+  });
+
+  it('keeps the FAQ to three items', () => {
+    expect(PRICING.faq).toHaveLength(3);
+    for (const { q, a } of PRICING.faq) {
+      expect(q.length).toBeGreaterThan(0);
+      expect(a.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps the meta description inside the snippet budget', () => {
+    // ~155 chars is where Google truncates — same budget MARKETING_META documents.
+    expect(PRICING.meta.description.length).toBeLessThanOrEqual(155);
+  });
+
+  it('does not append the title template by hand', () => {
+    // The root layout applies '%s | Jigged'; a hand-written suffix double-renders it.
+    expect(PRICING.meta.title).not.toContain('| Jigged');
+  });
+});

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import PricingPageContent from '@/components/marketing/PricingPageContent';
+import { PRICING } from '@/lib/constants/marketing';
+
+export const metadata: Metadata = {
+  // The root layout sets title.template = '%s | Jigged', so this bare string resolves to
+  // "Pricing — $399/month for your whole shop | Jigged". Don't append the suffix by hand.
+  title: PRICING.meta.title,
+  description: PRICING.meta.description,
+  // Resolves against metadataBase (https://www.jigged.app). The Terms of Service cites
+  // the apex https://jigged.app/pricing, which 307s to www like every other Jigged URL.
+  alternates: { canonical: '/pricing' },
+  // Deliberately NO openGraph override. A child openGraph replaces the parent's resolved
+  // object wholesale — there is no per-field merge — so adding one here would silently
+  // drop the site's OG card image (app/opengraph-image.tsx, attached at the root
+  // segment) along with siteName/locale/type. Inheriting means /pricing shares show the
+  // homepage og:title and og:url, exactly as /terms and /privacy already do.
+};
+
+export default function PricingPage() {
+  return <PricingPageContent />;
+}

--- a/components/marketing/MarketingFooter.tsx
+++ b/components/marketing/MarketingFooter.tsx
@@ -39,6 +39,10 @@ export default function MarketingFooter() {
           {/* Right: legal line, aligned with the logo row */}
           <Typography variant="body2" sx={{ color: 'rgba(255, 255, 255, 0.5)', fontSize: '0.85rem' }}>
             &copy; 2026 Jigged{' · '}
+            <MuiLink component={Link} href="/pricing" underline="hover" sx={linkSx}>
+              Pricing
+            </MuiLink>
+            {' · '}
             <MuiLink component={Link} href="/terms" underline="hover" sx={linkSx}>
               Terms
             </MuiLink>

--- a/components/marketing/MarketingHeader.tsx
+++ b/components/marketing/MarketingHeader.tsx
@@ -14,8 +14,17 @@ import MuiLink from '@mui/material/Link';
 import JiggedLogo from '@/components/branding/JiggedLogo';
 import { gradientButtonSx } from './marketingStyles';
 
+// "How it works" is root-relative, not a bare `#how-it-works`: this header renders on
+// every marketing route, and that section only exists on the landing page.
+//
+// Anything with a `#` stays a plain <a> (see the component= switch below) so it does a
+// full navigation rather than a Next soft nav. Soft-navigating from /pricing to
+// /#how-it-works scrolls to the anchor before the landing page's images have their
+// height, and you land a section or two past the target. A hard load lands correctly,
+// and on / itself the browser treats it as a same-page fragment jump with no reload.
 const navItems = [
-  { label: 'How it works', href: '#how-it-works' },
+  { label: 'How it works', href: '/#how-it-works' },
+  { label: 'Pricing', href: '/pricing' },
   { label: 'Log in', href: '/login' },
 ];
 
@@ -58,7 +67,7 @@ export default function MarketingHeader() {
           {navItems.map((item) => (
             <MuiLink
               key={item.label}
-              component={item.href.startsWith('#') ? 'a' : Link}
+              component={item.href.includes('#') ? 'a' : Link}
               href={item.href}
               underline="none"
               sx={{
@@ -111,7 +120,7 @@ export default function MarketingHeader() {
           {navItems.map((item) => (
             <ListItemButton
               key={item.label}
-              component={item.href.startsWith('#') ? 'a' : Link}
+              component={item.href.includes('#') ? 'a' : Link}
               href={item.href}
               onClick={() => setDrawerOpen(false)}
               sx={{ borderRadius: 2, mb: 0.5 }}

--- a/components/marketing/PricingPageContent.tsx
+++ b/components/marketing/PricingPageContent.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import MuiLink from '@mui/material/Link';
+import Link from 'next/link';
+import Section from './Section';
+import Reveal from './Reveal';
+import { PRICING } from '@/lib/constants/marketing';
+import { gradientButtonSx, DISPLAY_FONT } from './marketingStyles';
+
+/**
+ * One price, one card, three questions. Typography only — no imagery.
+ *
+ * Deliberately does NOT redirect signed-in users the way LandingPageContent does: this
+ * page is cited in the Terms of Service, so it has to render for everyone who follows
+ * that link, the same as /terms and /privacy.
+ */
+export default function PricingPageContent() {
+  return (
+    <>
+      <Section maxWidth="md" grid sx={{ pt: { xs: 7, md: 10 } }}>
+        <Reveal distance={28}>
+          <Typography
+            component="h1"
+            sx={{
+              textAlign: 'center',
+              fontFamily: DISPLAY_FONT,
+              fontWeight: 600,
+              fontSize: 'clamp(2.25rem, 5vw, 3.75rem)',
+              lineHeight: 1.02,
+              letterSpacing: '-0.03em',
+            }}
+          >
+            {PRICING.headlineLead}
+            {/* Forced break: at ≥1200px the full string all but fills the container, so
+                left to wrap it breaks raggedly on any font-metric variation. */}
+            <Box component="span" sx={{ display: 'block' }}>
+              {PRICING.headlineEmphasis}
+            </Box>
+          </Typography>
+        </Reveal>
+
+        <Reveal delay={100} distance={24}>
+          <Box
+            sx={{
+              mt: { xs: 5, md: 7 },
+              mx: 'auto',
+              maxWidth: 560,
+              p: { xs: 3.5, md: 6 },
+              textAlign: 'center',
+              borderRadius: 2,
+              // The `raised` surface recipe from Section.tsx, on a bounded card rather
+              // than a full-bleed band.
+              bgcolor: 'rgba(17, 20, 57, 0.55)',
+              backdropFilter: 'blur(6px)',
+              WebkitBackdropFilter: 'blur(6px)',
+              border: '1px solid rgba(255, 255, 255, 0.1)',
+            }}
+          >
+            {/* Solid white, not gradient text: the gradient is the "act here" signal and
+                belongs to the CTA below. This number also gets zoomed and read under
+                shop lighting, where 15:1 beats the gradient's ~4.3:1 steel stop. */}
+            <Typography
+              component="p"
+              sx={{
+                fontFamily: DISPLAY_FONT,
+                fontWeight: 600,
+                color: '#fff',
+                fontSize: { xs: '2.75rem', md: '3.5rem' },
+                lineHeight: 1,
+                letterSpacing: '-0.03em',
+              }}
+            >
+              {PRICING.amount}
+              <Box
+                component="span"
+                sx={{
+                  fontSize: { xs: '1.25rem', md: '1.5rem' },
+                  fontWeight: 500,
+                  letterSpacing: 0,
+                  color: 'rgba(255, 255, 255, 0.72)',
+                }}
+              >
+                {PRICING.period}
+              </Box>
+            </Typography>
+            <Typography
+              sx={{
+                mt: 1,
+                color: 'rgba(255, 255, 255, 0.72)',
+                fontSize: { xs: '1rem', md: '1.08rem' },
+              }}
+            >
+              {PRICING.unit}
+            </Typography>
+
+            <Box
+              component="ul"
+              sx={{
+                listStyle: 'none',
+                p: 0,
+                mb: 0,
+                mt: { xs: 3.5, md: 4 },
+                pt: { xs: 3.5, md: 4 },
+                borderTop: '1px solid rgba(255,255,255,0.14)',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 1.5,
+              }}
+            >
+              {PRICING.includes.map((line) => (
+                <Typography
+                  component="li"
+                  key={line}
+                  sx={{
+                    color: 'rgba(255, 255, 255, 0.78)',
+                    fontSize: { xs: '1rem', md: '1.05rem' },
+                    lineHeight: 1.5,
+                    maxWidth: 420,
+                    mx: 'auto',
+                  }}
+                >
+                  {line}
+                </Typography>
+              ))}
+            </Box>
+
+            <Button
+              component={Link}
+              href={PRICING.cta.href}
+              variant="contained"
+              size="large"
+              sx={{
+                mt: { xs: 4, md: 5 },
+                width: { xs: '100%', sm: 'auto' },
+                minWidth: { sm: 210 },
+                py: 1.4,
+                fontSize: '1rem',
+                ...gradientButtonSx,
+              }}
+            >
+              {PRICING.cta.label}
+            </Button>
+          </Box>
+        </Reveal>
+
+        <Reveal delay={160} distance={20}>
+          <Typography
+            sx={{
+              mt: { xs: 4, md: 5 },
+              textAlign: 'center',
+              color: 'rgba(255, 255, 255, 0.72)',
+              fontSize: { xs: '1rem', md: '1.05rem' },
+              lineHeight: 1.6,
+            }}
+          >
+            {PRICING.contact.lead}{' '}
+            <MuiLink
+              href={`mailto:${PRICING.contact.email}`}
+              underline="hover"
+              sx={{ color: 'rgba(255, 255, 255, 0.92)' }}
+            >
+              {PRICING.contact.email}
+            </MuiLink>
+            .
+          </Typography>
+        </Reveal>
+      </Section>
+
+      <Section surface="light" maxWidth="md" size="minor">
+        <Reveal distance={24}>
+          {/* SectionHeading isn't used here: its eyebrow/index row carries mb: 2.5
+              unconditionally, so with no eyebrow it leaves ~20px of dead space. Same
+              heading values, minus the gap. */}
+          <Typography
+            component="h2"
+            sx={{
+              textAlign: 'center',
+              fontFamily: DISPLAY_FONT,
+              fontWeight: 600,
+              fontSize: 'clamp(2rem, 4.6vw, 3.4rem)',
+              lineHeight: 1.04,
+              letterSpacing: '-0.025em',
+            }}
+          >
+            {PRICING.faqHeading}
+          </Typography>
+        </Reveal>
+
+        <Box sx={{ maxWidth: 720, mx: 'auto', mt: { xs: 5, md: 7 } }}>
+          {PRICING.faq.map((item, i) => (
+            <Reveal key={item.q} delay={i * 80} distance={20}>
+              <Box
+                sx={{
+                  mt: i === 0 ? 0 : { xs: 3.5, md: 4 },
+                  pt: i === 0 ? 0 : { xs: 3.5, md: 4 },
+                  borderTop: i === 0 ? 'none' : '1px solid rgba(255,255,255,0.14)',
+                }}
+              >
+                <Typography
+                  component="h3"
+                  sx={{
+                    fontFamily: DISPLAY_FONT,
+                    fontWeight: 600,
+                    fontSize: { xs: '1.3rem', md: '1.5rem' },
+                    letterSpacing: '-0.02em',
+                    mb: 1.5,
+                  }}
+                >
+                  {item.q}
+                </Typography>
+                <Typography
+                  sx={{
+                    color: 'rgba(255, 255, 255, 0.72)',
+                    fontSize: { xs: '1rem', md: '1.05rem' },
+                    lineHeight: 1.65,
+                  }}
+                >
+                  {item.a}
+                </Typography>
+              </Box>
+            </Reveal>
+          ))}
+        </Box>
+      </Section>
+    </>
+  );
+}

--- a/docs/modules/billing.md
+++ b/docs/modules/billing.md
@@ -269,10 +269,17 @@ Writes go through the `apply_stripe_subscription(...)` RPC (guarded upsert):
 
 ## 6. Prices & the reserved customer
 
-- **`STRIPE_PRICE_ID`** = the default $300 monthly price every self-serve company
-  gets. The frontend never names a price.
-- **`STRIPE_FOUNDING_PRICE_ID`** = the reserved $250 founder price id. **Not read by
-  the app** — it's the value you copy into a company's `override_price_id`.
+- **`STRIPE_PRICE_ID`** = the default $399 monthly price every self-serve company
+  gets — `price_1U0afKHxiLXphzfAu8VRTtBy`, the `Jigged` product's `default_price`.
+  The frontend never names a price. The superseded **$300** price
+  (`price_1TxIBTHxiLXphzfAna1ebqwx`) is still `active` in Stripe and must not be
+  pointed back at; subscriptions created on it keep it. The public price shown on
+  `/pricing` is a hardcoded string in `lib/constants/marketing.ts` (rendered by
+  `components/marketing/PricingPageContent.tsx`) and is cited in the Terms of
+  Service — **a price change edits Stripe and that constant, in the same PR.**
+- **`STRIPE_FOUNDING_PRICE_ID`** = the reserved $250 founder price id
+  (`price_1TqnlLHxiLXphzfABIdDneFk`). **Not read by the app** — it's the value you
+  copy into a company's `override_price_id`.
 - To put a company on the reserved deal (e.g. Contour), set two columns
   (service-role): `override_price_id = <$250 price id>`, `override_trial_days = 0`.
   Then they self-serve via Settings → Subscribe → $250, no trial. Overrides are

--- a/lib/constants/marketing.ts
+++ b/lib/constants/marketing.ts
@@ -227,7 +227,10 @@ export const PRICING = {
     },
     {
       q: 'What does setup look like?',
-      a: 'We set up your shop with you: your parts, your customers, your open jobs loaded before day one.',
+      // "your existing files", not "exports": plenty of 5-50 person shops run on
+      // spreadsheets and have no ERP to export from. It also stays true as the importer
+      // grows past CSV (Excel, drawings) without naming a format we'd have to keep current.
+      a: 'We set up your shop with you: your parts, your customers, your open jobs loaded from your existing files before day one.',
     },
   ],
 };

--- a/lib/constants/marketing.ts
+++ b/lib/constants/marketing.ts
@@ -178,3 +178,56 @@ export const FINAL_CTA = {
   primaryCta: { label: 'Request access', href: '/invite/early-access' },
   emailLabel: 'Or request early access and we’ll reach out:',
 };
+
+// ── Pricing page (/pricing) ─────────────────────────────────────────────────────────
+// THE PRICE BELOW IS PUBLIC COPY, AND IT IS ALSO CITED IN THE TERMS OF SERVICE. Stripe
+// is the source of truth for what anyone is actually charged, and nothing structurally
+// links this string to STRIPE_PRICE_ID — a price change means editing both, in the same
+// PR. As of 2026-08-18 they agree: the live default is $399/month
+// (price_1U0afKHxiLXphzfAu8VRTtBy, the Jigged product's default_price). The superseded
+// $300 price is still active in Stripe and must not be pointed back at. Raising the
+// price is a NEW Price object, never a mutation — docs/modules/billing.md §6.
+// The trial and cancellation claims below also come from that doc (§1, §8): 30-day
+// trial with card upfront, and Customer-Portal cancellation.
+export const PRICING = {
+  meta: {
+    // The root layout applies the '%s | Jigged' template — do NOT append the suffix
+    // here (/terms and /privacy do, and render "… – Jigged | Jigged").
+    title: 'Pricing — $399/month for your whole shop',
+    // Same ~155-char budget as MARKETING_META above. This is 122.
+    description:
+      'Jigged pricing: $399/month flat for your whole shop. Unlimited users, every feature included. 30-day trial, month to month.',
+  },
+  // Two display lines, split the way HERO is — the break is forced, not left to wrap.
+  headlineLead: 'Simple pricing.',
+  headlineEmphasis: 'Whole shop.',
+  amount: '$399',
+  period: '/month',
+  unit: 'per shop',
+  includes: [
+    'Unlimited users. Every feature included.',
+    'Quoting, jobs, operator workflows, inventory, shipping, QuickBooks.',
+    '30-day trial. Month to month. Cancel anytime.',
+  ],
+  cta: { label: 'Request access', href: '/invite/early-access' },
+  // Split so the address can be a mailto link; renders as one sentence.
+  contact: {
+    lead: 'Bigger shop or something unusual? Email',
+    email: 'hello@jigged.app',
+  },
+  faqHeading: 'Questions we get',
+  faq: [
+    {
+      q: 'Do you charge per user?',
+      a: 'No. Flat rate for the whole shop. We want your operators in Jigged, not locked out of it.',
+    },
+    {
+      q: 'Is there a long-term contract?',
+      a: 'No. Month to month, cancel anytime from your billing portal.',
+    },
+    {
+      q: 'What does setup look like?',
+      a: 'We set up your shop with you: your parts, your customers, your open jobs loaded before day one.',
+    },
+  ],
+};


### PR DESCRIPTION
Adds `/pricing` to the marketing site and wires it into the header nav, mobile drawer, and footer.

## The page

One flat price, one card, three questions. Typography only — no images, no Stripe wiring, no checkout.

Everything is lifted from the landing page's own system, so it reads as one more section of the site rather than a new design:

| Element | Borrowed from |
|---|---|
| Card surface | `Section.tsx`'s `raised` recipe, on a bounded box instead of a full-bleed band |
| `$399` | `HowItWorks.tsx`'s big-numeral scale — solid white, not `gradientTextSx` |
| `h1` | `FinalCTA.tsx`'s centred display scale, with the line break forced the way `Hero` does |
| FAQ band | the `light` "flip" surface `HowItWorks` uses |
| CTA | the one `gradientButtonSx`, pointing at `/invite/early-access` |

No new colours and no new components. The FAQ is static blocks rather than `Accordion` — that's app chrome (it appears nowhere in `components/marketing/`), and three one-sentence answers hide nothing worth a click.

## Because the ToS cites this URL

Two consequences, both deliberate:

- **It renders for signed-in users.** `LandingPageContent`'s post-login bounce is *not* copied — a lawyer or existing customer following the ToS link has to land on the page, the same as `/terms` and `/privacy`. Verified by signing in and visiting directly.
- **The price is a commercial term, not marketing copy.** `__tests__/lib/pricingCopy.test.ts` pins the amount, the CTA target and the FAQ count so an accidental edit fails loudly.

The ToS will cite the apex `https://jigged.app/pricing`, which 307s to www like every other Jigged URL; the page publishes `canonical: /pricing` accordingly. No per-page `openGraph` — a child block replaces the parent's resolved object wholesale and would silently drop the site's OG card image.

## The nav change worth reviewing

`How it works` becomes `/#how-it-works`, since the header now renders on a route where that section doesn't exist.

It deliberately stays a plain `<a>` rather than a `Link`. Soft-navigating from `/pricing` to `/#how-it-works` scrolls to the anchor before the landing page's images have their height, and you land a section or two past the target — reproduced, then fixed, then re-verified in both directions. A full load lands correctly, and on `/` itself the browser still treats it as a same-page fragment jump with no reload.

## Docs correction

`STRIPE_PRICE_ID` has pointed at a **$399** Price for a while — customers have started trials on it. `docs/modules/billing.md` §6 and `.env.local.example` still described the superseded **$300** one, and the placeholder encoded it too (`price_your-default-300-price-id`). Both corrected, with the live Price ids recorded in the doc so the next reader can verify against Stripe rather than trusting prose.

Verified against live Stripe: `price_1U0afKHxiLXphzfAu8VRTtBy` is $399/month and is the product's `default_price`.

## Not in scope

No Stripe changes, no checkout, no annual pricing, no tier above $399, no founding-rate mention. No PostHog capture — marketing is entirely uninstrumented today, and autocapture already covers the pageview and the CTA click.

## Verification

Driven in a real browser against a production build:

- `/pricing` at 1440px and 375px — h1 breaks after "Simple pricing.", `$399/month` clears the card edge, CTA goes full-width, no horizontal scroll
- Footer chain wraps cleanly at 375px with `hello@jigged.app` on its own line
- Mobile drawer: three items + CTA, correct order
- `How it works` from `/pricing` and from `/` — both land on the section
- Card CTA → `/invite/early-access`
- Signed in as a seed admin → `/pricing` renders, no bounce
- `prefers-reduced-motion` → all content visible immediately

`pnpm exec tsc --noEmit` clean · `pnpm lint` 0 errors, 17 warnings (at the ratchet, none new) · `pnpm build` passes with `/pricing` prerendered static · `pricingCopy`, `rscBoundary` and `__tests__/standards/` all green (68 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
