### PR TITLE
fix(vercel): stop shipping the pytest suite into eleven Python bundles

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,53 @@
+# What never needs to reach a Vercel build.
+#
+# EVERY DIRECTORY ENTRY IS ANCHORED WITH A LEADING SLASH, AND THAT IS LOAD-BEARING.
+# This file uses .gitignore syntax, where a bare name matches at ANY depth — so a
+# bare `supabase` would also match utils/supabase/, which app/auth/confirm/route.ts
+# and app/launch/page.tsx import. That would break `next build`, not just the
+# Python bundle. Anchoring pins each entry to the repo root.
+#
+# WHETHER THIS FILE APPLIES TO GIT DEPLOYMENTS IS UNSETTLED. Vercel's own docs
+# contradict each other — "only relevant when using Vercel CLI" (build features)
+# vs. an unqualified description under .vercelignore. It is definitely honoured by
+# `vercel build` / `vercel deploy` from a laptop. So nothing build-critical goes in
+# here; the function bundle is trimmed by `excludeFiles` in vercel.json, which is
+# documented and unambiguous. Confirm the git-deploy behaviour on a preview by
+# opening /_src and checking whether docs/ and e2e/ are present.
+#
+# The concrete reason this file exists at all: .claude/worktrees is 4.8 GB of git
+# worktrees. It is .gitignore'd, so a git deployment never sees it — but a local
+# `vercel build` does not read .gitignore, and .claude is not on Vercel's default
+# ignore list. Without this file, local verification globs 4.8 GB into the bundle,
+# which is a large part of why the local CLI and the hosted builder have never
+# agreed on function count or bundle size.
+
+# --- Local-only build/test artefacts. Also .gitignore'd. ---
+/.claude
+/.agents
+/.vscode
+/coverage
+/outputs
+/test-results
+/playwright-report
+/playwright
+/.pytest_cache
+/api/.cache
+/api/.pytest_cache
+/tsconfig.tsbuildinfo
+**/__pycache__
+**/*.pyc
+**/.DS_Store
+
+# --- Committed, but read by neither `next build` nor the Python function. ---
+/api/tests          # 55 files; proven unreachable from api/index.py by import graph
+/__tests__          # vitest only; already in tsconfig "exclude"
+/e2e                # playwright only
+/docs
+/.github            # workflows run on GitHub, never on Vercel
+/supabase           # migrations + seed; CLI and CI only. NOT utils/supabase.
+
+# NOT ignored, deliberately:
+#   scripts/  — package.json's postinstall runs scripts/copy-scanner-wasm.mjs, which
+#               copies the zxing WASM into public/ and throws if it fails.
+#   public/   — app/(marketing)/privacy/page.tsx reads public/legal/privacy.html at
+#               build time, and Hero.tsx serves /wireframe-scene.mp4 + /screenshots.

--- a/api/requirements-test.txt
+++ b/api/requirements-test.txt
@@ -5,3 +5,11 @@ pytest-mock>=3.11.0
 httpx>=0.24.0
 factory-boy>=3.3.0
 responses>=0.23.0
+
+# Not a test framework, but test-only in practice: three integration tests
+# (test_create_location_tree, test_jobs_search_cap,
+# test_location_children_hold_no_stock) connect over raw libpq to assert things
+# the Supabase client cannot express, such as a raised exception class. Nothing
+# under api/ imports psycopg2 at runtime, so it does not belong in
+# requirements.txt where it was shipped into every Vercel function bundle.
+psycopg2-binary>=2.9.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -32,9 +32,10 @@ httpx>=0.27.0
 # Function calling Resend over fetch (see docs/modules/invitation-system.md).
 
 # Database
-# psycopg2-binary is NOT imported anywhere under api/ — grep it and you will find
-# nothing, which is exactly why it keeps looking removable. It is used by
-# scripts/sync_demo_template.py, which lives outside this directory but installs
-# from this file. Removing it breaks that script with an ImportError at line 26.
-psycopg2-binary>=2.9.0
+# psycopg2-binary MOVED to requirements-test.txt. The comment that used to sit here
+# justified it by scripts/sync_demo_template.py — a file that no longer exists. Its
+# only live users are three api/tests/integration/ tests and
+# scripts/load_pilot_data_to_jigged.py, which pip-installs it itself (see its
+# docstring). It was ~11 MB of wheel shipped into every Vercel function bundle for
+# an import that never happens at runtime.
 asyncpg>=0.29.0

--- a/docs/runbooks/database-migrations.md
+++ b/docs/runbooks/database-migrations.md
@@ -206,30 +206,51 @@ which was always the point. Measured after the change: **gate 5s, trigger 5s.**
 >   bundle limit. Re-measure before treating it as a constraint, and do not repeat the mistake of
 >   narrowing the glob on the strength of it.
 
-> ### Correction, 2026-08-18 — limit #2 is resolved, and the glob is now narrowed
+> ### Correction, 2026-08-18 — limit #1 is misattributed, and it was measured
 >
-> The cap in limit #2 is **500 MB uncompressed**, and larger still on Fluid compute, which this
-> project already runs (`resourceConfig.fluid: true`). The 244 MB single-function measurement fits
-> with roughly 2× headroom, so the reason limit #2 was ever binding is gone. `vercel.json` now
-> declares `functions: { "api/index.py": … }` rather than `api/**`.
+> **The `functions` glob does not create the fan-out, and narrowing it does nothing.** Limit #1 above
+> says `vercel build` "expands this repo's `functions: { "api/**" }` glob into one Serverless Function
+> per matched Python file". That reads as cause and effect, and it is not. Vercel's docs are explicit:
+> *"Without a detected Python framework preset, each `.py` file inside `/api` becomes a separate Vercel
+> Function"*, and the `functions` property is used to **configure** file-based functions, not to select
+> them. The `/api` directory convention is the cause; the glob is only the config key that happens to
+> match.
 >
-> **What forced the issue was cost, not the cap.** Four days into the first Pro billing cycle the team
-> had spent **$15.75 of its $20 credit, 99.6% of it Build CPU Minutes**. Measured over 79 deployments:
-> billed machine time averaged **7.82 min/build**, split 84s compile+install, 70s deploying outputs,
-> and **314s creating and uploading the build cache**. Every build installed the Python dependency
-> stack **11 times** — the same fan-out limit #1 describes, no longer failing, just billing.
+> Measured, not reasoned: narrowing the glob to `api/index.py` and deploying produced **12 Python
+> lambdas and 11 `uv.lock` installs — byte-identical to `api/**`** (`meta.lambdaRuntimeStats`,
+> `{"nodejs":3,"python":12}` on both). See PR #772.
 >
-> Two things worth carrying forward, because both cost time here:
+> **The trap this creates.** Because the key only configures, narrowing it *silently unconfigures the
+> other eleven functions* — they keep existing, but lose `maxDuration: 60` and lose `excludeFiles`, so
+> they start bundling `api/tests/**`. Narrowing looks like a cleanup and is a regression. The glob must
+> stay wide enough to match every entrypoint.
+>
+> **What actually collapses the fan-out** is the framework preset: *"A Python framework preset takes
+> precedence over file-based functions… files under `/api` don't become separate Vercel Functions."*
+> That is a real change of shape for a project whose Vercel framework is `nextjs`, and Vercel points
+> Next.js + Python at [Services](https://vercel.com/docs/services) instead. Not a config tweak — treat
+> it as its own piece of work.
+>
+> **Limit #2 is resolved.** The cap is **500 MB uncompressed**, larger still on Fluid compute, which
+> this project already runs (`resourceConfig.fluid: true`). The 244 MB single-function measurement fits
+> with ~2× headroom, so the 225 MB figure that block flagged as stale is now settled — it just no
+> longer matters, because narrowing is not the lever anyone thought it was.
+>
+> **Why any of this got looked at.** Four days into the first Pro billing cycle the team had spent
+> **$15.75 of its $20 credit, 99.6% of it Build CPU Minutes**. Over 79 deployments, billed machine time
+> averaged **7.82 min/build**: 84s compile+install, 70s deploying outputs, and **314s creating and
+> uploading the build cache**. The build had not regressed — builds on Aug 12–14 ran *longer*, at
+> ~11 min. Hobby simply never billed for it.
+>
+> Two measurement traps worth carrying forward, because both cost time here:
 > - **Billed build duration is not `ready - buildingAt`.** That field stops at "Deployment completed"
 >   and undercounts by ~3×; the machine keeps running through cache creation. Measure first-event to
 >   last-event on `GET /v3/deployments/{id}/events?builds=1`.
 > - **The build cache has not been shown to pay for itself.** It costs 314s to accelerate a phase that
 >   takes 84s in total, so a perfect hit cannot save more than 84s. Settle it with one A/B against
->   `VERCEL_FORCE_NO_BUILD_CACHE=1` before assuming it helps.
->
-> The uv cache is content-addressed and deduplicated across entrypoints, so **do not expect narrowing
-> the glob to shrink the 265 MB build cache**. It removes 10 of 11 dependency installs and 10 of 11
-> uploaded bundles; the cache phase is a separate problem.
+>   `VERCEL_FORCE_NO_BUILD_CACHE=1` before assuming it helps. And do not expect the *glob* to shrink it
+>   — uv's cache is content-addressed and deduplicated across entrypoints, so eleven venvs already
+>   shared one copy of each wheel.
 
 **If deploys ever stop reaching production**, the first thing to check is whether the hook still
 exists (`vercel deploy-hooks list`) and matches the `VERCEL_DEPLOY_HOOK_URL` secret. Reverting

--- a/docs/runbooks/database-migrations.md
+++ b/docs/runbooks/database-migrations.md
@@ -206,6 +206,31 @@ which was always the point. Measured after the change: **gate 5s, trigger 5s.**
 >   bundle limit. Re-measure before treating it as a constraint, and do not repeat the mistake of
 >   narrowing the glob on the strength of it.
 
+> ### Correction, 2026-08-18 — limit #2 is resolved, and the glob is now narrowed
+>
+> The cap in limit #2 is **500 MB uncompressed**, and larger still on Fluid compute, which this
+> project already runs (`resourceConfig.fluid: true`). The 244 MB single-function measurement fits
+> with roughly 2× headroom, so the reason limit #2 was ever binding is gone. `vercel.json` now
+> declares `functions: { "api/index.py": … }` rather than `api/**`.
+>
+> **What forced the issue was cost, not the cap.** Four days into the first Pro billing cycle the team
+> had spent **$15.75 of its $20 credit, 99.6% of it Build CPU Minutes**. Measured over 79 deployments:
+> billed machine time averaged **7.82 min/build**, split 84s compile+install, 70s deploying outputs,
+> and **314s creating and uploading the build cache**. Every build installed the Python dependency
+> stack **11 times** — the same fan-out limit #1 describes, no longer failing, just billing.
+>
+> Two things worth carrying forward, because both cost time here:
+> - **Billed build duration is not `ready - buildingAt`.** That field stops at "Deployment completed"
+>   and undercounts by ~3×; the machine keeps running through cache creation. Measure first-event to
+>   last-event on `GET /v3/deployments/{id}/events?builds=1`.
+> - **The build cache has not been shown to pay for itself.** It costs 314s to accelerate a phase that
+>   takes 84s in total, so a perfect hit cannot save more than 84s. Settle it with one A/B against
+>   `VERCEL_FORCE_NO_BUILD_CACHE=1` before assuming it helps.
+>
+> The uv cache is content-addressed and deduplicated across entrypoints, so **do not expect narrowing
+> the glob to shrink the 265 MB build cache**. It removes 10 of 11 dependency installs and 10 of 11
+> uploaded bundles; the cache phase is a separate problem.
+
 **If deploys ever stop reaching production**, the first thing to check is whether the hook still
 exists (`vercel deploy-hooks list`) and matches the `VERCEL_DEPLOY_HOOK_URL` secret. Reverting
 `git.deploymentEnabled` in `vercel.json` restores Vercel's own auto-deploy immediately, at the cost of

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
     }
   },
   "functions": {
-    "api/index.py": {
+    "api/**": {
       "excludeFiles": "{.next/**,.git/**,.vercel/**,node_modules/**,.claude/**,.agents/**,.github/**,docs/**,e2e/**,__tests__/**,supabase/**,api/tests/**,coverage/**,outputs/**,test-results/**,playwright-report/**,**/__pycache__/**,**/*.pyc}",
       "maxDuration": 60
     }

--- a/vercel.json
+++ b/vercel.json
@@ -6,8 +6,8 @@
     }
   },
   "functions": {
-    "api/**": {
-      "excludeFiles": "{.next,.git,node_modules}/**",
+    "api/index.py": {
+      "excludeFiles": "{.next/**,.git/**,.vercel/**,node_modules/**,.claude/**,.agents/**,.github/**,docs/**,e2e/**,__tests__/**,supabase/**,api/tests/**,coverage/**,outputs/**,test-results/**,playwright-report/**,**/__pycache__/**,**/*.pyc}",
       "maxDuration": 60
     }
   },


### PR DESCRIPTION
## What this PR ended up being

It started as "narrow `functions: { "api/**" }` to the real entrypoint and collapse eleven Python functions into one." **I deployed that and measured it. It does nothing.** The PR now contains only the part that was true, plus the correction.

## The measurement that killed the original premise

| | `api/**` (before) | `api/index.py` (narrowed) |
|---|---|---|
| `meta.lambdaRuntimeStats` | `{"nodejs":3,"python":12}` | `{"nodejs":3,"python":12}` |
| `uv.lock` installs in build log | 11 | 11 |

Byte-identical. Vercel's [docs](https://vercel.com/docs/functions/runtimes/python/api-directory) say why:

> "Without a detected Python framework preset, **each `.py` file inside `/api` becomes a separate Vercel Function**."
> "Use the `functions` property in `vercel.json` to **configure** file-based Python functions."

The `/api` directory convention creates the functions. The glob is only the config key that happens to match them. The runbook's limit #1 phrases this as cause and effect (*"`vercel build` expands this repo's glob into one Serverless Function per matched Python file"*), which is what sent two rounds of work down the wrong path.

**And narrowing it is an active regression.** Because the key only configures, a narrower glob silently *unconfigures* the other eleven functions — they keep existing but lose `maxDuration: 60` and lose `excludeFiles`, so they start bundling `api/tests/**`. It looks like a cleanup and it is a downgrade.

## What actually changed

`vercel.json` — one line. Glob stays `api/**`; `excludeFiles` widened:

```diff
-      "excludeFiles": "{.next,.git,node_modules}/**",
+      "excludeFiles": "{.next/**,.git/**,.vercel/**,node_modules/**,.claude/**,.agents/**,.github/**,docs/**,e2e/**,__tests__/**,supabase/**,api/tests/**,coverage/**,outputs/**,test-results/**,playwright-report/**,**/__pycache__/**,**/*.pyc}",
```

Eleven bundles stop carrying the 55-file pytest suite, `docs/`, `e2e/`, `__tests__/` and `supabase/`.

- `.vercelignore` (new) — mainly for local `vercel build`, which does not read `.gitignore` and would otherwise glob **4.8 GB** of `.claude/worktrees` into the bundle. That is a large part of why the local CLI and the hosted builder have never agreed. Every entry is anchored with a leading `/`: this is gitignore syntax, so a bare `supabase` would also match `utils/supabase/`, which `app/auth/confirm/route.ts` imports.
- `api/requirements.txt` → `requirements-test.txt` — `psycopg2-binary` moved. Nothing under `api/` imports it; the comment defending it named `scripts/sync_demo_template.py`, **which no longer exists**. Live users are three `api/tests/integration/` tests and `scripts/load_pilot_data_to_jigged.py`, which pip-installs it itself. CI's backend job installs both files, so tests are unaffected.
- `docs/runbooks/database-migrations.md` — dated correction recording all of the above.

## Context: why this was being looked at

Four days into the first Pro billing cycle: **$15.75 of $20 credit, 99.6% of it Build CPU Minutes**. Over 79 deployments, billed machine time averaged **7.82 min/build** — 84s compile+install, 70s deploying outputs, **314s creating and uploading the build cache**.

The build did not regress. Builds on Aug 12–14 ran *longer*, ~11 min. **Hobby never billed for it; Pro does.**

The real fix was two Vercel settings, already applied and needing no code: build machine pinned to **Standard/fixed**, on-demand concurrency **disabled**. Per Vercel's pricing page those are the only two things that make a Standard build billable, and both were on.

## Two measurement traps, now in the runbook

- **Billed build duration is not `ready - buildingAt`.** That field stops at "Deployment completed" and undercounts by ~3×; the machine keeps running through cache creation. Use first-event to last-event on `GET /v3/deployments/{id}/events?builds=1`.
- **The build cache has not been shown to pay for itself.** It costs 314s to accelerate a phase that takes 84s in total. Worth one A/B against `VERCEL_FORCE_NO_BUILD_CACHE=1`.

## Follow-up, deliberately not in here

Collapsing the eleven functions needs Vercel to detect a **Python framework preset**, which takes precedence over file-based functions. For a project whose Vercel framework is `nextjs` that is a change of shape — Vercel points Next.js + Python at [Services](https://vercel.com/docs/services). Its own piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)