### PR TITLE
docs(runbooks): the build cache costs nine minutes to save eight seconds

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,9 @@ criterion · [inventory.md](modules/inventory.md)
   local-Supabase JWT fixtures, conventions and known holes
 - [runbooks/local-dev-and-testing.md](runbooks/local-dev-and-testing.md) — E2E setup, running from
   a git worktree, Vercel-preview verification, and the E2E gotchas
+- [runbooks/vercel-build-cost.md](runbooks/vercel-build-cost.md) — the two billing arms, the measured
+  build-phase breakdown, why the build cache is a net loss you cannot switch off, and how to measure
+  a build without undercounting it 3×
 - [runbooks/typed-select-drift.md](runbooks/typed-select-drift.md) — **proposed**: derive
   `.select()` result types with `QueryData` instead of hand-writing them. Also records what `tsc`
   can and cannot see about a select (FK hints: nothing), which is why `schemaEmbedCheck.ts` stays

--- a/docs/runbooks/database-migrations.md
+++ b/docs/runbooks/database-migrations.md
@@ -236,21 +236,11 @@ which was always the point. Measured after the change: **gate 5s, trigger 5s.**
 > with ~2× headroom, so the 225 MB figure that block flagged as stale is now settled — it just no
 > longer matters, because narrowing is not the lever anyone thought it was.
 >
-> **Why any of this got looked at.** Four days into the first Pro billing cycle the team had spent
-> **$15.75 of its $20 credit, 99.6% of it Build CPU Minutes**. Over 79 deployments, billed machine time
-> averaged **7.82 min/build**: 84s compile+install, 70s deploying outputs, and **314s creating and
-> uploading the build cache**. The build had not regressed — builds on Aug 12–14 ran *longer*, at
-> ~11 min. Hobby simply never billed for it.
->
-> Two measurement traps worth carrying forward, because both cost time here:
-> - **Billed build duration is not `ready - buildingAt`.** That field stops at "Deployment completed"
->   and undercounts by ~3×; the machine keeps running through cache creation. Measure first-event to
->   last-event on `GET /v3/deployments/{id}/events?builds=1`.
-> - **The build cache has not been shown to pay for itself.** It costs 314s to accelerate a phase that
->   takes 84s in total, so a perfect hit cannot save more than 84s. Settle it with one A/B against
->   `VERCEL_FORCE_NO_BUILD_CACHE=1` before assuming it helps. And do not expect the *glob* to shrink it
->   — uv's cache is content-addressed and deduplicated across entrypoints, so eleven venvs already
->   shared one copy of each wheel.
+> **Why any of this got looked at, and where the rest of it lives.** Four days into the first Pro
+> billing cycle the team had spent **$15.75 of its $20 credit, 99.6% of it Build CPU Minutes**. The
+> billing model, the measured phase breakdown, the build-cache A/B and the two measurement traps are
+> in [vercel-build-cost.md](vercel-build-cost.md). What belongs here is only the migration-adjacent
+> half: **Pro meters past the ceilings Hobby stopped at**, so a Spend Management cap is owed.
 
 **If deploys ever stop reaching production**, the first thing to check is whether the hook still
 exists (`vercel deploy-hooks list`) and matches the `VERCEL_DEPLOY_HOOK_URL` secret. Reverting

--- a/docs/runbooks/vercel-build-cost.md
+++ b/docs/runbooks/vercel-build-cost.md
@@ -1,0 +1,83 @@
+# Vercel build cost
+
+**As-built, verified 2026-08-18.** Written after four days of the first Pro billing cycle consumed
+**$15.75 of the $20 credit, 99.6% of it Build CPU Minutes** ($15.75 of a $15.82 infrastructure
+subtotal; everything else — functions, edge requests, observability — came to $0.07).
+
+## Billing has two independent arms, and it is an OR
+
+> "Builds on Standard build machines are only billed when on-demand concurrency is enabled **or**
+> Elastic build machines are selected." — [Vercel pricing](https://vercel.com/docs/pricing)
+
+The project had **both** on (`buildMachineSelection: "elastic"`, `elasticConcurrencyEnabled: true`),
+and Elastic had assigned the 8-vCPU Enhanced machine. **Turning off one arm changes nothing.** Both
+were switched off 2026-08-18 to `fixed` / `standard` / `false` via `PATCH /v9/projects/{id}`.
+
+Price is `ceil(minutes) × vCPU × $0.0035`. Nothing had regressed — builds on Aug 12–14 ran *longer*
+(~11 min). **Hobby never billed for it; Pro does.**
+
+| Consequence of the change | |
+|---|---|
+| Build CPU in the first of Pro's 3 slots | unbilled |
+| Slots 2–3 | still billed — concurrent builds still cost |
+| Same-branch rapid pushes | collapse (Git branch queue: "queued builds for earlier commits are skipped") |
+| Wall-clock | **worse** — see below |
+
+## The build cache is a large net loss, and cannot be turned off
+
+Measured on `chore/build-cache-ab`, two fresh commits, Standard 4-vCPU:
+
+| Phase | cache ON | `VERCEL_FORCE_NO_BUILD_CACHE=1` |
+|---|---|---|
+| restore cache | 8s | skipped |
+| compile + install | 165s | 154s |
+| deploying outputs | 119s | 105s |
+| **create + upload cache** | **544s** | **635s** |
+| **total machine time** | **837s (13.9 min)** | **894s (14.9 min)** |
+| cache written | 261.73 MB | 261.49 MB |
+
+**The cache costs ~9 minutes to save ~8 seconds.** Restoring it saved 8s, and the build was *faster*
+without it (154s vs 165s), so the cache does not even help the phase it exists for.
+
+**Withdrawn:** *set `VERCEL_FORCE_NO_BUILD_CACHE=1` to skip that cost* — wrong because the flag only
+skips **restoring** the cache; it is still created and uploaded, so the build gets strictly slower.
+Vercel is explicit that "it is not possible to manually configure which files are cached at this
+time." There is no opt-out.
+
+**The measurement trap that produced the withdrawn claim:** the events log ends at `Creating build
+cache` and the remaining ~10 minutes appear only later. Measured too early, the no-cache arm looked
+69% faster. **Wait past `Build cache uploaded` before reading any total.**
+
+## What would actually shrink the cache
+
+> "each Vercel Function is built separately in the Build step and **has its own cache**, based on the
+> Runtime used. Therefore, the number and size of Vercel functions will affect your Build time."
+> — [troubleshoot-a-build](https://vercel.com/docs/deployments/troubleshoot-a-build)
+
+This deployment builds **12 Python functions** (`meta.lambdaRuntimeStats` → `{"nodejs":3,"python":12}`)
+and installs the dependency stack 11 times per build. That fan-out is the cache. Collapsing it is
+the only lever that attacks the 544s — see the 2026-08-18 correction in
+[database-migrations.md](database-migrations.md) for why the `functions` glob is **not** that lever,
+and what is.
+
+Cache key includes the **git branch**, so every new branch pays to build a fresh ~261 MB cache. Max
+size 1 GB, retained one month.
+
+## Measuring it correctly
+
+Two traps, both of which cost time here:
+
+| Trap | Correction |
+|---|---|
+| `ready - buildingAt` from `/v6/deployments` | Undercounts ~3× — it stops at `Deployment completed` while the machine runs on through cache creation. Use first-event → last-event on `GET /v3/deployments/{id}/events?builds=1`. |
+| Reading the events log as soon as the deployment is `READY` | The cache phase lands minutes later. Poll until `Build cache uploaded` appears. |
+
+A redeploy of an unchanged SHA is **not** a valid A/B arm: it restores nothing (`_restored: false`)
+yet still writes the cache, so it isolates neither variable. Use two fresh commits.
+
+## Open
+
+- **Wall-clock got worse.** Pinning to Standard halved the cores, and cache creation is CPU-bound:
+  the cache phase went 314s (8 vCPU) → 544s (4 vCPU), taking a build from ~7.8 min to ~13.9 min.
+  Free, but slow. Reverting to Elastic restores the speed and the bill.
+- **Nothing enforces any of this.** No test fails if the second billing arm is switched back on.


### PR DESCRIPTION
## The experiment, and its result

Two fresh commits on this branch, Standard 4-vCPU machine, same tree:

| Phase | cache ON | `VERCEL_FORCE_NO_BUILD_CACHE=1` |
|---|---|---|
| restore cache | 8s | skipped |
| compile + install | 165s | 154s |
| deploying outputs | 119s | 105s |
| **create + upload cache** | **544s** | **635s** |
| **total machine time** | **837s (13.9 min)** | **894s (14.9 min)** |
| cache written | 261.73 MB | 261.49 MB |

**The cache spends ~9 minutes to save ~8 seconds**, and the build is *faster* without it (154s vs 165s) — so it does not help the phase it exists for.

## The recommendation that motivated this is withdrawn

I expected the flag to remove that 544s. **It does not.** `VERCEL_FORCE_NO_BUILD_CACHE=1` skips only the *restore*; the cache is still created and uploaded. So it drops the 8s of benefit, keeps all of the cost, and makes builds **strictly slower**. Vercel: *"it is not possible to manually configure which files are cached at this time."* There is no opt-out.

Recorded as **withdrawn** in the doc rather than deleted, per [writing-docs.md](docs/writing-docs.md) — the point is to stop the next person rebuilding on it.

## The trap that produced the wrong answer

The events log **ends at `Creating build cache`**; the remaining ~10 minutes appear only later. Read at `READY`, the no-cache arm looked **69% faster** when it was actually **7% slower**. The same mechanism makes `ready - buildingAt` undercount by ~3×. Both errors flatter the change, which is why they are now in the doc as a table.

Also recorded: a redeploy of an unchanged SHA is not a valid arm — it restores nothing yet still writes the cache, so it isolates neither variable.

## Where this leaves the 544s

Vercel builds each function separately and **gives each its own cache**, so the **12 Python functions are the cache**. Collapsing that fan-out is the only lever that touches it — which promotes the framework-preset / Services question from "deferrable" to the live one. Cross-referenced to the 2026-08-18 correction in `database-migrations.md`, which explains why the `functions` glob is *not* that lever.

## What changed

- `docs/runbooks/vercel-build-cost.md` — **new.** Billing arms, phase breakdown, the A/B, the traps.
- `docs/runbooks/database-migrations.md` — **trimmed.** The build-cost material moved out; only the migration-adjacent half stays (Pro meters past Hobby's ceilings, so a spend cap is owed).
- `docs/README.md` — indexed.

## Also worth knowing

Pinning to Standard halved the cores, and cache creation is CPU-bound: the cache phase went **314s (8 vCPU) → 544s (4 vCPU)**, taking a build from ~7.8 min to ~13.9 min. Builds are now free but noticeably slower. That trade is reversible with one PATCH.

**No production change in this PR** — the env var used for the experiment was created on Preview only and has been deleted (project env count back to 114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)