### PR TITLE
fix(parts): the list stopped answering, and answered "incomplete" instead

### DIFF
--- a/__tests__/lib/partsCompleteness.test.ts
+++ b/__tests__/lib/partsCompleteness.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  stampPriceability,
+  filterByCompleteness,
+  selectPartRows,
+} from '@/lib/partsCompleteness';
+
+/**
+ * The regression these lock is a production incident, not a hypothetical.
+ *
+ * On 2026-08-19 `get_priceable_part_ids` exceeded the 8s statement timeout at
+ * the pilot shop. The parts page caught the rejection and substituted an empty
+ * Set, so every part rendered ⚠ Incomplete — the shop was told its whole item
+ * master needed setting up, on the strength of a query that never answered.
+ *
+ * CLAUDE.md: "Couldn't check" is never "denied."
+ */
+const rows = [
+  { id: 'a', part_name: 'PRICEABLE' },
+  { id: 'b', part_name: 'NOT-PRICEABLE' },
+];
+
+describe('stampPriceability', () => {
+  it('stamps true/false from the verdict set', () => {
+    const out = stampPriceability(rows, new Set(['a']));
+    expect(out.map((r) => r.is_priceable)).toEqual([true, false]);
+  });
+
+  it('stamps null — never false — when there is no verdict', () => {
+    const out = stampPriceability(rows, null);
+    expect(out.map((r) => r.is_priceable)).toEqual([null, null]);
+    // The distinction the ⚠ renderer keys on: `=== false`, not falsy.
+    expect(out.every((r) => r.is_priceable !== false)).toBe(true);
+  });
+
+  it('leaves the rest of the row untouched', () => {
+    expect(stampPriceability(rows, new Set(['a']))[0]).toMatchObject({
+      id: 'a',
+      part_name: 'PRICEABLE',
+    });
+  });
+});
+
+describe('filterByCompleteness', () => {
+  const stamped = stampPriceability(rows, new Set(['a']));
+
+  it('partitions on an explicit verdict', () => {
+    expect(filterByCompleteness(stamped, 'complete').map((r) => r.id)).toEqual(['a']);
+    expect(filterByCompleteness(stamped, 'incomplete').map((r) => r.id)).toEqual(['b']);
+    expect(filterByCompleteness(stamped, 'all').map((r) => r.id)).toEqual(['a', 'b']);
+  });
+
+  it('never counts an unknown verdict as incomplete', () => {
+    const unknown = stampPriceability(rows, null);
+    expect(filterByCompleteness(unknown, 'incomplete')).toEqual([]);
+    expect(filterByCompleteness(unknown, 'complete')).toEqual([]);
+  });
+});
+
+describe('selectPartRows', () => {
+  it('applies the filter when the verdict is known', () => {
+    expect(selectPartRows(rows, new Set(['a']), 'incomplete').map((r) => r.id)).toEqual(['b']);
+  });
+
+  it('stands the filter down when the verdict is unknown', () => {
+    // A filter left on "Incomplete" from a previous render must not empty the
+    // grid the moment the RPC fails — that presents a failed read as a fact
+    // about the shop's data.
+    const out = selectPartRows(rows, null, 'incomplete');
+    expect(out.map((r) => r.id)).toEqual(['a', 'b']);
+    expect(out.every((r) => r.is_priceable === null)).toBe(true);
+  });
+
+  it('shows every row, unmarked, when the verdict is unknown and the filter is "all"', () => {
+    const out = selectPartRows(rows, null, 'all');
+    expect(out).toHaveLength(2);
+    expect(out.some((r) => r.is_priceable === false)).toBe(false);
+  });
+});

--- a/app/dashboard/[companyId]/parts/page.tsx
+++ b/app/dashboard/[companyId]/parts/page.tsx
@@ -3,6 +3,7 @@
 import ImportAllDataLink from '@/components/data-import/ImportAllDataLink';
 import LoadFailedState from '@/components/common/LoadFailedState';
 import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { selectPartRows, type CompletenessFilter } from '@/lib/partsCompleteness';
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useRouter, useParams } from 'next/navigation';
@@ -77,17 +78,16 @@ function buildPartsImpactLines(impact: PartsDeletionImpact | null): string[] {
   return lines;
 }
 
-// Augment Part with the "would the quote form accept this without a
-// warning" flag. Computed at render time from the priceableIds set so AG
-// Grid sees the change as row-data, not a stale closure.
-type PartRow = Part & { is_priceable: boolean };
+// Augment Part with the "would the quote form accept this without a warning" flag.
+// Computed at render time from the priceableIds set so AG Grid sees the change as
+// row-data, not a stale closure.
+/** `is_priceable: null` = verdict unavailable (still loading, or the RPC failed) — never "no". */
+type PartRow = Part & { is_priceable: boolean | null };
 type SourceFilter = 'all' | 'made' | 'bought';
-type CompletenessFilter = 'all' | 'complete' | 'incomplete';
 
 // Stable empty fallbacks so the filtered-rows memo doesn't recompute on every
 // render while the first load is in flight.
 const EMPTY_PARTS: Part[] = [];
-const EMPTY_PRICEABLE: Set<string> = new Set();
 
 export default function PartsPage() {
   const router = useRouter();
@@ -140,24 +140,14 @@ export default function PartsPage() {
   const hasRowsRef = useRef(false);
 
   // Pull every part the company owns (made + bought). The source filter narrows this
-  // client-side. The priceable-id set is fetched in parallel — an
-  // independent query, unaffected by search/sort; failure is non-fatal (an
-  // empty set degrades the Pricing column to "no pricing" rather than blocking
-  // the page). useLoad keeps every setState inside the async callback.
+  // client-side. useLoad keeps every setState inside the async callback.
   const {
     data: partsData,
     loading,
     error: loadError,
     reload: fetchParts,
   } = useLoad(
-    () =>
-      Promise.all([
-        getAllParts(companyId, searchDebounced, sortModel.field, sortModel.sort),
-        getPriceablePartIds(companyId).catch((err) => {
-          console.error('Error fetching priceable part ids:', err);
-          return new Set<string>();
-        }),
-      ]),
+    () => getAllParts(companyId, searchDebounced, sortModel.field, sortModel.sort),
     // Spread sortModel into its two primitives rather than passing the object —
     // useLoad wants primitive deps (see the warning in hooks/useLoad.ts).
     [companyId, searchDebounced, sortModel.field, sortModel.sort],
@@ -181,15 +171,31 @@ export default function PartsPage() {
       },
     },
   );
-  const rows = partsData?.[0] ?? EMPTY_PARTS;
+  const rows = partsData ?? EMPTY_PARTS;
   useEffect(() => {
     hasRowsRef.current = rows.length > 0;
   });
-  // Set of part ids the quote form accepts without warning (≥1 tier with a
-  // non-null computed cost) — single source of truth (get_priceable_part_ids
-  // RPC), matching QuoteForm.hasUsableTier so the Pricing column and the quote
-  // warning can't disagree.
-  const priceableIds = partsData?.[1] ?? EMPTY_PRICEABLE;
+
+  /**
+   * Set of part ids the quote form accepts without warning — single source of
+   * truth (`get_priceable_part_ids` RPC), matching QuoteForm.hasUsableTier so
+   * the incomplete marker and the quote warning can't disagree.
+   *
+   * Its OWN load, keyed on the company alone. It used to ride in a Promise.all
+   * with the rows, under their deps — so a whole-company priceability walk
+   * re-ran on every debounced keystroke and every sort click, for an answer that
+   * none of those inputs can change.
+   *
+   * `null` means WE DO NOT KNOW (still loading, or the load failed) and is not
+   * the same as "no part is priceable". Reading a failure as an empty set is
+   * exactly what drew ⚠ Incomplete on every part in production on 2026-08-19.
+   */
+  const { data: priceableIds } = useLoad(() => getPriceablePartIds(companyId), [companyId], {
+    // Non-fatal: the marker goes quiet rather than lying. Sentry already has the
+    // exception from the access layer; this is the local breadcrumb.
+    onError: (error) => console.error('Error fetching priceable part ids:', error),
+  });
+  const priceabilityKnown = priceableIds !== null;
 
   // Clear selection when the search query or source filter changes — the rows
   // on screen change, so any ids selected before may no longer be visible.
@@ -203,14 +209,15 @@ export default function PartsPage() {
   // Apply source filter client-side and stamp each row with is_priceable
   // from the RPC set so the grid, gridHeight, and empty-state checks all
   // see the same row set. The map runs O(n) — fine at shop scale.
+  //
+  // `is_priceable: null` when the verdict hasn't arrived: the marker renders
+  // nothing, and the completeness filter can't partition rows it has no verdict
+  // for, so it stands down to "all" rather than silently emptying the grid.
   const filteredRows = useMemo<PartRow[]>(() => {
     const bySource =
       sourceFilter === 'all' ? rows : rows.filter((r) => r.source === sourceFilter);
 
-    const stamped = bySource.map((r) => ({ ...r, is_priceable: priceableIds.has(r.id) }));
-    if (completenessFilter === 'complete') return stamped.filter((r) => r.is_priceable);
-    if (completenessFilter === 'incomplete') return stamped.filter((r) => !r.is_priceable);
-    return stamped;
+    return selectPartRows(bySource, priceableIds, completenessFilter);
   }, [rows, sourceFilter, priceableIds, completenessFilter]);
 
   const gridHeight = useMemo(() => {
@@ -339,7 +346,7 @@ export default function PartsPage() {
         if (!params.data) return (params.value as string) ?? '';
         return (
           <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
-            {!params.data.is_priceable && (
+            {params.data.is_priceable === false && (
               <Tooltip title="Incomplete — needs setup before it can be quoted">
                 <WarningAmberIcon fontSize="small" sx={{ color: 'warning.main', flexShrink: 0 }} />
               </Tooltip>
@@ -477,7 +484,9 @@ export default function PartsPage() {
           </Select>
         </FormControl>
 
-        <FormControl size="small" sx={{ minWidth: 170 }}>
+        {/* Disabled while the priceability verdict is unavailable — a filter that
+            cannot partition its rows would just empty the grid and blame the shop. */}
+        <FormControl size="small" sx={{ minWidth: 170 }} disabled={!priceabilityKnown}>
           <InputLabel id="parts-completeness-label">Completeness</InputLabel>
           <Select
             labelId="parts-completeness-label"
@@ -528,13 +537,18 @@ export default function PartsPage() {
         </Button>
       </Box>
 
-      {/* Legend for the inline incomplete marker. */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 2, color: 'text.secondary' }}>
-        <WarningAmberIcon fontSize="small" sx={{ color: 'warning.main' }} />
-        <Typography variant="caption">
-          Incomplete — needs setup (routing/materials, or a vendor cost) before it can be quoted.
-        </Typography>
-      </Box>
+      {/* Legend for the inline incomplete marker — only while there are verdicts to
+          explain. With none, it would describe a ⚠ that isn't on any row. */}
+      {priceabilityKnown && (
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 2, color: 'text.secondary' }}
+        >
+          <WarningAmberIcon fontSize="small" sx={{ color: 'warning.main' }} />
+          <Typography variant="caption">
+            Incomplete — needs setup (routing/materials, or a vendor cost) before it can be quoted.
+          </Typography>
+        </Box>
+      )}
 
       {!loading && filteredRows.length === 0 ? (
         <Card elevation={2}>

--- a/lib/partsCompleteness.ts
+++ b/lib/partsCompleteness.ts
@@ -1,0 +1,67 @@
+/**
+ * The parts list's completeness verdict, as a pure function — because the thing
+ * that broke in production was not the SQL, it was what the UI did when the SQL
+ * did not answer.
+ *
+ * On 2026-08-19 `get_priceable_part_ids` hit the 8s statement timeout for a
+ * whole afternoon. The page caught the rejection and substituted an EMPTY SET,
+ * so every part in the shop rendered ⚠ Incomplete — a definitive negative
+ * manufactured out of a failed read. CLAUDE.md names this exact failure:
+ * "Couldn't check" is never "denied."
+ *
+ * So the verdict is deliberately three-valued, and `null` is load-bearing:
+ *
+ *   true  — priceable, ready to quote
+ *   false — genuinely not priceable; show the ⚠
+ *   null  — WE DO NOT KNOW (loading, or the RPC failed); show nothing
+ *
+ * Keeping this out of the component is what lets the null case be asserted
+ * rather than described.
+ */
+
+export type CompletenessFilter = 'all' | 'complete' | 'incomplete';
+
+/**
+ * Stamp each row with its three-valued priceability.
+ *
+ * @param priceableIds the RPC's answer, or `null` when there isn't one yet.
+ */
+export function stampPriceability<T extends { id: string }>(
+  rows: readonly T[],
+  priceableIds: ReadonlySet<string> | null,
+): (T & { is_priceable: boolean | null })[] {
+  return rows.map((row) => ({
+    ...row,
+    is_priceable: priceableIds === null ? null : priceableIds.has(row.id),
+  }));
+}
+
+/** Narrow stamped rows by the completeness filter. Only ever called with verdicts in hand. */
+export function filterByCompleteness<T extends { is_priceable: boolean | null }>(
+  rows: readonly T[],
+  filter: CompletenessFilter,
+): T[] {
+  if (filter === 'complete') return rows.filter((r) => r.is_priceable === true);
+  if (filter === 'incomplete') return rows.filter((r) => r.is_priceable === false);
+  return [...rows];
+}
+
+/**
+ * The whole decision: stamp, then narrow — but only narrow when there is
+ * something to narrow ON.
+ *
+ * With no verdict the filter STANDS DOWN to "all" rather than partitioning rows
+ * it has no answer for. The UI also disables the control in that state, but this
+ * is the load-bearing half: a filter left on "Incomplete" from a previous render
+ * would otherwise empty the grid the moment the RPC failed, and present that
+ * emptiness as a fact about the shop's data.
+ */
+export function selectPartRows<T extends { id: string }>(
+  rows: readonly T[],
+  priceableIds: ReadonlySet<string> | null,
+  filter: CompletenessFilter,
+): (T & { is_priceable: boolean | null })[] {
+  const stamped = stampPriceability(rows, priceableIds);
+  if (priceableIds === null) return stamped;
+  return filterByCompleteness(stamped, filter);
+}

--- a/supabase/migrations/20260819155026_priceable_part_ids_without_per_row_predicates.sql
+++ b/supabase/migrations/20260819155026_priceable_part_ids_without_per_row_predicates.sql
@@ -1,0 +1,179 @@
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- The parts list stopped answering, and answered "incomplete" instead
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- On 2026-08-19 every part at the pilot shop rendered ⚠ Incomplete. Nothing was
+-- wrong with the parts. `get_priceable_part_ids` was exceeding the 8s
+-- `authenticated` statement_timeout, PostgREST returned 500 with SQLSTATE 57014,
+-- and the browser turned that into an empty set — so "we could not check" was
+-- drawn as "none of these can be quoted". The read path is fixed separately;
+-- this migration removes the reason the query was slow.
+--
+-- ## Where the time went
+--
+-- The fixed point re-derived, on EVERY iteration, three facts that cannot change
+-- between iterations:
+--
+--   1. `public.part_has_cost_basis(p.id)` — a `LANGUAGE sql` function carrying a
+--      `SET search_path` clause. A SET clause makes a SQL function permanently
+--      NON-INLINABLE: the planner cannot fold its body into the surrounding
+--      query, so it stays a per-row function call with its own executor setup,
+--      running a CASE over two correlated subqueries. Once per made part, per
+--      iteration.
+--   2. Whether any routing operation is unpriced or untimed.
+--   3. Whether any BOM line charges a child at price without that child carrying
+--      a markup tier.
+--
+-- Only the fourth condition — are this part's BOM children costable YET — is
+-- what the loop is actually iterating toward. So the loop paid depth × parts for
+-- work whose answer was fixed before it started. At seed scale (18 parts) this is
+-- invisible; a real catalogue with a routed, BOM'd item master crosses 8s.
+--
+-- ## What changed
+--
+-- The three invariants are computed ONCE, into `v_ready`, before the loop. The
+-- loop then does the only thing it needs to: grow the costable set until it stops
+-- growing. Splitting them out is sound because the original tested them inside a
+-- single `NOT EXISTS (A OR B)` over parts_bom, and
+--     NOT EXISTS (A OR B)  ≡  NOT EXISTS (A) AND NOT EXISTS (B)
+-- so the price-basis half (invariant) hoists out and the child-costable half
+-- (iterative) stays. The verdict is unchanged for every input — that is the
+-- point, and `api/tests/integration/test_priceability_agreement.py` is what holds
+-- it to that.
+--
+-- ## On duplicating part_has_cost_basis
+--
+-- `part_has_cost_basis` remains the scalar definition and remains what
+-- `compute_part_cost_explain` (the DETAIL view) calls — there it runs once per
+-- request, where a non-inlinable call costs nothing worth restructuring for.
+-- This function now expresses the same rule set-based, because a per-row call is
+-- exactly what it cannot afford. That is a deliberate second expression of one
+-- rule, and the thing that stops the two drifting is the agreement test above,
+-- which asserts list and detail return the same verdict across the full matrix.
+-- Change the rule in one place and that test fails — which is the intended
+-- tripwire. Do not "simplify" this back to a per-row call.
+
+CREATE OR REPLACE FUNCTION public.get_priceable_part_ids(p_company_id uuid)
+ RETURNS uuid[]
+ LANGUAGE plpgsql
+ STABLE
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+    v_costable  uuid[];
+    v_ready     uuid[];
+    v_priceable uuid[];
+    v_new       uuid[];
+BEGIN
+    -- COSTABLE base case: bought parts whose purchase price is on file. This is
+    -- part_has_cost_basis's 'bought' arm, expressed set-based.
+    SELECT COALESCE(array_agg(p.id), ARRAY[]::uuid[])
+    INTO v_costable
+    FROM public.parts p
+    WHERE p.company_id = p_company_id
+      AND p.source = 'bought'
+      AND EXISTS (
+          SELECT 1
+            FROM public.part_procurement_tiers t
+           WHERE t.part_id = p.id
+             AND (t.expires_at IS NULL OR t.expires_at >= CURRENT_DATE)
+      );
+
+    -- Everything true of a made part REGARDLESS of what is costable yet. Computed
+    -- once; the loop below never re-derives it.
+    SELECT COALESCE(array_agg(p.id), ARRAY[]::uuid[])
+    INTO v_ready
+    FROM public.parts p
+    WHERE p.company_id = p_company_id
+      AND p.source = 'made'
+      -- part_has_cost_basis's 'made' arm: work, materials, or both. Neither means
+      -- there is no basis, NOT that the part is free.
+      AND (
+          EXISTS (
+              SELECT 1
+                FROM public.routings r
+                JOIN public.routing_operations ro ON ro.routing_id = r.id
+               WHERE r.part_id = p.id
+          )
+          OR EXISTS (
+              SELECT 1 FROM public.parts_bom b WHERE b.parent_part_id = p.id
+          )
+      )
+      -- Every routing op must have full pricing.
+      AND NOT EXISTS (
+          SELECT 1
+            FROM public.routings r
+            JOIN public.routing_operations ro ON ro.routing_id = r.id
+            JOIN public.work_centers wc ON wc.id = ro.work_center_id
+           WHERE r.part_id = p.id
+             AND (
+                 -- Nobody said what an hour on this station costs.
+                 (wc.kind = 'internal'
+                     AND ro.labor_rate_override IS NULL
+                     AND wc.labor_rate IS NULL)
+                 -- Or nobody said how long it takes. A rate with no time multiplies
+                 -- out to zero, and zero is a PRICE — it reads as "this operation is
+                 -- free" rather than "we have not costed this yet".
+                 OR (wc.kind = 'internal'
+                     AND ro.setup_minutes IS NULL
+                     AND ro.cycle_minutes_per_unit IS NULL)
+                 -- An outside process is a price per unit, and its absence is the
+                 -- same silence.
+                 OR (wc.kind <> 'internal'
+                     AND ro.external_unit_price IS NULL)
+             )
+      )
+      -- A BOM line that charges its child at PRICE needs that child to carry its
+      -- own markup tier. Nothing covers for a missing one. (Invariant half of the
+      -- original combined NOT EXISTS.)
+      AND NOT EXISTS (
+          SELECT 1
+            FROM public.parts_bom b
+           WHERE b.parent_part_id = p.id
+             AND b.charge_basis = 'price'
+             AND NOT EXISTS (
+                 SELECT 1
+                   FROM public.part_pricing_tiers t
+                  WHERE t.part_id = b.child_part_id
+                    AND t.markup_percent IS NOT NULL
+             )
+      );
+
+    -- Fixed point over the BOM DAG (parts_bom_no_cycles guarantees a DAG, so this
+    -- terminates in at most BOM-depth iterations): a ready part becomes costable
+    -- once every child it consumes is costable.
+    LOOP
+        SELECT COALESCE(array_agg(r.id), ARRAY[]::uuid[])
+        INTO v_new
+        FROM unnest(v_ready) AS r(id)
+        WHERE NOT (r.id = ANY(v_costable))
+          AND NOT EXISTS (
+              SELECT 1
+                FROM public.parts_bom b
+               WHERE b.parent_part_id = r.id
+                 AND NOT (b.child_part_id = ANY(v_costable))
+          );
+
+        EXIT WHEN cardinality(v_new) = 0;
+        v_costable := v_costable || v_new;
+    END LOOP;
+
+    -- PRICEABLE = costable AND has its own non-null-markup pricing tier. Only the
+    -- part being sold needs a markup of its own; its materials need one only when
+    -- a line charges them at price (handled in v_ready above).
+    SELECT COALESCE(array_agg(p.id), ARRAY[]::uuid[])
+    INTO v_priceable
+    FROM public.parts p
+    WHERE p.id = ANY(v_costable)
+      AND EXISTS (
+          SELECT 1
+            FROM public.part_pricing_tiers t
+           WHERE t.part_id = p.id
+             AND t.markup_percent IS NOT NULL
+      );
+
+    RETURN v_priceable;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.get_priceable_part_ids(uuid) IS
+  'Ids of every part in a company that is ready to quote: its cost resolves (bought = a non-expired procurement tier; made = a cost basis, every routing op priced and timed, and every BOM child costable) AND the part itself carries a markup tier. Enforces the identical structural rule as compute_part_cost_explain.is_priceable, so the parts list and the part detail page can never disagree — locked by test_priceability_agreement.py. The per-part invariants (cost basis, op pricing, price-basis child markups) are evaluated ONCE into v_ready rather than on every pass of the fixed point; doing them per-pass via the non-inlinable part_has_cost_basis is what pushed this past the 8s statement timeout on a real catalogue and made the list render every part as Incomplete.';

--- a/utils/partPricingTiersAccess.ts
+++ b/utils/partPricingTiersAccess.ts
@@ -1,6 +1,8 @@
+import * as Sentry from '@sentry/nextjs';
+
 import { getSupabase } from '@/lib/supabase';
 import { toFriendlyError } from '@/lib/supabaseErrors';
-import { friendlyErrorMessage } from '@/lib/supabaseErrors';
+import { friendlyErrorMessage, toError } from '@/lib/supabaseErrors';
 import type {
   PartPricingTier,
   PartPricingTierInput,
@@ -227,7 +229,14 @@ export async function getPriceablePartIds(companyId: string): Promise<Set<string
     p_company_id: companyId,
   });
   if (error) {
-    console.error('Error fetching priceable part ids:', error);
+    // `.rpc()` is deliberately excluded from Sentry's Supabase integration, so
+    // nothing files this unless we do. It went unfiled once already: on
+    // 2026-08-19 this RPC hit the 8s statement timeout (57014) for a whole
+    // afternoon, the parts list drew every part as Incomplete, and the only
+    // trace anywhere was a console line in one user's browser.
+    Sentry.captureException(toError(error, 'get_priceable_part_ids'), {
+      tags: { area: 'part-pricing' },
+    });
     throw error;
   }
   return new Set((data ?? []) as string[]);

--- a/utils/partsAccess.ts
+++ b/utils/partsAccess.ts
@@ -1252,7 +1252,13 @@ export async function getPartCostExplain(
     .single();
 
   if (error) {
-    console.error('Error explaining part cost:', error);
+    // Same reason as get_priceable_part_ids: `.rpc()` is outside Sentry's
+    // Supabase integration, and the workspace swallows this into "no verdict",
+    // which renders as a part with no warnings at all. Unreported, that reads to
+    // the user as "this part is fine" while the list says Incomplete.
+    Sentry.captureException(toError(error, 'compute_part_cost_explain'), {
+      tags: { area: 'part-pricing' },
+    });
     throw error;
   }
 


### PR DESCRIPTION
## What happened

Every part at the pilot shop rendered ⚠ **Incomplete**. Nothing was wrong with the parts.

`get_priceable_part_ids` was exceeding the 8s `authenticated` `statement_timeout`; PostgREST returned 500 with SQLSTATE `57014`; the parts page caught the rejection and substituted an **empty Set** — so "we could not check" was drawn as "none of these can be quoted".

The part **detail** page swallowed the same failure in the opposite direction: `getPartCostExplain` throws → `isPriceable = null` → `setupStatus` is `null` → the "isn't ready to quote" alert never renders. The same part therefore looked *fine* on its own page while the list flagged it. One failure, two opposite confident answers, and no Sentry issue for either.

## Why it was slow

The fixed point re-derived, on **every iteration**, three facts that cannot change between iterations. Chief among them `part_has_cost_basis` — a `LANGUAGE sql` function carrying a `SET` clause, which makes it permanently **non-inlinable** and therefore a per-row function call running a CASE over correlated subqueries. Only *"are this part's BOM children costable yet"* actually iterates.

The invariants now hoist into `v_ready`, computed once. The split is sound because the original tested them inside a single `NOT EXISTS (A OR B)`, and `NOT EXISTS (A OR B) ≡ NOT EXISTS (A) AND NOT EXISTS (B)`.

**Measured on a 2000-part company, shallow BOM:**

| | time |
|---|---|
| as `postgres` (RLS bypassed) | 101 ms |
| **as `authenticated`, before** | **2,863 ms** |
| **as `authenticated`, after** | **28 ms** |

**RLS is the multiplier** that made this a timeout rather than a slow query — every per-row predicate re-evaluated the policies on `routings`, `routing_operations`, `work_centers` and `parts_bom`. A superuser benchmark hides it completely; that is worth knowing before anyone benchmarks one of these again.

## Correctness

The verdict is unchanged for every input. `api/tests/integration/test_priceability_agreement.py` (9 tests) passes untouched, and an A/B run over two BOM shapes (deep chain, wide catalogue) returned **identical sets** from old and new.

## Why it was asked for so often

`getPriceablePartIds` rode in a `Promise.all` under the rows' deps — so a whole-company priceability walk re-ran on **every debounced keystroke and every sort click**, for an answer none of those inputs can change. It now has its own `useLoad`, keyed on the company.

## Why it rendered as a verdict

Priceability is now three-valued — `true`, `false`, and `null` meaning **we do not know**:

- the ⚠ keys on `=== false`, not falsy
- the legend hides when there are no verdicts to explain
- the completeness filter **stands down** rather than partitioning rows it has no answer for (a filter left on "Incomplete" would otherwise empty the grid the instant the RPC failed)

`lib/partsCompleteness.ts` exists so that invariant is asserted by tests rather than described in a comment — CLAUDE.md's *"Couldn't check" is never "denied."*

## Why nobody saw it

`.rpc()` is deliberately outside Sentry's Supabase integration, and both call sites only `console.error`'d. Both now capture via `toError`. The only trace of a multi-hour production incident was one line in one user's browser console.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` — clean
- `pnpm test --run __tests__/lib/partsCompleteness.test.ts` — 8 passed (new)
- `pnpm test --run __tests__/utils/partPricingTiersAccess.test.ts __tests__/utils/partsAccess.test.ts` — 48 passed
- `pytest -m integration tests/integration/test_priceability_agreement.py` — 9 passed against the new function

No column changes, so `types/database.ts` is untouched (the RPC's signature is unchanged).

## Not in this PR

The **deploy-ordering gap** that produced the unrelated `column parts.is_stocked does not exist` errors the same afternoon: merging #778 applied the destructive migration to production immediately, while the Vercel deploy waited ~24 minutes for the required checks. `deploy-production.yml` guards against code shipping ahead of its migration; this is the mirror image and is currently unguarded. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
