### PR TITLE
fix(e2e): unblock the suite — a teardown race, and an install step that ate the job

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,7 +10,12 @@ jobs:
   e2e:
     name: Playwright E2E (local Supabase)
     timeout-minutes: 25
-    runs-on: ubuntu-latest
+    # PINNED, not `-latest`. The install step below deliberately drops
+    # `--with-deps`, which turns "Chromium's launch libraries are already here"
+    # from something apt guaranteed into an assumption about a SPECIFIC image.
+    # Audited on ubuntu-24.04 x64 only — the ubuntu-24.04-arm64 image ships no
+    # Chrome/Chromium and would NOT satisfy it. Re-audit before changing this.
+    runs-on: ubuntu-24.04
     # Pull the Supabase stack from GHCR, not the CLI's default AWS public ECR:
     # shared GitHub-runner IPs trip public.ecr.aws's anonymous rate limit
     # ("toomanyrequests"), which flakes `supabase start`. GHCR mirrors the same
@@ -60,7 +65,45 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+        # DELIBERATELY NOT `--with-deps`, and this is a considered deviation from
+        # Playwright's own GitHub Actions guidance rather than an oversight.
+        #
+        # Naming `chromium` does NOT narrow what that flag installs: Playwright's
+        # registry calls `targets.add("tools")` unconditionally, and `tools` is
+        # where all twelve font packages live. There is no flag that keeps the
+        # launch libraries and skips the fonts — it is all or nothing.
+        #
+        # The fonts are what cost us. On 2026-08-19 this step ran 1181s and 1358s
+        # (baseline 113s) fetching non-Latin fonts from the Ubuntu mirror, twice
+        # consuming the whole 25-minute job cap. One of those killed the run
+        # before a single test executed, and blocked a deploy recovery.
+        #
+        # Dropping the flag is safe here, measured rather than assumed:
+        #   * LAUNCH LIBRARIES — in run 32273804293 all 21 packages in Playwright's
+        #     chromium group reported "is already the newest version"; apt's own
+        #     summary was `0 upgraded, 9 newly installed` and all 9 were fonts.
+        #     They arrive with the image's preinstalled google-chrome-stable,
+        #     whose Depends closure covers 20 of the 21 (libdrm2 via libgbm1).
+        #   * FONTS — nothing in this suite can observe them. Zero
+        #     toHaveScreenshot/toMatchSnapshot across all specs, and Playwright's
+        #     text/role matching compares DOM strings, not glyphs (a tofu box has
+        #     the same textContent). The app self-hosts its faces via next/font,
+        #     so fontconfig is never consulted for body text.
+        #
+        # IF A LAUNCH LIBRARY EVER DOES GO MISSING, here is the signature, because
+        # it is not the obvious one: this step still exits 0 GREEN — the install's
+        # ldd check is swallowed into a "Playwright Host validation warning" — and
+        # the hard throw lands later at the first browser.launch(). Every spec then
+        # fails at once and presents as THE LOGIN FLOW failing, since auth.setup.ts
+        # is the `setup` project everything else depends on. The error names the
+        # missing .so and prints the apt line to fix it. Green install + red
+        # everything + a .so in the message = put `--with-deps` back.
+        #
+        # Bounded so a slow mirror fails THIS step instead of eating the job's
+        # budget. ~20x the expected ~30s; a stalled apt and a hung suite otherwise
+        # produce byte-identical `cancelled` jobs.
+        timeout-minutes: 10
+        run: pnpm exec playwright install chromium
 
       - name: Export Supabase + FastAPI + Next.js env
         # `supabase status -o env` emits API_URL / ANON_KEY / SERVICE_ROLE_KEY.

--- a/e2e/operator-time-capture.spec.ts
+++ b/e2e/operator-time-capture.spec.ts
@@ -143,19 +143,54 @@ async function stopTimer(page: Page): Promise<void> {
   await recordButton(page).click();
   await expect(runningOnStep(page)).toBeHidden({ timeout: 30_000 });
 
-  // WHICHEVER BRANCH THE PAGE LANDS ON. The quantity defaults to the remaining
-  // balance, so this usually completes the step OUTRIGHT — and a full completion
-  // flips the page to the complete banner instead of "Undo all (n)". They are
-  // the same action wearing different words, and which one appears depends on
-  // seeded quantities this file does not control.
+  await returnStepToIdle(page);
+}
+
+/**
+ * Put the step back to "nothing running", WHICHEVER control the page is
+ * currently offering — re-deciding on every attempt.
+ *
+ * WHICHEVER BRANCH THE PAGE LANDS ON. The quantity defaults to the remaining
+ * balance, so a record usually completes the step OUTRIGHT — and a full
+ * completion flips the page to the complete banner instead of "Undo all (n)".
+ * They are the same action wearing different words, and which one appears
+ * depends on seeded quantities this file does not control.
+ *
+ * WHY THIS IS A RETRY LOOP AND NOT AN `if`. The two controls are mutually
+ * exclusive once the page settles, but it passes THROUGH states on the way
+ * there: immediately after the record, "Undo all (n)" is still mounted and
+ * DISABLED while the write is in flight, and the complete banner has not
+ * rendered yet. A check-then-act read taken inside that window commits to the
+ * Undo branch, and then `click()` parks on a disabled button for the whole
+ * 120s test timeout — Playwright is waiting for an element that will never
+ * become enabled because the page has moved on to the other control.
+ *
+ * That is exactly how this flaked on `main` on 2026-08-19 (E2E run 32275027423,
+ * which blocked a production deploy). The trace reads:
+ *
+ *     locator resolved to <button disabled ... Mui-disabled ...>
+ *     - element was detached from the DOM, retrying
+ *
+ * `toPass` re-runs the DECISION as well as the action, and the short per-click
+ * timeout fails fast into the next attempt instead of swallowing the run. The
+ * early return on `startButton` makes it idempotent, so a retry after a click
+ * that did land is a no-op rather than a second undo.
+ */
+async function returnStepToIdle(page: Page): Promise<void> {
   const undo = page.getByRole('button', { name: /undo all/i });
   await undo.or(completeBanner(page)).first().waitFor({ timeout: 30_000 });
-  if (await completeBanner(page).isVisible()) {
-    await completeBanner(page).click();
-  } else {
-    await undo.click();
-  }
-  await expect(startButton(page)).toBeVisible({ timeout: 30_000 });
+
+  await expect(async () => {
+    // Already idle — a previous attempt landed, or there was nothing to undo.
+    if (await startButton(page).isVisible()) return;
+
+    if (await completeBanner(page).isVisible()) {
+      await completeBanner(page).click({ timeout: 5_000 });
+    } else {
+      await undo.click({ timeout: 5_000 });
+    }
+    await expect(startButton(page)).toBeVisible({ timeout: 10_000 });
+  }).toPass({ timeout: 60_000 });
 }
 
 test.describe.configure({ mode: 'serial' });
@@ -240,14 +275,7 @@ test.describe('operator time capture', () => {
     await expect(page.getByText(/recorded \d/i).first()).toBeVisible({ timeout: 30_000 });
 
     // Leave the seeded quantities as this file found them.
-    const undo = page.getByRole('button', { name: /undo all/i });
-    await undo.or(completeBanner(page)).first().waitFor({ timeout: 30_000 });
-    if (await completeBanner(page).isVisible()) {
-      await completeBanner(page).click();
-    } else {
-      await undo.click();
-    }
-    await expect(startButton(page)).toBeVisible({ timeout: 30_000 });
+    await returnStepToIdle(page);
   });
 
   test('recording a completion stops the timer', async ({ page }) => {
@@ -319,14 +347,7 @@ test.describe('operator time capture', () => {
     await expect(feedStartedRows(page)).toHaveCount(0);
 
     // Leave the seeded quantities as this file found them.
-    const undo = page.getByRole('button', { name: /undo all/i });
-    await undo.or(completeBanner(page)).first().waitFor({ timeout: 30_000 });
-    if (await completeBanner(page).isVisible()) {
-      await completeBanner(page).click();
-    } else {
-      await undo.click();
-    }
-    await expect(startButton(page)).toBeVisible({ timeout: 30_000 });
+    await returnStepToIdle(page);
   });
 
   test('the Me tab journal carries no aggregate figure', async ({ page }) => {


### PR DESCRIPTION
Two independent things kept the E2E suite from producing a verdict on 2026-08-19. They are separate causes with separate fixes; both are here because the second one blocks this PR from proving the first.

---

# 1. The teardown race (the original failure)

`operator-time-capture` failed on `main` and blocked the production deploy for #779 ([run 32275027423](https://github.com/debola31/Jigged/actions/runs/32275027423)). Not a flaky assertion — a check-then-act race with a definite mechanism.

The teardown reads which control the page is offering, then acts on that read:

```js
if (await completeBanner(page).isVisible()) { banner.click() }
else                                        { undo.click()   }
```

The two controls are mutually exclusive **once the page settles**, but it passes *through* a state on the way: right after the record, `Undo all (n)` is still mounted and **disabled** while the write is in flight, and the complete banner has not rendered yet. A read taken inside that window picks the Undo branch — then `click()` waits for a button that will *never* become enabled, because the page has since settled onto the **other** control. It burns the full 120s test timeout:

```
waiting for getByRole('button', { name: /undo all/i })
  - locator resolved to <button disabled ... Mui-disabled ...>
  - element was detached from the DOM, retrying
```

The failure snapshot confirms the page's actual end state is the complete banner — the control nothing was ever going to click.

> **Note for review:** the reported line (`158`, a `toBeVisible`) is **not** where it failed. The artifact shows the hang is the `click()` above it. Chasing that assertion would waste an afternoon.

**Fix:** `toPass` re-runs the *decision* as well as the action, so a stale read costs one cheap retry instead of the run. The 5s per-click cap fails fast into the next attempt rather than parking for the whole test, and the early return on `startButton` makes it idempotent — a retry after a click that *did* land is a no-op, not a second undo. The block existed in **three** places; it is now one helper.

**Not changed:** the unconditional `undo all` clicks at ~line 312 here and in `operator-completion.spec.ts:144`. Both follow a **partial** completion where the complete banner cannot appear, so the button does become enabled and there is no branch to get wrong.

That the same commit later passed on re-run is the point, not a counter-argument: identical code, three attempts, three outcomes.

---

# 2. The install step that ate the job (why this PR could not go green)

The job was killed at its 25-minute cap **twice**, once before a single test executed, because `playwright install --with-deps` spent **1181s and 1358s** (baseline **113s**) fetching fonts from the Ubuntu mirror.

Naming `chromium` does **not** narrow what `--with-deps` installs — Playwright's registry calls `targets.add("tools")` unconditionally, and `tools` holds all twelve font packages. There is no flag that keeps the launch libraries and skips the fonts.

Dropping it is safe here, measured rather than argued:

| | finding |
|---|---|
| **Launch libraries** | We were never getting them from this flag. In [run 32273804293](https://github.com/debola31/Jigged/actions/runs/32273804293) all **21** packages in Playwright's chromium group reported `is already the newest version`; apt's summary was `0 upgraded, 9 newly installed` — **all 9 fonts**. They ship with the image's preinstalled `google-chrome-stable`, whose `Depends` closure covers 20 of the 21 (`libdrm2` via `libgbm1`). |
| **Fonts** | Unobservable by this suite. No `toHaveScreenshot`/`toMatchSnapshot` anywhere; Playwright's text and role matching compares **DOM strings, not glyphs** (a tofu box has the same `textContent`). The app self-hosts its faces via `next/font`, so fontconfig never serves body text. Every stalled package was non-Latin. |

**`runs-on` is pinned to `ubuntu-24.04`** as a direct consequence: without `--with-deps`, "the launch libraries are present" stops being something apt guarantees and becomes an assumption about a specific image. The arm64 variant ships no Chrome and would not satisfy it.

### The job cap deliberately stays at 25

Raising it was considered and rejected:

- The four stalled installs were killed at **1327/1358/1368/1371s — still climbing**. No cap value rescues them; 35 would have rescued one timeout in the last 100 runs.
- Everything *except* this step fits in **773s** across the last 95 jobs. All the variance is in one place.
- `deploy-production.yml:82` sets `GATE_TIMEOUT_SECONDS: 1500` — the same 25 minutes from the same instant, and already binding. Raising `timeout-minutes` alone converts a legible `E2E → cancelled` into `checks never reported`, which is strictly worse to debug.

Bounding the offending step (`timeout-minutes: 10`) partitions the budget instead of enlarging it, and keeps a mirror stall distinguishable from a hung suite — today the two produce byte-identical `cancelled` jobs.

### If a launch library ever does go missing

Worth writing down, because the signature is not the obvious one. The install step **still exits 0 green** — its `ldd` check is swallowed into a "Playwright Host validation warning" — and the hard throw lands later at the first `browser.launch()`. Every spec then fails at once and presents as **the login flow failing**, since `auth.setup.ts` is the `setup` project everything depends on. The error names the missing `.so` and prints the apt line to fix it.

**Green install + red everything + a `.so` in the message = put `--with-deps` back.**

---

## Verification

- `tsc --noEmit` clean, `pnpm lint` clean, all 5 tests still discovered by `playwright test --list`.
- Spec run **twice end to end against a real local stack — 11 passed**. That is not proof the race is gone (it passed 14 of 15 CI runs before this too), but the failure **mode** is now structurally unreachable: no click can park longer than 5s, and every retry re-reads the page.
- The workflow change validates itself — this PR's own E2E run exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
