### PR TITLE
feat(quotes): a note to the customer, printed under the total

### DIFF
--- a/__tests__/components/quotes/QuoteForm.test.tsx
+++ b/__tests__/components/quotes/QuoteForm.test.tsx
@@ -11,7 +11,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, routerMocks, resetRouterMocks } from '../../test-utils';
 import userEvent from '@testing-library/user-event';
 import QuoteForm from '@/components/quotes/QuoteForm';
-import type { QuoteFormData } from '@/types/quote';
+import { MAX_QUOTE_CUSTOMER_NOTE_LENGTH, type QuoteFormData } from '@/types/quote';
 
 // Quote access — primary surface under test
 const createQuote = vi.fn();
@@ -129,6 +129,7 @@ const initialBlank: QuoteFormData = {
   parts: [],
   lead_time_text: '',
   payment_terms: '',
+  customer_note: '',
   expiration_date: '',
 };
 
@@ -142,6 +143,9 @@ const initialPopulated: QuoteFormData = {
   // Payment terms are required to submit a quote, so the "populated/complete"
   // fixture carries one.
   payment_terms: 'Net 30',
+  // Deliberately absent: the note is the one optional field in the Terms card, so the
+  // "complete" fixture proves a quote submits without one.
+  customer_note: '',
   expiration_date: '',
 };
 
@@ -280,6 +284,73 @@ describe('QuoteForm', () => {
         '/dashboard/test-company-id/quotes/new-quote-id',
       );
     });
+  });
+
+  it('sends the note to the customer through to createQuote', async () => {
+    render(<QuoteForm mode="create" initialData={initialPopulated} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create quote/i })).toBeEnabled();
+    });
+
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByLabelText(/note to customer/i),
+      'Prices exclude freight and sales tax.',
+    );
+    await user.click(screen.getByRole('button', { name: /create quote/i }));
+
+    await waitFor(() => {
+      expect(createQuote).toHaveBeenCalledTimes(1);
+    });
+    const [, payload] = createQuote.mock.calls[0];
+    expect(payload.customer_note).toBe('Prices exclude freight and sales tax.');
+  });
+
+  it('leaves the note optional — a quote submits with the box untouched', async () => {
+    // Lead time and payment terms block submit when empty. The note must not: most quotes have
+    // nothing extra to say, and a required note would be answered with a full stop.
+    render(<QuoteForm mode="create" initialData={initialPopulated} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create quote/i })).toBeEnabled();
+    });
+
+    expect(screen.getByLabelText(/note to customer/i)).toHaveValue('');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /create quote/i }));
+
+    await waitFor(() => {
+      expect(createQuote).toHaveBeenCalledTimes(1);
+    });
+    expect(createQuote.mock.calls[0][1].customer_note).toBe('');
+  });
+
+  it('says on the field itself that the note prints, because that is the whole promise', async () => {
+    // The label and helper text ARE the visibility contract — there is no eye icon or
+    // internal/external toggle to get backwards. If this wording goes, a shop can no longer tell
+    // from the form that what it types reaches the customer.
+    render(<QuoteForm mode="create" initialData={initialPopulated} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/note to customer/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/prints on the quote pdf/i)).toBeInTheDocument();
+  });
+
+  it('caps the note at the same length the database enforces', async () => {
+    render(<QuoteForm mode="create" initialData={initialPopulated} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/note to customer/i)).toBeInTheDocument();
+    });
+    // Same constant as the quotes_customer_note_length CHECK, so the form refuses what the
+    // database would reject rather than surfacing a 23514 after a full save.
+    expect(screen.getByLabelText(/note to customer/i)).toHaveAttribute(
+      'maxlength',
+      String(MAX_QUOTE_CUSTOMER_NOTE_LENGTH),
+    );
   });
 
   it('accepts a fractional order quantity (parts sold by length/weight) and forwards it', async () => {

--- a/__tests__/types/quote.test.ts
+++ b/__tests__/types/quote.test.ts
@@ -134,6 +134,48 @@ describe('calculateTotalPrice', () => {
   });
 });
 
+describe('quoteToFormData — customer note', () => {
+  // The form binds this to a TextField, which cannot hold null. If the mapping ever leaks a null
+  // through, React flips the input from controlled to uncontrolled on the first quote that has no
+  // note — every one of them, on the edit path.
+  function quoteWithNote(note: string | null): QuoteWithRelations {
+    return {
+      id: 'quote-1',
+      company_id: 'company-1',
+      quote_number: 'Q-0001',
+      customer_id: 'customer-1',
+      billing_address_id: 'addr-1',
+      shipping_address_id: 'addr-1',
+      contact_id: 'contact-1',
+      lead_time_text: '14 days',
+      payment_terms: 'Net 30',
+      customer_note: note,
+      expiration_date: '2099-12-31',
+      status: 'active',
+      status_changed_at: null,
+      converted_at: null,
+      created_by: null,
+      created_at: '2026-06-01T00:00:00Z',
+      updated_at: '2026-06-01T00:00:00Z',
+      line_items: [],
+    } as unknown as QuoteWithRelations;
+  }
+
+  it('round-trips a note the shop wrote', () => {
+    expect(quoteToFormData(quoteWithNote('Prices exclude freight.')).customer_note).toBe(
+      'Prices exclude freight.',
+    );
+  });
+
+  it("maps a quote with no note to '' rather than null", () => {
+    expect(quoteToFormData(quoteWithNote(null)).customer_note).toBe('');
+  });
+
+  it("preserves the shop's own line breaks", () => {
+    expect(quoteToFormData(quoteWithNote('One.\nTwo.')).customer_note).toBe('One.\nTwo.');
+  });
+});
+
 describe('quoteToFormData', () => {
   function makeQuote(lineItems: QuoteWithRelations['line_items']): QuoteWithRelations {
     return {
@@ -146,6 +188,7 @@ describe('quoteToFormData', () => {
       contact_id: 'contact-1',
       lead_time_text: '14 days',
       payment_terms: 'Net 30',
+      customer_note: null,
       expiration_date: '2099-12-31',
       status: 'active',
       status_changed_at: null,

--- a/__tests__/utils/quotePdf.test.ts
+++ b/__tests__/utils/quotePdf.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Hoisted mocks so they're set up before imports resolve.
-const { jsPDFCtor, autoTableFn } = vi.hoisted(() => {
+const { jsPDFCtor, autoTableFn, docInstance: sharedDoc } = vi.hoisted(() => {
   const saveMock = vi.fn();
   const textMock = vi.fn();
   const lineMock = vi.fn();
@@ -43,7 +43,7 @@ const { jsPDFCtor, autoTableFn } = vi.hoisted(() => {
   });
   const autoTableFn = vi.fn();
 
-  return { jsPDFCtor, autoTableFn };
+  return { jsPDFCtor, autoTableFn, docInstance };
 });
 
 vi.mock('jspdf', () => ({
@@ -74,6 +74,7 @@ const baseQuote: QuoteWithRelations = {
   contact_id: 'contact-1',
   lead_time_text: '14 days',
   payment_terms: null,
+  customer_note: null,
   expiration_date: '2099-12-31',
   status: 'active',
   status_changed_at: null,
@@ -715,5 +716,188 @@ describe('generateQuotePdf — company logo', () => {
     await generateQuotePdf(baseQuote, { ...baseCompany, logo_url: 'co/company/logo.png' });
     const docInstance = jsPDFCtor.mock.results[0].value;
     expect(docInstance.addImage).not.toHaveBeenCalled();
+  });
+});
+
+
+/**
+ * The note to the customer — the one block on this document the shop writes in its own words.
+ *
+ * Two things are worth pinning down by test rather than by care. The block sits BELOW the total and
+ * ABOVE the footer loop, and the ordering is load-bearing in both directions: printed before the
+ * total it stops being the caveat that qualifies a price, and emitted after the footer loop any
+ * page it adds would print with no rule, no preparer credit and no page number.
+ *
+ * The other is that it is absent, not empty, when there is nothing to say. A quote is a document a
+ * shop hands to a customer, and a bare NOTES heading over blank space reads as something lost in
+ * transit.
+ */
+describe('generateQuotePdf — note to the customer', () => {
+  // The shared docInstance is created once in vi.hoisted and `vi.clearAllMocks()` clears call
+  // history WITHOUT restoring implementations, so a mockReturnValue set here would leak into
+  // whatever runs next. Every test sets what it needs and afterEach puts the default back.
+  const DEFAULT_SPLIT = ['wrapped'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    sharedDoc.splitTextToSize.mockReturnValue(DEFAULT_SPLIT);
+  });
+
+  /** Every string the document drew, in draw order. */
+  const drawnText = (): string[] => {
+    return sharedDoc.text.mock.calls
+      .map((c: unknown[]) => c[0])
+      .filter((t: unknown): t is string => typeof t === 'string');
+  };
+
+  /** The y coordinate of the first call that drew `text`. */
+  const yOf = (text: string): number => {
+    const call = sharedDoc.text.mock.calls.find((c: unknown[]) => c[0] === text);
+    return call?.[2] as number;
+  };
+
+  it('prints the note under a NOTES heading', async () => {
+    const note = 'Prices exclude freight and sales tax.';
+    sharedDoc.splitTextToSize.mockReturnValue([note]);
+
+    await generateQuotePdf({ ...baseQuote, customer_note: note }, baseCompany);
+
+    const rendered = drawnText();
+    expect(rendered).toContain('NOTES');
+    expect(rendered).toContain(note);
+  });
+
+  it('prints the note BELOW the grand total, which is what makes it a caveat on the price', async () => {
+    const note = 'Tooling quoted separately.';
+    sharedDoc.splitTextToSize.mockReturnValue([note]);
+
+    // baseQuote has one part at one quantity, so it is a firm quote and prints a Total.
+    await generateQuotePdf({ ...baseQuote, customer_note: note }, baseCompany);
+
+    expect(drawnText()).toContain('Total');
+    expect(yOf('NOTES')).toBeGreaterThan(yOf('Total'));
+    expect(yOf(note)).toBeGreaterThan(yOf('NOTES'));
+  });
+
+  it('omits the block entirely when there is no note', async () => {
+    await generateQuotePdf(baseQuote, baseCompany);
+    expect(drawnText()).not.toContain('NOTES');
+  });
+
+  it('omits the block when the note is only whitespace, rather than printing a bare heading', async () => {
+    await generateQuotePdf({ ...baseQuote, customer_note: '   \n  \t ' }, baseCompany);
+    expect(drawnText()).not.toContain('NOTES');
+  });
+
+  it("keeps the shop's own line breaks as separate lines", async () => {
+    // Each paragraph is wrapped independently, so splitTextToSize is called once per line.
+    sharedDoc.splitTextToSize.mockImplementation((t: string) => [t]);
+
+    await generateQuotePdf(
+      { ...baseQuote, customer_note: 'Freight excluded.\nTooling separate.' },
+      baseCompany,
+    );
+
+    const rendered = drawnText();
+    expect(rendered).toContain('Freight excluded.');
+    expect(rendered).toContain('Tooling separate.');
+    // Two distinct baselines, not one overprinted row.
+    expect(yOf('Tooling separate.')).toBeGreaterThan(yOf('Freight excluded.'));
+  });
+
+  it('starts a new page rather than printing the note over the footer', async () => {
+    // 40 lines cannot fit between the total (~y 440) and the footer rule (y 738) at 13pt.
+    const many = Array.from({ length: 40 }, (_, i) => `line ${i}`);
+    sharedDoc.splitTextToSize.mockReturnValue(many);
+
+    await generateQuotePdf({ ...baseQuote, customer_note: 'long' }, baseCompany);
+
+    expect(sharedDoc.addPage).toHaveBeenCalled();
+    // Nothing was drawn below the footer rule at pageHeight - MARGIN - 14 = 738.
+    const noteYs = sharedDoc.text.mock.calls
+      .filter((c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).startsWith('line '))
+      .map((c: unknown[]) => c[2] as number);
+    expect(noteYs.length).toBe(40);
+    expect(Math.max(...noteYs)).toBeLessThanOrEqual(738);
+  });
+
+  it('emits the block BEFORE the footer loop, so a page it adds still gets stamped', async () => {
+    // The other half of the ordering this describe calls load-bearing — and the half that was
+    // stated in prose above and asserted nowhere. The footer reads getNumberOfPages() ONCE and then
+    // stamps exactly that many pages. Move this block below that loop and a note long enough to
+    // paginate ships the customer a page with no rule, no preparer credit, and "Page 1 of 1"
+    // printed on a two-page document.
+    //
+    // Only call ORDER can see it: addPage is an inert vi.fn() and getNumberOfPages is pinned to 1,
+    // so page identity is invisible to every coordinate- or text-based assertion in this file.
+    const many = Array.from({ length: 40 }, (_, i) => `line ${i}`);
+    sharedDoc.splitTextToSize.mockReturnValue(many);
+
+    await generateQuotePdf({ ...baseQuote, customer_note: 'long' }, baseCompany);
+
+    expect(sharedDoc.addPage).toHaveBeenCalled();
+    const lastAddPage = sharedDoc.addPage.mock.invocationCallOrder.at(-1) as number;
+    const firstPageCountRead = sharedDoc.getNumberOfPages.mock.invocationCallOrder[0] as number;
+    expect(lastAddPage).toBeLessThan(firstPageCountRead);
+  });
+
+  it('draws the note ahead of the footer, on every quote and not only paginating ones', async () => {
+    // The cheap companion to the test above, which needs a note long enough to paginate before it
+    // has anything to bite on. This one holds for the one-line note that most quotes will carry.
+    sharedDoc.splitTextToSize.mockReturnValue(['a note line']);
+
+    await generateQuotePdf({ ...baseQuote, customer_note: 'a note line' }, baseCompany);
+
+    const rendered = drawnText();
+    const notesAt = rendered.indexOf('NOTES');
+    const footerAt = rendered.findIndex((t: string) => /Page \d+ of \d+/.test(t));
+    expect(notesAt).toBeGreaterThanOrEqual(0);
+    expect(footerAt).toBeGreaterThanOrEqual(0);
+    expect(notesAt).toBeLessThan(footerAt);
+  });
+
+  it('measures the wrap in the body font, not the one the total left behind', async () => {
+    // splitTextToSize wraps against the document's CURRENT font. The grand total draws in bold
+    // 13pt immediately above, so measuring before switching to the note's normal 10pt breaks every
+    // line about a third short of the right margin — a real defect that overflows nothing and so
+    // shows up in no mocked assertion. This pins the ordering instead.
+    sharedDoc.splitTextToSize.mockReturnValue(['a line']);
+
+    await generateQuotePdf({ ...baseQuote, customer_note: 'a line' }, baseCompany);
+
+    const firstSplitAt = sharedDoc.splitTextToSize.mock.invocationCallOrder[0];
+    const sizeSetToBodyBefore = sharedDoc.setFontSize.mock.calls
+      .map((c: unknown[], i: number) => ({
+        size: c[0],
+        order: sharedDoc.setFontSize.mock.invocationCallOrder[i],
+      }))
+      .filter((x: { size: unknown; order: number }) => x.order < firstSplitAt)
+      .pop();
+
+    expect(sizeSetToBodyBefore?.size).toBe(10);
+  });
+
+  it('never strands the NOTES heading at the foot of a page without its first line', async () => {
+    sharedDoc.splitTextToSize.mockReturnValue(['the note']);
+    // Push the table's end down so the heading cannot fit above the footer rule. finalY is shared
+    // mutable state on the hoisted doc, so the restore goes in a finally: a bare reassignment after
+    // the assertions leaks 730 into every test that runs after a failure here, and the next red
+    // test would be someone else's.
+    const originalFinalY = sharedDoc.lastAutoTable.finalY;
+    sharedDoc.lastAutoTable.finalY = 730;
+
+    try {
+      await generateQuotePdf({ ...baseQuote, customer_note: 'the note' }, baseCompany);
+
+      expect(sharedDoc.addPage).toHaveBeenCalled();
+      // Heading and first line landed on the same (new) page, in order and above the rule.
+      expect(yOf('NOTES')).toBeLessThan(yOf('the note'));
+      expect(yOf('the note')).toBeLessThanOrEqual(738);
+    } finally {
+      sharedDoc.lastAutoTable.finalY = originalFinalY;
+    }
   });
 });

--- a/__tests__/utils/quotesAccess.test.ts
+++ b/__tests__/utils/quotesAccess.test.ts
@@ -414,6 +414,7 @@ describe('quotesAccess utilities', () => {
       parts: [{ part_id: 'part-1', order_quantity: 100 }],
       lead_time_text: '14 business days',
       payment_terms: '',
+      customer_note: '',
       expiration_date: '',
     };
 
@@ -522,6 +523,49 @@ describe('quotesAccess utilities', () => {
       expect(insertSpy.mock.calls[0][0].lead_time_text).toBe('2–3 weeks');
     });
 
+    it('persists the note to the customer verbatim', async () => {
+      const insertSpy = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: { id: 'quote-new', company_id: 'company-1' },
+            error: null,
+          }),
+        }),
+      });
+      (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) =>
+        table === 'quotes' ? { insert: insertSpy } : mockQueryBuilder,
+      );
+      getTiersWithComputedPricesMock.mockResolvedValue([]);
+      insertLineItemForPartMock.mockResolvedValue({});
+
+      await createQuote('company-1', {
+        ...baseForm,
+        customer_note: 'Prices exclude freight and sales tax.',
+      });
+      expect(insertSpy.mock.calls[0][0].customer_note).toBe(
+        'Prices exclude freight and sales tax.',
+      );
+    });
+
+    it('stores a whitespace-only note as null, so the PDF prints no empty heading', async () => {
+      const insertSpy = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: { id: 'quote-new', company_id: 'company-1' },
+            error: null,
+          }),
+        }),
+      });
+      (mockSupabase.from as ReturnType<typeof vi.fn>).mockImplementation((table: string) =>
+        table === 'quotes' ? { insert: insertSpy } : mockQueryBuilder,
+      );
+      getTiersWithComputedPricesMock.mockResolvedValue([]);
+      insertLineItemForPartMock.mockResolvedValue({});
+
+      await createQuote('company-1', { ...baseForm, customer_note: '   \n  ' });
+      expect(insertSpy.mock.calls[0][0].customer_note).toBeNull();
+    });
+
     it('stores a blank lead time as null', async () => {
       const insertSpy = vi.fn().mockReturnValue({
         select: vi.fn().mockReturnValue({
@@ -583,6 +627,7 @@ describe('quotesAccess utilities', () => {
       parts: [{ part_id: 'part-1', order_quantity: 200 }],
       lead_time_text: '14 business days',
       payment_terms: '',
+      customer_note: '',
       expiration_date: '',
     };
 
@@ -932,6 +977,7 @@ describe('quotesAccess utilities', () => {
       parts: [],
       lead_time_text: '14 business days',
       payment_terms: '',
+      customer_note: '',
       expiration_date: '',
     };
 
@@ -1385,6 +1431,7 @@ describe('quotesAccess utilities', () => {
       parts: [{ part_id: 'part-1', order_quantity: 10 }],
       lead_time_text: '14 business days',
       payment_terms: '',
+      customer_note: '',
       expiration_date,
     });
 
@@ -1415,6 +1462,31 @@ describe('quotesAccess utilities', () => {
       expect(payload.expiration_date).toBe(futureDate);
       // A real transition (expired → active) stamps status_changed_at.
       expect(payload.status_changed_at).toEqual(expect.any(String));
+    });
+
+    it('writes a note added on the edit path — the way an existing quote gains one', async () => {
+      // The likelier route than create: a quote already sent picks up "we should have said
+      // freight is extra". createQuote's coverage does not reach this write.
+      const { updateSpy } = stubUpdateQuoteCapture('active');
+
+      await updateQuote('quote-1', {
+        ...formWith(futureDate),
+        customer_note: 'Prices exclude freight and sales tax.',
+      });
+
+      expect(updateSpy.mock.calls[0][0].customer_note).toBe(
+        'Prices exclude freight and sales tax.',
+      );
+    });
+
+    it('clears a note back to null when the shop empties the box', async () => {
+      const { updateSpy } = stubUpdateQuoteCapture('active');
+
+      await updateQuote('quote-1', { ...formWith(futureDate), customer_note: '  ' });
+
+      // null, not '' — the PDF and the detail page both test truthiness, and a blank string
+      // would print a NOTES heading over nothing.
+      expect(updateSpy.mock.calls[0][0].customer_note).toBeNull();
     });
 
     it('keeps an expired quote expired when the saved date is still in the past', async () => {

--- a/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
+++ b/app/dashboard/[companyId]/quotes/[quoteId]/page.tsx
@@ -843,6 +843,29 @@ export default function QuoteDetailPage() {
         </Grid>
       </Grid>
 
+      {/* Note to the customer — between the total and the preparer credit, which is exactly where
+          the PDF prints it. This page mirrors the printed document deliberately (see "Prepared by"
+          below and the header comment on "Created by"), so someone checking a quote before sending
+          it reads the blocks in the order the customer will. Rendering it up in the compact terms
+          stack would break that and squeeze a paragraph into a list of one-line meta.
+
+          Absent when blank rather than shown as an empty heading, matching the PDF. */}
+      {quote.customer_note?.trim() && (
+        <Box sx={{ mt: 3 }}>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ fontWeight: 600, letterSpacing: 0.5 }}
+          >
+            NOTES
+          </Typography>
+          {/* pre-wrap: the shop's own line breaks are meaningful and the PDF honours them too. */}
+          <Typography variant="body2" sx={{ mt: 0.5, whiteSpace: 'pre-wrap' }}>
+            {quote.customer_note}
+          </Typography>
+        </Box>
+      )}
+
       {/* Prepared by — relocated from the header, mirroring the PDF footer. */}
       {(quote.created_by_member?.name || quote.created_by_member?.email) && (
         <Typography variant="body2" color="text.secondary" sx={{ mt: 3 }}>

--- a/components/quotes/QuoteForm.tsx
+++ b/components/quotes/QuoteForm.tsx
@@ -32,7 +32,7 @@ import RefreshIcon from '@mui/icons-material/Refresh';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
-import type { QuoteFormData } from '@/types/quote';
+import { MAX_QUOTE_CUSTOMER_NOTE_LENGTH, type QuoteFormData } from '@/types/quote';
 import {
   getCompanyDefaultPaymentTerms,
 } from '@/utils/companyAccess';
@@ -515,6 +515,21 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [partBlocks.length, partBlocks.map((b) => b.part?.id ?? '').join(',')]);
+
+  /**
+   * The note field's helper line, which does two jobs and only one of them at a time.
+   *
+   * Normally it states the promise — this prints — because the label and this line ARE the
+   * visibility contract; there is no eye icon or internal/external switch to read. The character
+   * count replaces it only as the cap gets close: a permanent "0/500" under a box most quotes
+   * leave blank is noise, while silently refusing the 501st keystroke with nothing on screen is
+   * the kind of small mystery that makes software feel broken.
+   */
+  const customerNoteLength = formData.customer_note.length;
+  const customerNoteHelper =
+    customerNoteLength > MAX_QUOTE_CUSTOMER_NOTE_LENGTH - 100
+      ? `Prints on the quote PDF, below the total — ${customerNoteLength}/${MAX_QUOTE_CUSTOMER_NOTE_LENGTH} characters`
+      : 'Prints on the quote PDF, below the total — e.g. “Prices exclude freight and sales tax.”';
 
   const handleFieldChange = (field: keyof QuoteFormData, value: string | QuoteFormData['parts']) => {
     setFormData((prev) => ({ ...prev, [field]: value } as QuoteFormData));
@@ -1125,6 +1140,9 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
           // price — the amount is the customer's business data.
           custom_priced_line_count: payload.parts.filter((p) => p.override).length,
           customer_id: formData.customer_id,
+          // Whether the shop wrote a note — never what it says. The note is
+          // addressed to the customer and is their business data.
+          has_customer_note: formData.customer_note.trim() !== '',
         });
         onSave?.();
         router.push(`/dashboard/${companyId}/quotes/${quote.id}`);
@@ -1422,6 +1440,31 @@ export default function QuoteForm({ mode, initialData, quoteId, onCancel, onSave
                     ? standingTermsHelper('payment_terms', '')
                     : undefined
                 }
+              />
+            </Grid>
+            <Grid size={{ xs: 12 }}>
+              {/* The note the customer actually reads. Optional, and the only
+                  field in this card that is — lead time and payment terms are
+                  answers every quote owes, whereas a quote with nothing extra
+                  to say should not be blocked into inventing something.
+
+                  NOT in STANDING_TERM_FIELDS, and deliberately: a note is
+                  written for THIS quote, so it takes no prefill from the
+                  customer record and raises no drift chip when that record
+                  later changes. There is also no internal twin — the label and
+                  helper text promise this prints, and that promise is the whole
+                  feature. Internal commentary has the notes feed. */}
+              <TextField
+                label="Note to customer"
+                size="small"
+                fullWidth
+                multiline
+                rows={3}
+                value={formData.customer_note}
+                onChange={(e) => handleFieldChange('customer_note', e.target.value)}
+                helperText={customerNoteHelper}
+                slotProps={{ htmlInput: { maxLength: MAX_QUOTE_CUSTOMER_NOTE_LENGTH } }}
+                InputLabelProps={{ shrink: true }}
               />
             </Grid>
           </Grid>

--- a/docs/modules/quotes.md
+++ b/docs/modules/quotes.md
@@ -101,9 +101,22 @@ A thin header — per-part, per-quantity pricing lives on the line items.
 | `customer_id` | Required |
 | `lead_time_text` | Free text as stated ("2–3 weeks", "In stock"). **Quote-level default**; a line item can override per part. Does **not** drive the job due date |
 | `payment_terms` | Required. A single free-text string, no enum |
+| `customer_note` | Optional free-text note **to the customer**, printed on the PDF below the total. Capped at 500 chars (`quotes_customer_note_length`; `MAX_QUOTE_CUSTOMER_NOTE_LENGTH` in [types/quote.ts](../../types/quote.ts) is the same number). **There is no internal counterpart** — see below |
 | `expiration_date` | Defaults to `created_at + 10 days`. Labelled **"Quote valid until"** on the form and `Valid Until:` on the PDF; the column keeps its original name |
 | `status`, `status_changed_at` | `active` \| `expired` |
 | `converted_at` | First conversion only |
+
+**The note to the customer is customer-facing, and only that.** A `quotes.notes` column once
+existed, labelled "Internal Notes" on the form, and was removed on 2026-01-02 (`595733c0`) along
+with `jobs.notes`, `parts.notes` and `routings.notes`. It never printed. `customer_note` is not
+that column returning: it exists to be printed, the form says so where it is typed, and there is
+deliberately no visibility flag — a field that can only ever be shown cannot leak by having a
+boolean set the wrong way. Internal commentary belongs in the `notes` feed, which has no quote FK.
+
+It takes **no prefill** and raises **no drift chip**: a note is written for one quote, so it is not
+a standing term. If shops start retyping the same boilerplate, a shop-wide default belongs in
+`companies.settings` following `readCompanyDefaultPaymentTerms`'s resolve-once-at-create discipline
+([lib/companyDefaults.ts](../../lib/companyDefaults.ts)) — never a read-time lookup.
 
 **Payment terms prefill from the customer's standing commercial contract.**
 `default_payment_terms` rides along on the detail select so the page can compare what was used

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -144,7 +144,7 @@ fails, and so does a listed property nothing passes.
 | `invitation accepted` | An invitee completes acceptance | `role`, `existing_user` | [accept-invite/page.tsx](../app/accept-invite/[invitationId]/page.tsx) |
 | `terms accepted` | Someone ticks the clickwrap box and it is recorded. One event per click, NOT per document: one tick writes a row for each document in a single call, and firing twice would double the denominator for a single act of assent | `surface`, `is_reacceptance` | [TermsAcceptanceDialog.tsx](../components/legal/TermsAcceptanceDialog.tsx) |
 | `terms document opened` | A legal document is opened from beside the checkbox. **Whether anyone actually reads them is the legally interesting fact** — it goes to conspicuousness, and nothing else in the product records it | `surface`, `document_type` | [TermsConsentCheckbox.tsx](../components/legal/TermsConsentCheckbox.tsx) |
-| `quote created` | A new quote is saved | `line_item_count`, `custom_priced_line_count`, `customer_id` | [QuoteForm.tsx](../components/quotes/QuoteForm.tsx) |
+| `quote created` | A new quote is saved | `line_item_count`, `custom_priced_line_count`, `customer_id`, `has_customer_note` | [QuoteForm.tsx](../components/quotes/QuoteForm.tsx) |
 | `quote converted to job` | A quote is accepted and becomes a job | `quote_id`, `part_count`, `is_hot` | [ConvertToJobModal.tsx](../components/quotes/ConvertToJobModal.tsx) |
 | `job created from purchase order` | A job is created directly from a PO | `part_count`, `total_value`, `is_hot` | [AcceptPurchaseOrderModal.tsx](../components/jobs/AcceptPurchaseOrderModal.tsx) |
 | `jobs bulk cancelled` | Several jobs are cancelled in one action | `count` | [jobs/page.tsx](../app/dashboard/[companyId]/jobs/page.tsx) |

--- a/supabase/migrations/20260819175206_add_quote_customer_note.sql
+++ b/supabase/migrations/20260819175206_add_quote_customer_note.sql
@@ -1,0 +1,21 @@
+-- A quote's note to the customer.
+--
+-- Jigged briefly had a `quotes.notes` column, removed 2026-01-02 (595733c0), whose comment read
+-- "Internal notes about the quote". This is deliberately NOT that column brought back. That one was
+-- internal and never printed; this one exists only to be printed, and is labelled as such
+-- everywhere it is edited. Internal commentary on shop work has its own home in the `notes` feed.
+--
+-- Nullable with no backfill: a quote without a note is a real state, not an inconsistency, so there
+-- is nothing at rest to fix. `quotes` is an existing table, so it already carries its Data API
+-- grants and its billing_gate_* write gate — adding a column changes neither.
+
+ALTER TABLE public.quotes
+  ADD COLUMN customer_note text,
+  ADD CONSTRAINT quotes_customer_note_length CHECK (char_length(customer_note) <= 500);
+
+COMMENT ON COLUMN public.quotes.customer_note IS
+  'Free-text note from the shop to the customer, printed on the quote PDF below the grand total. '
+  'Customer-facing by definition — there is no internal counterpart. Written per quote and never '
+  'inherited from the customer record, so it takes no standing-terms prefill and no drift chip. '
+  'Capped at 500 characters by quotes_customer_note_length so an imported or pasted value cannot '
+  'overrun the printed document.';

--- a/types/database.ts
+++ b/types/database.ts
@@ -2948,6 +2948,7 @@ export type Database = {
           created_by: string | null
           customer_id: string | null
           customer_name: string | null
+          customer_note: string | null
           deleted_at: string | null
           expiration_date: string | null
           id: string
@@ -2971,6 +2972,7 @@ export type Database = {
           created_by?: string | null
           customer_id?: string | null
           customer_name?: string | null
+          customer_note?: string | null
           deleted_at?: string | null
           expiration_date?: string | null
           id?: string
@@ -2994,6 +2996,7 @@ export type Database = {
           created_by?: string | null
           customer_id?: string | null
           customer_name?: string | null
+          customer_note?: string | null
           deleted_at?: string | null
           expiration_date?: string | null
           id?: string

--- a/types/quote.ts
+++ b/types/quote.ts
@@ -62,6 +62,13 @@ export interface Quote {
   // that's entered manually at conversion.
   lead_time_text: string | null;
   payment_terms: string | null;
+  // Free-text note from the shop TO THE CUSTOMER, printed on the quote PDF
+  // below the grand total. Customer-facing by definition — there is no internal
+  // counterpart, and internal commentary belongs in the `notes` feed. NOT a
+  // revival of the `quotes.notes` column removed in January 2026: that one was
+  // internal and never printed. Capped at MAX_QUOTE_CUSTOMER_NOTE_LENGTH, which
+  // the quotes_customer_note_length CHECK enforces at rest.
+  customer_note: string | null;
   expiration_date: string | null;
   status: QuoteStatus;
   status_changed_at: string | null;
@@ -308,6 +315,10 @@ export interface QuoteFormData {
   lead_time_text: string;
   // Payment terms shown on the quote (preset or custom free text). '' = unset.
   payment_terms: string;
+  // Note to the customer, printed on the PDF. '' = unset, and unlike
+  // lead_time_text/payment_terms it is OPTIONAL — a quote with nothing to say
+  // says nothing rather than being blocked at validation.
+  customer_note: string;
   expiration_date: string; // ISO date (YYYY-MM-DD)
   status?: QuoteStatus;
 }
@@ -359,6 +370,18 @@ export interface CompanyMember {
 export const DEFAULT_QUOTE_VALIDITY_DAYS = 10;
 
 /**
+ * How long a quote's note to the customer may be.
+ *
+ * The same number the `quotes_customer_note_length` CHECK enforces
+ * (20260819175206_add_quote_customer_note.sql) — declared once here so the
+ * form's maxLength and the database agree by construction rather than by
+ * coincidence. It is a printed-document limit, not a storage one: the note
+ * shares a page with the line items, and past roughly this length it stops
+ * being the "short note to the customer" it is offered as.
+ */
+export const MAX_QUOTE_CUSTOMER_NOTE_LENGTH = 500;
+
+/**
  * Expiration date for a NEW quote: today + `validityDays`. The validity window
  * is company-configurable (companies.settings.defaults.quote_validity_days,
  * read via readQuoteValidityDays); callers that don't have the company row pass
@@ -380,6 +403,7 @@ export const EMPTY_QUOTE_FORM: QuoteFormData = {
   parts: [],
   lead_time_text: '',
   payment_terms: '',
+  customer_note: '',
   expiration_date: defaultExpirationDate(),
 };
 
@@ -419,6 +443,7 @@ export function quoteToFormData(quote: QuoteWithRelations): QuoteFormData {
       })),
     lead_time_text: quote.lead_time_text ?? '',
     payment_terms: quote.payment_terms ?? '',
+    customer_note: quote.customer_note ?? '',
     expiration_date: quote.expiration_date || defaultExpirationDate(),
     status: quote.status,
   };

--- a/utils/quotePdf.ts
+++ b/utils/quotePdf.ts
@@ -402,6 +402,72 @@ export async function generateQuotePdf(
     cursorY += 20;
   }
 
+  // ---------- Notes to the customer ----------
+  // Below the total, above the footer: the customer reads the price, then the caveat that qualifies
+  // it ("Prices exclude freight", "Tooling quoted separately"). That is where every comparable
+  // document puts it, and it is the only gap in this layout that does not push something else down.
+  //
+  // **This block must stay ahead of the footer loop below.** That loop walks `getNumberOfPages()`
+  // and stamps every page, so a page added here still gets its rule, preparer credit and page
+  // number; a page added after it would print bare.
+  //
+  // There is no internal counterpart to guard against. `quotes.customer_note` is customer-facing by
+  // definition — the form says so where it is typed — so there is no visibility flag to check and
+  // no way to leak a private remark onto a document by getting a boolean backwards.
+  const customerNote = (quote.customer_note ?? '').trim();
+  if (customerNote !== '') {
+    // **Set the body font BEFORE measuring.** `splitTextToSize` wraps against whatever font the
+    // document is currently in, and at this point that is still the grand total's bold 13pt.
+    // Measuring there and drawing at normal 10pt is silently wrong in the safe direction — every
+    // line breaks about a third short of the right margin, so the note reads as a ragged narrow
+    // column and runs onto more lines than it needs. Nothing overflows, which is exactly why it
+    // survived a mocked test suite: only a real render shows it.
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(10);
+
+    // The user's own line breaks are meaningful — a shop writing three caveats writes three lines —
+    // so paragraphs are split first and each is wrapped to the text column independently. A blank
+    // line survives as a blank line rather than being collapsed away.
+    const noteLines = customerNote.split('\n').flatMap((paragraph) => {
+      const trimmed = paragraph.trimEnd();
+      return trimmed === '' ? [''] : (doc.splitTextToSize(trimmed, usableWidth) as string[]);
+    });
+
+    // The footer's rule sits 14pt above the baseline at `pageHeight - MARGIN`; nothing may cross it.
+    const footerTop = pageHeight - MARGIN - 14;
+    const LINE_HEIGHT = 13;
+
+    // Keep the heading with at least its first line — a NOTES label stranded alone at the foot of
+    // page 1 with the note itself on page 2 reads as a formatting fault.
+    if (cursorY + 16 + LINE_HEIGHT > footerTop) {
+      doc.addPage();
+      cursorY = MARGIN;
+    }
+
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(9);
+    doc.setTextColor(120);
+    doc.text('NOTES', MARGIN, cursorY);
+
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(10);
+    doc.setTextColor(40);
+    let noteY = cursorY + 16;
+    for (const line of noteLines) {
+      // Per-line rather than measuring the block once: the 500-char cap
+      // (MAX_QUOTE_CUSTOMER_NOTE_LENGTH, enforced at rest by
+      // quotes_customer_note_length) means a note cannot actually outrun a fresh page today, but a
+      // block that paginates by construction cannot be broken by raising that cap later.
+      if (noteY > footerTop) {
+        doc.addPage();
+        noteY = MARGIN;
+      }
+      if (line !== '') doc.text(line, MARGIN, noteY);
+      noteY += LINE_HEIGHT;
+    }
+    cursorY = noteY + 4;
+  }
+
   // ---------- Footer (every page) ----------
   // The company name and quote dates already sit in the header, so the footer carries the preparer
   // credit (relocated from the old top "CREATED BY" column) on the left and, on the right, the

--- a/utils/quotesAccess.ts
+++ b/utils/quotesAccess.ts
@@ -423,6 +423,10 @@ export async function createQuote(
   const leadTimeText = nullIfBlank(formData.lead_time_text);
   const expirationDate = formData.expiration_date || null;
   const paymentTerms = nullIfBlank(formData.payment_terms);
+  // A whitespace-only note stores NULL, not '  ': the PDF and the detail page
+  // both decide whether to render a NOTES block by truthiness, and a blank
+  // string would print an empty heading.
+  const customerNote = nullIfBlank(formData.customer_note);
 
   const { data: { user } } = await supabase.auth.getUser();
 
@@ -452,6 +456,7 @@ export async function createQuote(
       shipping_address_id: nullIfEmpty(formData.shipping_address_id),
       lead_time_text: leadTimeText,
       payment_terms: paymentTerms,
+      customer_note: customerNote,
       expiration_date: expirationDate,
       status: 'active',
       created_by: user?.id ?? null,
@@ -580,6 +585,7 @@ export async function updateQuote(
       shipping_address_id: nullIfEmpty(formData.shipping_address_id),
       lead_time_text: leadTimeText,
       payment_terms: nullIfBlank(formData.payment_terms),
+      customer_note: nullIfBlank(formData.customer_note),
       expiration_date: newExpiration,
       status: nextStatus,
       ...(nextStatus !== existing.status


### PR DESCRIPTION
Closes the request from Johnnie Trammell at Contour Tool & Machine:

> I just did a customer quote and wanted to add a note to the customer in the quote. For some reason I thought we had the feature before but I do not see anywhere to add a short note to the customer.

## Did we have it before?

Half. A `quotes.notes` column with an **"Internal Notes"** box on the quote form existed and was removed on 2026-01-02 (`595733c0`), in the same cull that dropped `jobs.notes`, `parts.notes` and `routings.notes`. So he isn't imagining it — but it was internal and `utils/quotePdf.ts` has never printed a notes section (`git log -S"notes" -- utils/quotePdf.ts` is empty), so it would not have reached his customer. The unified `notes` feed has no quote FK.

## What this adds

One field, `quotes.customer_note`, customer-facing and only that. The label and helper text on the form say it prints — that *is* the visibility contract, so there is no flag to set backwards and leak a private remark onto a document a customer reads. Internal commentary keeps the notes feed.

It prints below the grand total, above the footer, which is where the category puts it: Paperless Parts makes "Quote Notes" a configurable section around the line items; JobBOSS prints Quotation Comments and deliberately withholds Quote Notes; QuickBooks has a per-estimate "Message displayed on estimate". The detail page renders it in the same slot so the screen reads in the order the customer's page will.

## Two things worth a reviewer's eye

**The block must stay ahead of the footer loop.** That loop reads `getNumberOfPages()` once and stamps that many pages; a page added after it ships with no rule, no preparer credit, and "Page 1 of 1" on a two-page document. Both directions of the ordering are now pinned by test — mutation-checked by moving the block below the loop and confirming the tests go red.

**The body font is set before `splitTextToSize`.** It wraps against the document's *current* font, which at that point is still the grand total's bold 13pt while the note draws at normal 10pt — every line broke about a third short of the margin. It overflows nothing, so no mocked assertion could ever see it; only a real render does. Fixed, with a regression guard that fails on the old ordering.

## Deliberately out of scope

- No shop-wide default and no saved snippets. If shops retype boilerplate, `readCompanyDefaultPaymentTerms` in `lib/companyDefaults.ts` is the resolve-once-at-create pattern to copy — never a read-time lookup.
- The note does not follow a quote into its job (jobs have the notes feed).
- It does not touch the QuickBooks `CustomerMemo`, which already carries the customer PO number that AP pays from.
- No internal counterpart. That is the field we deleted in January.

## Verification

- 2967 unit tests green (15 new), `tsc` clean, `pnpm build` clean, no new lint warnings, all five guard scripts pass.
- Migration replayed clean as file #132 into a throwaway DB — **not** `supabase db reset`, since the local stack is shared across worktrees. CHECK boundary proven exact: 500 accepted, 501 rejected.
- **Real PDFs rendered and inspected** across 30 table heights with a max-length note: no line crosses the footer rule at y=738, every page keeps its footer, the heading is never stranded. The new-page path genuinely fires in 4 of the 30.
- **Driven end to end in the running app** — form → save → database → detail page → PDF preview — for a quote with a note and one without. No console errors.
- E2E not run locally (the runbook calls that an anti-pattern); checked statically instead that every quote spec's locators are name-scoped and the only unnamed `getByRole('textbox')` queries are scoped to the Parts page.

## Note for a follow-up, not this PR

`scripts/analyticsEventsCheck.ts` has a latent bug: `splitTopLevel` splits the properties object on top-level commas without skipping comments, so a comma inside a code comment severs the property key after it and the property reads as un-instrumented. It bit me here; I reworded rather than touch a CI guard in an unrelated PR. The existing `custom_priced_line_count` comment only survives by accident — an apostrophe in "shops' tiers" opens a fake string that swallows its comma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)